### PR TITLE
Share dialog: Don't hide account settings before showing #6185

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -1123,8 +1123,11 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         return;
     }
 
+#ifdef Q_OS_MAC
     // For https://github.com/owncloud/client/issues/3783
+    // see also #6185, #3015
     _settingsDialog->hide();
+#endif
 
     const auto accountState = folder->accountState();
 


### PR DESCRIPTION
At least on windows and linux. OSX would need tests first since
the addition was originally supposed to help with OSX problems,
see owncloud/client/issues/3783.

PR owncloud/client/pull/6452