### PR TITLE
Trigger builds for tagging on the 2.6.0 branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -344,10 +344,9 @@ steps:
       from_secret: DEBIAN_SECRET_IV
 trigger:
   branch:
-    - master
+    - stable-2.6
   event:
-    - pull_request
-    - push
+    - tag
 ---
 kind: pipeline
 name: Documentation


### PR DESCRIPTION
This patch modifies ```.drone.yml``` to trigger the Debian builds on the ```stable-2.6.0``` branch when it is tagged. This way the next releases will hopefully be built automatically.