### PR TITLE
Fix KDEInstallDirs deprecation warnings

### DIFF
--- a/shell_integration/dolphin/CMakeLists.txt
+++ b/shell_integration/dolphin/CMakeLists.txt
@@ -20,7 +20,12 @@ set_package_properties(DolphinVcs PROPERTIES
     PURPOSE "Provides plugin interfaces for Dolphin."
 )
 
+set(KDE_INSTALL_DIRS_NO_DEPRECATED TRUE)
 include(KDEInstallDirs)
+# Before KF5 5.54, kcoreaddons_add_plugin uses deprecated VAR PLUGIN_INSTALL_DIR
+# when that is fixed and you want to remove this workaround,
+# you need to _require_ the new enough kcoreaddons
+set(PLUGIN_INSTALL_DIR "${KDE_INSTALL_PLUGINDIR}")
 include(KDECMakeSettings)
 include(KDECompilerSettings)
 include(ECMMarkNonGuiExecutable)


### PR DESCRIPTION
Get rid of a bunch of such warnings from configuring the Dolphin plugin:
```
CMake Deprecation Warning at /usr/share/ECM/kde-modules/KDEInstallDirs.cmake:345 (message):
  BIN_INSTALL_DIR is deprecated, use KDE_INSTALL_BINDIR instead.
Call Stack (most recent call first):
  /usr/share/ECM/kde-modules/KDEInstallDirs.cmake:433 (_define_relative)
  shell_integration/dolphin/CMakeLists.txt:23 (include)
```
Modified from https://github.com/owncloud/client/pull/6922

Original author: Dominik Schmidt <dev@dominik-schmidt.de>