### PR TITLE
Adds parameter to retrieve shares with its reshares.

### DIFF
--- a/src/gui/ocsshareejob.cpp
+++ b/src/gui/ocsshareejob.cpp
@@ -21,7 +21,7 @@ namespace OCC {
 OcsShareeJob::OcsShareeJob(AccountPtr account)
     : OcsJob(account)
 {
-    setPath("ocs/v1.php/apps/files_sharing/api/v1/sharees");
+    setPath("ocs/v2.php/apps/files_sharing/api/v1/sharees");
     connect(this, &OcsJob::jobFinished, this, &OcsShareeJob::jobDone);
 }
 

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -24,7 +24,7 @@ namespace OCC {
 OcsShareJob::OcsShareJob(AccountPtr account)
     : OcsJob(account)
 {
-    setPath("ocs/v1.php/apps/files_sharing/api/v1/shares");
+    setPath("ocs/v2.php/apps/files_sharing/api/v1/shares");
     connect(this, &OcsJob::jobFinished, this, &OcsShareJob::jobDone);
 }
 
@@ -33,6 +33,7 @@ void OcsShareJob::getShares(const QString &path)
     setVerb("GET");
 
     addParam(QString::fromLatin1("path"), path);
+    addParam(QString::fromLatin1("reshares"), QString("true"));
     addPassStatusCode(404);
 
     start();

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -271,6 +271,7 @@ void ShareDialog::showSharingUi()
         auto label = new QLabel(this);
         label->setText(tr("The file can not be shared because it was shared without sharing permission."));
         label->setWordWrap(true);
+        _ui->verticalLayout->insertWidget(1, label);
         return;
     }
 

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -420,6 +420,13 @@ ShareUserLine::ShareUserLine(QSharedPointer<Share> share,
         _permissionReshare->setVisible(false);
     }
 
+    //If the initiator is not you. And the recipient is not you. Show it without any options.
+    if(share->account()->id() != share->getId() && share->account()->davUser() != share->getShareWith()->shareWith()){
+        _ui->permissionsEdit->hide();
+        _ui->permissionToolButton->hide();
+        _ui->deleteShareButton->hide();
+    }
+
     loadAvatar();
 }
 

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -202,6 +202,7 @@ void ShareUserGroupWidget::slotSharesFetched(const QList<QSharedPointer<Share>> 
         connect(s, &ShareUserLine::visualDeletionDone, this, &ShareUserGroupWidget::getShares);
         s->setBackgroundRole(layout->count() % 2 == 0 ? QPalette::Base : QPalette::AlternateBase);
         layout->addWidget(s);
+        s->setVisible(true);
 
         x++;
         if (x <= 3) {


### PR DESCRIPTION
If the initiator or the recipient is not the current user,
show the list of sharees without any options to edit it.

Minor change: updates api to v2. 

![reshares](https://user-images.githubusercontent.com/241266/57649508-b3aed800-75c8-11e9-8b84-88bad6790b75.png)

