### PR TITLE
Use user-provided username in `displayName()` - Fix #836

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -119,7 +119,7 @@ void Account::setAvatar(const QImage &img)
 
 QString Account::displayName() const
 {
-    QString dn = QString("%1@%2").arg(davUser(), _url.host());
+    QString dn = QString("%1@%2").arg(credentials()->user(), _url.host());
     int port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         dn.append(QLatin1Char(':'));


### PR DESCRIPTION
Fixes #836

Finally found the time to track this down:

When the client has just started, the user shown in the tray menu is actually correct.  While establishing the connection, `davUser` is replaced by the DAV username from the server's JSON response:

https://github.com/nextcloud/desktop/blob/a1407209016bb8754ffae2f63ee8d634f123f2a1/src/gui/connectionvalidator.cpp#L303-L308

This PR replaces `davUser()` in `displayName()` with `credentials()->user()` which results in the actual username (that the user is aware of) being shown in the menu.