### PR TITLE
Fix building with Qt 5.12

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -1,5 +1,6 @@
 #include "webview.h"
 
+#include <QWebEngineCertificateError>
 #include <QWebEnginePage>
 #include <QWebEngineProfile>
 #include <QWebEngineUrlRequestInterceptor>


### PR DESCRIPTION
This patches fixes the following error:
```
[ 89%] Building CXX object src/gui/CMakeFiles/nextcloud.dir/wizard/webview.cpp.o
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp: In member function 「virtual QWebEnginePage* OCC::WebEnginePage::createWindow(QWebEnginePage::WebWindowType)」:
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:153:76: 警告：unused parameter 「type」 [-Wunused-parameter]
 QWebEnginePage * WebEnginePage::createWindow(QWebEnginePage::WebWindowType type) {
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp: In member function 「virtual bool OCC::WebEnginePage::certificateError(const QWebEngineCertificateError&)」:
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:164:9: 錯誤：invalid use of incomplete type 「const class QWebEngineCertificateError」
     if (certificateError.error() == QWebEngineCertificateError::CertificateAuthorityInvalid) {
         ^~~~~~~~~~~~~~~~
In file included from /usr/include/qt/QtWebEngineWidgets/QWebEnginePage:1,
                 from /home/yen/Projects/desktop/src/gui/wizard/webview.cpp:3:
/usr/include/qt/QtWebEngineWidgets/qwebenginepage.h:62:7: 附註：forward declaration of 「class QWebEngineCertificateError」
 class QWebEngineCertificateError;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:164:65: 錯誤：巢狀名指定中使用了不完全的類型 「QWebEngineCertificateError」
     if (certificateError.error() == QWebEngineCertificateError::CertificateAuthorityInvalid) {
                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:165:16: 錯誤：invalid use of incomplete type 「const class QWebEngineCertificateError」
         return certificateError.url().host() == _rootUrl.host();
                ^~~~~~~~~~~~~~~~
In file included from /usr/include/qt/QtWebEngineWidgets/QWebEnginePage:1,
                 from /home/yen/Projects/desktop/src/gui/wizard/webview.cpp:3:
/usr/include/qt/QtWebEngineWidgets/qwebenginepage.h:62:7: 附註：forward declaration of 「class QWebEngineCertificateError」
 class QWebEngineCertificateError;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp: In member function 「virtual bool OCC::ExternalWebEnginePage::acceptNavigationRequest(const QUrl&, QWebEnginePage::NavigationType, bool)」:
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:176:101: 警告：unused parameter 「type」 [-Wunused-parameter]
 bool ExternalWebEnginePage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame)
                                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
/home/yen/Projects/desktop/src/gui/wizard/webview.cpp:176:112: 警告：unused parameter 「isMainFrame」 [-Wunused-parameter]
 bool ExternalWebEnginePage::acceptNavigationRequest(const QUrl &url, QWebEnginePage::NavigationType type, bool isMainFrame)
                                                                                                           ~~~~~^~~~~~~~~~~
At global scope:
cc1plus: 警告：unrecognized command line option 「-Wno-gnu-zero-variadic-macro-arguments」
make[2]: *** [src/gui/CMakeFiles/nextcloud.dir/build.make:1364: src/gui/CMakeFiles/nextcloud.dir/wizard/webview.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:343: src/gui/CMakeFiles/nextcloud.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

Thanks the Arch Linux user Aleksandar Trifunovic (akstrfn) for finding the issue and proposing a solution. (https://bugs.archlinux.org/task//61033)