### PR TITLE
Windows: Don't ignore files with FILE_ATTRIBUTE_TEMPORARY

### DIFF
--- a/src/csync/vio/csync_vio_local_win.cpp
+++ b/src/csync/vio/csync_vio_local_win.cpp
@@ -181,7 +181,7 @@ std::unique_ptr<csync_file_stat_t> csync_vio_local_readdir(csync_vio_handle_t *d
       }
     } else if (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_DEVICE
                 || handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_OFFLINE
-                || handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_TEMPORARY) {
+              ) {
         file_stat->type = ItemTypeSkip;
     } else if (handle->ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         file_stat->type = ItemTypeDirectory;


### PR DESCRIPTION
Too many applications incorrectly use this attribute.

For owncloud/client/issues/6696 owncloud/client/issues/6610