### PR TITLE
Compare QDateTime objects more efficient

### DIFF
--- a/src/gui/activitydata.cpp
+++ b/src/gui/activitydata.cpp
@@ -21,7 +21,7 @@ namespace OCC {
 
 bool operator<(const Activity &rhs, const Activity &lhs)
 {
-    return rhs._dateTime.toMSecsSinceEpoch() > lhs._dateTime.toMSecsSinceEpoch();
+    return rhs._dateTime > lhs._dateTime;
 }
 
 bool operator==(const Activity &rhs, const Activity &lhs)


### PR DESCRIPTION
There is no need to call toMSecsSinceEpoch() as QDateTime implements an
comparison operator itself. This is more efficient, because the
QDateTimes comparison operator doesn't call localtime() in all cases. Thus, we
don't read /etc/localtime for every comparison. This improves
performance in some cases.

This should fix #942 .