### PR TITLE
Fix for #1382 "linux client crashes for no discernable reason"

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -346,6 +346,7 @@ void PropagateUploadFileCommon::slotStartUpload(const QByteArray &transmissionCh
         }
         qDebug() << "prevModtime" << prevModtime << "Curr" << _item->_modtime;
         done(SyncFileItem::SoftError, tr("Local file changed during syncing. It will be resumed."));
+        return;
     }
 
     quint64 fileSize = FileSystem::getSize(fullFilePath);


### PR DESCRIPTION
There in no "return" in
PropagateUploadFileCommon::slotStartUpload in if (prevModtime != _item-
>_modtime) {... }

There is possibility that
PropagateItemJob::done(status, errorString)
maybe called two times from PropagateUploadFileCommon::slotStartUpload
1. in if (prevModtime != _item->_modtime) {... }
2. in if (fileIsStillChanging(*_item)) {..}
if changes in files are frequent the second call is possible.

This two calls has effect in PropagatorCompositeJob::slotSubJobFinished
and job is removed two times in _runningJobs.remove(i);
(the second time with argumetnt -1 (because first call removed job).

This return was removed in commit
efc039863b096f0e39543001b6cb53937808bebf - by accident I think.

Good simulation is to synchronize firefox profile with frequent page
refresh.