### PR TITLE
Notifications: Lower hiding timeout

### DIFF
--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -91,7 +91,7 @@ private slots:
     void slotNotifyNetworkError(QNetworkReply *);
     void slotNotifyServerFinished(const QString &reply, int replyCode);
     void endNotificationRequest(NotificationWidget *widget, int replyCode);
-    void scheduleWidgetToRemove(NotificationWidget *widget, int milliseconds = 4500);
+    void scheduleWidgetToRemove(NotificationWidget *widget, int milliseconds = 100);
     void slotCheckToCleanWidgets();
 
 private:


### PR DESCRIPTION
With the 4.5sec timeout, it was very easy to accidently hit the wrong notification
when the previous one dissapeared so late.