### PR TITLE
Nautilus shell integration: Print python version on startup #6406

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -35,6 +35,7 @@ from gi.repository import GObject, Nautilus
 appname = 'ownCloud'
 
 print("Initializing "+appname+"-client-nautilus extension")
+print("Using python version {}".format(sys.version_info))
 
 def get_local_path(url):
     if url[0:7] == 'file://':


### PR DESCRIPTION
Issue owncloud/client/issues/6406 