### PR TITLE
[WIP] Windows: Workaround for storing >= 4k (4096 bit) client-cert SSL keys

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -586,7 +586,7 @@ void WebFlowCredentials::slotReadClientKeyPEMJobDone(QKeychain::Job *incomingJob
         if (_clientSslKey.isNull()) {
             qCWarning(lcWebFlowCredentials) << "Could not load SSL key into Qt!";
         }
-        _clientSslKeyChunkCount = 0;
+        // clear key chunk buffer, but don't set _clientSslKeyChunkCount to zero because we need it for deleteKeychainEntries
         _clientSslKeyChunkBufferPEM.clear();
     }
 

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -432,14 +432,7 @@ void WebFlowCredentials::forgetSensitiveData() {
 
     invalidateToken();
 
-    /* IMPORTANT
-     * TODO: For "Log out" & "Remove account": Remove client CA certs and KEY!
-     *
-     *       Disabled as long as selecting another cert is not supported by the UI.
-     *
-     *       Being able to specify a new certificate is important anyway: expiry etc.
-    */
-    //deleteKeychainEntries();
+    deleteKeychainEntries();
 }
 
 void WebFlowCredentials::setAccount(Account *account) {
@@ -706,19 +699,34 @@ void WebFlowCredentials::deleteKeychainEntries(bool oldKeychainEntries) {
     };
 
     startDeleteJob(_user);
-    startDeleteJob(_user + clientKeyPEMC);
-    startDeleteJob(_user + clientCertificatePEMC);
 
-    for (auto i = 0; i < _clientSslCaCertificates.count(); i++) {
-        startDeleteJob(_user + clientCaCertificatePEMC + QString::number(i));
-    }
+    /* IMPORTANT - remove later - FIXME MS@2019-12-07 -->
+      * TODO: For "Log out" & "Remove account": Remove client CA certs and KEY!
+      *
+      *       Disabled as long as selecting another cert is not supported by the UI.
+      *
+      *       Being able to specify a new certificate is important anyway: expiry etc.
+      *
+      *       We introduce this dirty hack here, to allow deleting them upon Remote Wipe.
+     */
+    if(_account->isRemoteWipeRequested_HACK()) {
+    // <-- FIXME MS@2019-12-07
+        startDeleteJob(_user + clientKeyPEMC);
+        startDeleteJob(_user + clientCertificatePEMC);
+
+        for (auto i = 0; i < _clientSslCaCertificates.count(); i++) {
+            startDeleteJob(_user + clientCaCertificatePEMC + QString::number(i));
+        }
 
 #if defined(Q_OS_WIN)
-    // also delete key sub-chunks (Windows workaround)
-    for (auto i = 1; i < _clientSslKeyChunkCount; i++) {
-        startDeleteJob(_user + clientKeyPEMC + QString(".") + QString::number(i));
-    }
+        // also delete key sub-chunks (Windows workaround)
+        for (auto i = 1; i < _clientSslKeyChunkCount; i++) {
+            startDeleteJob(_user + clientKeyPEMC + QString(".") + QString::number(i));
+        }
 #endif
+    // FIXME MS@2019-12-07 -->
+    }
+    // <-- FIXME MS@2019-12-07
 }
 
 }

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -691,7 +691,7 @@ void WebFlowCredentials::deleteKeychainEntries(bool oldKeychainEntries) {
     auto startDeleteJob = [this, oldKeychainEntries](QString user) {
         DeletePasswordJob *job = new DeletePasswordJob(Theme::instance()->appName());
         addSettingsToJob(_account, job);
-        job->setInsecureFallback(true);
+        job->setInsecureFallback(false);
         job->setKey(keychainKey(_account->url().toString(),
                                 user,
                                 oldKeychainEntries ? QString() : _account->id()));

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -276,7 +276,7 @@ void WebFlowCredentials::writeSingleClientKeyChunkPEM(QKeychain::Job *incomingJo
 #if defined(Q_OS_WIN)
         // Windows workaround: Split the private key into chunks of 2048 bytes,
         // to allow 4k (4096 bit) keys to be saved (obey Windows's limits)
-        auto chunk = _clientSslKeyChunkBufferPEM.left(_clientSslCaKeyChunkSize);
+        auto chunk = _clientSslKeyChunkBufferPEM.left(_clientSslKeyChunkSize);
 
         _clientSslKeyChunkBufferPEM = _clientSslKeyChunkBufferPEM.right(_clientSslKeyChunkBufferPEM.size() - chunk.size());
 #else

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -83,13 +83,27 @@ private:
     void writeSingleClientCaCertPEM();
 
     /*
-     * Since we're limited by Windows limits we just create our own
+     * Since we're limited by Windows limits, we just create our own
      * limit to avoid evil things happening by endless recursion
      *
      * Better than storing the count and relying on maybe-hacked values
      */
     static constexpr int _clientSslCaCertificatesMaxCount = 10;
     QQueue<QSslCertificate> _clientSslCaCertificatesWriteQueue;
+
+    /*
+     * Workaround: ...and this time only on Windows:
+     *
+     * Split the private key into chunks of 2048 bytes,
+     * to allow 4k (4096 bit) keys to be saved (see limits above)
+     */
+    void writeSingleClientCaKeyPEM(QKeychain::Job *incomingJob);
+
+    static constexpr int _clientSslCaKeyChunkSize = 2048;
+    static constexpr int _clientSslCaKeyMaxChunks = 10;
+    QQueue<QByteArray> _clientSslCaKeyWriteQueue;
+    int _clientSslCaKeyChunkCount = 0;
+    QByteArray _clientSslCaKeyReadBuffer;
 
 protected:
     /** Reads data from keychain locations

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -97,13 +97,12 @@ private:
      * Split the private key into chunks of 2048 bytes,
      * to allow 4k (4096 bit) keys to be saved (see limits above)
      */
-    void writeSingleClientCaKeyPEM(QKeychain::Job *incomingJob);
+    void writeSingleClientKeyChunkPEM(QKeychain::Job *incomingJob);
 
-    static constexpr int _clientSslCaKeyChunkSize = 2048;
-    static constexpr int _clientSslCaKeyMaxChunks = 10;
-    QQueue<QByteArray> _clientSslCaKeyWriteQueue;
-    int _clientSslCaKeyChunkCount = 0;
-    QByteArray _clientSslCaKeyReadBuffer;
+    static constexpr int _clientSslKeyChunkSize = 2048;
+    static constexpr int _clientSslKeyMaxChunks = 10;
+    int _clientSslKeyChunkCount = 0;
+    QByteArray _clientSslKeyChunkBufferPEM;
 
 protected:
     /** Reads data from keychain locations

--- a/src/gui/remotewipe.cpp
+++ b/src/gui/remotewipe.cpp
@@ -100,6 +100,18 @@ void RemoteWipe::checkJobSlot()
     auto accountState = manager->account(_account->displayName()).data();
 
     if(wipe){
+        /* IMPORTANT - remove later - FIXME MS@2019-12-07 -->
+         * TODO: For "Log out" & "Remove account": Remove client CA certs and KEY!
+         *
+         *       Disabled as long as selecting another cert is not supported by the UI.
+         *
+         *       Being able to specify a new certificate is important anyway: expiry etc.
+         *
+         *       We introduce this dirty hack here, to allow deleting them upon Remote Wipe.
+         */
+        _account->setRemoteWipeRequested_HACK();
+        // <-- FIXME MS@2019-12-07
+
         // delete account
         manager->deleteAccount(accountState);
         manager->save();

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -323,6 +323,22 @@ private:
     bool _wroteAppPassword = false;
 
     friend class AccountManager;
+
+    /* IMPORTANT - remove later - FIXME MS@2019-12-07 -->
+     * TODO: For "Log out" & "Remove account": Remove client CA certs and KEY!
+     *
+     *       Disabled as long as selecting another cert is not supported by the UI.
+     *
+     *       Being able to specify a new certificate is important anyway: expiry etc.
+     *
+     *       We introduce this dirty hack here, to allow deleting them upon Remote Wipe.
+    */
+    public:
+        void setRemoteWipeRequested_HACK() { _isRemoteWipeRequested_HACK = true; }
+        bool isRemoteWipeRequested_HACK() { return _isRemoteWipeRequested_HACK; }
+    private:
+        bool _isRemoteWipeRequested_HACK = false;
+    // <-- FIXME MS@2019-12-07
 };
 }
 


### PR DESCRIPTION
With QtKeychain on Windows, storing larger keys in one keychain entry causes the following error due to limits in the Windows APIs:
`Error: "Credential size exceeds maximum size of 2560"`

To avoid overhead on the other platforms and balance code duplication, this approach puts some read- and write-parts into Windows-only defines.

For reference also see previous fixes:
- https://github.com/nextcloud/desktop/pull/1389
- https://github.com/nextcloud/desktop/pull/1394

This (again) fixes the re-opened issue:
- https://github.com/nextcloud/desktop/issues/863

Heavily tested on:
- [X] Windows
- [x] Mac
- [x] Linux