### PR TITLE
Fixed l18n issue. Added space for separating string

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -179,6 +179,7 @@ void ActivityWidget::slotItemCompleted(const QString &folder, const SyncFileItem
 
         if(item->_status == SyncFileItem::NoStatus || item->_status == SyncFileItem::Success){
             qCWarning(lcActivity) << "Item " << item->_file << " retrieved successfully.";
+            activity._message.prepend(" ");
             activity._message.prepend(tr("Synced"));
             _model->addSyncFileItemToActivityList(activity);
         } else {


### PR DESCRIPTION
Related to #1068 

Reported at forums with screenshots. See 

https://help.nextcloud.com/t/client-2-5-1-linux-typo/46796

Signed-off-by: Mark Ziegler <mark.ziegler@rakekniven.de>