### PR TITLE
Fix several memory leaks in cloudproviders and add translation support

### DIFF
--- a/src/gui/cloudproviders/cloudprovidermanager.cpp
+++ b/src/gui/cloudproviders/cloudprovidermanager.cpp
@@ -24,7 +24,7 @@ extern "C" {
 
 CloudProvidersProviderExporter *_providerExporter;
 
-void on_bus_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
+void on_name_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
 {
     Q_UNUSED(name);
     CloudProviderManager *self;
@@ -32,6 +32,14 @@ void on_bus_acquired (GDBusConnection *connection, const gchar *name, gpointer u
     _providerExporter = cloud_providers_provider_exporter_new(connection, LIBCLOUDPROVIDERS_DBUS_BUS_NAME, LIBCLOUDPROVIDERS_DBUS_OBJECT_PATH);
     cloud_providers_provider_exporter_set_name (_providerExporter, APPLICATION_NAME);
     self->registerSignals();
+}
+
+void on_name_lost (GDBusConnection *connection, const gchar *name, gpointer user_data)
+{
+    Q_UNUSED(connection);
+    Q_UNUSED(name);
+    Q_UNUSED(user_data);
+    g_clear_object (&_providerExporter);
 }
 
 void CloudProviderManager::registerSignals()
@@ -45,7 +53,7 @@ CloudProviderManager::CloudProviderManager(QObject *parent) : QObject(parent)
 {
     _map = new QMap<QString, CloudProviderWrapper*>();
     QString busName = QString(LIBCLOUDPROVIDERS_DBUS_BUS_NAME);
-    g_bus_own_name (G_BUS_TYPE_SESSION, busName.toAscii().data(), G_BUS_NAME_OWNER_FLAGS_NONE, on_bus_acquired, nullptr, nullptr, this, nullptr);
+    g_bus_own_name (G_BUS_TYPE_SESSION, busName.toAscii().data(), G_BUS_NAME_OWNER_FLAGS_NONE, nullptr, on_name_acquired, nullptr, this, nullptr);
 }
 
 void CloudProviderManager::slotFolderListChanged(const Folder::Map &folderMap)


### PR DESCRIPTION
On `cloudprovidermanager.cpp`
 * I changed the callback to use the on_name_acquired as on_bus_acquired is a little bit early, there might be something else owning the name.
 * I also added `on_name_lost` so that the memory is correctly freed when unused.

On `cloudproviderwrapper.cpp`:
 * I removed `qstring_to_gchar` which was prone to lots of memory leaks when not correctly used.
 * I used the QString object when dealing with string formating and only used C strings when giving the string to CloudProvider Objects (GLib expects UTF-8 strings, I therefore used `.toUtf8().data()`)
 * `cloud_providers_account_exporter_set_menu_model` and `cloud_providers_account_exporter_set_action_group` are not consuming the reference of `getMenuModel()` and `getActionGroup()` I therefore added some `g_clear_object()` that decrease the reference of an object (and assigns it to NULL on the go)
 * I created `menu_item_new` and `menu_item_new_submenu` that are almost like `g_menu_item_new` and `g_menu_item_new_submenu` but takes a QString as label (only added for clarity afterward as I added many `tr("")` calls.
 * I always make sure to decrease the reference of all GMenuItem as `g_menu_append_item` isn't consuming them.