### PR TITLE
Provide parent to QAction

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -96,7 +96,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
         accountAdded(ai.data());
     }
 
-    _actionBefore = new QAction;
+    _actionBefore = new QAction(this);
     _toolBar->addAction(_actionBefore);
 
     // Adds space between users + activities and general + network actions


### PR DESCRIPTION
Up until and including Qt 5.6, the QAction constructor required at least one argument (see http://doc.qt.io/qt-5.6/qaction.html#QAction vs. http://doc.qt.io/qt-5/qaction.html#QAction). This patch provides it.

The reason for this fix is that the omission of the argument breaks the build on Xenial. Xenial has Qt 5.5, but since the argument was required also in Qt 5.6, which is officially supported by the client, I think the right way to fix it is to provide the argument. (As opposed to providing a patch specifically for Xenial.)