### PR TITLE
Allow to use the login flow with a self signed certificate

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -41,6 +41,13 @@ class WebEnginePage : public QWebEnginePage {
 public:
     WebEnginePage(QWebEngineProfile *profile, QObject* parent = nullptr);
     QWebEnginePage * createWindow(QWebEnginePage::WebWindowType type) override;
+    void setUrl(const QUrl &url);
+
+protected:
+    bool certificateError(const QWebEngineCertificateError &certificateError) override;
+
+private:
+    QUrl _rootUrl;
 };
 
 // We need a separate class here, since we cannot simply return the same WebEnginePage object
@@ -144,6 +151,19 @@ WebEnginePage::WebEnginePage(QWebEngineProfile *profile, QObject* parent) : QWeb
 QWebEnginePage * WebEnginePage::createWindow(QWebEnginePage::WebWindowType type) {
     ExternalWebEnginePage *view = new ExternalWebEnginePage(this->profile());
     return view;
+}
+
+void WebEnginePage::setUrl(const QUrl &url) {
+    QWebEnginePage::setUrl(url);
+    _rootUrl = url;
+}
+
+bool WebEnginePage::certificateError(const QWebEngineCertificateError &certificateError) {
+    if (certificateError.error() == QWebEngineCertificateError::CertificateAuthorityInvalid) {
+        return certificateError.url().host() == _rootUrl.host();
+    }
+
+    return false;
 }
 
 ExternalWebEnginePage::ExternalWebEnginePage(QWebEngineProfile *profile, QObject* parent) : QWebEnginePage(profile, parent) {


### PR DESCRIPTION
The QWebEngine uses a different certificate store/system. So we can't
just pass wour accepted certificates in there.

As a work around we now trust the url we set by definition. As this has
to already be approved before we access this.

Replaces #630