### PR TITLE
Add error category for http file lock error status 423.

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -105,7 +105,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
                } else if(a._status == SyncFileItem::SoftError
                          || a._status == SyncFileItem::FileIgnored
                          || a._status == SyncFileItem::Conflict
-                         || a._status == SyncFileItem::Restoration){
+                         || a._status == SyncFileItem::Restoration
+                         || a._status == SyncFileItem::FileLocked){
                    return QIcon(QLatin1String(":/client/resources/state-warning.svg"));
                }
                return QIcon(QLatin1String(":/client/resources/state-sync.svg"));

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -121,6 +121,11 @@ void ActivityWidget::slotProgressInfo(const QString &folder, const ProgressInfo 
                 continue;
             }
 
+            if(activity._status == SyncFileItem::FileLocked && !QFileInfo(f->path() + activity._file).exists()){
+                _model->removeActivityFromActivityList(activity);
+                continue;
+            }
+
 
             if(activity._status == SyncFileItem::FileIgnored && !QFileInfo(f->path() + activity._file).exists()){
                 _model->removeActivityFromActivityList(activity);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -351,6 +351,10 @@ void Folder::showSyncResultPopup()
         createGuiLog(_syncResult.firstItemError()->_file, LogStatusError, errorCount);
     }
 
+    if (int lockedCount = _syncResult.numLockedItems()) {
+        createGuiLog(_syncResult.firstItemLocked()->_file, LogStatusFileLocked, lockedCount);
+    }
+
     qCInfo(lcFolder) << "Folder sync result: " << int(_syncResult.status());
 }
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -344,7 +344,8 @@ private:
         LogStatusNew,
         LogStatusError,
         LogStatusConflict,
-        LogStatusUpdated
+        LogStatusUpdated,
+        LogStatusFileLocked
     };
 
     void createGuiLog(const QString &filename, LogStatus status, int count,

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -269,6 +269,7 @@ void PropagateItemJob::done(SyncFileItem::Status statusArg, const QString &error
     case SyncFileItem::FileIgnored:
     case SyncFileItem::NoStatus:
     case SyncFileItem::BlacklistedError:
+    case SyncFileItem::FileLocked:
         // nothing
         break;
     }

--- a/src/libsync/owncloudpropagator_p.h
+++ b/src/libsync/owncloudpropagator_p.h
@@ -93,7 +93,7 @@ inline SyncFileItem::Status classifyError(QNetworkReply::NetworkError nerror,
         if (anotherSyncNeeded) {
             *anotherSyncNeeded = true;
         }
-        return SyncFileItem::SoftError;
+        return SyncFileItem::FileLocked;
     }
 
     return SyncFileItem::NormalError;

--- a/src/libsync/progressdispatcher.cpp
+++ b/src/libsync/progressdispatcher.cpp
@@ -91,7 +91,8 @@ bool Progress::isWarningKind(SyncFileItem::Status kind)
     return kind == SyncFileItem::SoftError || kind == SyncFileItem::NormalError
         || kind == SyncFileItem::FatalError || kind == SyncFileItem::FileIgnored
         || kind == SyncFileItem::Conflict || kind == SyncFileItem::Restoration
-        || kind == SyncFileItem::DetailError || kind == SyncFileItem::BlacklistedError;
+        || kind == SyncFileItem::DetailError || kind == SyncFileItem::BlacklistedError
+        || kind == SyncFileItem::FileLocked;
 }
 
 bool Progress::isIgnoredKind(SyncFileItem::Status kind)

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -571,6 +571,12 @@ void PropagateDownloadFile::slotGetFinished()
             qCWarning(lcPropagateDownload) << "server replied 404, assuming file was deleted";
         }
 
