### PR TITLE
WebView: Properly handle usernames with spaces and plus signs in it

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -136,7 +136,7 @@ WebViewPageUrlSchemeHandler::WebViewPageUrlSchemeHandler(QObject *parent)
 void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request) {
     QUrl url = request->requestUrl();
 
-    QString path = url.path().mid(1);
+    QString path = url.path(0).mid(1); // get undecoded path
     QStringList parts = path.split("&");
 
     QString server;
@@ -153,11 +153,13 @@ void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *reques
         }
     }
 
-    user = QUrl::fromPercentEncoding(user.toUtf8());
-    password = QUrl::fromPercentEncoding(password.toUtf8());
+    qCDebug(lcWizardWebiew()) << "Got raw user from request path: " << user;
 
     user = user.replace(QChar('+'), QChar(' '));
     password = password.replace(QChar('+'), QChar(' '));
+
+    user = QUrl::fromPercentEncoding(user.toUtf8());
+    password = QUrl::fromPercentEncoding(password.toUtf8());
 
     if (!server.startsWith("http://") && !server.startsWith("https://")) {
         server = "https://" + server;


### PR DESCRIPTION
The path returned from the server encodes a space in the username with `+` and if the username contains a `+` sign it is encoded as `%2B` (cf. https://www.php.net/manual/function.urlencode.php).

Fix: Don't (double) decode the URL path and then replace `+` with space (introduced in issue #279 resp. commit 9ec61a84ce682399b4c39182887e488c99f1d87a). Instead first replace `+` with space, then decode percent encoding.

Tested with a username containing a space, a username containing a `+`sign and a username containing just A-Za-z0-9- (with Nextcloud 16).

(fixes issue #1266)