### PR TITLE
Proxy settings: Fix bad behavior with empty host

### DIFF
--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -164,6 +164,9 @@ void NetworkSettings::saveProxySettings()
         cfgFile.setProxyType(QNetworkProxy::DefaultProxy);
     } else if (_ui->manualProxyRadioButton->isChecked()) {
         int type = _ui->typeComboBox->itemData(_ui->typeComboBox->currentIndex()).toInt();
+        QString host = _ui->hostLineEdit->text();
+        if (host.isEmpty())
+            type = QNetworkProxy::NoProxy;
         bool needsAuth = _ui->authRequiredcheckBox->isChecked();
         QString user = _ui->userLineEdit->text();
         QString pass = _ui->passwordLineEdit->text();
@@ -224,6 +227,7 @@ void NetworkSettings::showEvent(QShowEvent *event)
         && _ui->hostLineEdit->text().isEmpty()) {
         _ui->noProxyRadioButton->setChecked(true);
         checkEmptyProxyHost();
+        saveProxySettings();
     }
 
     QWidget::showEvent(event);


### PR DESCRIPTION
Fixes f6a075ef54a3434e758dcddc6a29b218c4f2a247 for #5885

When no host is given it shouldn't just *appear* that there is no
proxy, there actually shouldn't be a proxy set then.

PR owncloud/client/pull/6491