### PR TITLE
Update Qt 5.5 compatibility patch for Xenial

### DIFF
--- a/admin/linux/debian/debian.xenial/post-patches/qt5.5-compat.patch
+++ b/admin/linux/debian/debian.xenial/post-patches/qt5.5-compat.patch
@@ -38,3 +38,15 @@
  };
  
  } // namespace OCC
+--- nextcloud-client-2.5.3.orig/src/3rdparty/kmessagewidget/kmessagewidget.cpp	2019-07-26 18:40:34.949349387 +0000
++++ nextcloud-client-2.5.3/src/3rdparty/kmessagewidget/kmessagewidget.cpp	2019-07-26 18:41:39.866478051 +0000
+@@ -105,6 +105,9 @@
+     q->setMessageType(KMessageWidget::Information);
+ }
+ 
++template <typename T>
++constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
++
+ void KMessageWidgetPrivate::createLayout()
+ {
+     delete content->layout();


### PR DESCRIPTION
Since Ubuntu Xenial provides Qt 5.5 only, the client code needs to be patched. This pull request updates the existing patch, so that the latest versions also compile under Xenial. The patch is applied when building for Xenial only.