### PR TITLE
Fix remote wipe keychain storage (issue #1592)

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -420,7 +420,7 @@ void WebFlowCredentials::slotFinished(QNetworkReply *reply) {
         _credentialsValid = true;
 
         /// Used later for remote wipe
-        _account->setAppPassword(_password);
+        _account->writeAppPasswordOnce(_password);
     }
 }
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -545,7 +545,7 @@ void Account::retrieveAppPassword(){
     ReadPasswordJob *job = new ReadPasswordJob(Theme::instance()->appName());
     job->setInsecureFallback(false);
     job->setKey(kck);
-    connect(job, &WritePasswordJob::finished, [this](Job *incoming) {
+    connect(job, &ReadPasswordJob::finished, [this](Job *incoming) {
         ReadPasswordJob *readJob = static_cast<ReadPasswordJob *>(incoming);
         QString pwd("");
         // Error or no valid public key error out

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -513,7 +513,10 @@ void Account::setNonShib(bool nonShib)
     }
 }
 
-void Account::setAppPassword(QString appPassword){
+void Account::writeAppPasswordOnce(QString appPassword){
+    if(_wroteAppPassword)
+        return;
+
     const QString kck = AbstractCredentials::keychainKey(
                 url().toString(),
                 davUser() + app_password,
@@ -524,8 +527,10 @@ void Account::setAppPassword(QString appPassword){
     job->setInsecureFallback(false);
     job->setKey(kck);
     job->setBinaryData(appPassword.toLatin1());
-    connect(job, &WritePasswordJob::finished, [](Job *) {
+    connect(job, &WritePasswordJob::finished, [this](Job *) {
         qCInfo(lcAccount) << "appPassword stored in keychain";
+
+        _wroteAppPassword = true;
     });
     job->start();
 }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -243,7 +243,7 @@ public:
 
     /// Used in RemoteWipe
     void retrieveAppPassword();
-    void setAppPassword(QString appPassword);
+    void writeAppPasswordOnce(QString appPassword);
     void deleteAppPassword();
 
 public slots:
@@ -318,6 +318,9 @@ private:
 
     QString _davPath; // defaults to value from theme, might be overwritten in brandings
     ClientSideEncryption _e2e;
+
+    /// Used in RemoteWipe
+    bool _wroteAppPassword = false;
 
     friend class AccountManager;
 };


### PR DESCRIPTION
The app password for the remote wipe was constantly being written in `WebFlowCredentials::slotFinished` to the keychain, leading to unnecessary write and log overhead on the system.

This fix introduces a check to only store the app password once in a lifetime of the Account class. Also the method used to store the password will be renamed from `setAppPassword` to `writeAppPasswordOnce` to be more expressive.

Should solve these issues:
- #1592 
- #1607 
- #1638 
- #1639 