### PR TITLE
Ignore files that are ignored by git.

### DIFF
--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(${CSYNC_LIBRARY}
   ${CSYNC_REQUIRED_LIBRARIES}
   ${SQLITE3_LIBRARIES}
   Qt5::Core Qt5::Concurrent
+  git2
 )
 
 if(ZLIB_FOUND)

--- a/src/csync/csync_exclude.h
+++ b/src/csync/csync_exclude.h
@@ -92,7 +92,8 @@ public:
     bool isExcluded(
         const QString &filePath,
         const QString &basePath,
-        bool excludeHidden) const;
+        bool excludeHidden,
+        bool excludeGitignoreFiles) const;
 
     /**
      * Adds an exclude pattern.

--- a/src/csync/csync_misc.h
+++ b/src/csync/csync_misc.h
@@ -48,4 +48,6 @@ int csync_fnmatch(const char *pattern, const char *name, int flags);
  */
 CSYNC_STATUS csync_errno_to_status(int error, CSYNC_STATUS default_status);
 
+#define CSYNC_IGNORE_GITIGNORE_FILES_DEFAULT true
+
 #endif /* _CSYNC_MISC_H */

--- a/src/csync/csync_private.h
+++ b/src/csync/csync_private.h
@@ -205,6 +205,8 @@ struct OCSYNC_EXPORT csync_s {
 
   bool ignore_hidden_files = true;
 
+  bool ignore_gitignore_files = CSYNC_IGNORE_GITIGNORE_FILES_DEFAULT;
+
   bool upload_conflict_files = false;
 
   csync_s(const char *localUri, OCC::SyncJournalDb *statedb);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -201,6 +201,15 @@ void Folder::setIgnoreHiddenFiles(bool ignore)
     _definition.ignoreHiddenFiles = ignore;
 }
 
+bool Folder::ignoreGitignoreFiles() const {
+    bool re(_definition.ignoreGitignoreFiles);
+    return re;
+}
+
+void Folder::setIgnoreGitignoreFiles(bool ignore) {
+    _definition.ignoreGitignoreFiles = ignore;
+}
+
 QString Folder::cleanPath() const
 {
     QString cleanedPath = QDir::cleanPath(_canonicalLocalPath);
@@ -550,12 +559,13 @@ void Folder::removeFromSettings() const
 
 bool Folder::isFileExcludedAbsolute(const QString &fullPath) const
 {
-    return _engine->excludedFiles().isExcluded(fullPath, path(), _definition.ignoreHiddenFiles);
+    return _engine->excludedFiles().isExcluded(fullPath, path(), _definition.ignoreHiddenFiles,
+                                               _definition.ignoreGitignoreFiles);
 }
 
 bool Folder::isFileExcludedRelative(const QString &relativePath) const
 {
-    return _engine->excludedFiles().isExcluded(path() + relativePath, path(), _definition.ignoreHiddenFiles);
+    return isFileExcludedAbsolute(path() + relativePath);
 }
 
 void Folder::slotTerminateSync()

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -23,6 +23,7 @@
 #include "networkjobs.h"
 
 #include <csync.h>
+#include <csync/csync_misc.h>
 
 #include <QObject>
 #include <QStringList>
@@ -50,6 +51,7 @@ public:
     FolderDefinition()
         : paused(false)
         , ignoreHiddenFiles(false)
+        , ignoreGitignoreFiles(CSYNC_IGNORE_GITIGNORE_FILES_DEFAULT)
     {
     }
 
@@ -65,6 +67,8 @@ public:
     bool paused;
     /// whether the folder syncs hidden files
     bool ignoreHiddenFiles;
+    /// whether the folder syncs files ignored by git
+    bool ignoreGitignoreFiles;
     /// the folder has client side encryption
     bool isClientSideEncrypted;
     /// The CLSID where this folder appears in registry for the Explorer navigation pane entry.
@@ -188,6 +192,9 @@ public:
       */
     bool ignoreHiddenFiles();
     void setIgnoreHiddenFiles(bool ignore);
+
+    bool ignoreGitignoreFiles() const;
+    void setIgnoreGitignoreFiles(bool ignore);
 
     // Used by the Socket API
     SyncJournalDb *journalDb() { return &_journal; }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1389,6 +1389,23 @@ void FolderMan::setIgnoreHiddenFiles(bool ignore)
     }
 }
 
+bool FolderMan::ignoreGitignoreFiles() const
+{
+    if (_folderMap.empty()) {
+        // Currently no folders in the manager -> return default
+        return CSYNC_IGNORE_GITIGNORE_FILES_DEFAULT;
+    }
+    // Since the hiddenFiles settings is the same for all folders, just return the settings of the first folder
+    return _folderMap.begin().value()->ignoreGitignoreFiles();
+}
+
+void FolderMan::setIgnoreGitignoreFiles(bool ignore) {
+    foreach (Folder *folder, _folderMap) {
+        folder->setIgnoreGitignoreFiles(ignore);
+        folder->saveToSettings();
+    }
+}
+
 QQueue<Folder *> FolderMan::scheduleQueue() const
 {
     return _scheduledFolders;

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -153,6 +153,9 @@ public:
     bool ignoreHiddenFiles() const;
     void setIgnoreHiddenFiles(bool ignore);
 
+    bool ignoreGitignoreFiles() const;
+    void setIgnoreGitignoreFiles(bool ignore);
+
     /**
      * Access to the current queue of scheduled folders.
      */

--- a/src/gui/ignorelisteditor.cpp
+++ b/src/gui/ignorelisteditor.cpp
@@ -63,6 +63,7 @@ IgnoreListEditor::IgnoreListEditor(QWidget *parent)
     ui->tableWidget->verticalHeader()->setVisible(false);
 
     ui->syncHiddenFilesCheckBox->setChecked(!FolderMan::instance()->ignoreHiddenFiles());
+    ui->syncGitignoreFilesCheckBox->setChecked(!FolderMan::instance()->ignoreGitignoreFiles());
 }
 
 IgnoreListEditor::~IgnoreListEditor()
