### PR TITLE
Write the actual folder to the log

### DIFF
--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -143,7 +143,7 @@ void SyncRunFileLog::start(const QString &folderPath)
 
 
     if (!exists) {
-        _out << folderPath.toLatin1() << endl;
+        _out << folderPath << endl;
         // We are creating a new file, add the note.
         _out << "# timestamp | duration | file | instruction | dir | modtime | etag | "
                 "size | fileId | status | errorString | http result code | "


### PR DESCRIPTION
Fixes #873
Not all folder names are proper latin1.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>