### PR TITLE
MSVC Fix for PR #1526: Fix clang's variadic macro warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,12 +29,12 @@ if(NOT MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FORTIFY_SOURCE=2")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2")
   endif()
-endif()
 
-# Calling Qt's qCWarning(category, ...) with no params for "..." is a GNU
-# extension (C++11 §16.3/4 forbids them). Silence clang's warnings.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+  # Calling Qt's qCWarning(category, ...) with no params for "..." is a GNU
+  # extension (C++11 §16.3/4 forbids them). Silence clang's warnings.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+endif()
 
 if(WIN32)
   # Enable DEP & ASLR


### PR DESCRIPTION
The recently merged #1526 caused the MSVC Builds on Windows to fail.

This patch sets the new CMake flag only if the compiler it not MSVC.