### PR TITLE
Remove Ubuntu Cosmic and add Eoan package

### DIFF
--- a/admin/linux/debian/debian.eoan/changelog
+++ b/admin/linux/debian/debian.eoan/changelog
@@ -1,22 +1,22 @@
-nextcloud-client (2.3.3-1.0~cosmic1) cosmic; urgency=medium
+nextcloud-client (2.3.3-1.0~eoan1) eoan; urgency=medium
 
   * Debian build support for the forked client.
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Mon, 6 Nov 2017 20:20:04 +0100
 
-nextcloud-client (2.3.1-1.0~cosmic1) cosmic; urgency=medium
+nextcloud-client (2.3.1-1.0~eoan1) eoan; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 23 Mar 2017 19:07:36 +0100
 
-nextcloud-client (2.3.0-1.0~cosmic1) cosmic; urgency=medium
+nextcloud-client (2.3.0-1.0~eoan1) eoan; urgency=medium
 
   * New upstream version
 
  -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 21 Mar 2017 19:34:13 +0100
 
-nextcloud-client (2.2.4-1.4~cosmic1) cosmic; urgency=medium
+nextcloud-client (2.2.4-1.4~eoan1) eoan; urgency=medium
 
   * The locale-specific icon names are correct too
 

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -51,7 +51,7 @@ if ! wget http://ppa.launchpad.net/${repo}/ubuntu/pool/main/n/nextcloud-client/n
     origsourceopt="-sa"
 fi
 
-for distribution in xenial bionic cosmic disco stable; do
+for distribution in xenial bionic disco eoan stable; do
     rm -rf nextcloud-client_${basever}
     cp -a ${DRONE_WORKSPACE} nextcloud-client_${basever}
 


### PR DESCRIPTION
This patch removes the building of a Ubuntu Cosmic source package, as Cosmic is not supported anymore. It also adds building for Eoan, the next release.