### PR TITLE
Debian/Ubuntu target repository update

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -36,12 +36,11 @@ read basever kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchang
 cd "${DRONE_DIR}"
 
 echo "$kind" > kind
-kind="release"
 
 if test "$kind" = "beta"; then
-    repo=nextcloud-devs/client-alpha
-else
     repo=nextcloud-devs/client-beta
+else
+    repo=nextcloud-devs/client
 fi
 
 origsourceopt=""

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -6,8 +6,8 @@ shopt -s extglob
 PPA=ppa:nextcloud-devs/client-beta
 PPA_BETA=ppa:nextcloud-devs/client-alpha
 
-OBS_PROJECT=home:ivaradi:beta
-OBS_PROJECT_BETA=home:ivaradi:alpha
+OBS_PROJECT=home:ivaradi
+OBS_PROJECT_BETA=home:ivaradi:beta
 OBS_PACKAGE=nextcloud-client
 
 pull_request=${DRONE_PULL_REQUEST:=master}

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -3,8 +3,8 @@
 set -xe
 shopt -s extglob
 
-PPA=ppa:nextcloud-devs/client-beta
-PPA_BETA=ppa:nextcloud-devs/client-alpha
+PPA=ppa:nextcloud-devs/client
+PPA_BETA=ppa:nextcloud-devs/client-beta
 
 OBS_PROJECT=home:ivaradi
 OBS_PROJECT_BETA=home:ivaradi:beta

--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -73,11 +73,13 @@ def collectEntries(baseCommit, baseVersion, kind):
         (commit, name, email, date, revdate, subject) = line.split("\t")
         revdate = datetime.datetime.utcfromtimestamp(long(revdate)).strftime("%Y%m%d.%H%M%S")
 
+        kind = "beta"
+
         if commit==newVersionCommit:
             result = processVersionTag(newVersionTag)
             if result:
                 newVersionOrigTag = lastVersionTag
-                (baseVersion, kind) = result
+                (baseVersion, _kind) = result
 
 
         version=getCommitVersion(commit)
@@ -88,7 +90,7 @@ def collectEntries(baseCommit, baseVersion, kind):
                 if result:
                     lastVersionTag = tag
                     lastCMAKEVersion = version
-                    (baseVersion, kind) = result
+                    (baseVersion, _kind) = result
 
         for tag in subprocess.check_output(["git", "tag",
                                             "--points-at",
@@ -132,7 +134,7 @@ if __name__ == "__main__":
     distribution = sys.argv[2]
 
     #entries = collectEntries("8aade24147b5313f8241a8b42331442b7f40eef9", "2.2.4", "release")
-    entries = collectEntries("f9b1c724d6ab5431e0cd56b7cd834f2dd48cebb1", "2.4.0", "release")
+    entries = collectEntries("f9b1c724d6ab5431e0cd56b7cd834f2dd48cebb1", "2.4.0", "beta")
 
 
     with open(sys.argv[1], "wt") as f:


### PR DESCRIPTION
So far the build script uploaded the source packages to the beta repositories (PPAs for Ubuntu).

However, with tagging resumed, it would be useful to upload the package for release versions to the stable repository. This patches update the build script to do so. If the version being built is tagged with a release tag (such as "v2.5.0"), it is considered a stable version and thus uploaded to the stable repository. Otherwise it goes to the beta one.