### PR TITLE
Fixes issues in the share dialog

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -58,6 +58,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     , _unshareLinkAction(nullptr)
 {
     _ui->setupUi(this);
+    _ui->shareLinkToolButton->hide();
 
     //Is this a file or folder?
     QFileInfo fi(localPath);
@@ -265,6 +266,9 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         _ui->shareLinkToolButton->setEnabled(true);
         _ui->enableShareLink->setEnabled(true);
         _ui->enableShareLink->setChecked(true);
+
+        // show sharing options
+        _ui->shareLinkToolButton->show();
     }
 }
 
@@ -411,6 +415,7 @@ void ShareLinkWidget::slotDeleteShareFetched()
     _linkShare.clear();
     _ui->enableShareLink->setChecked(false);
     _ui->shareLinkToolButton->setEnabled(false);
+    _ui->shareLinkToolButton->hide();
     getShares();
 }
 

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -75,7 +75,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
 //    _ui->verticalLayout->addWidget(_pi_password, Qt::AlignCenter);
 //    _ui->verticalLayout->addWidget(_pi_editing, Qt::AlignCenter);
 
-    connect(_ui->enableShareLink, &QCheckBox::toggled, this, &ShareLinkWidget::slotCreateorDeleteShareLink);
+    connect(_ui->enableShareLink, &QCheckBox::toggled, this, &ShareLinkWidget::slotCreateOrDeleteShareLink);
     connect(_ui->lineEdit_password, &QLineEdit::returnPressed, this, &ShareLinkWidget::slotCreatePassword);
     connect(_ui->confirmPassword, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCreatePassword);
     connect(_ui->confirmExpirationDate, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCreatePassword);
@@ -354,7 +354,7 @@ void ShareLinkWidget::slotCreatePassword()
     }
 }
 
-void ShareLinkWidget::slotCreateorDeleteShareLink(bool checked)
+void ShareLinkWidget::slotCreateOrDeleteShareLink(bool checked)
 {
     if (!_manager) {
         qCWarning(lcSharing) << "No share manager set.";
@@ -371,8 +371,6 @@ void ShareLinkWidget::slotCreateorDeleteShareLink(bool checked)
         }
         confirmAndDeleteShare();
     }
-
-    _ui->shareLinkToolButton->setEnabled(checked);
 }
 
 void ShareLinkWidget::setPassword(const QString &password)
@@ -410,6 +408,9 @@ void ShareLinkWidget::slotPasswordSet()
 
 void ShareLinkWidget::slotDeleteShareFetched()
 {
+    _linkShare.clear();
+    _ui->enableShareLink->setChecked(false);
+    _ui->shareLinkToolButton->setEnabled(false);
     getShares();
 }
 
@@ -469,12 +470,8 @@ void ShareLinkWidget::confirmAndDeleteShare()
 
     connect(messageBox, &QMessageBox::finished, this,
         [messageBox, yesButton, this]() {
-        if (messageBox->clickedButton() == yesButton){
-            // TODO: dlete is not hapenning correctly
+        if (messageBox->clickedButton() == yesButton)
             this->_linkShare->deleteShare();
-            this->_ui->enableShareLink->setChecked(false);
-            this->_ui->shareLinkToolButton->setEnabled(false);
-        }
     });
     messageBox->open();
 }
@@ -525,7 +522,7 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
         toggleExpireDateOptions(state);
 
     } else if (action == _unshareLinkAction) {
-        confirmAndDeleteShare();
+        slotCreateOrDeleteShareLink(state);
     }
 }
 

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -173,12 +173,15 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         SharePermissions perm = _linkShare->getPermissions();
         QActionGroup *permissionsGroup = new QActionGroup(this);
 
+        // Prepare sharing menu
+        _linkContextMenu = new QMenu(this);
+
         // radio button style
         permissionsGroup->setExclusive(true);
 
         if(_isFile){
             checked = perm & (SharePermissionRead & SharePermissionUpdate);
-            _allowEditingLinkAction = permissionsGroup->addAction(tr("Allow Editing"));
+            _allowEditingLinkAction = _linkContextMenu->addAction(tr("Allow Editing"));
             _allowEditingLinkAction->setCheckable(true);
             _allowEditingLinkAction->setChecked(checked);
 
@@ -201,9 +204,6 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
             _allowUploadLinkAction->setCheckable(true);
             _allowUploadLinkAction->setChecked(checked);
         }
