### PR TITLE
Fix copyright year in MacOSXBundleInfo.plist.in for 2019

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -27,7 +27,7 @@
         <key>CFBundleShortVersionString</key>
         <string>@MIRALL_VERSION_STRING@</string>
         <key>NSHumanReadableCopyright</key>
-        <string>(C) 2014-2018 @APPLICATION_VENDOR@</string>
+        <string>(C) 2014-2019 @APPLICATION_VENDOR@</string>
         <key>NSSupportsAutomaticGraphicsSwitching</key>
         <true/>
         <key>SUShowReleaseNotes</key>


### PR DESCRIPTION
Happy new year for Mac too ;)

See PR #1641 

Fixes issue #1541