### PR TITLE
Upload: Adjust timeout for final job based on size #6527

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -606,6 +606,16 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
     abortWithError(status, errorString);
 }
 
+void PropagateUploadFileCommon::adjustLastJobTimeout(AbstractNetworkJob *job, quint64 fileSize)
+{
+    job->setTimeout(qBound(
+        job->timeoutMsec(),
+        // Calculate 3 minutes for each gigabyte of data
+        qint64((3 * 60 * 1000) * fileSize / 1e9),
+        // Maximum of 30 minutes
+        qint64(30 * 60 * 1000)));
+}
+
 void PropagateUploadFileCommon::slotJobDestroyed(QObject *job)
 {
     _jobs.erase(std::remove(_jobs.begin(), _jobs.end(), job), _jobs.end());

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -296,6 +296,17 @@ protected:
      */
     void commonErrorHandling(AbstractNetworkJob *job);
 
+    /**
+     * Increases the timeout for the final MOVE/PUT for large files.
+     *
+     * This is an unfortunate workaround since the drawback is not being able to
+     * detect real disconnects in a timely manner. Shall go away when the server
+     * response starts coming quicker, or there is some sort of async api.
+     *
+     * See #6527, enterprise#2480
+     */
+    static void adjustLastJobTimeout(AbstractNetworkJob *job, quint64 fileSize);
+
     // Bases headers that need to be sent with every chunk
     QMap<QByteArray, QByteArray> headers();
 private:

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -300,6 +300,7 @@ void PropagateUploadFileNG::startNextChunk()
         connect(job, &MoveJob::finishedSignal, this, &PropagateUploadFileNG::slotMoveJobFinished);
         connect(job, &QObject::destroyed, this, &PropagateUploadFileCommon::slotJobDestroyed);
         propagator()->_activeJobList.append(this);
+        adjustLastJobTimeout(job, fileSize);
         job->start();
         return;
     }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -145,6 +145,8 @@ void PropagateUploadFileV1::startNextChunk()
     connect(job, &PUTFileJob::uploadProgress, this, &PropagateUploadFileV1::slotUploadProgress);
     connect(job, &PUTFileJob::uploadProgress, device, &UploadDevice::slotJobUploadProgress);
     connect(job, &QObject::destroyed, this, &PropagateUploadFileCommon::slotJobDestroyed);
+    if (isFinalChunk)
+        adjustLastJobTimeout(job, fileSize);
     job->start();
     propagator()->_activeJobList.append(this);
     _currentChunk++;


### PR DESCRIPTION
Some servers have virus scanners and the like that can delay the
response of the final chunked upload assembly significantly, often
breaking the current 5min (!) timeout. See owncloud/enterprise#2480
for details.

Issue owncloud/client/issues/6527
PR owncloud/client/pull/6532