### PR TITLE
Forbid to encrypt or decrypt a non-empty folder.

### DIFF
--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -25,6 +25,7 @@
 #include "quotainfo.h"
 #include "progressdispatcher.h"
 #include "owncloudgui.h"
+#include "folderstatusmodel.h"
 
 class QModelIndex;
 class QNetworkReply;
@@ -55,7 +56,7 @@ public:
     explicit AccountSettings(AccountState *accountState, QWidget *parent = 0);
     ~AccountSettings();
     QSize sizeHint() const Q_DECL_OVERRIDE { return ownCloudGui::settingsDialogSize(); }
-
+    bool canEncryptOrDecrypt(const FolderStatusModel::SubFolderInfo* folderInfo);
 
 signals:
     void folderChanged();
@@ -85,8 +86,8 @@ protected slots:
     void slotOpenAccountWizard();
     void slotAccountAdded(AccountState *);
     void refreshSelectiveSyncStatus();
-    void slotMarkSubfolderEncrpted(const QByteArray& fileId);
-    void slotMarkSubfolderDecrypted(const QByteArray& fileId);
+    void slotMarkSubfolderEncrpted(const FolderStatusModel::SubFolderInfo* folderInfo);
+    void slotMarkSubfolderDecrypted(const FolderStatusModel::SubFolderInfo* folderInfo);
     void slotSubfolderContextMenuRequested(const QModelIndex& idx, const QPoint& point);
     void slotCustomContextMenuRequested(const QPoint &);
     void slotFolderListClicked(const QModelIndex &indx);


### PR DESCRIPTION
The specs forbid the encryption or decryption of a
non empty folder. so...
1 - check for the sync status, if it's not synced return

as there's no way that I can say that there's items on the
server right now without waiting for the sync to finish

2 - verify if the folder is empty locally

as the user could have send some files to the folder.