### PR TITLE
[WIP] Sync hidden files by default

### DIFF
--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -49,7 +49,7 @@ class FolderDefinition
 public:
     FolderDefinition()
         : paused(false)
-        , ignoreHiddenFiles(true)
+        , ignoreHiddenFiles(false)
     {
     }
 


### PR DESCRIPTION
Currently, syncing hidden files is disabled by default. This is a bit annoying since sometimes there are .gitignore, or .bashrc files or similar. Like, really useful stuff and personal data which I expect to be synced automatically.

@camilasan @rullzer would this be the line which needs to be edited? Last time I was told "it is just editing the exclude file" but it seems [the exclude file](https://github.com/nextcloud/desktop/blob/master/sync-exclude.lst) doesn’t handle the `syncHiddenFilesCheckBox`.