### PR TITLE
Pick from upstream: Update qtmacgoodies for an OSX crash fix #6930

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -181,6 +181,9 @@ if (APPLE)
         ../3rdparty/qtmacgoodies/src/macstandardicon.mm
         ../3rdparty/qtmacgoodies/src/macwindow.mm
         )
+    # We want to access Cocoa specific structures in the code above
+    # and need the platform plugin interface for that - which is private.
+    include_directories(${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 
 if(NOT WIN32)


### PR DESCRIPTION
With Qt 5.12.5 this OC crash also applies to the Nextcloud Desktop Client on macOS.

For reference please see:
- https://github.com/owncloud/client/issues/6930
- https://github.com/guruz/qtmacgoodies/commit/0dc7bc33282bdf3ea262cbd1e6c380a8ab9d6dcf

For the required changes in the qtmacgoodies submodule see:
https://github.com/camilasan/qtmacgoodies/pull/1