### PR TITLE
Actually open the activity view on a click for more info

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -625,7 +625,7 @@ void AccountSettings::slotFolderListClicked(const QModelIndex &indx)
             return;
         }
         if (FolderStatusDelegate::errorsListRect(tv->visualRect(indx)).contains(pos)) {
-            emit showIssuesList(_model->data(indx, FolderStatusDelegate::FolderAliasRole).toString());
+            emit showIssuesList(_accountState);
             return;
         }
 

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -61,7 +61,7 @@ public:
 signals:
     void folderChanged();
     void openFolderAlias(const QString &);
-    void showIssuesList(const QString &folderAlias);
+    void showIssuesList(AccountState *account);
     void requesetMnemonic();
 
 public slots:

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -88,6 +88,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     connect(AccountManager::instance(), &AccountManager::accountRemoved,
         this, &SettingsDialog::accountRemoved);
 
+
     _actionGroup = new QActionGroup(this);
     _actionGroup->setExclusive(true);
     connect(_actionGroup, &QActionGroup::triggered, this, &SettingsDialog::slotSwitchPage);
@@ -188,6 +189,15 @@ void SettingsDialog::showActivityPage()
     }
 }
 
+void SettingsDialog::showIssuesList(AccountState *account) {
+    for (auto it = _actionGroupWidgets.begin(); it != _actionGroupWidgets.end(); ++it) {
+        if (it.value() == _activitySettings[account]) {
+            it.key()->activate(QAction::ActionEvent::Trigger);
+            break;
+        }
+    }
+}
+
 void SettingsDialog::activityAdded(AccountState *s){
     _ui->stack->addWidget(_activitySettings[s]);
     connect(_activitySettings[s], &ActivitySettings::guiLog, _gui,
@@ -246,6 +256,7 @@ void SettingsDialog::accountAdded(AccountState *s)
     connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotFoldersChanged);
     connect(accountSettings, &AccountSettings::openFolderAlias,
         _gui, &ownCloudGui::slotFolderOpenAction);
+    connect(accountSettings, &AccountSettings::showIssuesList, this, &SettingsDialog::showIssuesList);
     connect(s->account().data(), &Account::accountChangedAvatar, this, &SettingsDialog::slotAccountAvatarChanged);
     connect(s->account().data(), &Account::accountChangedDisplayName, this, &SettingsDialog::slotAccountDisplayNameChanged);
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -56,7 +56,7 @@ public:
 public slots:
     void showFirstPage();
     void showActivityPage();
-//    void showIssuesList(const QString &folderAlias);
+    void showIssuesList(AccountState *account);
     void slotSwitchPage(QAction *action);
     void slotRefreshActivity(AccountState *accountState);
     void slotRefreshActivityAccountStateSender();


### PR DESCRIPTION
TO test:

1. Have an account setup
2. Sync a file 'foo.txt'
3. Close the client
4. Edit foo.txt on the web
5. edit foo.txt local
6. Open the sync client

You get an image like:
![conf](https://user-images.githubusercontent.com/45821/48259666-f7a60200-e418-11e8-9ef8-86d27700b39c.png)

Before: click and nothings happens
Now: click and the window is changed :)