### PR TITLE
Fixes #518: adds more margin for the text in the activity 

### DIFF
--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -60,6 +60,10 @@ int ActivityItemDelegate::rowHeight()
         QFontMetrics fm(f);
 
         _margin = fm.height() / 2;
+
+#if defined(Q_OS_WIN)
+        _margin += 5;
+#endif
     }
     return iconHeight() + 5 * _margin;
 }


### PR DESCRIPTION
Only for Windows.

![space](https://user-images.githubusercontent.com/241266/44098371-57f83bf0-9fe0-11e8-9726-f6b16b7f6e06.png)