-
-        // Prepare sharing menu
-        _linkContextMenu = new QMenu(this);
 
         // Add copy action (icon only)
         _copyLinkAction = _linkContextMenu->addAction(QIcon(":/client/resources/copy.svg"),

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -66,20 +66,14 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
 
     // the following progress indicator widgets are added to layouts which makes them
     // automatically deleted once the dialog dies.
-    _pi_create = new QProgressIndicator();
-    _pi_password = new QProgressIndicator();
-    _pi_date = new QProgressIndicator();
-    _pi_editing = new QProgressIndicator();
-
-// TODO: where to loading should show up?
-//    _ui->verticalLayout->addWidget(_pi_create, Qt::AlignCenter);
-//    _ui->verticalLayout->addWidget(_pi_password, Qt::AlignCenter);
-//    _ui->verticalLayout->addWidget(_pi_editing, Qt::AlignCenter);
+    _pi_indicator = new QProgressIndicator();
+    _ui->horizontalLayout->insertWidget(1, _pi_indicator, Qt::AlignCenter);
+    _ui->indicatorWidget->hide();
 
     connect(_ui->enableShareLink, &QCheckBox::toggled, this, &ShareLinkWidget::slotCreateOrDeleteShareLink);
     connect(_ui->lineEdit_password, &QLineEdit::returnPressed, this, &ShareLinkWidget::slotCreatePassword);
     connect(_ui->confirmPassword, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCreatePassword);
-    connect(_ui->confirmExpirationDate, &QAbstractButton::clicked, this, &ShareLinkWidget::slotCreatePassword);
+    connect(_ui->confirmExpirationDate, &QAbstractButton::clicked, this, &ShareLinkWidget::slotSetExpireDate);
     connect(_ui->calendar, &QDateTimeEdit::dateChanged, this, &ShareLinkWidget::slotExpireDateChanged);
 
     _ui->errorLabel->hide();
@@ -144,9 +138,19 @@ ShareLinkWidget::~ShareLinkWidget()
     delete _ui;
 }
 
+void ShareLinkWidget::toggleAnimation(bool start){
+    if(start && !_pi_indicator->isAnimated())
+        _pi_indicator->startAnimation();
+    else
+        _pi_indicator->stopAnimation();
+
+    _ui->indicatorWidget->setVisible(start);
+}
+
 void ShareLinkWidget::getShares()
 {
     if (_manager) {
+        toggleAnimation(true);
         _manager->fetchShares(_sharePath);
     }
 }
@@ -165,7 +169,7 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         // Connect all shares signals to gui slots
         connect(share.data(), &Share::serverError, this, &ShareLinkWidget::slotServerError);
         connect(share.data(), &Share::shareDeleted, this, &ShareLinkWidget::slotDeleteShareFetched);
-        //TODO connect(_linkShare.data(), &LinkShare::expireDateSet, this, &ShareLinkWidget::slotExpireSet);
+        connect(_linkShare.data(), &LinkShare::expireDateSet, this, &ShareLinkWidget::slotExpireDateSet);
         connect(_linkShare.data(), &LinkShare::passwordSet, this, &ShareLinkWidget::slotPasswordSet);
         connect(_linkShare.data(), &LinkShare::passwordSetError, this, &ShareLinkWidget::slotPasswordSetError);
 
@@ -241,6 +245,7 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         _expirationDateLinkAction = _linkContextMenu->addAction(tr("Expiration Date"));
         _expirationDateLinkAction->setCheckable(true);
         if(_linkShare->getExpireDate().isValid()){
+            _ui->calendar->setDate(_linkShare->getExpireDate());
             _expirationDateLinkAction->setChecked(true);
             _ui->expirationShareProperty->show();
         }
@@ -270,73 +275,32 @@ void ShareLinkWidget::slotSharesFetched(const QList<QSharedPointer<Share>> &shar
         // show sharing options
         _ui->shareLinkToolButton->show();
     }
+
+    toggleAnimation(false);
 }
