### PR TITLE
Uses configuraion to determine if it should show empty folder popup.

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -750,7 +750,7 @@ void ConfigFile::setMoveToTrash(bool isChecked)
 bool ConfigFile::promptDeleteFiles() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(promptDeleteC), true).toBool();
+    return settings.value(QLatin1String(promptDeleteC), false).toBool();
 }
 
 void ConfigFile::setPromptDeleteFiles(bool promptDeleteFiles)

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -26,6 +26,8 @@
 #include "propagateremotedelete.h"
 #include "propagatedownload.h"
 #include "common/asserts.h"
+#include "configfile.h"
+
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -1035,7 +1037,8 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
         }
     }
 
-    if (!_hasNoneFiles && _hasRemoveFile) {
+    ConfigFile cfgFile;
+    if (!_hasNoneFiles && _hasRemoveFile && cfgFile.promptDeleteFiles()) {
         qCInfo(lcEngine) << "All the files are going to be changed, asking the user";
         bool cancel = false;
         emit aboutToRemoveAllFiles(syncItems.first()->_direction, &cancel);

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -8,6 +8,7 @@
 #include <QtTest>
 #include "syncenginetestutils.h"
 #include <syncengine.h>
+#include <configfile.h>
 
 using namespace OCC;
 
@@ -48,6 +49,8 @@ private slots:
     {
         QFETCH(bool, deleteOnRemote);
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        ConfigFile config;
+        config.setPromptDeleteFiles(true);
 
         //Just set a blacklist so we can check it is still there. This directory does not exists but
         // that does not matter for our purposes.


### PR DESCRIPTION
Configuration default value is set to false because  users are getting
the popup message too often.

