### PR TITLE
 Avoiding copying in range-based loops

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -342,8 +342,8 @@ bool ExcludedFiles::reloadExcludeFiles()
     _fullRegexDir.clear();
 
     bool success = true;
-    for (auto basePath : _excludeFiles.keys()) {
-        for (auto file : _excludeFiles.value(basePath)) {
+    for (const auto& basePath : _excludeFiles.keys()) {
+        for (const auto& file : _excludeFiles.value(basePath)) {
             success = loadExcludeFile(basePath, file);
         }
     }

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -628,7 +628,7 @@ void SocketApi::command_GET_STRINGS(const QString &argument, SocketListener *lis
         { "EMAIL_PRIVATE_LINK_MENU_TITLE", tr("Send private link by email...") },
     } };
     listener->sendMessage(QString("GET_STRINGS:BEGIN"));
-    for (auto key_value : strings) {
+    for (const auto& key_value : strings) {
         if (argument.isEmpty() || argument == QLatin1String(key_value.first)) {
             listener->sendMessage(QString("STRING:%1:%2").arg(key_value.first, key_value.second));
         }

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -543,7 +543,7 @@ private slots:
         QVERIFY(conflicts.size() == 2);
         QVERIFY(conflicts[0].contains("A (conflicted copy"));
         QVERIFY(conflicts[1].contains("B (conflicted copy"));
-        for (auto conflict : conflicts)
+        for (const auto& conflict : conflicts)
             QDir(fakeFolder.localPath() + conflict).removeRecursively();
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
 
@@ -581,7 +581,7 @@ private slots:
         auto conflicts = findConflicts(fakeFolder.currentLocalState());
         QVERIFY(conflicts.size() == 1);
         QVERIFY(conflicts[0].contains("A (conflicted copy"));
-        for (auto conflict : conflicts)
+        for (const auto& conflict : conflicts)
             QDir(fakeFolder.localPath() + conflict).removeRecursively();
 
         QVERIFY(fakeFolder.syncEngine().isAnotherSyncNeeded() == ImmediateFollowUp);

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -289,12 +289,12 @@ private slots:
             << "foo bla bar/file"
             << "fo_"
             << "fo_/file";
-        for (auto elem : elements)
+        for (const auto& elem : elements)
             makeEntry(elem);
 
         auto checkElements = [&]() {
             bool ok = true;
-            for (auto elem : elements) {
+            for (const auto& elem : elements) {
                 SyncJournalFileRecord record;
                 _db.getFileRecord(elem, &record);
                 if (!record.isValid()) {

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -523,13 +523,13 @@ private slots:
         auto currentLocal = fakeFolder.currentLocalState();
         auto conflicts = findConflicts(currentLocal.children["A4"]);
         QCOMPARE(conflicts.size(), 1);
-        for (auto c : conflicts) {
+        for (const auto& c : conflicts) {
             QCOMPARE(currentLocal.find(c)->contentChar, 'L');
             local.remove(c);
         }
         conflicts = findConflicts(currentLocal.children["B4"]);
         QCOMPARE(conflicts.size(), 1);
-        for (auto c : conflicts) {
+        for (const auto& c : conflicts) {
             QCOMPARE(currentLocal.find(c)->contentChar, 'L');
             local.remove(c);
         }


### PR DESCRIPTION
Small optimization. Used const references in range-based loops to avoid copying every items