### PR TITLE
Flow2 ui qt5 compat

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -778,14 +778,14 @@ void FolderStatusModel::slotLscolFinishedWithError(QNetworkReply *r)
 
         parentInfo->resetSubs(this, idx);
 
-        if (r->error() == QNetworkReply::ContentNotFoundError) {
+        /*if (r->error() == QNetworkReply::ContentNotFoundError) {
             parentInfo->_fetched = true;
         } else {
             ASSERT(!parentInfo->hasLabel());
             beginInsertRows(idx, 0, 0);
             parentInfo->_hasError = true;
             endInsertRows();
-        }
+        }*/
     }
 }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -466,7 +466,41 @@ void OwncloudSetupWizard::slotCreateLocalAndRemoteFolders(const QString &localFo
         _ocWizard->appendToConfigurationLog(res);
     }
     if (nextStep) {
-        EntityExistsJob *job = new EntityExistsJob(_ocWizard->account(), _ocWizard->account()->davPath() + remoteFolder, this);
+        /*
+         * BEGIN - Sanitize URL paths to elaminate double-slashes
+         *
+         *         Purpose: Don't rely on unsafe paths, be extra careful.
+         *
+         *         Example: https://cloud.example.com/remote.php/webdav//
+         *
+        */
+        qCInfo(lcWizard) << "Sanitize got URL path:" << QString(_ocWizard->account()->url().toString() + '/' + _ocWizard->account()->davPath() + remoteFolder);
+
+        QString newDavPath = _ocWizard->account()->davPath(),
+                newRemoteFolder = remoteFolder;
+
+        while (newDavPath.startsWith('/')) {
+            newDavPath.remove(0, 1);
+        }
+        while (newDavPath.endsWith('/')) {
+            newDavPath.chop(1);
+        }
+
+        while (newRemoteFolder.startsWith('/')) {
+            newRemoteFolder.remove(0, 1);
+        }
+        while (newRemoteFolder.endsWith('/')) {
+            newRemoteFolder.chop(1);
+        }
+
+        QString newUrlPath = newDavPath + '/' + newRemoteFolder;
+
+        qCInfo(lcWizard) << "Sanitized to URL path:" << _ocWizard->account()->url().toString() + '/' + newUrlPath;
+        /*
+         * END - Sanitize URL paths to elaminate double-slashes
+        */
+
+        EntityExistsJob *job = new EntityExistsJob(_ocWizard->account(), newUrlPath, this);
         connect(job, &EntityExistsJob::exists, this, &OwncloudSetupWizard::slotRemoteFolderExists);
         job->start();
     } else {

--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -184,10 +184,15 @@ QString SslErrorDialog::certDiv(QSslCertificate cert) const
 
     msg += QL("<p>");
 
-    QString md5sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Md5).toHex());
-    QString sha1sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha1).toHex());
-    msg += tr("Fingerprint (MD5): <tt>%1</tt>").arg(md5sum) + QL("<br/>");
-    msg += tr("Fingerprint (SHA1): <tt>%1</tt>").arg(sha1sum) + QL("<br/>");
+    if (cert.effectiveDate() < QDateTime(QDate(2016, 1, 1), QTime(), Qt::UTC)) {
+	QString sha1sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha1).toHex());
+        msg += tr("Fingerprint (SHA1): <tt>%1</tt>").arg(sha1sum) + QL("<br/>");
+    }
+
+    QString sha256sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha256).toHex());
+    QString sha512sum = Utility::formatFingerprint(cert.digest(QCryptographicHash::Sha512).toHex());
+    msg += tr("Fingerprint (SHA-256): <tt>%1</tt>").arg(sha256sum) + QL("<br/>");
+    msg += tr("Fingerprint (SHA-512): <tt>%1</tt>").arg(sha512sum) + QL("<br/>");
     msg += QL("<br/>");
     msg += tr("Effective Date: %1").arg(cert.effectiveDate().toString()) + QL("<br/>");
     msg += tr("Expiration Date: %1").arg(cert.expiryDate().toString()) + QL("</p>");

--- a/src/gui/wizard/flow2authcredspage.cpp
+++ b/src/gui/wizard/flow2authcredspage.cpp
@@ -46,21 +46,8 @@ Flow2AuthCredsPage::Flow2AuthCredsPage()
     setTitle(WizardCommon::titleTemplate().arg(tr("Connect to %1").arg(Theme::instance()->appNameGUI())));
     setSubTitle(WizardCommon::subTitleTemplate().arg(tr("Login in your browser (Login Flow v2)")));
 