-
-// TODO
-//void ShareLinkWidget::slotShareSelectionChanged()
-//{
-//    // Disable running progress indicators
-//    _pi_create->stopAnimation();
-//    _pi_editing->stopAnimation();
-//    _pi_date->stopAnimation();
-//    _pi_password->stopAnimation();
-
-//    _ui->errorLabel->hide();
-//    _ui->passwordShareProperty->show();
-//    _ui->expirationShareProperty->show();
-
-//    if (!_account->capabilities().sharePublicLinkAllowUpload()) {
-//        _allowUploadEditingLinkAction->setEnabled(false);
-//        _allowUploadLinkAction->setEnabled(false);
-//    }
-
-//    // Password state
-//    _ui->lineEdit_password->setEnabled(_linkShare->isPasswordSet());
-//    if(_linkShare->isPasswordSet()) _ui->lineEdit_password->setPlaceholderText("********");
-//    _ui->lineEdit_password->setText(QString());
-//    _ui->lineEdit_password->setEnabled(_linkShare->isPasswordSet());
-//    _ui->confirmPassword->setEnabled(_linkShare->isPasswordSet());
-
-//    // Expiry state
-//    _ui->calendar->setMinimumDate(QDate::currentDate().addDays(1));
-//    if (_linkShare->getExpireDate().isValid()) {
-//        _ui->calendar->setDate(_linkShare->getExpireDate());
-//        _ui->calendar->setEnabled(true);
-//    }
-//    // Public upload state (box is hidden for files)
-//    if (!_isFile) {
-//        if (_linkShare->getPublicUpload()) {
-//            if (_linkShare->getShowFileListing()) {
-//                _allowUploadEditingLinkAction->setChecked(true);
-//            } else {
-//                _allowUploadLinkAction->setChecked(true);
-//            }
-//        } else {
-//            _readOnlyLinkAction->setChecked(true);
-//        }
-//    }
-//}
 
 void ShareLinkWidget::setExpireDate(const QDate &date)
 {
     if (_linkShare) {
-        _pi_date->startAnimation();
+        toggleAnimation(true);
         _ui->errorLabel->hide();
         _linkShare->setExpireDate(date);
     }
 }
 
-// TODO
-//void ShareLinkWidget::slotExpireSet()
-//{
-//    if (sender() == _linkShare.data()) {
-//        slotShareSelectionChanged();
-//    }
-//}
+void ShareLinkWidget::slotExpireDateSet()
+{
+    toggleAnimation(false);
+}
 
 void ShareLinkWidget::slotExpireDateChanged(const QDate &date)
 {
     setExpireDate(date);
+}
+
+void ShareLinkWidget::slotSetExpireDate()
+{
+    slotExpireDateChanged(_ui->calendar->date());
 }
 
 void ShareLinkWidget::slotCreatePassword()
@@ -344,6 +308,9 @@ void ShareLinkWidget::slotCreatePassword()
     if (!_manager) {
         return;
     }
+
+    toggleAnimation(true);
+
     if (!_linkShare) {
         // If share creation requires a password, we'll be in this case
         if (_ui->lineEdit_password->text().isEmpty()) {
@@ -351,7 +318,6 @@ void ShareLinkWidget::slotCreatePassword()
             return;
         }
 
-        _pi_create->startAnimation();
         _manager->createLinkShare(_sharePath, QString(), _ui->lineEdit_password->text());
     } else {
         setPassword(_ui->lineEdit_password->text());
@@ -365,7 +331,8 @@ void ShareLinkWidget::slotCreateOrDeleteShareLink(bool checked)
         return;
     }
 
