### PR TITLE
Set Accept-language header for webview requests

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -8,6 +8,7 @@
 #include <QWebEngineView>
 #include <QProgressBar>
 #include <QLoggingCategory>
+#include <QLocale>
 
 #include "common/utility.h"
 
@@ -51,6 +52,23 @@ WebView::WebView(QWidget *parent)
     _profile->setHttpUserAgent(Utility::userAgentString());
     _profile->setRequestInterceptor(_interceptor);
     _profile->installUrlSchemeHandler("nc", _schemeHandler);
+
+    /*
+     * Set a proper accept langauge to the language of the client
+     * code from: http://code.qt.io/cgit/qt/qtbase.git/tree/src/network/access/qhttpnetworkconnection.cpp
+     */
+    {
+        QString systemLocale = QLocale::system().name().replace(QChar::fromLatin1('_'),QChar::fromLatin1('-'));
+        QString acceptLanguage;
+        if (systemLocale == QLatin1String("C")) {
+            acceptLanguage = QString::fromLatin1("en,*");
+        } else if (systemLocale.startsWith(QLatin1String("en-"))) {
+            acceptLanguage = systemLocale + QLatin1String(",*");
+        } else {
+            acceptLanguage = systemLocale + QLatin1String(",en,*");
+        }
+        _profile->setHttpAcceptLanguage(acceptLanguage);
+    }
 
     _webview->setPage(_page);
     _ui.verticalLayout->addWidget(_webview);


### PR DESCRIPTION
This way the server will properly translate it for you if it has
translations.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>