### PR TITLE
Add timestamp to Mac installer code signing

### DIFF
--- a/admin/osx/create_mac.sh.cmake
+++ b/admin/osx/create_mac.sh.cmake
@@ -49,7 +49,7 @@ fi
 if [ ! -z "$identity" ]; then
 	echo "Will try to sign the installer"
 	pushd $install_path
-	productsign --sign "$identity" "$installer_file" "$installer_file.new"
+	productsign --timestamp --sign "$identity" "$installer_file" "$installer_file.new"
 	mv "$installer_file".new "$installer_file"
 	popd
 else


### PR DESCRIPTION
Use the --timestamp option for 'productsign' to add a secure timestamp.

See: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues