### PR TITLE
Fixing E2E CSR transmission failure for new connections

### DIFF
--- a/src/libsync/clientsideencryptionjobs.cpp
+++ b/src/libsync/clientsideencryptionjobs.cpp
@@ -432,6 +432,7 @@ void SignPublicKeyApiJob::start()
 {
     QNetworkRequest req;
     req.setRawHeader("OCS-APIREQUEST", "true");
+    req.setHeader(QNetworkRequest::ContentTypeHeader, QByteArrayLiteral("application/x-www-form-urlencoded"));
     QUrlQuery query;
     query.addQueryItem(QLatin1String("format"), QLatin1String("json"));
     QUrl url = Utility::concatUrlPath(account()->url(), path());


### PR DESCRIPTION
Fixes at least: 

https://github.com/nextcloud/server/issues/12365
https://github.com/nextcloud/end_to_end_encryption/issues/87
#560 
#868 
#977 
#830 

Summary/problem: After E2E-activation on the server, desktop client fails on initial setup (wizard) or sync (when already configured).

Summary/bug: Missing content-type setting on QNetworkRequest when doing sendrequest() for the corresponding API job. 