### PR TITLE
TestOAuth: Don't have global static QObject

### DIFF
--- a/test/testoauth.cpp
+++ b/test/testoauth.cpp
@@ -22,7 +22,7 @@ signals:
     void hooked(const QUrl &);
 public:
     DesktopServiceHook() { QDesktopServices::setUrlHandler("oauthtest", this, "hooked"); }
-} desktopServiceHook;
+};
 
 static const QUrl sOAuthTestServer("oauthtest://someserver/owncloud");
 
@@ -90,6 +90,7 @@ public:
 class OAuthTestCase : public QObject
 {
     Q_OBJECT
+    DesktopServiceHook desktopServiceHook;
 public:
     enum State { StartState, BrowserOpened, TokenAsked, CustomState } state = StartState;
     Q_ENUM(State);


### PR DESCRIPTION
Fix a strange warning seen on the log from the CI on Windows in
https://github.com/owncloud/client/pull/6621

The test shows, at the beginning
QObject::connect: No such signal DesktopServiceHook::destroyed(QObject*)
And crashes at the and.

My guess is that when QDesktopServices::setUrlHandler is called, the
QMetaObject is not yet initialized

But this is probably not the reason of the crash