### PR TITLE
Folder: normalize the local path.

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -119,6 +119,10 @@ void Folder::checkLocalPath()
 {
     const QFileInfo fi(_definition.localPath);
     _canonicalLocalPath = fi.canonicalFilePath();
+#ifdef Q_OS_MAC
+    // Workaround QTBUG-55896  (Should be fixed in Qt 5.8)
+    _canonicalLocalPath = _canonicalLocalPath.normalized(QString::NormalizationForm_C);
+#endif
     if (_canonicalLocalPath.isEmpty()) {
         qCWarning(lcFolder) << "Broken symlink:" << _definition.localPath;
         _canonicalLocalPath = _definition.localPath;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -588,8 +588,7 @@ bool OwncloudPropagator::localFileNameClash(const QString &relFile)
             re = false;
             qCWarning(lcPropagator) << "No valid fileinfo";
         } else {
-            // Need to normalize to composited form because of
-            // https://bugreports.qt-project.org/browse/QTBUG-39622
+            // Need to normalize to composited form because of QTBUG-39622/QTBUG-55896
             const QString cName = fileInfo.canonicalFilePath().normalized(QString::NormalizationForm_C);
             bool equal = (file == cName);
             re = (!equal && !cName.endsWith(relFile, Qt::CaseSensitive));


### PR DESCRIPTION
We otherwise normalize all path in the C form, so we must have
the Folder's path normalized the same. Or all comparizon will fail
(such as knowing if a file from the SocketAPI or the FilesystemWatcher
are part of the folder)

Issue owncloud/client/issues/4424