### PR TITLE
Use the VERSION.cmake file to determine Ubuntu/Debian main package version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(client)
 
 set(BIN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-set(Qt5WebEngineCore_FIND_VERSION_EXACT FALSE)
-
 set(OEM_THEME_DIR "" CACHE STRING "Define directory containing a custom theme")
 if ( EXISTS ${OEM_THEME_DIR}/OEM.cmake )
      include ( ${OEM_THEME_DIR}/OEM.cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(client)
 
 set(BIN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
+set(Qt5WebEngineCore_FIND_VERSION_EXACT FALSE)
+
 set(OEM_THEME_DIR "" CACHE STRING "Define directory containing a custom theme")
 if ( EXISTS ${OEM_THEME_DIR}/OEM.cmake )
      include ( ${OEM_THEME_DIR}/OEM.cmake )


### PR DESCRIPTION
The Ubuntu/Debian build script used the repository tags to determine the main version of the packages (which worked with the theming repo). However, it seems that this repo is not being tagged. So this patch modifies the build (actually, the changelog generator) script  to use the contents of the ```VERSION.cmake``` file to determine the version.

However, I am wondering if the repository should be rather tagged, as currently there is no way to determine if a version is a beta or a release one. While still an experimental PPA is used for uploads, eventually it would be good to be able to differentiate between a beta and a release version and hence PPA.