### PR TITLE
Added missing Include

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -10,6 +10,7 @@
 #include <QProgressBar>
 #include <QLoggingCategory>
 #include <QLocale>
+#include <QWebEngineCertificateError>
 
 #include "common/utility.h"
 


### PR DESCRIPTION
When using the newest Qt Framework (Qt 5.12.0) there is an error during build:

```
src/gui/wizard/webview.cpp:164:25: error: member access into incomplete type 'const QWebEngineCertificateError'
    if (certificateError.error() == QWebEngineCertificateError::CertificateAuthorityInvalid) {
```

Including `QWebEngineCertificateError` fixes it.