### PR TITLE
Improve the translation of "Share via …"

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinpluginhelper.h
+++ b/shell_integration/dolphin/ownclouddolphinpluginhelper.h
@@ -35,11 +35,11 @@ public:
 
     QString contextMenuTitle() const
     {
-        return _strings.value("CONTEXT_MENU_TITLE", "ownCloud");
+        return _strings.value("CONTEXT_MENU_TITLE", "Nextcloud");
     }
     QString shareActionTitle() const
     {
-        return _strings.value("SHARE_MENU_TITLE", "Share...");
+        return _strings.value("SHARE_MENU_TITLE", "Share …");
     }
 
     QString copyPrivateLinkTitle() const { return _strings["COPY_PRIVATE_LINK_MENU_TITLE"]; }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1032,7 +1032,7 @@ void AccountSettings::slotAccountStateChanged()
                                        "<a href='%1'>Click here</a> to re-open the browser.")
                                         .arg(url.toString(QUrl::FullyEncoded)));
             } else {
-                showConnectionLabel(tr("Connecting to %1...").arg(serverWithUser));
+                showConnectionLabel(tr("Connecting to %1 …").arg(serverWithUser));
             }
         } else {
             showConnectionLabel(tr("No connection to %1 at %2.")

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -746,7 +746,7 @@ void AccountSettings::slotFolderWizardAccepted()
             qCInfo(lcAccountSettings) << "Creating folder" << definition.localPath;
             if (!dir.mkpath(".")) {
                 QMessageBox::warning(this, tr("Folder creation failed"),
-                    tr("<p>Could not create local folder <i>%1</i>.")
+                    tr("<p>Could not create local folder <i>%1</i>.</p>")
                         .arg(QDir::toNativeSeparators(definition.localPath)));
                 return;
             }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -186,7 +186,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
                 return QVariant(tr("Error while loading the list of folders from the server.")
                     + QString("\n") + x->_lastErrorString);
             } else {
-                return tr("Fetching folder list from server...");
+                return tr("Fetching folder list from server …");
             }
             break;
         default:
@@ -1099,15 +1099,15 @@ void FolderStatusModel::slotFolderSyncStateChange(Folder *f)
         }
         QString message;
         if (pos <= 0) {
-            message = tr("Waiting...");
+            message = tr("Waiting …");
         } else {
-            message = tr("Waiting for %n other folder(s)...", "", pos);
+            message = tr("Waiting for %n other folder(s) …", "", pos);
         }
         pi = SubFolderInfo::Progress();
         pi._overallSyncString = message;
     } else if (state == SyncResult::SyncPrepare) {
         pi = SubFolderInfo::Progress();
-        pi._overallSyncString = tr("Preparing to sync...");
+        pi._overallSyncString = tr("Preparing to sync …");
     } else if (state == SyncResult::Problem || state == SyncResult::Success) {
         // Reset the progress info after a sync.
         pi = SubFolderInfo::Progress();

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -943,7 +943,7 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const ProgressInfo &
         quint64 totalFileCount = qMax(progress.totalFiles(), currentFile);
         QString msg;
         if (progress.trustEta()) {
-            msg = tr("Syncing %1 of %2  (%3 left)")
+            msg = tr("Syncing %1 of %2 (%3 left)")
                       .arg(currentFile)
                       .arg(totalFileCount)
                       .arg(Utility::durationToDescriptiveString2(progress.totalProgress().estimatedEta));

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -421,7 +421,7 @@ void ownCloudGui::addAccountContextMenu(AccountStatePtr accountState, QMenu *men
         }
 
         if (accountState->isSignedOut()) {
-            QAction *signin = menu->addAction(tr("Log in..."));
+            QAction *signin = menu->addAction(tr("Log in …"));
             signin->setProperty(propertyAccountC, QVariant::fromValue(accountState));
             connect(signin, &QAction::triggered, this, &ownCloudGui::slotLogin);
         } else {
@@ -786,9 +786,9 @@ void ownCloudGui::setupActions()
     _actionStatus->setEnabled(false);
     _navLinksMenu = new QMenu(tr("Apps"));
     _navLinksMenu->setEnabled(false);
-    _actionSettings = new QAction(tr("Settings..."), this);
-    _actionNewAccountWizard = new QAction(tr("New account..."), this);
-    _actionRecent = new QAction(tr("View more activity..."), this);
+    _actionSettings = new QAction(tr("Settings …"), this);
+    _actionNewAccountWizard = new QAction(tr("New account …"), this);
+    _actionRecent = new QAction(tr("View more activity …"), this);
     _actionRecent->setEnabled(true);
 
     QObject::connect(_actionRecent, &QAction::triggered, this, &ownCloudGui::slotShowSyncProtocol);

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -331,7 +331,7 @@ void OwncloudSetupWizard::slotConnectToOCUrl(const QString &url)
     AbstractCredentials *creds = _ocWizard->getCredentials();
     _ocWizard->account()->setCredentials(creds);
     _ocWizard->setField(QLatin1String("OCUrl"), url);
-    _ocWizard->appendToConfigurationLog(tr("Trying to connect to %1 at %2...")
+    _ocWizard->appendToConfigurationLog(tr("Trying to connect to %1 at %2 …")
                                             .arg(Theme::instance()->appNameGUI())
                                             .arg(url));
 
@@ -452,7 +452,7 @@ void OwncloudSetupWizard::slotCreateLocalAndRemoteFolders(const QString &localFo
             tr("Local sync folder %1 already exists, setting it up for sync.<br/><br/>")
                 .arg(Utility::escape(localFolder)));
     } else {
-        QString res = tr("Creating local sync folder %1...").arg(localFolder);
+        QString res = tr("Creating local sync folder %1 …").arg(localFolder);
         if (fi.mkpath(localFolder)) {
             FileSystem::setFolderMinimumPermissions(localFolder);
             Utility::setupFavLink(localFolder);

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -70,7 +70,7 @@ SelectiveSyncWidget::SelectiveSyncWidget(AccountPtr account, QWidget *parent)
     , _inserting(false)
     , _folderTree(new QTreeWidget(this))
 {
-    _loading = new QLabel(tr("Loading ..."), _folderTree);
+    _loading = new QLabel(tr("Loading …"), _folderTree);
 
     auto layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -625,7 +625,7 @@ void SocketApi::command_GET_STRINGS(const QString &argument, SocketListener *lis
         { "SHARE_MENU_TITLE", tr("Share options") },
         { "CONTEXT_MENU_TITLE", tr("Share via %1").arg(Theme::instance()->appNameGUI())},
         { "COPY_PRIVATE_LINK_MENU_TITLE", tr("Copy private link to clipboard") },
-        { "EMAIL_PRIVATE_LINK_MENU_TITLE", tr("Send private link by email...") },
+        { "EMAIL_PRIVATE_LINK_MENU_TITLE", tr("Send private link by email …") },
     } };
     listener->sendMessage(QString("GET_STRINGS:BEGIN"));
     for (const auto& key_value : strings) {
@@ -673,7 +673,7 @@ void SocketApi::sendSharingContextMenuOptions(const FileData &fileData, SocketLi
 
     // Disabled: only providing email option for private links would look odd,
     // and the copy option is more general.
-    //listener->sendMessage(QLatin1String("MENU_ITEM:EMAIL_PRIVATE_LINK") + flagString + tr("Send private link by email..."));
+    //listener->sendMessage(QLatin1String("MENU_ITEM:EMAIL_PRIVATE_LINK") + flagString + tr("Send private link by email …"));
 }
 
 SocketApi::FileData SocketApi::FileData::get(const QString &localFile)

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -623,7 +623,7 @@ void SocketApi::command_GET_STRINGS(const QString &argument, SocketListener *lis
 {
     static std::array<std::pair<const char *, QString>, 5> strings { {
         { "SHARE_MENU_TITLE", tr("Share options") },
-        { "CONTEXT_MENU_TITLE", tr("Share via ") + Theme::instance()->appNameGUI()},
+        { "CONTEXT_MENU_TITLE", tr("Share via %1").arg(Theme::instance()->appNameGUI())},
         { "COPY_PRIVATE_LINK_MENU_TITLE", tr("Copy private link to clipboard") },
         { "EMAIL_PRIVATE_LINK_MENU_TITLE", tr("Send private link by email...") },
     } };

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -140,7 +140,7 @@ QString OCUpdater::statusString() const
 
     switch (downloadState()) {
     case Downloading:
-        return tr("Downloading version %1. Please wait...").arg(updateVersion);
+        return tr("Downloading version %1. Please wait …").arg(updateVersion);
     case DownloadComplete:
         return tr("%1 version %2 available. Restart application to start the update.").arg(Theme::instance()->appNameGUI(), updateVersion);
     case DownloadFailed:
@@ -150,7 +150,7 @@ QString OCUpdater::statusString() const
     case UpdateOnlyAvailableThroughSystem:
         return tr("New %1 version %2 is available. Please click <a href='%3'>here</a> to download the update.").arg(Theme::instance()->appNameGUI(), updateVersion, _updateInfo.web());
     case CheckingServer:
-        return tr("Checking update server...");
+        return tr("Checking update server …");
     case Unknown:
         return tr("Update status is unknown: Did not check for new updates.");
     case UpToDate:

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -58,7 +58,7 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage()
     setupCustomization();
 
     connect(_ui.pbSelectLocalFolder, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectFolder);
-    setButtonText(QWizard::NextButton, tr("Connect..."));
+    setButtonText(QWizard::NextButton, tr("Connect …"));
 
     connect(_ui.rSyncEverything, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSyncEverythingClicked);
     connect(_ui.rSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -83,7 +83,7 @@ QString Theme::statusHeaderText(SyncResult::Status status) const
         resultStr = QCoreApplication::translate("theme", "Preparing to sync");
         break;
     case SyncResult::SyncAbortRequested:
-        resultStr = QCoreApplication::translate("theme", "Aborting...");
+        resultStr = QCoreApplication::translate("theme", "Aborting …");
         break;
     case SyncResult::Paused:
         resultStr = QCoreApplication::translate("theme", "Sync is paused");


### PR DESCRIPTION
Too many translations fail to keep the trailing space (it's invisible on transifex).

> ![image_2019-11-14_22-29-30](https://user-images.githubusercontent.com/213943/68897761-6efa2a00-072e-11ea-925b-5642d0b0646a.png)

So instead a placeholder is now used.