### PR TITLE
Bump Qt5.12 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -237,7 +237,7 @@ name: qt-5.12
 
 steps:
 - name: build and test
-  image: nextcloudci/client-5.12:client-5.12-2
+  image: nextcloudci/client-5.12:client-5.12-3
   commands:
     # Install QtKeyChain
     - /bin/bash -c "
@@ -278,7 +278,7 @@ name: qt-5.12-clang
 
 steps:
 - name: build and test
-  image: nextcloudci/client-5.12:client-5.12-2
+  image: nextcloudci/client-5.12:client-5.12-3
   commands:
     # Install QtKeyChain
     - /bin/bash -c "
@@ -319,7 +319,7 @@ name: AppImage
 
 steps:
 - name: build
-  image: nextcloudci/client-5.12:client-5.12-2
+  image: nextcloudci/client-5.12:client-5.12-3
   commands:
     - /bin/bash -c "./admin/linux/build-appimage.sh"
 trigger:


### PR DESCRIPTION
Main improvement is that this image contains the libsecret.
So when building qtkeychain that should be used.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>