### PR TITLE
Do not read system exclude list if user exclude is present

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -842,11 +842,19 @@ void ConfigFile::setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles)
 {
     ConfigFile cfg;
     QString systemList = cfg.excludeFile(ConfigFile::SystemScope);
-    qCInfo(lcConfigFile) << "Adding system ignore list to csync:" << systemList;
-    excludedFiles.addExcludeFilePath(systemList);
-
     QString userList = cfg.excludeFile(ConfigFile::UserScope);
-    if (QFile::exists(userList)) {
+
+    if (!QFile::exists(userList)) {
+        qCInfo(lcConfigFile) << "User defined ignore list does not exist:" << userList;
+        if (!QFile::copy(systemList, userList)) {
+            qCInfo(lcConfigFile) << "Could not copy over default list to:" << userList;
+        }
+    }
+
+    if (!QFile::exists(userList)) {
+        qCInfo(lcConfigFile) << "Adding system ignore list to csync:" << systemList;
+        excludedFiles.addExcludeFilePath(systemList);
+    } else {
         qCInfo(lcConfigFile) << "Adding user defined ignore list to csync:" << userList;
         excludedFiles.addExcludeFilePath(userList);
     }


### PR DESCRIPTION
For #566

Since we only showed the user exclude list (and some extra items) the
system exclude list was still used.

This copies over the system exclude list (if it isn't there).
If it fails we use the system one still.

However if you now remove items from your own list it will really be
gone.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>