### PR TITLE
SocketAPI: Allow opening share dialog if contents still syncing #4608

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -376,10 +376,8 @@ void SocketApi::processShareRequest(const QString &localFile, SocketListener *li
         const QString message = QLatin1String("SHARE:NOP:") + QDir::toNativeSeparators(localFile);
         listener->sendMessage(message);
     } else {
-        SyncFileStatus fileStatus = fileData.syncFileStatus();
-
-        // Verify the file is on the server (to our knowledge of course)
-        if (fileStatus.tag() != SyncFileStatus::StatusUpToDate) {
+        // If the file doesn't have a journal record, it might not be uploaded yet
+        if (!fileData.journalRecord().isValid()) {
             const QString message = QLatin1String("SHARE:NOTSYNCED:") + QDir::toNativeSeparators(localFile);
             listener->sendMessage(message);
             return;

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -95,7 +95,6 @@ private:
 
     Q_INVOKABLE void command_VERSION(const QString &argument, SocketListener *listener);
 
-    Q_INVOKABLE void command_SHARE_STATUS(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_SHARE_MENU_TITLE(const QString &argument, SocketListener *listener);
 
     // The context menu actions


### PR DESCRIPTION
With the previous changes the "Share..." action was shown but it didn't
work yet.

PR owncloud/client/pull/6481