### PR TITLE
Removed explicit initialization; Fixed RAND_bytes not found

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -21,9 +21,6 @@
 #include <sys/resource.h>
 #endif
 
-#include <openssl/conf.h>
-#include <openssl/err.h>
-
 #include "application.h"
 #include "theme.h"
 #include "common/utility.h"
@@ -51,10 +48,7 @@ int main(int argc, char **argv)
 {
     Q_INIT_RESOURCE(client);
 
-    /* Initialise the library */
-    ERR_load_crypto_strings();
-    OpenSSL_add_all_algorithms();
-    OPENSSL_config(NULL);
+    // OpenSSL 1.1.0: No explicit initialisation or de-initialisation is necessary.
 
 #ifdef Q_OS_WIN
 // If the font size ratio is set on Windows, we need to

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -3,6 +3,7 @@
 #include <openssl/pem.h>
 #include <openssl/err.h>
 #include <openssl/engine.h>
+#include <openssl/rand.h>
 
 
 #include "clientsideencryption.h"


### PR DESCRIPTION
I got a few issues with OpenSSL v1.1.0 when tried to compile the desktop client under Windows, so here the fixes.