### PR TITLE
Added default scheme when server returns just a host

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -137,7 +137,9 @@ void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *reques
             password = part.mid(9);
         }
     }
-
+    if (!server.startsWith("http://") && !server.startsWith("https://")) {
+        server = "https://" + server;
+    }
     qCInfo(lcWizardWebiew()) << "Got user: " << user << ", server: " << server;
 
     emit urlCatched(user, password, server);


### PR DESCRIPTION
When the alternative log in is selected server returns just Host, and the desktop client fails to use it because of the missed scheme. I think it's a server side issue, so I just added the default value in the same way as in initial login dialog.