### PR TITLE
Conflicts: Change tags to be more user friendly #6365

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -222,13 +222,13 @@ public:
     /// Store a new or updated record in the database
     void setConflictRecord(const ConflictRecord &record);
 
-    /// Retrieve a conflict record by path of the _conflict- file
+    /// Retrieve a conflict record by path of the file with the conflict tag
     ConflictRecord conflictRecord(const QByteArray &path);
 
-    /// Delete a conflict record by path of the _conflict- file
+    /// Delete a conflict record by path of the file with the conflict tag
     void deleteConflictRecord(const QByteArray &path);
 
-    /// Return all paths of _conflict- files with records in the db
+    /// Return all paths of files with a conflict tag in the name and records in the db
     QByteArrayList conflictRecordPaths();
 
 

--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -115,18 +115,15 @@ public:
 
 /** Represents a conflict in the conflicts table.
  *
- * In the following the "conflict file" is the file with the "_conflict-"
- * tag and the base file is the file that its a conflict for. So if
- * a/foo.txt is the base file, its conflict file could be
- * a/foo_conflict-1234.txt.
+ * In the following the "conflict file" is the file that has the conflict
+ * tag in the filename, and the base file is the file that it's a conflict for.
+ * So if "a/foo.txt" is the base file, its conflict file could be
+ * "a/foo (conflicted copy 1234).txt".
  */
 class OCSYNC_EXPORT ConflictRecord
 {
 public:
-    /** Path to the _conflict- file
-     *
-     * So if a/foo.txt has a conflict, this path would point to
-     * a/foo_conflict-1234.txt.
+    /** Path to the file with the conflict tag in the name
      *
      * The path is sync-folder relative.
      */

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -559,19 +559,23 @@ QString Utility::makeConflictFileName(
     const QString &fn, const QDateTime &dt, const QString &user)
 {
     QString conflictFileName(fn);
-    // Add _conflict-XXXX  before the extension.
+    // Add conflict tag before the extension.
     int dotLocation = conflictFileName.lastIndexOf('.');
     // If no extension, add it at the end  (take care of cases like foo/.hidden or foo.bar/file)
     if (dotLocation <= conflictFileName.lastIndexOf('/') + 1) {
         dotLocation = conflictFileName.size();
     }
 
-    QString conflictMarker = QStringLiteral("_conflict-");
+    QString conflictMarker = QStringLiteral(" (conflicted copy ");
     if (!user.isEmpty()) {
-        conflictMarker.append(sanitizeForFileName(user));
-        conflictMarker.append('-');
+        // Don't allow parens in the user name, to ensure
+        // we can find the beginning and end of the conflict tag.
+        const auto userName = sanitizeForFileName(user).replace('(', '_').replace(')', '_');
+        conflictMarker.append(userName);
+        conflictMarker.append(' ');
     }
-    conflictMarker.append(dt.toString("yyyyMMdd-hhmmss"));
+    conflictMarker.append(dt.toString("yyyy-MM-dd hhmmss"));
+    conflictMarker.append(')');
 
     conflictFileName.insert(dotLocation, conflictMarker);
     return conflictFileName;
@@ -586,13 +590,28 @@ bool Utility::isConflictFile(const char *name)
         bname = name;
     }
 
-    return std::strstr(bname, "_conflict-");
+    // Old pattern
+    if (std::strstr(bname, "_conflict-"))
+        return true;
+
+    // New pattern
+    if (std::strstr(bname, "(conflicted copy"))
+        return true;
+
+    return false;
 }
 
 bool Utility::isConflictFile(const QString &name)
 {
     auto bname = name.midRef(name.lastIndexOf('/') + 1);
-    return bname.contains("_conflict-", Utility::fsCasePreserving() ? Qt::CaseInsensitive : Qt::CaseSensitive);
+
+    if (bname.contains(QStringLiteral("_conflict-")))
+        return true;
+
+    if (bname.contains(QStringLiteral("(conflicted copy")))
+        return true;
+
+    return false;
 }
 
 QByteArray Utility::conflictFileBaseName(const QByteArray &conflictName)
