### PR TITLE
Don't run connection wizard when quitting the application

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -108,6 +108,7 @@ Application::Application(int &argc, char **argv)
     , _userTriggeredConnect(false)
     , _debugMode(false)
     , _backgroundMode(false)
+    , _isQuitting(false)
 {
     _startedAt.start();
 
@@ -283,7 +284,7 @@ void Application::slotAccountStateRemoved(AccountState *accountState)
     }
 
     // if there is no more account, show the wizard.
-    if (AccountManager::instance()->accounts().isEmpty()) {
+    if (!_isQuitting && AccountManager::instance()->accounts().isEmpty()) {
         // allow to add a new account if there is non any more. Always think
         // about single account theming!
         OwncloudSetupWizard::runWizard(this, SLOT(slotownCloudWizardDone(int)));
@@ -306,6 +307,8 @@ void Application::slotAccountStateAdded(AccountState *accountState)
 
 void Application::slotCleanup()
 {
+    _isQuitting = true;
+
     AccountManager::instance()->save();
     FolderMan::instance()->unloadAndDeleteAllFolders();
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -108,7 +108,6 @@ Application::Application(int &argc, char **argv)
     , _userTriggeredConnect(false)
     , _debugMode(false)
     , _backgroundMode(false)
-    , _isQuitting(false)
 {
     _startedAt.start();
 
@@ -265,6 +264,8 @@ Application::~Application()
     }
 
     // Remove the account from the account manager so it can be deleted.
+    disconnect(AccountManager::instance(), &AccountManager::accountRemoved,
+        this, &Application::slotAccountStateRemoved);
     AccountManager::instance()->shutdown();
 }
 
@@ -284,7 +285,7 @@ void Application::slotAccountStateRemoved(AccountState *accountState)
     }
 
     // if there is no more account, show the wizard.
-    if (!_isQuitting && AccountManager::instance()->accounts().isEmpty()) {
+    if (AccountManager::instance()->accounts().isEmpty()) {
         // allow to add a new account if there is non any more. Always think
         // about single account theming!
         OwncloudSetupWizard::runWizard(this, SLOT(slotownCloudWizardDone(int)));
@@ -307,8 +308,6 @@ void Application::slotAccountStateAdded(AccountState *accountState)
 
 void Application::slotCleanup()
 {
-    _isQuitting = true;
-
     AccountManager::instance()->save();
     FolderMan::instance()->unloadAndDeleteAllFolders();
 

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -114,6 +114,7 @@ private:
     bool _userTriggeredConnect;
     bool _debugMode;
     bool _backgroundMode;
+    bool _isQuitting;
 
     ClientProxy _proxy;
 

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -114,7 +114,6 @@ private:
     bool _userTriggeredConnect;
     bool _debugMode;
     bool _backgroundMode;
-    bool _isQuitting;
 
     ClientProxy _proxy;
 


### PR DESCRIPTION
Problem: When you quit Nextcloud it shows the "New connection" wizard briefly before exit every time.

I nailed it down to the `accountRemoved` signal of `AccountManager` which is handled in `Application::slotAccountStateRemoved()`. That handler runs the connection wizard when there are no accounts left. Because all the accounts are removed from `AccountManager` during application shutdown, this event gets triggered at that time.

As a "fix" I added a new flag `_isQuitting` to the Application class that is set in the `aboutToQuit` handler (`slotCleanup`). This is probably a little ugly and there might be a better way to do it, e.g. remove the signal handler for `accountRemoved` instead of setting a flag, but I'm not 100% sure this would not break something, so I chose a safer route 😃  