### PR TITLE
Fix duplicate items in Apps menu (a bug introduced in #1477)

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -827,6 +827,10 @@ void ownCloudGui::fetchNavigationApps(AccountStatePtr account){
 
 void ownCloudGui::buildNavigationAppsMenu(AccountStatePtr account, QMenu *accountMenu){
     auto navLinks = _navApps.value(account);
+
+    _navLinksMenu->clear();
+    _navLinksMenu->setEnabled(navLinks.size() > 0);
+
     if(navLinks.size() > 0){
         // when there is only one account add the nav links above the settings
         QAction *actionBefore = _actionSettings;
@@ -853,7 +857,6 @@ void ownCloudGui::buildNavigationAppsMenu(AccountStatePtr account, QMenu *accoun
             connect(action, &QAction::triggered, this, [href] { QDesktopServices::openUrl(href); });
             _navLinksMenu->addAction(action);
         }
-        _navLinksMenu->setEnabled(true);
     }
 }
 


### PR DESCRIPTION
As noted in comments in #1477 if you open tray context menu more than once, there will be duplicate items in the Apps menu. To fix it we should clear `_navLinksMenu` before adding items to it in `buildNavigationAppsMenu`.