### PR TITLE
SettingsDialog: disable unnecessary wrapping for the about label

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -57,7 +57,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     QString about = Theme::instance()->about();
     _ui->aboutLabel->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextBrowserInteraction);
     _ui->aboutLabel->setText(about);
-    _ui->aboutLabel->setWordWrap(true);
     _ui->aboutLabel->setOpenExternalLinks(true);
 
     // About legal notice


### PR DESCRIPTION
For some reason, QLabel with rich text and word wrapping enabled
calculates quite a bit too large size hint. Luckily, it's rich text
that is already divided to paragraphs so that wrapping makes actually
very little visual difference. For example, on my screen, when the
settings dialog is resized horizontally to the minimum, the only word
that actually wrapped was "2017". After this patch, it naturally won't
wrap anymore, but the General Settings page also doesn't leave a large
gap at the bottom. As a result, the minimum height of the dialog went
down from 581 to 525. The exact values depend on the style and fonts.

Fixes #91.