### PR TITLE
Network settings: If no proxy host given, show "no proxy" #5885

### DIFF
--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -217,4 +217,16 @@ void NetworkSettings::checkEmptyProxyHost()
     }
 }
 
+void NetworkSettings::showEvent(QShowEvent *event)
+{
+    if (!event->spontaneous()
+        && _ui->manualProxyRadioButton->isChecked()
+        && _ui->hostLineEdit->text().isEmpty()) {
+        _ui->noProxyRadioButton->setChecked(true);
+        checkEmptyProxyHost();
+    }
+
+    QWidget::showEvent(event);
+}
+
 } // namespace OCC

--- a/src/gui/networksettings.h
+++ b/src/gui/networksettings.h
@@ -44,6 +44,9 @@ private slots:
     /// Red marking of host field if empty and enabled
     void checkEmptyProxyHost();
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 private:
     void loadProxySettings();
     void loadBWLimitSettings();


### PR DESCRIPTION
What happens internally is that a proxy without a hostname gets treated
as no proxy.

PR owncloud/client/pull/6458