### PR TITLE
Ensure GETFileJob notices finishing #6581

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -149,6 +149,7 @@ void GETFileJob::newReplyHook(QNetworkReply *reply)
 
     connect(reply, &QNetworkReply::metaDataChanged, this, &GETFileJob::slotMetaDataChanged);
     connect(reply, &QIODevice::readyRead, this, &GETFileJob::slotReadyRead);
+    connect(reply, &QNetworkReply::finished, this, &GETFileJob::slotReadyRead);
     connect(reply, &QNetworkReply::downloadProgress, this, &GETFileJob::downloadProgress);
 }
 

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -728,9 +728,18 @@ public:
         setAttribute(QNetworkRequest::HttpStatusCodeAttribute, _httpErrorCode);
         setError(InternalServerError, "Internal Server Fake Error");
         emit metaDataChanged();
+        emit readyRead();
+        // finishing can come strictly after readyRead was called
+        QTimer::singleShot(5, this, &FakeErrorReply::slotSetFinished);
+    }
+
+public slots:
+    void slotSetFinished() {
+        setFinished(true);
         emit finished();
     }
 
+public:
     void abort() override { }
     qint64 readData(char *, qint64) override { return 0; }
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -255,7 +255,8 @@ private slots:
             } else if(item->_file == "Y/Z/d3") {
                 QVERIFY(item->_status != SyncFileItem::Success);
             }
-            QVERIFY(item->_file != "Y/Z/d9"); // we should have aborted the sync before d9 starts
+            // We do not know about the other files - maybe the sync was aborted,
+            // maybe they finished before the error caused the abort.
         }
     }
 


### PR DESCRIPTION
It could happen that readyRead was emitted for incoming data while the
download was not yet finished. Then the network job could finish with
no more data arriving - so readyRead wasn't emitted again.

To fix this, the finished signal also gets connected to the readyRead
slot.

Issue owncloud/client/issues/6581
PR owncloud/client/pull/6582