### PR TITLE
Use the beta PPA for builds (re #402)

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -3,11 +3,11 @@
 set -xe
 shopt -s extglob
 
-PPA=ppa:nextcloud-devs/client-alpha
-PPA_BETA=ppa:nextcloud-devs/client-beta
+PPA=ppa:nextcloud-devs/client-beta
+PPA_BETA=ppa:nextcloud-devs/client-alpha
 
-OBS_PROJECT=home:ivaradi:alpha
-OBS_PROJECT_BETA=home:ivaradi:beta
+OBS_PROJECT=home:ivaradi:beta
+OBS_PROJECT_BETA=home:ivaradi:alpha
 OBS_PACKAGE=nextcloud-client
 
 pull_request=${DRONE_PULL_REQUEST:=master}
@@ -39,9 +39,9 @@ echo "$kind" > kind
 kind="release"
 
 if test "$kind" = "beta"; then
-    repo=nextcloud-devs/client-beta
-else
     repo=nextcloud-devs/client-alpha
+else
+    repo=nextcloud-devs/client-beta
 fi
 
 origsourceopt=""


### PR DESCRIPTION
This patch modifies the Ubuntu/Debian build script to upload the source packages to the beta PPA to allow for more extended testing.