### PR TITLE
Add proper CA to client side certificate connection

### DIFF
--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -392,6 +392,12 @@ void OwncloudSetupPage::slotCertificateAccepted()
         // cert will come via the HttpCredentials
         sslConfiguration.setLocalCertificate(_ocWizard->_clientSslCertificate);
         sslConfiguration.setPrivateKey(_ocWizard->_clientSslKey);
+
+        // Be sure to merge the CAs
+        auto ca = sslConfiguration.systemCaCertificates();
+        ca.append(clientCaCertificates);
+        sslConfiguration.setCaCertificates(ca);
+
         acc->setSslConfiguration(sslConfiguration);
 
         // Make sure TCP connections get re-established


### PR DESCRIPTION
If the cert has a chain of certs we should send them all properly

This doesn't solve the issue with the webview not accepting client side certificates unfortunatly :S