@@ -600,19 +619,29 @@ QByteArray Utility::conflictFileBaseName(const QByteArray &conflictName)
     // This function must be able to deal with conflict files for conflict files.
     // To do this, we scan backwards, for the outermost conflict marker and
     // strip only that to generate the conflict file base name.
-    int from = conflictName.size();
-    while (from != -1) {
-        auto start = conflictName.lastIndexOf("_conflict-", from);
-        if (start == -1)
-            return "";
-        from = start - 1;
+    auto startOld = conflictName.lastIndexOf("_conflict-");
 
-        auto end = conflictName.indexOf('.', start);
-        if (end == -1)
-            end = conflictName.size();
-        return conflictName.left(start) + conflictName.mid(end);
+    // A single space before "(conflicted copy" is considered part of the tag
+    auto startNew = conflictName.lastIndexOf("(conflicted copy");
+    if (startNew > 0 && conflictName[startNew - 1] == ' ')
+        startNew -= 1;
+
+    // The rightmost tag is relevant
+    auto tagStart = qMax(startOld, startNew);
+    if (tagStart == -1)
+        return "";
+
+    // Find the end of the tag
+    auto tagEnd = conflictName.size();
+    auto dot = conflictName.lastIndexOf('.'); // dot could be part of user name for new tag!
+    if (dot > tagStart)
+        tagEnd = dot;
+    if (tagStart == startNew) {
+        auto paren = conflictName.indexOf(')', tagStart);
+        if (paren != -1)
+            tagEnd = paren + 1;
     }
-    return "";
+    return conflictName.left(tagStart) + conflictName.mid(tagEnd);
 }
 
 QString Utility::sanitizeForFileName(const QString &name)

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -289,7 +289,7 @@ private slots:
         // There is a conflict file with our version
         auto &stateAChildren = localState.find("A")->children;
         auto it = std::find_if(stateAChildren.cbegin(), stateAChildren.cend(), [&](const FileInfo &fi) {
-            return fi.name.startsWith("a0_conflict");
+            return fi.name.startsWith("a0 (conflicted copy");
         });
         QVERIFY(it != stateAChildren.cend());
         QCOMPARE(it->contentChar, 'B');

--- a/test/testexcludedfiles.cpp
+++ b/test/testexcludedfiles.cpp
@@ -37,6 +37,7 @@ private slots:
         QVERIFY(!excluded.isExcluded("/a/.b", "/a", keepHidden));
         QVERIFY(excluded.isExcluded("/a/.Trashes", "/a", keepHidden));
         QVERIFY(excluded.isExcluded("/a/foo_conflict-bar", "/a", keepHidden));
+        QVERIFY(excluded.isExcluded("/a/foo (conflicted copy bar)", "/a", keepHidden));
         QVERIFY(excluded.isExcluded("/a/.b", "/a", excludeHidden));
     }
 };

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -42,7 +42,7 @@ QStringList findConflicts(const FileInfo &dir)
 {
     QStringList conflicts;
     for (const auto &item : dir.children) {
-        if (item.name.contains("conflict")) {
+        if (item.name.contains("(conflicted copy")) {
             conflicts.append(item.path());
         }
     }
@@ -56,7 +56,7 @@ bool expectAndWipeConflict(FileModifier &local, FileInfo state, const QString pa
     if (!base)
         return false;
     for (const auto &item : base->children) {
-        if (item.name.startsWith(pathComponents.fileName()) && item.name.contains("_conflict")) {
+        if (item.name.startsWith(pathComponents.fileName()) && item.name.contains("(conflicted copy")) {
             local.remove(item.path());
             return true;
         }


### PR DESCRIPTION
From "_conflict-user-yyyymmdd-hhmmss"
to   " (conflicted copy user yyyy-mm-dd hhmmss)"

Issue https://github.com/owncloud/client/issues/6365
PR https://github.com/owncloud/client/pull/6417