-    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, [this] {
-        _ui.errorLabel->hide();
-        if (_asyncAuth)
-            _asyncAuth->openBrowser();
-    });
-    _ui.openLinkButton->setContextMenuPolicy(Qt::CustomContextMenu);
-    QObject::connect(_ui.openLinkButton, &QWidget::customContextMenuRequested, [this](const QPoint &pos) {
-        auto menu = new QMenu(_ui.openLinkButton);
-        menu->addAction(tr("Copy link to clipboard"), this, [this] {
-            if (_asyncAuth)
-                QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
-        });
-        menu->setAttribute(Qt::WA_DeleteOnClose);
-        menu->popup(_ui.openLinkButton->mapToGlobal(pos));
-    });
+    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, this, &Flow2AuthCredsPage::slotOpenBrowser);
+    connect(_ui.copyLinkButton, &QCommandLinkButton::clicked, this, &Flow2AuthCredsPage::slotCopyLinkToClipboard);
 }
 
 void Flow2AuthCredsPage::initializePage()
@@ -144,6 +131,21 @@ AbstractCredentials *Flow2AuthCredsPage::getCredentials() const
 bool Flow2AuthCredsPage::isComplete() const
 {
     return false; /* We can never go forward manually */
+}
+
+void Flow2AuthCredsPage::slotOpenBrowser()
+{
+    if (_ui.errorLabel)
+        _ui.errorLabel->hide();
+
+    if (_asyncAuth)
+        _asyncAuth->openBrowser();
+}
+
+void Flow2AuthCredsPage::slotCopyLinkToClipboard()
+{
+    if (_asyncAuth)
+        QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
 }
 
 } // namespace OCC

--- a/src/gui/wizard/flow2authcredspage.h
+++ b/src/gui/wizard/flow2authcredspage.h
@@ -56,6 +56,10 @@ public:
     QString _appPassword;
     QScopedPointer<Flow2Auth> _asyncAuth;
     Ui_Flow2AuthCredsPage _ui;
+
+protected slots:
+    void slotOpenBrowser();
+    void slotCopyLinkToClipboard();
 };
 
 } // namespace OCC

--- a/src/gui/wizard/flow2authcredspage.ui
+++ b/src/gui/wizard/flow2authcredspage.ui
@@ -53,7 +53,20 @@
    <item>
     <widget class="QCommandLinkButton" name="openLinkButton">
      <property name="text">
-      <string>Re-open Browser (or right-click to copy link)</string>
+      <string>Re-open Browser</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCommandLinkButton" name="copyLinkButton">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Copy link</string>
      </property>
     </widget>
    </item>

--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -50,21 +50,8 @@ Flow2AuthWidget::Flow2AuthWidget(Account *account, QWidget *parent)
 
     WizardCommon::initErrorLabel(_ui.errorLabel);
 
-    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, [this] {
-        _ui.errorLabel->hide();
-        if (_asyncAuth)
-            _asyncAuth->openBrowser();
-    });
-    _ui.openLinkButton->setContextMenuPolicy(Qt::CustomContextMenu);
-    QObject::connect(_ui.openLinkButton, &QWidget::customContextMenuRequested, [this](const QPoint &pos) {
-        auto menu = new QMenu(_ui.openLinkButton);
-        menu->addAction(tr("Copy link to clipboard"), this, [this] {
-            if (_asyncAuth)
-                QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
-        });
-        menu->setAttribute(Qt::WA_DeleteOnClose);
-        menu->popup(_ui.openLinkButton->mapToGlobal(pos));
-    });
+    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, this, &Flow2AuthWidget::slotOpenBrowser);
+    connect(_ui.copyLinkButton, &QCommandLinkButton::clicked, this, &Flow2AuthWidget::slotCopyLinkToClipboard);
 
     _asyncAuth.reset(new Flow2Auth(_account, this));
     connect(_asyncAuth.data(), &Flow2Auth::result, this, &Flow2AuthWidget::asyncAuthResult, Qt::QueuedConnection);
@@ -110,4 +97,19 @@ Flow2AuthWidget::~Flow2AuthWidget() {
     _user.clear();
 }
 
+void Flow2AuthWidget::slotOpenBrowser()
+{
+    if (_ui.errorLabel)
+        _ui.errorLabel->hide();
+
+    if (_asyncAuth)
+        _asyncAuth->openBrowser();
 }
+
+void Flow2AuthWidget::slotCopyLinkToClipboard()
+{
+    if (_asyncAuth)
+        QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
+}
+
+} // namespace OCC

--- a/src/gui/wizard/flow2authwidget.h
+++ b/src/gui/wizard/flow2authwidget.h
@@ -45,6 +45,10 @@ private:
     QString _appPassword;
     QScopedPointer<Flow2Auth> _asyncAuth;
     Ui_Flow2AuthWidget _ui;
+
+protected slots:
+    void slotOpenBrowser();
+    void slotCopyLinkToClipboard();
 };
 
 }

--- a/src/gui/wizard/flow2authwidget.ui
+++ b/src/gui/wizard/flow2authwidget.ui
@@ -65,7 +65,20 @@
    <item>
     <widget class="QCommandLinkButton" name="openLinkButton">
      <property name="text">