-    _pi_create->startAnimation();
+    toggleAnimation(true);
+
     if(checked){
         _manager->createLinkShare(_sharePath, QString(), QString());
     } else {
@@ -380,7 +347,8 @@ void ShareLinkWidget::slotCreateOrDeleteShareLink(bool checked)
 void ShareLinkWidget::setPassword(const QString &password)
 {
     if (_linkShare) {
-        _pi_password->startAnimation();
+        toggleAnimation(true);
+
         _ui->errorLabel->hide();
         _linkShare->setPassword(password);
     }
@@ -391,7 +359,6 @@ void ShareLinkWidget::slotPasswordSet()
     if (!_linkShare)
         return;
 
-    _pi_password->stopAnimation();
     _ui->lineEdit_password->setText(QString());
     if (_linkShare->isPasswordSet()) {
         _ui->lineEdit_password->setPlaceholderText("********");
@@ -399,6 +366,8 @@ void ShareLinkWidget::slotPasswordSet()
     } else {
         _ui->lineEdit_password->setPlaceholderText(QString());
     }
+
+    toggleAnimation(false);
 
     /*
      * When setting/deleting a password from a share the old share is
@@ -412,25 +381,26 @@ void ShareLinkWidget::slotPasswordSet()
 
 void ShareLinkWidget::slotDeleteShareFetched()
 {
+    toggleAnimation(true);
     _linkShare.clear();
     _ui->enableShareLink->setChecked(false);
     _ui->shareLinkToolButton->setEnabled(false);
     _ui->shareLinkToolButton->hide();
+    togglePasswordOptions(false);
+    toggleExpireDateOptions(false);
     getShares();
 }
 
 void ShareLinkWidget::slotCreateShareFetched()
 {
-    _pi_create->stopAnimation();
-    _pi_password->stopAnimation();
+    toggleAnimation(true);
     getShares();
 }
 
 void ShareLinkWidget::slotCreateShareRequiresPassword(const QString &message)
 {
-    // Prepare password entry
-    _pi_create->stopAnimation();
-    _pi_password->stopAnimation();
+    toggleAnimation(true);
+
     _ui->passwordShareProperty->show();
     if (!message.isEmpty()) {
         _ui->errorLabel->setText(message);
@@ -445,7 +415,14 @@ void ShareLinkWidget::slotCreateShareRequiresPassword(const QString &message)
 void ShareLinkWidget::togglePasswordOptions(bool enable)
 {
     _ui->passwordShareProperty->setVisible(enable);
-    if(enable) _ui->lineEdit_password->setFocus();
+
+    if(enable) {
+        _ui->lineEdit_password->setFocus();
+    } else {
+        // 'deletes' password
+        if(_linkShare)
+            _linkShare->setPassword(QString());
+    }
 }
 
 void ShareLinkWidget::toggleExpireDateOptions(bool enable)
@@ -453,9 +430,13 @@ void ShareLinkWidget::toggleExpireDateOptions(bool enable)
     _ui->expirationShareProperty->setVisible(enable);
     if (enable) {
         const QDate date = QDate::currentDate().addDays(1);
-        setExpireDate(date);
         _ui->calendar->setDate(date);
         _ui->calendar->setMinimumDate(date);
+        _ui->calendar->setFocus();
+    } else {
+        // 'deletes' expire date
+        if(_linkShare)
+            _linkShare->setExpireDate(QDate());
     }
 }
 
@@ -533,10 +514,7 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
 
 void ShareLinkWidget::slotServerError(int code, const QString &message)
 {
-    _pi_create->stopAnimation();
-    _pi_date->stopAnimation();
-    _pi_password->stopAnimation();
-    _pi_editing->stopAnimation();
+    toggleAnimation(false);
 
     qCWarning(lcSharing) << "Error from server" << code << message;
     displayError(message);

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -65,6 +65,7 @@ private slots:
     void slotCreatePassword();
 
     void slotExpireDateChanged(const QDate &date);
+    void slotSetExpireDate();
 
     void slotContextMenuButtonClicked();
     void slotLinkContextMenuActionTriggered(QAction *action);
@@ -72,8 +73,9 @@ private slots:
     void slotDeleteShareFetched();
     void slotCreateShareFetched();
     void slotCreateShareRequiresPassword(const QString &message);
+
     void slotPasswordSet();
-    //void slotExpireSet();
+    void slotExpireDateSet();
 
     void slotServerError(int code, const QString &message);
     void slotPasswordSetError(int code, const QString &message);
@@ -95,10 +97,7 @@ private:
     /** Retrieve a share's name, accounting for _namesSupported */
     QString shareName() const;
 
-    /**
-     * Retrieve the selected share, returning 0 if none.
-     */
-    //QSharedPointer<LinkShare> selectedShare() const;
+    void toggleAnimation(bool start);
 
     Ui::ShareLinkWidget *_ui;
     AccountPtr _account;
@@ -106,10 +105,7 @@ private:
     QString _localPath;
     QString _shareUrl;
 
-    QProgressIndicator *_pi_create;
-    QProgressIndicator *_pi_password;
-    QProgressIndicator *_pi_date;
-    QProgressIndicator *_pi_editing;
+    QProgressIndicator *_pi_indicator;
 
     ShareManager *_manager;
     QSharedPointer<LinkShare> _linkShare;

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -61,7 +61,7 @@ private slots:
     void slotSharesFetched(const QList<QSharedPointer<Share>> &shares);
     //void slotShareSelectionChanged();
 
-    void slotCreateorDeleteShareLink(bool checked);
+    void slotCreateOrDeleteShareLink(bool checked);
     void slotCreatePassword();
 
     void slotExpireDateChanged(const QDate &date);

--- a/src/gui/sharelinkwidget.ui
+++ b/src/gui/sharelinkwidget.ui
@@ -182,6 +182,27 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="indicatorWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="passwordShareProperty" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
@@ -266,7 +287,7 @@
          <enum>QLineEdit::Password</enum>
         </property>
         <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -376,8 +376,9 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
 
     // adds permissions
     // can edit permission
-    bool enabled = maxSharingPermissions & (SharePermissionRead & SharePermissionUpdate);
-    if(!_isFile) enabled = enabled & (SharePermissionCreate & SharePermissionDelete);
+    bool enabled = (maxSharingPermissions & SharePermissionUpdate);
+    if(!_isFile) enabled = enabled && (maxSharingPermissions & SharePermissionCreate &&
+                                      maxSharingPermissions & SharePermissionDelete);
     _ui->permissionsEdit->setEnabled(enabled);
     connect(_ui->permissionsEdit, &QAbstractButton::clicked, this, &ShareUserLine::slotEditPermissionsChanged);
 
@@ -526,24 +527,27 @@ void ShareUserLine::slotEditPermissionsChanged()
 
     Share::Permissions permissions = SharePermissionRead;
 
-    if (_permissionReshare->isChecked()) {
-        permissions |= SharePermissionShare;
-    }
-
+    //  folders edit = CREATE, READ, UPDATE, DELETE
+    //  files edit = READ + UPDATE
     if (_ui->permissionsEdit->checkState() == Qt::Checked) {
-        if (_permissionChange->isEnabled())
-            permissions |= SharePermissionUpdate;
 
         /*
          * Files can't have create or delete permisisons
          */
         if (!_isFile) {
+            if (_permissionChange->isEnabled())
+                permissions |= SharePermissionUpdate;
             if (_permissionCreate->isEnabled())
                 permissions |= SharePermissionCreate;
             if (_permissionDelete->isEnabled())
                 permissions |= SharePermissionDelete;
+        } else {
+            permissions |= SharePermissionUpdate;
         }
     }
+
+    if(_isFile && _permissionReshare->isEnabled() && _permissionReshare->isChecked())
+        permissions |= SharePermissionShare;
 
     _share->setPermissions(permissions);
 }
@@ -554,23 +558,20 @@ void ShareUserLine::slotPermissionsChanged()
 
     Share::Permissions permissions = SharePermissionRead;
 
-    if (_permissionReshare->isChecked()) {
+    if (_permissionReshare->isChecked())
         permissions |= SharePermissionShare;
-    }
 
     if (!_isFile) {
-        if (_permissionCreate->isChecked()) {
-            permissions |= SharePermissionCreate;
-        }
-
-        if (_permissionChange->isChecked()) {
+        if (_permissionChange->isChecked())
             permissions |= SharePermissionUpdate;
-        }
-
-        if (_permissionDelete->isChecked()) {
+        if (_permissionCreate->isChecked())
+            permissions |= SharePermissionCreate;
+        if (_permissionDelete->isChecked())
             permissions |= SharePermissionDelete;
-        }
-     }
+    } else {
+        if (_ui->permissionsEdit->isChecked())
+            permissions |= SharePermissionUpdate;
+    }
 
     _share->setPermissions(permissions);
 }
