### PR TITLE
Add a 'Content-Length: 0' header to initial POST requests

### DIFF
--- a/src/gui/creds/flow2auth.cpp
+++ b/src/gui/creds/flow2auth.cpp
@@ -52,7 +52,11 @@ void Flow2Auth::openBrowser()
     // Step 1: Initiate a login, do an anonymous POST request
     QUrl url = Utility::concatUrlPath(_account->url().toString(), QLatin1String("/index.php/login/v2"));
 
-    auto job = _account->sendRequest("POST", url);
+    // add 'Content-Length: 0' header (see https://github.com/nextcloud/desktop/issues/1473)
+    QNetworkRequest req;
+    req.setHeader(QNetworkRequest::ContentLengthHeader, "0");
+
+    auto job = _account->sendRequest("POST", url, req);
     job->setTimeout(qMin(30 * 1000ll, job->timeoutMsec()));
 
     QObject::connect(job, &SimpleNetworkJob::finishedSignal, this, [this](QNetworkReply *reply) {


### PR DESCRIPTION
The webserver lighttpd rejected POST requests without a Content-length header
with "411 Length Required".

See: https://github.com/nextcloud/desktop/issues/1473