### PR TITLE
Use a format that supports alpha channels for avatars

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -649,7 +649,7 @@ QImage AvatarJob::makeCircularAvatar(const QImage &baseAvatar)
 {
     int dim = baseAvatar.width();
 
-    QImage avatar(dim, dim, baseAvatar.format());
+    QImage avatar(dim, dim, QImage::Format_ARGB32);
     avatar.fill(Qt::transparent);
 
     QPainter painter(&avatar);


### PR DESCRIPTION
If we use the source format it can result in fully black images. As the
basic generated avatar doesn't have an alpha channel.

Before:
![before](https://user-images.githubusercontent.com/45821/48261686-2bd0f100-e420-11e8-8355-9994f58d67ec.png)


After:
![after](https://user-images.githubusercontent.com/45821/48261663-18258a80-e420-11e8-8234-4d98f237ba43.png)
