### PR TITLE
Use newer digest algorithms in TLS error dialog

### DIFF
--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -184,10 +184,15 @@ QString SslErrorDialog::certDiv(QSslCertificate cert) const
 
     msg += QL("<p>");
 
-    QString md5sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Md5).toHex());
-    QString sha1sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha1).toHex());
-    msg += tr("Fingerprint (MD5): <tt>%1</tt>").arg(md5sum) + QL("<br/>");
-    msg += tr("Fingerprint (SHA1): <tt>%1</tt>").arg(sha1sum) + QL("<br/>");
+    if (cert.effectiveDate() < QDateTime(QDate(2016, 1, 1), QTime(), Qt::UTC)) {
+	QString sha1sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha1).toHex());
+        msg += tr("Fingerprint (SHA1): <tt>%1</tt>").arg(sha1sum) + QL("<br/>");
+    }
+
+    QString sha256sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha256).toHex());
+    QString sha512sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha512).toHex());
+    msg += tr("Fingerprint (SHA-256): <tt>%1</tt>").arg(sha256sum) + QL("<br/>");
+    msg += tr("Fingerprint (SHA-512): <tt>%1</tt>").arg(sha512sum) + QL("<br/>");
     msg += QL("<br/>");
     msg += tr("Effective Date: %1").arg(cert.effectiveDate().toString()) + QL("<br/>");
     msg += tr("Expiration Date: %1").arg(cert.expiryDate().toString()) + QL("</p>");


### PR DESCRIPTION
MD5 has been broken for a long time now and SHA1 has been
deprecated as well. SHA1 is not used when issuing new
publicly trusted certificates since 1 January 2016[1] and
there are more and more effective attacks[2][3] against it,
so display SHA1 fingerprint only for old certificates
to encourage use of safer digests by users.

So, we display SHA-256 and SHA-512 fingerprints instead in
the common case.

[1] https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.5.pdf
[2] https://shattered.io/static/shattered.pdf
[3] https://eprint.iacr.org/2019/459.pdf