### PR TITLE
Link IRC to webchat so people without a client can do something

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Request](https://github.com/nextcloud/client/pulls).
 
 If you want to contact us, e.g. before starting a more complex feature, for questions :question:
 you can join us at
-[#nextcloud-client](irc://irc.freenode.net/#nextcloud-client).
+[#nextcloud-client](https://webchat.freenode.net/?channels=nextcloud-client).
 
 ## :v: Code of conduct
 


### PR DESCRIPTION
Also note that github doesn't render irc:// links, so it just showed the name