### PR TITLE
Do not display dismissed notifications

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -233,6 +233,12 @@ void ActivityListModel::addNotificationToActivityList(Activity activity) {
     combineActivityLists();
 }
 
+void ActivityListModel::clearNotifications() {
+    qCInfo(lcActivity) << "Clear the notifications";
+    _notificationLists.clear();
+    combineActivityLists();
+}
+
 void ActivityListModel::removeActivityFromActivityList(int row) {
     Activity activity =  _finalList.at(row);
     removeActivityFromActivityList(activity);

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -49,6 +49,7 @@ public:
     ActivityList activityList() { return _finalList; }
     ActivityList errorsList() { return _notificationErrorsLists; }
     void addNotificationToActivityList(Activity activity);
+    void clearNotifications();
     void addErrorToActivityList(Activity activity);
     void addSyncFileItemToActivityList(Activity activity);
     void removeActivityFromActivityList(int row);

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -430,19 +430,16 @@ void ActivityWidget::slotOpenFile(QModelIndex indx)
 // collected.
 void ActivityWidget::slotBuildNotificationDisplay(const ActivityList &list)
 {
-    QString listAccountName;
-
     // Whether a new notification was added to the list
     bool newNotificationShown = false;
+
+    _model->clearNotifications();
 
     foreach (auto activity, list) {
         if (_blacklistedNotifications.contains(activity)) {
             qCInfo(lcActivity) << "Activity in blacklist, skip";
             continue;
         }
-
-        // remember the list account name for the strayCat handling below.
-        listAccountName = activity._accName;
 
         // handle gui logs. In order to NOT annoy the user with every fetching of the
         // notifications the notification id is stored in a Set. Only if an id
@@ -468,14 +465,15 @@ void ActivityWidget::slotBuildNotificationDisplay(const ActivityList &list)
                     emit guiLog(activity._subject, activity._accName);
                 }
             }
-
-            _model->addNotificationToActivityList(activity);
         }
+
+        _model->addNotificationToActivityList(activity);
     }
 
     // restart the gui log timer now that we show a new notification
-    if(newNotificationShown)
+    if(newNotificationShown) {
         _guiLogTimer.start();
+    }
 }
 
 void ActivityWidget::slotSendNotificationRequest(const QString &accountName, const QString &link, const QByteArray &verb, int row)


### PR DESCRIPTION
Fixes #685

The view doesn't live update for me. But I think that is a different (and less urgent) issue.


To test:

1. create some notifications for a user (@ mention them in comments for example)
2. start the client for that user see the notifications in the activities
3. dismiss a notification on server
4. wait a little while
5. switch to account and back to activity

before: All notifications still there
now: only active notifications still there