### PR TITLE
SettingsDialog: fix a little glitch in the account tool button size

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -93,10 +93,6 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _actionGroup->setExclusive(true);
     connect(_actionGroup, &QActionGroup::triggered, this, &SettingsDialog::slotSwitchPage);
 
-    foreach(auto ai, AccountManager::instance()->accounts()) {
-        accountAdded(ai.data());
-    }
-
     _actionBefore = new QAction(this);
     _toolBar->addAction(_actionBefore);
 
@@ -120,6 +116,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
 
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
+
+    foreach(auto ai, AccountManager::instance()->accounts()) {
+        accountAdded(ai.data());
+    }
 
     QTimer::singleShot(1, this, &SettingsDialog::showFirstPage);
 


### PR DESCRIPTION
SettingsDialog::accountAdded() uses the height of the toolbar to
calculate the desired default size for toolbuttons. Make sure to have
the "General" and "Network" tool buttons in place before calling
accountAdded() to avoid cramped first button.