### PR TITLE
Fix a bunch of warning with clang

### DIFF
--- a/cmake/modules/Warnings.cmake
+++ b/cmake/modules/Warnings.cmake
@@ -7,10 +7,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
     # Fix sqlite compilation on macOS
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types-discards-qualifiers")
-    # Fix sqlite compilation on MinGW
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-discarded-qualifiers")
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        # Fix sqlite compilation on MinGW
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-discarded-qualifiers")
+
         execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                         OUTPUT_VARIABLE GCC_VERSION)
         if(GCC_VERSION VERSION_GREATER 4.8 OR GCC_VERSION VERSION_EQUAL 4.8)

--- a/src/gui/networksettings.h
+++ b/src/gui/networksettings.h
@@ -35,7 +35,7 @@ class NetworkSettings : public QWidget
 public:
     explicit NetworkSettings(QWidget *parent = 0);
     ~NetworkSettings();
-    QSize sizeHint() const;
+    QSize sizeHint() const override;
 
 private slots:
     void saveProxySettings();


### PR DESCRIPTION
The option -Wno-discarded-qualifiers only exists with GCC, clang warns that
it has no effects.

Also it warns when some virtual fuction are marked with override but not
all of them.