### PR TITLE
Drop the ToolTipRole from the activity list

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -121,7 +121,6 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return type;
         break;
     }
-    case Qt::ToolTipRole:
     case ActivityItemDelegate::ActionTextRole:
         return a._subject;
         break;


### PR DESCRIPTION
Fix #515 

The tooltip role did not receive any treatment. It was then in my understanding jumping to the next case and returning the subject of the activity, that is repeating the same text as in the activity itself.

Dropping this case, allows to return with the default and do nothing.