-      <string>Re-open Browser (or right-click to copy link)</string>
+      <string>Re-open Browser</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCommandLinkButton" name="copyLinkButton">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Copy link</string>
      </property>
     </widget>
    </item>

--- a/src/gui/wizard/owncloudoauthcredspage.cpp
+++ b/src/gui/wizard/owncloudoauthcredspage.cpp
@@ -45,21 +45,8 @@ OwncloudOAuthCredsPage::OwncloudOAuthCredsPage()
     setTitle(WizardCommon::titleTemplate().arg(tr("Connect to %1").arg(Theme::instance()->appNameGUI())));
     setSubTitle(WizardCommon::subTitleTemplate().arg(tr("Login in your browser")));
 
-    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, [this] {
-        _ui.errorLabel->hide();
-        if (_asyncAuth)
-            _asyncAuth->openBrowser();
-    });
-    _ui.openLinkButton->setContextMenuPolicy(Qt::CustomContextMenu);
-    QObject::connect(_ui.openLinkButton, &QWidget::customContextMenuRequested, [this](const QPoint &pos) {
-        auto menu = new QMenu(_ui.openLinkButton);
-        menu->addAction(tr("Copy link to clipboard"), this, [this] {
-            if (_asyncAuth)
-                QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
-        });
-        menu->setAttribute(Qt::WA_DeleteOnClose);
-        menu->popup(_ui.openLinkButton->mapToGlobal(pos));
-    });
+    connect(_ui.openLinkButton, &QCommandLinkButton::clicked, this, &OwncloudOAuthCredsPage::slotOpenBrowser);
+    connect(_ui.copyLinkButton, &QCommandLinkButton::clicked, this, &OwncloudOAuthCredsPage::slotCopyLinkToClipboard);
 }
 
 void OwncloudOAuthCredsPage::initializePage()
@@ -131,6 +118,21 @@ AbstractCredentials *OwncloudOAuthCredsPage::getCredentials() const
 bool OwncloudOAuthCredsPage::isComplete() const
 {
     return false; /* We can never go forward manually */
+}
+
+void OwncloudOAuthCredsPage::slotOpenBrowser()
+{
+    if (_ui.errorLabel)
+        _ui.errorLabel->hide();
+
+    if (_asyncAuth)
+        _asyncAuth->openBrowser();
+}
+
+void OwncloudOAuthCredsPage::slotCopyLinkToClipboard()
+{
+    if (_asyncAuth)
+        QApplication::clipboard()->setText(_asyncAuth->authorisationLink().toString(QUrl::FullyEncoded));
 }
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudoauthcredspage.h
+++ b/src/gui/wizard/owncloudoauthcredspage.h
@@ -57,6 +57,10 @@ public:
     QString _refreshToken;
     QScopedPointer<OAuth> _asyncAuth;
     Ui_OwncloudOAuthCredsPage _ui;
+
+protected slots:
+    void slotOpenBrowser();
+    void slotCopyLinkToClipboard();
 };
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudoauthcredspage.ui
+++ b/src/gui/wizard/owncloudoauthcredspage.ui
@@ -58,6 +58,19 @@
     </widget>
    </item>
    <item>
+    <widget class="QCommandLinkButton" name="copyLinkButton">
+     <property name="font">
+      <font>
+       <weight>50</weight>
+       <bold>false</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Copy link</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -234,7 +234,7 @@ void AbstractNetworkJob::slotFinished()
     bool discard = finished();
     if (discard) {
         qCDebug(lcNetworkJob) << "Network job" << metaObject()->className() << "finished for" << path();
-        deleteLater();
+        //deleteLater();
     }
 }
 

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -71,6 +71,23 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
 {
     QNetworkRequest newRequest(request);
 
+    /*
+     * SUPPORT HOTFIX - 2019-09-05
+     *
+     * Remove double-slashes in URLs like http://localhost/remote.php/webdav//
+    */
+    /*auto strUrl = newRequest.url().toString();
+    if (strUrl.endsWith("//")) {
+        qWarning(lcAccessManager) << "Removing double-slashes in URL" << strUrl;
+
+        while (strUrl.endsWith("//")) {
+            strUrl.chop(1);
+        }
+
+        newRequest.setUrl(QUrl(strUrl));
+    }*/
+    /* END HOTFIX */
+
     if (newRequest.hasRawHeader("cookie")) {
         // This will set the cookie into the QNetworkCookieJar which will then override the cookie header
         setRawCookie(request.rawHeader("cookie"), request.url());


### PR DESCRIPTION
    Qt5.5 compatiblity patch for login flow V2 + UI improvment

    Removes the right-click function for the "Re-open browser" buttons because
    they are not intuitive for the user.

    Adds a dedicated "Copy link" button.

    Implements Qt 5.5 fixes based on: https://github.com/nextcloud/desktop/pull/1392


See: https://github.com/nextcloud/desktop/pull/1392