### PR TITLE
Hide login button on setup screen

### DIFF
--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -100,13 +100,12 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     _ui.hostButton->hide();
 #endif
     setStyleSheet(QString("background-color:%1; color:%2 QLabel { color:%2; } QSpacerItem { color: red; }").arg(theme->wizardHeaderBackgroundColor().name(), theme->wizardHeaderTitleColor().name()));
-
 }
 
 #ifdef WITH_PROVIDERS
 void OwncloudSetupPage::nextSlide()
 {
-    if (_currentSlide < _slideshow.length()-1) {
+    if (_currentSlide < _slideshow.length() - 1) {
         _currentSlide++;
     } else {
         _currentSlide = 0;
@@ -155,6 +154,7 @@ void OwncloudSetupPage::slotLogin()
     animation->setStartValue(500);
     animation->setEndValue(500);
     _ui.login->show();
+    _ui.loginButton->hide();
     wizard()->resize(wizard()->sizeHint());
     animation->start();
 }


### PR DESCRIPTION
Fix #576 

Once the user clicks Log in. That button disappears, the register with a provider is kept as deleting it would imply needing to put a back button which is way harder. It also turns out to be more intuitive if you click login and you get as prompt to put a server address. The fact that the register with a provider button remains, helps you understand that you need a provider to continue.

There are some minor cosmetic changes, that clang formatter did for me according to your style guide file.