### PR TITLE
Windows: Workaround for CredWriteW used by QtKeychain

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -160,7 +160,7 @@ void WebFlowCredentials::askFromUser() {
     }
 
     QString msg = tr("You have been logged out of %1 as user %2. Please login again")
-                      .arg(_account->displayName(), _user);
+            .arg(_account->displayName(), _user);
     _askDialog->setInfo(msg);
 
     _askDialog->show();
@@ -177,7 +177,7 @@ void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user,
         qCInfo(lcWebFlowCredentials()) << "Authed with the wrong user!";
 
         QString msg = tr("Please login with the user: %1")
-                          .arg(_user);
+                .arg(_user);
         _askDialog->setError(msg);
 
         if (!_askDialog->isUsingFlow2()) {
@@ -439,7 +439,7 @@ void WebFlowCredentials::slotReadClientCertPEMJobDone(QKeychain::Job *incomingJo
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
     Q_ASSERT(!incomingJob->insecureFallback()); // If insecureFallback is set, the next test would be pointless
     if (_retryOnKeyChainError && (incomingJob->error() == QKeychain::NoBackendAvailable
-        || incomingJob->error() == QKeychain::OtherError)) {
+            || incomingJob->error() == QKeychain::OtherError)) {
         // Could be that the backend was not yet available. Wait some extra seconds.
         // (Issues #4274 and #6522)
         // (For kwallet, the error is OtherError instead of NoBackendAvailable, maybe a bug in QtKeychain)
@@ -587,20 +587,19 @@ void WebFlowCredentials::slotReadPasswordJobDone(Job *incomingJob) {
     if (_keychainMigration && _ready) {
         _keychainMigration = false;
         persist();
-        deleteKeychainEntries(true);
+        deleteKeychainEntries(true); // true: delete old entries
         qCInfo(lcWebFlowCredentials) << "Migrated old keychain entries";
     }
 }
 
-void WebFlowCredentials::deleteKeychainEntries(bool oldKeychainEntries)
-{
+void WebFlowCredentials::deleteKeychainEntries(bool oldKeychainEntries) {
     auto startDeleteJob = [this, oldKeychainEntries](QString user) {
         DeletePasswordJob *job = new DeletePasswordJob(Theme::instance()->appName());
         addSettingsToJob(_account, job);
         job->setInsecureFallback(true);
         job->setKey(keychainKey(_account->url().toString(),
-            user,
-            oldKeychainEntries ? QString() : _account->id()));
+                                user,
+                                oldKeychainEntries ? QString() : _account->id()));
         job->start();
     };
 

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -14,7 +14,7 @@ class QNetworkReply;
 class QAuthenticator;
 
 namespace QKeychain {
-class Job;
+    class Job;
 }
 
 namespace OCC {
@@ -32,11 +32,11 @@ public:
 
     explicit WebFlowCredentials();
     WebFlowCredentials(
-        const QString &user,
-        const QString &password,
-        const QSslCertificate &certificate = QSslCertificate(),
-        const QSslKey &key = QSslKey(),
-        const QList<QSslCertificate> &caCertificates = QList<QSslCertificate>());
+            const QString &user,
+            const QString &password,
+            const QSslCertificate &certificate = QSslCertificate(),
+            const QSslKey &key = QSslKey(),
+            const QList<QSslCertificate> &caCertificates = QList<QSslCertificate>());
 
     QString authType() const override;
     QString user() const override;


### PR DESCRIPTION
Saving all client CA's within one credential may result in:
  Error: "Credential size exceeds maximum size of 2560"

Client CA certificates are now being stored in separate slots
within the keychain and are being processed by a queue mechanism.

<br/>
IMPORTANT TODO:

forgetSensitiveData(): Invoked by "Log out" & "Remove account"

- Remove client CA certs and KEY!
  (uncomment "//deleteKeychainEntries();" )

  Disabled as long as selecting another cert is not supported by the UI.

<br/>
Signed-off-by: Michael Schuster <michael@schuster.ms>