### PR TITLE
Fixes mac build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/3rdparty/qtmacgoodies"]
 	path = src/3rdparty/qtmacgoodies
-	url = https://github.com/guruz/qtmacgoodies.git
+	url = https://github.com/camilasan/qtmacgoodies.git
 [submodule "binary"]
 	path = binary
 	url = git://github.com/owncloud/owncloud-client-binary.git

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -127,7 +127,7 @@ private:
     void setPauseOnAllFoldersHelper(bool pause);
     void setupActions();
     void addAccountContextMenu(AccountStatePtr accountState, QMenu *menu, bool separateMenu);
-    void fetchNavigationApps(AccountStatePtr account, QMenu *accountMenu);
+    void fetchNavigationApps(AccountStatePtr account);
     void buildNavigationAppsMenu(AccountStatePtr account, QMenu *accountMenu);
 
     QPointer<Systray> _tray;


### PR DESCRIPTION
- The fork has the functions needed to add separators in the toolbar.
- Removes dynamic cast when building navigation apps.

