### PR TITLE
Fix updater message: Download link instead of "use the system's updat…

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -148,7 +148,7 @@ QString OCUpdater::statusString() const
     case DownloadTimedOut:
         return tr("Could not check for new updates.");
     case UpdateOnlyAvailableThroughSystem:
-        return tr("New %1 version %2 available. Please use the system's update tool to install it.").arg(Theme::instance()->appNameGUI(), updateVersion);
+        return tr("New %1 version %2 is available. Please click <a href='%3'>here</a> to download the update.").arg(Theme::instance()->appNameGUI(), updateVersion, _updateInfo.web());
     case CheckingServer:
         return tr("Checking update server...");
     case Unknown:


### PR DESCRIPTION
…e tool"

Provide a download link to the new version instead of the confusing message that
users should use their "system's update tool to install it".