### PR TITLE
Fix typo in translation string

### DIFF
--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -285,7 +285,7 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Ser&amp;ver Address</string>
+               <string>Server Address</string>
               </property>
               <property name="buddy">
                <cstring>leUrl</cstring>


### PR DESCRIPTION
Or is this some special flag for the shortcuts?

Thanks to @cowai for finding this.