+        // Getting a 423 means that the file is locked
+        const bool fileLocked = _item->_httpErrorCode == 423;
+        if (fileLocked) {
+            qCWarning(lcPropagateDownload) << "server replied 423, file is Locked";
+        }
+
         // Don't keep the temporary file if it is empty or we
         // used a bad range header or the file's not on the server anymore.
         if (_tmpFile.size() == 0 || badRangeHeader || fileNotFound) {

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -59,6 +59,7 @@ public:
         Conflict,
 
         FileIgnored, ///< The file is in the ignored list (or blacklisted with no retries left)
+        FileLocked, ///< The file is locked
         Restoration, ///< The file was restored because what should have been done was not allowed
 
         /** For errors that should only appear in the error view.

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -105,7 +105,8 @@ static inline bool showWarningInSocketApi(const SyncFileItem &item)
     return item._instruction == CSYNC_INSTRUCTION_IGNORE
         || status == SyncFileItem::FileIgnored
         || status == SyncFileItem::Conflict
-        || status == SyncFileItem::Restoration;
+        || status == SyncFileItem::Restoration
+        || status == SyncFileItem::FileLocked;
 }
 
 SyncFileStatusTracker::SyncFileStatusTracker(SyncEngine *syncEngine)

--- a/src/libsync/syncresult.cpp
+++ b/src/libsync/syncresult.cpp
@@ -28,6 +28,7 @@ SyncResult::SyncResult()
     , _numNewConflictItems(0)
     , _numOldConflictItems(0)
     , _numErrorItems(0)
+    , _numLockedItems(0)
 
 {
 }
@@ -137,6 +138,13 @@ void SyncResult::processCompletedItem(const SyncFileItemPtr &item)
                                   || item->_instruction == CSYNC_INSTRUCTION_REMOVE
                                   || item->_instruction == CSYNC_INSTRUCTION_RENAME)) {
         _folderStructureWasChanged = true;
+    }
+
+    if(item->_status == SyncFileItem::FileLocked){
+        _numLockedItems++;
+        if (!_firstItemLocked) {
+            _firstItemLocked = item;
+        }
     }
 
     // Process the item to the gui

--- a/src/libsync/syncresult.h
+++ b/src/libsync/syncresult.h
@@ -72,12 +72,16 @@ public:
     int numErrorItems() const { return _numErrorItems; }
     bool hasUnresolvedConflicts() const { return _numNewConflictItems + _numOldConflictItems > 0; }
 
+    int numLockedItems() const { return _numLockedItems; }
+    bool hasLockedFiles() const { return _numLockedItems > 0; }
+
     const SyncFileItemPtr &firstItemNew() const { return _firstItemNew; }
     const SyncFileItemPtr &firstItemDeleted() const { return _firstItemDeleted; }
     const SyncFileItemPtr &firstItemUpdated() const { return _firstItemUpdated; }
     const SyncFileItemPtr &firstItemRenamed() const { return _firstItemRenamed; }
     const SyncFileItemPtr &firstNewConflictItem() const { return _firstNewConflictItem; }
     const SyncFileItemPtr &firstItemError() const { return _firstItemError; }
+    const SyncFileItemPtr &firstItemLocked() const { return _firstItemLocked; }
 
     void processCompletedItem(const SyncFileItemPtr &item);
 
@@ -101,6 +105,7 @@ private:
     int _numNewConflictItems;
     int _numOldConflictItems;
     int _numErrorItems;
+    int _numLockedItems;
 
     SyncFileItemPtr _firstItemNew;
     SyncFileItemPtr _firstItemDeleted;
@@ -108,6 +113,7 @@ private:
     SyncFileItemPtr _firstItemRenamed;
     SyncFileItemPtr _firstNewConflictItem;
     SyncFileItemPtr _firstItemError;
+    SyncFileItemPtr _firstItemLocked;
 };
 }
 


### PR DESCRIPTION
It filters the error out of the list of blocking errors. It now shows up
in the Activities and Notificattions list as a warning.

![filelocked](https://user-images.githubusercontent.com/241266/59308416-4bbfe000-8ca1-11e9-9bba-07828ff38137.png)


It also logs the error:
[OCC::ActivityWidget::slotItemCompleted 	Item  "welcome.txt"  retrieved resulted in error  "File locked"