### PR TITLE
Credentials: Retry fetching from the keychain in case the keychain is…

### DIFF
--- a/src/libsync/creds/httpcredentials.h
+++ b/src/libsync/creds/httpcredentials.h
@@ -141,6 +141,7 @@ protected:
     QSslKey _clientSslKey;
     QSslCertificate _clientSslCertificate;
     bool _keychainMigration;
+    bool _retryOnKeyChainError = true; // true if we haven't done yet any reading from keychain
 };
 
 


### PR DESCRIPTION
… still starting

When owncloud is restored, at boot time, it might be started before the
crendential manager. So if we detect an error, wait 10 seconds and hopefully
it'd be loaded by then.

Issues: https://github.com/owncloud/client/issues/4274, https://github.com/owncloud/client/issues/6522

PR https://github.com/owncloud/client/pull/6525