### PR TITLE
WIP: Add to the file manager extension the option to edit a file.

### DIFF
--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -123,6 +123,8 @@ private:
      */
     Q_INVOKABLE void command_GET_MENU_ITEMS(const QString &argument, SocketListener *listener);
 
+    Q_INVOKABLE void command_EDIT(const QString &localFile, SocketListener *listener);
+
     QString buildRegisterPathMessage(const QString &path);
 
     QSet<QString> _registeredAliases;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -107,6 +107,10 @@ bool Capabilities::hasActivities() const {
     return _capabilities.contains("activity");
 }
 
+bool Capabilities::hasRichDocuments() const {
+    return _capabilities.contains("richdocuments");
+}
+
 QList<QByteArray> Capabilities::supportedChecksumTypes() const
 {
     QList<QByteArray> list;
@@ -174,5 +178,19 @@ bool Capabilities::uploadConflictFiles() const
         return envValue != 0;
 
     return _capabilities["uploadConflictFiles"].toBool();
+}
+
+QList<QByteArray> Capabilities::supportedRichDocumentsMimetypes() const
+{
+    QList<QByteArray> list;
+    foreach (const auto &t, _capabilities["richdocuments"].toMap()["mimetypes"].toList()) {
+        list.push_back(t.toByteArray());
+    }
+    return list;
+}
+
+QString Capabilities::richDocumentsProductName() const
+{
+    return _capabilities["richdocuments"].toMap()["productName"].toString();
 }
 }

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -62,6 +62,9 @@ public:
     /// return true if the activity app is enabled
     bool hasActivities() const;
 
+    /// return true if Collabora/OnlyOffice is enabled
+    bool hasRichDocuments() const;
+
     /**
      * Returns the checksum types the server understands.
      *
@@ -126,6 +129,18 @@ public:
      * Whether conflict files should remain local (default) or should be uploaded.
      */
     bool uploadConflictFiles() const;
+
+    /**
+     * Returns the richdocuments supported mimetypes
+     *
+     */
+    QList<QByteArray> supportedRichDocumentsMimetypes() const;
+
+    /**
+     * Returns the richdocuments productName
+     *
+     */
+    QString richDocumentsProductName() const;
 
 private:
     QVariantMap _capabilities;


### PR DESCRIPTION
The file can be edited in the browser via one of our apps Text,
Collabora or OnlyOffice.

TODO:
- [ ] create the request with the file id and token to be able to open the file in edit more in the browser
Answer: https://github.com/nextcloud/richdocuments/blob/master/docs/mobile_flow.md
"Basically it is checking if is supported and if it is. A simple post with the file id gets you the URL to open then there are some messages to handle etc. But I must admit I don't know them all by heart. But @tobiasKaminsky does"
- [ ] "This would also work with **OnlyOffice** and **Text** and others? **Both require server work**, as OnlyOffice currently does not allow to edit files directly. But Julius and me discussed this with OO guys at Conf. For Text Julius is already working on it. It is planned, that this is somehow abstracted in a more generic way, but this is up to Julius."

Also see nextcloud-gmbh/server#14.

 
![edit](https://user-images.githubusercontent.com/241266/65625077-6bb6ad80-dfcb-11e9-807e-38aebd7edc75.png)
