### PR TITLE
allow to switch to the integrated gpu on MacOS

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -28,6 +28,8 @@
         <string>@MIRALL_VERSION_STRING@</string>
         <key>NSHumanReadableCopyright</key>
         <string>(C) 2014-2018 @APPLICATION_VENDOR@</string>
+        <key>NSSupportsAutomaticGraphicsSwitching</key>
+        <true/>
         <key>SUShowReleaseNotes</key>
         <false/>
         <key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
without that key, the client automatically runs on the dedicated gpu (if
present). now it allows the system to use the integrated one.

closes #501 