### PR TITLE
SyncEngine: Fix renames making hierarchy inversion

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1233,6 +1233,14 @@ QString SyncEngine::adjustRenamedPath(const QString &original)
     while ((slashPos = original.lastIndexOf('/', slashPos - 1)) > 0) {
         QHash<QString, QString>::const_iterator it = _renamedFolders.constFind(original.left(slashPos));
         if (it != _renamedFolders.constEnd()) {
+            // This is a band-aid fix for a specific problem:
+            // See issue #6694: "hierarchy inversion" and discussion in PR #6695.
+            // There's a larger unfixed issue here, see testInvertFolderHierarchy().
+            auto original_it = _renamedFolders.constFind(original);
+            if (original_it != _renamedFolders.constEnd() && it->startsWith(*original_it)) {
+                return original;
+            }
+
             return *it + original.mid(slashPos);
         }
     }

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -576,6 +576,87 @@ private slots:
             //QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         }
     }
+
+    // https://github.com/owncloud/client/issues/6629#issuecomment-402450691
+    // When a file is moved and the server mtime was not in sync, the local mtime should be kept
+    void testMoveAndMTimeChange()
+    {
+        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
+        int nPUT = 0;
+        int nDELETE = 0;
+        int nGET = 0;
+        int nMOVE = 0;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *) {
+            if (op == QNetworkAccessManager::PutOperation)
+                ++nPUT;
+            if (op == QNetworkAccessManager::DeleteOperation)
+                ++nDELETE;
+            if (op == QNetworkAccessManager::GetOperation)
+                ++nGET;
+            if (req.attribute(QNetworkRequest::CustomVerbAttribute) == "MOVE")
+                ++nMOVE;
+            return nullptr;
+        });
+
+        // Changing the mtime on the server (without invalidating the etag)
+        fakeFolder.remoteModifier().find("A/a1")->lastModified = QDateTime::currentDateTimeUtc().addSecs(-50000);
+        fakeFolder.remoteModifier().find("A/a2")->lastModified = QDateTime::currentDateTimeUtc().addSecs(-40000);
+
+        // Move a few files
+        fakeFolder.remoteModifier().rename("A/a1", "A/a1_server_renamed");
+        fakeFolder.localModifier().rename("A/a2", "A/a2_local_renamed");
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nGET, 0);
+        QCOMPARE(nPUT, 0);
+        QCOMPARE(nMOVE, 1);
+        QCOMPARE(nDELETE, 0);
+
+        // Another sync should do nothing
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nGET, 0);
+        QCOMPARE(nPUT, 0);
+        QCOMPARE(nMOVE, 1);
+        QCOMPARE(nDELETE, 0);
+
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
+
+    // Test for https://github.com/owncloud/client/issues/6694
+    void testInvertFolderHierarchy()
+    {
+        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
+        fakeFolder.remoteModifier().mkdir("A/Empty");
+        fakeFolder.remoteModifier().mkdir("A/Empty/Foo");
+        fakeFolder.remoteModifier().mkdir("C/AllEmpty");
+        fakeFolder.remoteModifier().mkdir("C/AllEmpty/Bar");
+        QVERIFY(fakeFolder.syncOnce());
+
+        // "Empty" is after "A", alphabetically
+        fakeFolder.localModifier().rename("A/Empty", "Empty");
+        fakeFolder.localModifier().rename("A", "Empty/A");
+
+        // "AllEmpty" is before "C", alphabetically
+        fakeFolder.localModifier().rename("C/AllEmpty", "AllEmpty");
+        fakeFolder.localModifier().rename("C", "AllEmpty/C");
+
+        auto expectedState = fakeFolder.currentLocalState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), expectedState);
+        QCOMPARE(fakeFolder.currentRemoteState(), expectedState);
+
+        /* FIXME - likely addressed by ogoffart's sync code refactor
+        // Now, the revert, but "crossed"
+        fakeFolder.localModifier().rename("Empty/A", "A");
+        fakeFolder.localModifier().rename("AllEmpty/C", "C");
+        fakeFolder.localModifier().rename("Empty", "C/Empty");
+        fakeFolder.localModifier().rename("AllEmpty", "A/AllEmpty");
+        expectedState = fakeFolder.currentLocalState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), expectedState);
+        QCOMPARE(fakeFolder.currentRemoteState(), expectedState);
+        */
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncMove)


### PR DESCRIPTION
Issue owncloud/client/issues/6694