### PR TITLE
propagateuploadv1: don't finalize after a done()

### DIFF
--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -323,6 +323,7 @@ void PropagateUploadFileV1::slotPutFinished()
         qCWarning(lcPropagateUpload) << "Server does not support X-OC-MTime" << job->reply()->rawHeader("X-OC-MTime");
         // Well, the mtime was not set
         done(SyncFileItem::SoftError, "Server does not support X-OC-MTime");
+        return;
     }
 
     finalize();


### PR DESCRIPTION
We otherwise normalize all path in the C form, so we must have
the Folder's path normalized the same. Or all comparizon will fail
(such as knowing if a file from the SocketAPI or the FilesystemWatcher
are part of the folder)

Issue owncloud/client/issues/6403