### PR TITLE
SyncJournal: Check file existence even for open dbs #6049

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -273,6 +273,11 @@ bool SyncJournalDb::sqlFail(const QString &log, const SqlQuery &query)
 bool SyncJournalDb::checkConnect()
 {
     if (_db.isOpen()) {
+        if (!QFile::exists(_dbFile)) {
+            qCWarning(lcDb) << "Database open, but file file" + _dbFile + " does not exist";
+            close();
+            return false;
+        }
         return true;
     }
 

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -273,8 +273,10 @@ bool SyncJournalDb::sqlFail(const QString &log, const SqlQuery &query)
 bool SyncJournalDb::checkConnect()
 {
     if (_db.isOpen()) {
+        // Unfortunately the sqlite isOpen check can return true even when the underlying storage
+        // has become unavailable - and then some operations may cause crashes. See #6049
         if (!QFile::exists(_dbFile)) {
-            qCWarning(lcDb) << "Database open, but file file" + _dbFile + " does not exist";
+            qCWarning(lcDb) << "Database open, but file " + _dbFile + " does not exist";
             close();
             return false;
         }


### PR DESCRIPTION
With WAL mode sqlite seems to occasionally crash when the
underlying filesystem goes away.

Issue owncloud/client/issues/6049
PR owncloud/client/pull/6530