### PR TITLE
Do not add double slash to login flow url

### DIFF
--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -35,7 +35,10 @@ void WebViewPage::initializePage() {
         url = "https://nextcloud.com/register";
     } else {
         url = _ocWizard->ocUrl();
-        url += "/index.php/login/flow";
+        if (!url.endsWith('/')) {
+            url += "/";
+        }
+        url += "index.php/login/flow";
     }
     qCInfo(lcWizardWebiewPage()) << "Url to auth at: " << url;
     _webView->setUrl(QUrl(url));


### PR DESCRIPTION
If the entered url ends with a slash we should not add another one.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>