### PR TITLE
Remove HTTP/2 support from Xenial

### DIFF
--- a/admin/linux/debian/debian.xenial/post-patches/qt5.5-compat.patch
+++ b/admin/linux/debian/debian.xenial/post-patches/qt5.5-compat.patch
@@ -10,3 +10,55 @@
  void KMessageWidgetPrivate::createLayout()
  {
      delete content->layout();
+--- b/src/libsync/abstractnetworkjob.cpp
++++ a/src/libsync/abstractnetworkjob.cpp
+@@ -160,37 +160,6 @@ void AbstractNetworkJob::slotFinished()
+         qCWarning(lcNetworkJob) << "SslHandshakeFailedError: " << errorString() << " : can be caused by a webserver wanting SSL client certificates";
+     }
+ 
+-   // Qt doesn't yet transparently resend HTTP2 requests, do so here
+-    const auto maxHttp2Resends = 5;
+-    QByteArray verb = requestVerb(*reply());
+-    if (_reply->error() == QNetworkReply::ContentReSendError
+-        && _reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()) {
+-
+-        if ((_requestBody && !_requestBody->isSequential()) || verb.isEmpty()) {
+-            qCWarning(lcNetworkJob) << "Can't resend HTTP2 request, verb or body not suitable"
+-                                    << _reply->request().url() << verb << _requestBody;
+-        } else if (_http2ResendCount >= maxHttp2Resends) {
+-            qCWarning(lcNetworkJob) << "Not resending HTTP2 request, number of resends exhausted"
+-                                    << _reply->request().url() << _http2ResendCount;
+-        } else {
+-            qCInfo(lcNetworkJob) << "HTTP2 resending" << _reply->request().url();
+-            _http2ResendCount++;
+-
+-            resetTimeout();
+-            if (_requestBody) {
+-                if(!_requestBody->isOpen())
+-                   _requestBody->open(QIODevice::ReadOnly);
+-                _requestBody->seek(0);
+-            }
+-            sendRequest(
+-                verb,
+-                _reply->request().url(),
+-                _reply->request(),
+-                _requestBody);
+-            return;
+-        }
+-    }
+-
+     if (_reply->error() != QNetworkReply::NoError) {
+         if (!_ignoreCredentialFailure || _reply->error() != QNetworkReply::AuthenticationRequiredError) {
+             qCWarning(lcNetworkJob) << _reply->error() << errorString()
+--- b/src/libsync/abstractnetworkjob.h
++++ a/src/libsync/abstractnetworkjob.h
+@@ -188,8 +188,7 @@ private:
+     QPointer<QNetworkReply> _reply; // (QPointer because the NetworkManager may be destroyed before the jobs at exit)
+     QString _path;
+     QTimer _timer;
+-    int _redirectCount = 0;
+-    int _http2ResendCount = 0;
++    int _redirectCount;
+ 
+     // Set by the xyzRequest() functions and needed to be able to redirect
+     // requests, should it be required.


### PR DESCRIPTION
Recently, HTTP/2 support was added by commit cf1532acf18a7e9f530a42b100ec9a437a0057fd. However, Qt 5.5, available in Ubuntu Xenial, does not support HTTP/2, hence the code does not work there. This patch reverts the effects of the commit in question for Xenial only.