### PR TITLE
Improve wording of right-click sync menu

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -624,8 +624,8 @@ void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listen
 {
     listener->sendMessage(QLatin1String("SHARE_MENU_TITLE:") + tr("Share with %1", "parameter is ownCloud").arg(Theme::instance()->appNameGUI()));
     listener->sendMessage(QLatin1String("STREAM_SUBMENU_TITLE:") + tr("Claro drive FS"));
-    listener->sendMessage(QLatin1String("STREAM_OFFLINE_ITEM_TITLE:") + tr("0ff line"));
-    listener->sendMessage(QLatin1String("STREAM_ONLINE_ITEM_TITLE:") + tr("On line"));
+    listener->sendMessage(QLatin1String("STREAM_OFFLINE_ITEM_TITLE:") + tr("Available offline"));
+    listener->sendMessage(QLatin1String("STREAM_ONLINE_ITEM_TITLE:") + tr("Online only"));
 }
 
 // don't pull the share manager into socketapi unittests


### PR DESCRIPTION
"Off line" and "On line" is a bit difficult to understand and the words look too similar. So taking a bit of inspiration from the wording Dropbox, Google Drive and OneDrive use, and adjusting it to:

- Available offline
- Online only

What do you think @camilasan @zkoria?