### PR TITLE
Windows: moves translation files to /i18n.

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -264,9 +264,10 @@ if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)
             string(REPLACE "-${APPLICATION_ICON_NAME}-icon.png" "" _res ${_res})
             install(FILES ${_file} RENAME ${APPLICATION_ICON_NAME}.png DESTINATION ${DATADIR}/icons/hicolor/${_res}x${_res}/apps)
         endforeach(_file)
-    endif(NOT WIN32)
-
-    install(FILES ${client_I18N} DESTINATION ${SHAREDIR}/${APPLICATION_EXECUTABLE}/i18n)
+        install(FILES ${client_I18N} DESTINATION ${SHAREDIR}/${APPLICATION_EXECUTABLE}/i18n)
+    else()
+        install(FILES ${client_I18N} DESTINATION i18n)
+    endif()
 
     # we may not add MACOSX_BUNDLE here, if not building one
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -83,7 +83,7 @@ namespace {
             return devTrPath;
         }
 #if defined(Q_OS_WIN)
-        return QApplication::applicationDirPath();
+        return QApplication::applicationDirPath() + QLatin1String("/i18n/");
 #elif defined(Q_OS_MAC)
         return QApplication::applicationDirPath() + QLatin1String("/../Resources/Translations"); // path defaults to app dir.
 #elif defined(Q_OS_UNIX)


### PR DESCRIPTION
Reason: Windows desktop translation was only working when moving all translation files to the root of the install folder. Pretty messy.