### PR TITLE
Do not fetch activities if they are not enabled

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -291,18 +291,28 @@ void ActivityListModel::combineActivityLists()
     endInsertRows();
 }
 
+bool ActivityListModel::canFetchActivities() const {
+    return _accountState->isConnected() && _accountState->account()->capabilities().hasActivities();
+}
+
 void ActivityListModel::fetchMore(const QModelIndex &)
 {
-    if (_accountState->isConnected()) {
-        _activityLists = ActivityList();
+    _activityLists = ActivityList();
+    if (canFetchActivities()) {
         startFetchJob();
+    } else {
+        combineActivityLists();
     }
 }
 
 void ActivityListModel::slotRefreshActivity()
 {
     _activityLists.clear();
-    startFetchJob();
+    if (canFetchActivities()) {
+        startFetchJob();
+    } else {
+        combineActivityLists();
+    }
 }
 
 void ActivityListModel::slotRemoveAccount()

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -67,6 +67,7 @@ signals:
 private:
     void startFetchJob();
     void combineActivityLists();
+    bool canFetchActivities() const;
 
     ActivityList _activityLists;
     ActivityList _syncFileItemLists;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -103,6 +103,10 @@ bool Capabilities::isValid() const
     return !_capabilities.isEmpty();
 }
 
+bool Capabilities::hasActivities() const {
+    return _capabilities.contains("activity");
+}
+
 QList<QByteArray> Capabilities::supportedChecksumTypes() const
 {
     QList<QByteArray> list;

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -59,6 +59,9 @@ public:
     /// returns true if the capabilities are loaded already.
     bool isValid() const;
 
+    /// return true if the activity app is enabled
+    bool hasActivities() const;
+
     /**
      * Returns the checksum types the server understands.
      *


### PR DESCRIPTION
Fixes #788
Fixes #834

1. Disable activities app on the server
2. Open client
3. Open activities tab

Before:
- observe a :hankey:-ton of requests to your server

After:
- No :hankey:-ton of requests to your server