### PR TITLE
In setup wizard put link to nextcloud installation

### DIFF
--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -61,22 +61,11 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="hostButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <underline>true</underline>
-        </font>
-       </property>
+      <widget class="QLabel" name="installLink">
        <property name="text">
-        <string>Host your own server</string>
+        <string>&lt;a href=&quot;https://docs.nextcloud.com/server/13/admin_manual/installation/index.html#installation&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Host your own server&lt;/span&gt;&lt;/a&gt;</string>
        </property>
-       <property name="flat">
+       <property name="openExternalLinks">
         <bool>true</bool>
        </property>
       </widget>

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -97,7 +97,7 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     _ui.slideImage->hide();
     _ui.slideLabel->hide();
     _ui.loginButton->hide();
-    _ui.hostButton->hide();
+    _ui.installLink->hide();
 #endif
     setStyleSheet(QString("background-color:%1; color:%2 QLabel { color:%2; } QSpacerItem { color: red; }").arg(theme->wizardHeaderBackgroundColor().name(), theme->wizardHeaderTitleColor().name()));
 }


### PR DESCRIPTION
Fix #604

Remove the not actionable button for a direct link to the nextcloud
installation page. In this case the hostButton is changed for a label with an
html link to the website.