### PR TITLE
Fixup the port in server notification URLs

### DIFF
--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -128,6 +128,9 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
                 link.setScheme(ai->account()->url().scheme());
                 link.setHost(ai->account()->url().host());
             }
+            if (link.port() == -1) {
+                link.setPort(ai->account()->url().port());
+            }
         }
         a._link = link;
         a._dateTime = QDateTime::fromString(json.value("datetime").toString(), Qt::ISODate);


### PR DESCRIPTION
... in addition to fixing up the scheme and host.

For example, the survey app sends "/settings/admin/survey_client" as
a link. Clicking the "More information" button wouldn't lead to the
correct place if NC was running on a custom port.