@@ -616,21 +617,20 @@ void ShareUserLine::displayPermissions()
 {
     auto perm = _share->getPermissions();
 
-    if (perm & SharePermissionUpdate
-        && (_isFile
-               || (perm & SharePermissionCreate
-                      && perm & SharePermissionDelete))) {
+//  folders edit = CREATE, READ, UPDATE, DELETE
+//  files edit = READ + UPDATE
+    if (perm & SharePermissionUpdate && (_isFile ||
+                                         (perm & SharePermissionCreate && perm & SharePermissionDelete))) {
         _ui->permissionsEdit->setCheckState(Qt::Checked);
-    } else if (perm & (SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete)) {
+    } else if (!_isFile && perm & (SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete)) {
         _ui->permissionsEdit->setCheckState(Qt::PartiallyChecked);
-    } else {
+    } else if(perm & SharePermissionRead) {
         _ui->permissionsEdit->setCheckState(Qt::Unchecked);
     }
 
-    _permissionReshare->setChecked(Qt::Unchecked);
-    if (perm & SharePermissionShare) {
+//  edit is independent of reshare
+    if (perm & SharePermissionShare)
         _permissionReshare->setChecked(Qt::Checked);
-    }
 
     if(!_isFile){
         _permissionCreate->setChecked(perm & SharePermissionCreate);


### PR DESCRIPTION
- Fixes #534: interactions with expiration date and password.
   - Fixes call for slot when date is set - it was the password
slot for that.
   - Adds QProgressIndicator and function to toggle animation.
   - Fixes: when date was set, the date was not being correctly set and
displayed.
  - Fixes: hides and 'deletes' passsword and expire. date widgets when
the user unchecks it in the toolbox menu.
- Fixes #534: can edit permission were always disabled. 
   - Properly checks files and folder share permissions when displaying can edit checkbox - which can also be partially checked - and listing
permissios in the tollbutton menu.
- Fixes click on can edit checkbox - which can also change state of
permissions in the toolbutton menu.
- Enhancement #534: hide tool button when there is no share link.
- Fixes share link delete action when clicking on tool button menu.
- Changes 'Allow editing' for file sharing to a checkbox instead of a radiobutton.
