### PR TITLE
Enabled address sanitizing for tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,11 +22,11 @@ steps:
       source /opt/qt57/bin/qt57-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1  ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -59,11 +59,11 @@ steps:
       source /opt/qt58/bin/qt58-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1  ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -96,11 +96,11 @@ steps:
       source /opt/qt59/bin/qt59-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1  ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -137,11 +137,11 @@ steps:
       source /opt/qt510/bin/qt510-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -178,11 +178,11 @@ steps:
       source /opt/qt511/bin/qt511-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -219,11 +219,11 @@ steps:
       source /opt/qt511/bin/qt511-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -260,11 +260,11 @@ steps:
       source /opt/qt512/bin/qt512-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master
@@ -301,11 +301,11 @@ steps:
       source /opt/qt512/bin/qt512-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
-      su -c 'ctest --output-on-failure' test"
+      su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
 trigger:
   branch:
     - master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ if (APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
+option(SANITIZE_ADDRESS "Enable address sanitizer in tests" OFF)
+if (SANITIZE_ADDRESS)
+    include(SanitizerFlags)
+    enable_sanitizer()
+endif ()
+
 # Handle Translations, pick all client_* files from trans directory.
 file( GLOB TRANS_FILES ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
 set(TRANSLATIONS ${TRANS_FILES})

--- a/cmake/modules/SanitizerFlags.cmake
+++ b/cmake/modules/SanitizerFlags.cmake
@@ -1,0 +1,17 @@
+
+# Enable address sanitizer (gcc/clang only)
+macro(ENABLE_SANITIZER)
+
+  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    message(FATAL_ERROR "Sanitizer supported only for gcc/clang")
+  endif()
+
+  set(SANITIZER_FLAGS "-fsanitize=address  -fsanitize=leak -g")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZER_FLAGS}")
+
+  set(LINKER_FLAGS "-fsanitize=address,undefined -fuse-ld=gold")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
+
+endmacro()
+


### PR DESCRIPTION
Added a new cmake flag SANITIZE_ADDRESS,  which allows to perform address sanitizing.
Enable sanitizer for build and test in Drone ci.

I disabled leaks detecting, because  it requires a special environment, such as sanitized qt build.