@@ -81,6 +82,11 @@ void IgnoreListEditor::setupTableReadOnlyItems(){
 bool IgnoreListEditor::ignoreHiddenFiles()
 {
     return !ui->syncHiddenFilesCheckBox->isChecked();
+}
+
+bool IgnoreListEditor::ignoreGitignoreFiles()
+{
+    return !ui->syncGitignoreFilesCheckBox->isChecked();
 }
 
 void IgnoreListEditor::slotItemSelectionChanged()
@@ -143,6 +149,9 @@ void IgnoreListEditor::slotUpdateLocalIgnoreList()
      * handled globally. Save it to every folder that is defined.
      */
     folderMan->setIgnoreHiddenFiles(ignoreHiddenFiles());
+
+    /* handle the gitignore checkbox */
+    folderMan->setIgnoreGitignoreFiles(ignoreGitignoreFiles());
 
     // We need to force a remote discovery after a change of the ignore list.
     // Otherwise we would not download the files/directories that are no longer

--- a/src/gui/ignorelisteditor.h
+++ b/src/gui/ignorelisteditor.h
@@ -39,6 +39,7 @@ public:
     ~IgnoreListEditor();
 
     bool ignoreHiddenFiles();
+    bool ignoreGitignoreFiles();
 
 private slots:
     void slotItemSelectionChanged();

--- a/src/gui/ignorelisteditor.ui
+++ b/src/gui/ignorelisteditor.ui
@@ -27,6 +27,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+      <widget class="QCheckBox" name="syncGitignoreFilesCheckBox">
+        <property name="text">
+         <string>Sync files ignored by Git</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -617,6 +617,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
             folderDefinition.localPath = localFolder;
             folderDefinition.targetPath = FolderDefinition::prepareTargetPath(_remoteFolder);
             folderDefinition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();
+            folderDefinition.ignoreGitignoreFiles = folderMan->ignoreGitignoreFiles();
             if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
                 folderDefinition.navigationPaneClsid = QUuid::createUuid();
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -206,7 +206,8 @@ void SelectiveSyncWidget::slotUpdateDirectories(QStringList list)
     QMutableListIterator<QString> it(list);
     while (it.hasNext()) {
         it.next();
-        if (_excludedFiles.isExcluded(it.value(), pathToRemove, FolderMan::instance()->ignoreHiddenFiles()))
+        if (_excludedFiles.isExcluded(it.value(), pathToRemove, FolderMan::instance()->ignoreHiddenFiles(),
+                                      FolderMan::instance()->ignoreGitignoreFiles()))
             it.remove();
     }
 

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -79,6 +79,8 @@ public:
     void setSyncOptions(const SyncOptions &options) { _syncOptions = options; }
     bool ignoreHiddenFiles() const { return _csync_ctx->ignore_hidden_files; }
     void setIgnoreHiddenFiles(bool ignore) { _csync_ctx->ignore_hidden_files = ignore; }
+    bool ignoreGitignoreFiles() const { return _csync_ctx->ignore_gitignore_files; }
+    void setIgnoreGitignoreFiles(bool ignore) { _csync_ctx->ignore_gitignore_files = ignore; }
 
     ExcludedFiles &excludedFiles() { return *_excludedFiles; }
     Utility::StopWatch &stopWatch() { return _stopWatch; }

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -137,7 +137,9 @@ SyncFileStatus SyncFileStatusTracker::fileStatus(const QString &relativePath)
     // it's an acceptable compromize to treat all exclude types the same.
     if (_syncEngine->excludedFiles().isExcluded(_syncEngine->localPath() + relativePath,
             _syncEngine->localPath(),
-            _syncEngine->ignoreHiddenFiles())) {
+            _syncEngine->ignoreHiddenFiles(),
+            _syncEngine->ignoreGitignoreFiles())
+        ) {
         return SyncFileStatus(SyncFileStatus::StatusWarning);
     }
 


### PR DESCRIPTION
This commit adds a new configuration option, similar to "sync hidden files".
By default, any file that would be ignored by git is not synced.
This introduces a dependency to libgit2.

Related issue: #26.

Some notes:
- Is this something that we want? Otherwise we might turn it off by default as to not change the behaviour.
- I did add git2 as cmake dependency, I don't know if this is enough to make it build everywhere.
- Most of the code is basically just copied from the logic to exclude hidden files which could use some refactoring. In particular, the configuration on whether to sync is stored per folder, but it can only be set once. Perhaps we want to improve on that before merging this.