### PR TITLE
Fixed path to configuration file on macOS

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -7,7 +7,7 @@ On Microsoft Windows systems:
         ``%APPDATA%\Nextcloud\nextcloud.cfg``
 
 On macOS systems:
-        ``$HOME/Library/Preferences/Nextcloud/nextcloud.cfg``
+        ``$HOME/Library/Application Support/Nextcloud/nextcloud.cfg``
 
 
 The configuration file contains settings using the Microsoft Windows .ini file


### PR DESCRIPTION
On my system (macOS High Sierra 10.13.6 with Nextcloud client 2.3.3 (build 84)) the configuration file is located in `Application Support`, not `Preferences`.

In code, this actual location is determined by [Qt core](http://doc.qt.io/qt-5/qstandardpaths.html#). I tried to [find the location where it is defined in Qt](http://code.qt.io/cgit/qt/qtbase.git/diff/src/corelib/io/qstandardpaths.cpp?h=5.9&id=4c980aedc17c1da8f7160989fbb845ea72b36f44), but I only found the value `Preferences`.

Also, I would expect this file in `Application Support`, since `Preferences` is used for user preferences stored via the [defaults](https://ss64.com/osx/defaults.html) system.

So I think this edit is correct, but I can't find the documentation to back this.