### PR TITLE
Fix macOS GUI (Qt 5.12) No. 2 (continuation of #1651)

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -845,7 +845,7 @@ void AccountSettings::showConnectionLabel(const QString &message, QStringList er
         errors.prepend(message);
         QString msg = errors.join(QLatin1String("\n"));
         qCDebug(lcAccountSettings) << msg;
-        Theme::replaceLinkColorStringBackgroundAware(msg, QColor("#bb4d4d"));
+        Theme::replaceLinkColorString(msg, QColor("#c1c8e6"));
         ui->connectLabel->setText(msg);
         ui->connectLabel->setToolTip(QString());
         ui->connectLabel->setStyleSheet(errStyle);

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -109,13 +109,13 @@ protected:
 
 AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     : QWidget(parent)
-    , ui(new Ui::AccountSettings)
+    , _ui(new Ui::AccountSettings)
     , _wasDisabledBefore(false)
     , _accountState(accountState)
     , _quotaInfo(accountState)
     , _menuShown(false)
 {
-    ui->setupUi(this);
+    _ui->setupUi(this);
 
     _model = new FolderStatusModel;
     _model->setAccountState(_accountState);
@@ -126,37 +126,37 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
     connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);
 
-    ui->_folderList->header()->hide();
-    ui->_folderList->setItemDelegate(delegate);
-    ui->_folderList->setModel(_model);
+    _ui->_folderList->header()->hide();
+    _ui->_folderList->setItemDelegate(delegate);
+    _ui->_folderList->setModel(_model);
 #if defined(Q_OS_MAC)
-    ui->_folderList->setMinimumWidth(400);
+    _ui->_folderList->setMinimumWidth(400);
 #else
     ui->_folderList->setMinimumWidth(300);
 #endif
-    new ToolTipUpdater(ui->_folderList);
+    new ToolTipUpdater(_ui->_folderList);
 
     auto mouseCursorChanger = new MouseCursorChanger(this);
-    mouseCursorChanger->folderList = ui->_folderList;
+    mouseCursorChanger->folderList = _ui->_folderList;
     mouseCursorChanger->model = _model;
-    ui->_folderList->setMouseTracking(true);
-    ui->_folderList->setAttribute(Qt::WA_Hover, true);
-    ui->_folderList->installEventFilter(mouseCursorChanger);
+    _ui->_folderList->setMouseTracking(true);
+    _ui->_folderList->setAttribute(Qt::WA_Hover, true);
+    _ui->_folderList->installEventFilter(mouseCursorChanger);
 
     createAccountToolbox();
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, &AccountSettings::slotAccountAdded);
     connect(this, &AccountSettings::removeAccountFolders,
             AccountManager::instance(), &AccountManager::removeAccountFolders);
-    connect(ui->_folderList, &QWidget::customContextMenuRequested,
+    connect(_ui->_folderList, &QWidget::customContextMenuRequested,
         this, &AccountSettings::slotCustomContextMenuRequested);
-    connect(ui->_folderList, &QAbstractItemView::clicked,
+    connect(_ui->_folderList, &QAbstractItemView::clicked,
         this, &AccountSettings::slotFolderListClicked);
-    connect(ui->_folderList, &QTreeView::expanded, this, &AccountSettings::refreshSelectiveSyncStatus);
-    connect(ui->_folderList, &QTreeView::collapsed, this, &AccountSettings::refreshSelectiveSyncStatus);
-    connect(ui->selectiveSyncNotification, &QLabel::linkActivated,
+    connect(_ui->_folderList, &QTreeView::expanded, this, &AccountSettings::refreshSelectiveSyncStatus);
+    connect(_ui->_folderList, &QTreeView::collapsed, this, &AccountSettings::refreshSelectiveSyncStatus);
+    connect(_ui->selectiveSyncNotification, &QLabel::linkActivated,
         this, &AccountSettings::slotLinkActivated);
-    connect(_model, &FolderStatusModel::suggestExpand, ui->_folderList, &QTreeView::expand);
+    connect(_model, &FolderStatusModel::suggestExpand, _ui->_folderList, &QTreeView::expand);
     connect(_model, &FolderStatusModel::dirtyChanged, this, &AccountSettings::refreshSelectiveSyncStatus);
     refreshSelectiveSyncStatus();
     connect(_model, &QAbstractItemModel::rowsInserted,
@@ -173,11 +173,11 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     addAction(syncNowWithRemoteDiscovery);
 
 
-    connect(ui->selectiveSyncApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
-    connect(ui->selectiveSyncCancel, &QAbstractButton::clicked, _model, &FolderStatusModel::resetFolders);
-    connect(ui->bigFolderApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
-    connect(ui->bigFolderSyncAll, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncAllPendingBigFolders);
-    connect(ui->bigFolderSyncNone, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncNoPendingBigFolders);
+    connect(_ui->selectiveSyncApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
+    connect(_ui->selectiveSyncCancel, &QAbstractButton::clicked, _model, &FolderStatusModel::resetFolders);
+    connect(_ui->bigFolderApply, &QAbstractButton::clicked, _model, &FolderStatusModel::slotApplySelectiveSync);
+    connect(_ui->bigFolderSyncAll, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncAllPendingBigFolders);
+    connect(_ui->bigFolderSyncNone, &QAbstractButton::clicked, _model, &FolderStatusModel::slotSyncNoPendingBigFolders);
 
     connect(FolderMan::instance(), &FolderMan::folderListChanged, _model, &FolderStatusModel::resetFolders);
     connect(this, &AccountSettings::folderChanged, _model, &FolderStatusModel::resetFolders);
@@ -185,9 +185,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 
     // quotaProgressBar style now set in customizeStyle()
     /*QColor color = palette().highlight().color();
-     ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));*/
+     _ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));*/
 
-    ui->connectLabel->setText(tr("No account configured."));
+    _ui->connectLabel->setText(tr("No account configured."));
 
     connect(_accountState, &AccountState::stateChanged, this, &AccountSettings::slotAccountStateChanged);
     slotAccountStateChanged();
@@ -204,7 +204,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     {
         slotNewMnemonicGenerated();
     } else {
-        ui->encryptionMessage->hide();
+        _ui->encryptionMessage->hide();
     }
 
     customizeStyle();
@@ -229,9 +229,9 @@ void AccountSettings::createAccountToolbox()
     menu->addAction(action);
     connect(action, &QAction::triggered, this, &AccountSettings::slotDeleteAccount);
 
-    ui->_accountToolbox->setText(tr("Account") + QLatin1Char(' '));
-    ui->_accountToolbox->setMenu(menu);
-    ui->_accountToolbox->setPopupMode(QToolButton::InstantPopup);
+    _ui->_accountToolbox->setText(tr("Account") + QLatin1Char(' '));
+    _ui->_accountToolbox->setMenu(menu);
+    _ui->_accountToolbox->setPopupMode(QToolButton::InstantPopup);
 
     slotAccountAdded(_accountState);
 }
@@ -239,14 +239,14 @@ void AccountSettings::createAccountToolbox()
 
 void AccountSettings::slotNewMnemonicGenerated()
 {
-    ui->encryptionMessage->setText(tr("This account supports end-to-end encryption"));
+    _ui->encryptionMessage->setText(tr("This account supports end-to-end encryption"));
 
     QAction *mnemonic = new QAction(tr("Enable encryption"), this);
     connect(mnemonic, &QAction::triggered, this, &AccountSettings::requesetMnemonic);
-    connect(mnemonic, &QAction::triggered, ui->encryptionMessage, &KMessageWidget::hide);
+    connect(mnemonic, &QAction::triggered, _ui->encryptionMessage, &KMessageWidget::hide);
 
-    ui->encryptionMessage->addAction(mnemonic);
-    ui->encryptionMessage->show();
+    _ui->encryptionMessage->addAction(mnemonic);
+    _ui->encryptionMessage->show();
 }
 
 void AccountSettings::slotMenuBeforeShow() {
@@ -254,7 +254,7 @@ void AccountSettings::slotMenuBeforeShow() {
         return;
     }
 
-    auto menu = ui->_accountToolbox->menu();
+    auto menu = _ui->_accountToolbox->menu();
 
     // We can't check this during the initial creation as there is no account yet then
     if (_accountState->account()->capabilities().clientSideEncryptionAvaliable()) {
@@ -269,7 +269,7 @@ void AccountSettings::slotMenuBeforeShow() {
 
 QString AccountSettings::selectedFolderAlias() const
 {
-    QModelIndex selected = ui->_folderList->selectionModel()->currentIndex();
+    QModelIndex selected = _ui->_folderList->selectionModel()->currentIndex();
     if (!selected.isValid())
         return "";
     return _model->data(selected, FolderStatusDelegate::FolderAliasRole).toString();
@@ -298,7 +298,7 @@ void AccountSettings::slotToggleSignInState()
 
 void AccountSettings::doExpand()
 {
-    ui->_folderList->expandToDepth(0);
+    _ui->_folderList->expandToDepth(0);
 }
 
 void AccountSettings::slotShowMnemonic(const QString &mnemonic) {
@@ -546,7 +546,7 @@ void AccountSettings::slotEditCurrentIgnoredFiles()
 
 void AccountSettings::slotEditCurrentLocalIgnoredFiles()
 {
-    QModelIndex selected = ui->_folderList->selectionModel()->currentIndex();
+    QModelIndex selected = _ui->_folderList->selectionModel()->currentIndex();
     if (!selected.isValid() || _model->classify(selected) != FolderStatusModel::SubFolder)
         return;
     QString fileName = _model->data(selected, FolderStatusDelegate::FolderPathRole).toString();
@@ -618,7 +618,7 @@ void AccountSettings::slotSubfolderContextMenuRequested(const QModelIndex& index
 
 void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
 {
-    QTreeView *tv = ui->_folderList;
+    QTreeView *tv = _ui->_folderList;
     QModelIndex index = tv->indexAt(pos);
     if (!index.isValid()) {
         return;
@@ -649,7 +649,7 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
     ac = menu->addAction(tr("Edit Ignored Files"));
     connect(ac, &QAction::triggered, this, &AccountSettings::slotEditCurrentIgnoredFiles);
 
-    if (!ui->_folderList->isExpanded(index)) {
+    if (!_ui->_folderList->isExpanded(index)) {
         ac = menu->addAction(tr("Choose what to sync"));
         ac->setEnabled(folderConnected);
         connect(ac, &QAction::triggered, this, &AccountSettings::doExpand);
@@ -688,7 +688,7 @@ void AccountSettings::slotFolderListClicked(const QModelIndex &indx)
     }
     if (_model->classify(indx) == FolderStatusModel::RootFolder) {
         // tries to find if we clicked on the '...' button.
-        QTreeView *tv = ui->_folderList;
+        QTreeView *tv = _ui->_folderList;
         auto pos = tv->mapFromGlobal(QCursor::pos());
         if (FolderStatusDelegate::optionsButtonRect(tv->visualRect(indx), layoutDirection()).contains(pos)) {
             slotCustomContextMenuRequested(pos);
@@ -701,8 +701,8 @@ void AccountSettings::slotFolderListClicked(const QModelIndex &indx)
 
         // Expand root items on single click
         if (_accountState && _accountState->state() == AccountState::Connected) {
-            bool expanded = !(ui->_folderList->isExpanded(indx));
-            ui->_folderList->setExpanded(indx, expanded);
+            bool expanded = !(_ui->_folderList->isExpanded(indx));
+            _ui->_folderList->setExpanded(indx, expanded);
         }
     }
 }
@@ -784,7 +784,7 @@ void AccountSettings::slotRemoveCurrentFolder()
 {
     FolderMan *folderMan = FolderMan::instance();
     auto folder = folderMan->folder(selectedFolderAlias());
-    QModelIndex selected = ui->_folderList->selectionModel()->currentIndex();
+    QModelIndex selected = _ui->_folderList->selectionModel()->currentIndex();
     if (selected.isValid() && folder) {
         int row = selected.row();
 
@@ -826,7 +826,7 @@ void AccountSettings::slotOpenCurrentFolder()
 
 void AccountSettings::slotOpenCurrentLocalSubFolder()
 {
-    QModelIndex selected = ui->_folderList->selectionModel()->currentIndex();
+    QModelIndex selected = _ui->_folderList->selectionModel()->currentIndex();
     if (!selected.isValid() || _model->classify(selected) != FolderStatusModel::SubFolder)
         return;
     QString fileName = _model->data(selected, FolderStatusDelegate::FolderPathRole).toString();
@@ -842,19 +842,19 @@ void AccountSettings::showConnectionLabel(const QString &message, QStringList er
     if (errors.isEmpty()) {
         QString msg = message;
         Theme::replaceLinkColorStringBackgroundAware(msg);
-        ui->connectLabel->setText(msg);
-        ui->connectLabel->setToolTip(QString());
-        ui->connectLabel->setStyleSheet(QString());
+        _ui->connectLabel->setText(msg);
+        _ui->connectLabel->setToolTip(QString());
+        _ui->connectLabel->setStyleSheet(QString());
     } else {
         errors.prepend(message);
         QString msg = errors.join(QLatin1String("\n"));
         qCDebug(lcAccountSettings) << msg;
         Theme::replaceLinkColorString(msg, QColor("#c1c8e6"));
-        ui->connectLabel->setText(msg);
-        ui->connectLabel->setToolTip(QString());
-        ui->connectLabel->setStyleSheet(errStyle);
+        _ui->connectLabel->setText(msg);
+        _ui->connectLabel->setToolTip(QString());
+        _ui->connectLabel->setStyleSheet(errStyle);
     }
-    ui->accountStatus->setVisible(!message.isEmpty());
+    _ui->accountStatus->setVisible(!message.isEmpty());
 }
 
 void AccountSettings::slotEnableCurrentFolder()
@@ -952,29 +952,29 @@ void AccountSettings::slotOpenOC()
 void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
 {
     if (total > 0) {
-        ui->quotaProgressBar->setVisible(true);
-        ui->quotaProgressBar->setEnabled(true);
+        _ui->quotaProgressBar->setVisible(true);
+        _ui->quotaProgressBar->setEnabled(true);
         // workaround the label only accepting ints (which may be only 32 bit wide)
         const double percent = used / (double)total * 100;
         const int percentInt = qMin(qRound(percent), 100);
-        ui->quotaProgressBar->setValue(percentInt);
+        _ui->quotaProgressBar->setValue(percentInt);
         QString usedStr = Utility::octetsToString(used);
         QString totalStr = Utility::octetsToString(total);
         QString percentStr = Utility::compactFormatDouble(percent, 1);
         QString toolTip = tr("%1 (%3%) of %2 in use. Some folders, including network mounted or shared folders, might have different limits.").arg(usedStr, totalStr, percentStr);
-        ui->quotaInfoLabel->setText(tr("%1 of %2 in use").arg(usedStr, totalStr));
-        ui->quotaInfoLabel->setToolTip(toolTip);
-        ui->quotaProgressBar->setToolTip(toolTip);
+        _ui->quotaInfoLabel->setText(tr("%1 of %2 in use").arg(usedStr, totalStr));
+        _ui->quotaInfoLabel->setToolTip(toolTip);
+        _ui->quotaProgressBar->setToolTip(toolTip);
     } else {
-        ui->quotaProgressBar->setVisible(false);
-        ui->quotaInfoLabel->setToolTip(QString());
+        _ui->quotaProgressBar->setVisible(false);
+        _ui->quotaInfoLabel->setToolTip(QString());
 
         /* -1 means not computed; -2 means unknown; -3 means unlimited  (#3940)*/
         if (total == 0 || total == -1) {
-            ui->quotaInfoLabel->setText(tr("Currently there is no storage usage information available."));
+            _ui->quotaInfoLabel->setText(tr("Currently there is no storage usage information available."));
         } else {
             QString usedStr = Utility::octetsToString(used);
-            ui->quotaInfoLabel->setText(tr("%1 in use").arg(usedStr));
+            _ui->quotaInfoLabel->setText(tr("%1 in use").arg(usedStr));
         }
     }
 }
@@ -983,7 +983,7 @@ void AccountSettings::slotAccountStateChanged()
 {
     int state = _accountState ? _accountState->state() : AccountState::Disconnected;
     if (_accountState) {
-        ui->sslButton->updateAccountState(_accountState);
+        _ui->sslButton->updateAccountState(_accountState);
         AccountPtr account = _accountState->account();
         QUrl safeUrl(account->url());
         safeUrl.setPassword(QString()); // Remove the password from the URL to avoid showing it in the UI
@@ -1042,14 +1042,14 @@ void AccountSettings::slotAccountStateChanged()
     }
 
     /* Allow to expand the item if the account is connected. */
-    ui->_folderList->setItemsExpandable(state == AccountState::Connected);
+    _ui->_folderList->setItemsExpandable(state == AccountState::Connected);
 
     if (state != AccountState::Connected) {
         /* check if there are expanded root items, if so, close them */
         int i;
         for (i = 0; i < _model->rowCount(); ++i) {
-            if (ui->_folderList->isExpanded(_model->index(i)))
-                ui->_folderList->setExpanded(_model->index(i), false);
+            if (_ui->_folderList->isExpanded(_model->index(i)))
+                _ui->_folderList->setExpanded(_model->index(i), false);
         }
     } else if (_model->isDirty()) {
         // If we connect and have pending changes, show the list.
@@ -1093,21 +1093,21 @@ void AccountSettings::slotLinkActivated(const QString &link)
         // Make sure the folder itself is expanded
         Folder *f = FolderMan::instance()->folder(alias);
         QModelIndex folderIndx = _model->indexForPath(f, QString());
-        if (!ui->_folderList->isExpanded(folderIndx)) {
-            ui->_folderList->setExpanded(folderIndx, true);
+        if (!_ui->_folderList->isExpanded(folderIndx)) {
+            _ui->_folderList->setExpanded(folderIndx, true);
         }
 
         QModelIndex indx = _model->indexForPath(f, myFolder);
         if (indx.isValid()) {
             // make sure all the parents are expanded
             for (auto i = indx.parent(); i.isValid(); i = i.parent()) {
-                if (!ui->_folderList->isExpanded(i)) {
-                    ui->_folderList->setExpanded(i, true);
+                if (!_ui->_folderList->isExpanded(i)) {
+                    _ui->_folderList->setExpanded(i, true);
                 }
             }
-            ui->_folderList->setSelectionMode(QAbstractItemView::SingleSelection);
-            ui->_folderList->setCurrentIndex(indx);
-            ui->_folderList->scrollTo(indx);
+            _ui->_folderList->setSelectionMode(QAbstractItemView::SingleSelection);
+            _ui->_folderList->setCurrentIndex(indx);
+            _ui->_folderList->scrollTo(indx);
         } else {
             qCWarning(lcAccountSettings) << "Unable to find a valid index for " << myFolder;
         }
@@ -1116,7 +1116,7 @@ void AccountSettings::slotLinkActivated(const QString &link)
 
 AccountSettings::~AccountSettings()
 {
-    delete ui;
+    delete _ui;
 }
 
 void AccountSettings::refreshSelectiveSyncStatus()
@@ -1154,8 +1154,8 @@ void AccountSettings::refreshSelectiveSyncStatus()
     }
 
     if (msg.isEmpty()) {
-        ui->selectiveSyncButtons->setVisible(true);
-        ui->bigFolderUi->setVisible(false);
+        _ui->selectiveSyncButtons->setVisible(true);
+        _ui->bigFolderUi->setVisible(false);
     } else {
         ConfigFile cfg;
         QString info = !cfg.confirmExternalStorage()
@@ -1164,27 +1164,27 @@ void AccountSettings::refreshSelectiveSyncStatus()
                 ? tr("There are folders that were not synchronized because they are external storages: ")
                 : tr("There are folders that were not synchronized because they are too big or external storages: ");
 
-        ui->selectiveSyncNotification->setText(info + msg);
-        ui->selectiveSyncButtons->setVisible(false);
-        ui->bigFolderUi->setVisible(true);
+        _ui->selectiveSyncNotification->setText(info + msg);
+        _ui->selectiveSyncButtons->setVisible(false);
+        _ui->bigFolderUi->setVisible(true);
         shouldBeVisible = true;
     }
 
-    ui->selectiveSyncApply->setEnabled(_model->isDirty() || !msg.isEmpty());
-    bool wasVisible = !ui->selectiveSyncStatus->isHidden();
+    _ui->selectiveSyncApply->setEnabled(_model->isDirty() || !msg.isEmpty());
+    bool wasVisible = !_ui->selectiveSyncStatus->isHidden();
     if (wasVisible != shouldBeVisible) {
-        QSize hint = ui->selectiveSyncStatus->sizeHint();
+        QSize hint = _ui->selectiveSyncStatus->sizeHint();
         if (shouldBeVisible) {
-            ui->selectiveSyncStatus->setMaximumHeight(0);
-            ui->selectiveSyncStatus->setVisible(true);
+            _ui->selectiveSyncStatus->setMaximumHeight(0);
+            _ui->selectiveSyncStatus->setVisible(true);
         }
-        auto anim = new QPropertyAnimation(ui->selectiveSyncStatus, "maximumHeight", ui->selectiveSyncStatus);
+        auto anim = new QPropertyAnimation(_ui->selectiveSyncStatus, "maximumHeight", _ui->selectiveSyncStatus);
         anim->setEndValue(shouldBeVisible ? hint.height() : 0);
         anim->start(QAbstractAnimation::DeleteWhenStopped);
         connect(anim, &QPropertyAnimation::finished, [this, shouldBeVisible]() {
-            ui->selectiveSyncStatus->setMaximumHeight(QWIDGETSIZE_MAX);
+            _ui->selectiveSyncStatus->setMaximumHeight(QWIDGETSIZE_MAX);
             if (!shouldBeVisible) {
-                ui->selectiveSyncStatus->hide();
+                _ui->selectiveSyncStatus->hide();
             }
         });
     }
@@ -1244,7 +1244,7 @@ bool AccountSettings::event(QEvent *e)
         // Expand the folder automatically only if there's only one, see #4283
         // The 2 is 1 folder + 1 'add folder' button
         if (_model->rowCount() <= 2) {
-            ui->_folderList->setExpanded(_model->index(0, 0), true);
+            _ui->_folderList->setExpanded(_model->index(0, 0), true);
         }
     }
     return QWidget::event(e);
@@ -1260,12 +1260,12 @@ void AccountSettings::slotStyleChanged()
 
 void AccountSettings::customizeStyle()
 {
-    QString msg = ui->connectLabel->text();
+    QString msg = _ui->connectLabel->text();
     Theme::replaceLinkColorStringBackgroundAware(msg);
-    ui->connectLabel->setText(msg);
+    _ui->connectLabel->setText(msg);
 
     QColor color = palette().highlight().color();
-    ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));
+    _ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));
 }
 
 } // namespace OCC

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -132,7 +132,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 #if defined(Q_OS_MAC)
     _ui->_folderList->setMinimumWidth(400);
 #else
-    ui->_folderList->setMinimumWidth(300);
+    _ui->_folderList->setMinimumWidth(300);
 #endif
     new ToolTipUpdater(_ui->_folderList);
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -123,6 +123,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     FolderStatusDelegate *delegate = new FolderStatusDelegate;
     delegate->setParent(this);
 
+    // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
+    connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);
+
     ui->_folderList->header()->hide();
     ui->_folderList->setItemDelegate(delegate);
     ui->_folderList->setModel(_model);
@@ -180,8 +183,9 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(this, &AccountSettings::folderChanged, _model, &FolderStatusModel::resetFolders);
 
 
-    QColor color = palette().highlight().color();
-    ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));
+    // quotaProgressBar style now set in customizeStyle()
+    /*QColor color = palette().highlight().color();
+     ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));*/
 
     ui->connectLabel->setText(tr("No account configured."));
 
@@ -1249,6 +1253,9 @@ bool AccountSettings::event(QEvent *e)
 void AccountSettings::slotStyleChanged()
 {
     customizeStyle();
+
+    // Notify the other widgets (Dark-/Light-Mode switching)
+    emit styleChanged();
 }
 
 void AccountSettings::customizeStyle()
@@ -1256,6 +1263,9 @@ void AccountSettings::customizeStyle()
     QString msg = ui->connectLabel->text();
     Theme::replaceLinkColorStringBackgroundAware(msg);
     ui->connectLabel->setText(msg);
+
+    QColor color = palette().highlight().color();
+    ui->quotaProgressBar->setStyleSheet(QString::fromLatin1(progressBarStyleC).arg(color.name()));
 }
 
 } // namespace OCC

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -136,7 +136,7 @@ private:
     /// Returns the alias of the selected folder, empty string if none
     QString selectedFolderAlias() const;
 
-    Ui::AccountSettings *ui;
+    Ui::AccountSettings *_ui;
 
     FolderStatusModel *_model;
     QUrl _OCUrl;

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -64,6 +64,7 @@ signals:
     void showIssuesList(AccountState *account);
     void requesetMnemonic();
     void removeAccountFolders(AccountState *account);
+    void styleChanged();
 
 public slots:
     void slotOpenOC();

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -27,6 +27,12 @@
 #include <QPainter>
 #include <QApplication>
 
+#define FIXME_USE_HIGH_DPI_RATIO
+#ifdef FIXME_USE_HIGH_DPI_RATIO
+    // FIXME: Find a better way to calculate the text width on high-dpi displays (Retina).
+    #include <QDesktopWidget>
+#endif
+
 #define HASQT5_11 (QT_VERSION >= QT_VERSION_CHECK(5,11,0))
 
 namespace OCC {
@@ -97,6 +103,11 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     int iconOffset = qRound(fm.height() / 4.0 * 7.0);
     int offset = 4;
     const bool isSelected = (option.state & QStyle::State_Selected);
+#ifdef FIXME_USE_HIGH_DPI_RATIO
+    // FIXME: Find a better way to calculate the text width on high-dpi displays (Retina).
+    const int device_pixel_ration = QApplication::desktop()->devicePixelRatio();
+    int pixel_ratio = (device_pixel_ration > 1 ? device_pixel_ration : 1);
+#endif
 
     // get the data
     Activity::Type activityType = qvariant_cast<Activity::Type>(index.data(ActionRole));
@@ -134,6 +145,10 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     actionTextBox.setTop(option.rect.top() + margin + offset/2);
     actionTextBox.setHeight(fm.height());
     actionTextBox.setLeft(actionIconRect.right() + margin);
+#ifdef FIXME_USE_HIGH_DPI_RATIO
+    // FIXME: Find a better way to calculate the text width on high-dpi displays (Retina).
+    actionTextBoxWidth *= pixel_ratio;
+#endif
     actionTextBox.setRight(actionTextBox.left() + actionTextBoxWidth + margin);
 
     // message text rect
@@ -167,6 +182,10 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     timeBox.setTop(timeTop);
     timeBox.setHeight(fm.height());
     timeBox.setBottom(timeBox.top() + fm.height());
+#ifdef FIXME_USE_HIGH_DPI_RATIO
+    // FIXME: Find a better way to calculate the text width on high-dpi displays (Retina).
+    timeTextWidth *= pixel_ratio;
+#endif
     timeBox.setRight(timeBox.left() + timeTextWidth + margin);
 
     // buttons - default values

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -156,9 +156,8 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     // time box rect
     QRect timeBox = messageTextBox;
-    QString timeStr = tr("%1").arg(timeText);
 #if (HASQT5_11)
-    int timeTextWidth = fm.horizontalAdvance(timeStr);
+    int timeTextWidth = fm.horizontalAdvance(timeText);
 #else
     int timeTextWidth = fm.width(timeStr);
 #endif
@@ -315,7 +314,7 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         painter->setPen(p.color(QPalette::Disabled, QPalette::Text));
 
     // draw the time
-    const QString elidedTime = fm.elidedText(timeStr, Qt::ElideRight, spaceLeftForText);
+    const QString elidedTime = fm.elidedText(timeText, Qt::ElideRight, spaceLeftForText);
     painter->drawText(timeBox, elidedTime);
 
     painter->restore();

--- a/src/gui/activityitemdelegate.cpp
+++ b/src/gui/activityitemdelegate.cpp
@@ -174,7 +174,7 @@ void ActivityItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 #if (HASQT5_11)
     int timeTextWidth = fm.horizontalAdvance(timeText);
 #else
-    int timeTextWidth = fm.width(timeStr);
+    int timeTextWidth = fm.width(timeText);
 #endif
     int timeTop = option.rect.top() + fm.height() + fm.height() + margin + offset/2;
     if(messageText.isEmpty() || actionText.isEmpty())

--- a/src/gui/activityitemdelegate.h
+++ b/src/gui/activityitemdelegate.h
@@ -43,6 +43,8 @@ public:
         AccountConnectedRole,
         SyncFileStatusRole };
 
+    ActivityItemDelegate();
+
     void paint(QPainter *, const QStyleOptionViewItem &, const QModelIndex &) const override;
     QSize sizeHint(const QStyleOptionViewItem &, const QModelIndex &) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option,
@@ -51,11 +53,16 @@ public:
     static int rowHeight();
     static int iconHeight();
 
+public slots:
+    void slotStyleChanged();
+
 signals:
     void primaryButtonClickedOnItemView(const QModelIndex &index);
     void secondaryButtonClickedOnItemView(const QModelIndex &index);
 
 private:
+    void customizeStyle();
+
     static int _margin;
     static int _iconHeight;
     static int _primaryButtonWidth;
@@ -65,6 +72,23 @@ private:
     static int _buttonHeight;
     static const QString _remote_share;
     static const QString _call;
+
+    QIcon _iconClose;
+    QIcon _iconClose_sel;
+    QIcon _iconMore;
+    QIcon _iconMore_sel;
+
+    QIcon _iconFolder;
+
+    QIcon _iconActivity;
+    QIcon _iconActivity_sel;
+    QIcon _iconBell;
+    QIcon _iconBell_sel;
+
+    QIcon _iconStateError;
+    QIcon _iconStateWarning;
+    QIcon _iconStateInfo;
+    QIcon _iconStateSync;
 };
 
 } // namespace OCC

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -109,39 +109,30 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
                }
         } else {
             actionIcon.iconType = ActivityIconType::iconActivity;
-               }
+        }
         QVariant icn;
         icn.setValue(actionIcon);
         return icn;
-        }
-        break;
+    }
     case ActivityItemDelegate::ObjectTypeRole:
         return a._objectType;
-        break;
     case ActivityItemDelegate::ActionRole:{
         QVariant type;
         type.setValue(a._type);
         return type;
-        break;
     }
     case ActivityItemDelegate::ActionTextRole:
         return a._subject;
-        break;
     case ActivityItemDelegate::MessageRole:
         return a._message;
-        break;
     case ActivityItemDelegate::LinkRole:
         return a._link;
-        break;
     case ActivityItemDelegate::AccountRole:
         return a._accName;
-        break;
     case ActivityItemDelegate::PointInTimeRole:
         return Utility::timeAgoInWords(a._dateTime);
-        break;
     case ActivityItemDelegate::AccountConnectedRole:
         return (ast && ast->isConnected());
-        break;
     default:
         return QVariant();
     }
@@ -266,7 +257,7 @@ void ActivityListModel::clearNotifications() {
 }
 
 void ActivityListModel::removeActivityFromActivityList(int row) {
-    Activity activity =  _finalList.at(row);
+    Activity activity = _finalList.at(row);
     removeActivityFromActivityList(activity);
     combineActivityLists();
 }

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -79,31 +79,41 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         }
         return customList;
     }
-    case ActivityItemDelegate::ActionIconRole:
+    case ActivityItemDelegate::ActionIconRole:{
+        ActionIcon actionIcon;
         if(a._type == Activity::NotificationType){
            QIcon cachedIcon = ServerNotificationHandler::iconCache.value(a._id);
-           if(!cachedIcon.isNull())
-               return cachedIcon;
-           else return QIcon(QLatin1String(":/client/resources/bell.svg"));
+            if(!cachedIcon.isNull()) {
+               actionIcon.iconType = ActivityIconType::iconUseCached;
+               actionIcon.cachedIcon = cachedIcon;
+            } else {
+                actionIcon.iconType = ActivityIconType::iconBell;
+            }
         } else if(a._type == Activity::SyncResultType){
-            return QIcon(QLatin1String(":/client/resources/state-error.svg"));
+            actionIcon.iconType = ActivityIconType::iconStateError;
         } else if(a._type == Activity::SyncFileItemType){
                if(a._status == SyncFileItem::NormalError
                    || a._status == SyncFileItem::FatalError
                    || a._status == SyncFileItem::DetailError
                    || a._status == SyncFileItem::BlacklistedError) {
-                   return QIcon(QLatin1String(":/client/resources/state-error.svg"));
+                   actionIcon.iconType = ActivityIconType::iconStateError;
                } else if(a._status == SyncFileItem::SoftError
                          || a._status == SyncFileItem::Conflict
                          || a._status == SyncFileItem::Restoration
                          || a._status == SyncFileItem::FileLocked){
-                   return QIcon(QLatin1String(":/client/resources/state-warning.svg"));
+                   actionIcon.iconType = ActivityIconType::iconStateWarning;
                } else if(a._status == SyncFileItem::FileIgnored){
-                   return QIcon(QLatin1String(":/client/resources/state-info.svg"));
+                   actionIcon.iconType = ActivityIconType::iconStateInfo;
+               } else {
+                   actionIcon.iconType = ActivityIconType::iconStateSync;
                }
-               return QIcon(QLatin1String(":/client/resources/state-sync.svg"));
+        } else {
+            actionIcon.iconType = ActivityIconType::iconActivity;
+               }
+        QVariant icn;
+        icn.setValue(actionIcon);
+        return icn;
         }
-        return QIcon(QLatin1String(":/client/resources/activity.png"));
         break;
     case ActivityItemDelegate::ObjectTypeRole:
         return a._objectType;

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -99,6 +99,6 @@ private:
 };
 }
 
-Q_DECLARE_METATYPE(OCC::ActivityListModel::ActionIcon);
+Q_DECLARE_METATYPE(OCC::ActivityListModel::ActionIcon)
 
 #endif // ACTIVITYLISTMODEL_H

--- a/src/gui/activitylistmodel.h
+++ b/src/gui/activitylistmodel.h
@@ -38,6 +38,20 @@ class ActivityListModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
+    enum ActivityIconType {
+        iconUseCached = 0,
+        iconActivity,
+        iconBell,
+        iconStateError,
+        iconStateWarning,
+        iconStateInfo,
+        iconStateSync
+    };
+    struct ActionIcon {
+        ActivityIconType iconType;
+        QIcon cachedIcon;
+    };
+
     explicit ActivityListModel(AccountState *accountState, QWidget *parent = nullptr);
 
     QVariant data(const QModelIndex &index, int role) const override;
@@ -84,4 +98,7 @@ private:
     int _currentItem = 0;
 };
 }
+
+Q_DECLARE_METATYPE(OCC::ActivityListModel::ActionIcon);
+
 #endif // ACTIVITYLISTMODEL_H

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -643,6 +643,9 @@ ActivitySettings::~ActivitySettings()
 
 void ActivitySettings::slotStyleChanged()
 {
+    if(_progressIndicator)
+        _progressIndicator->setColor(QGuiApplication::palette().color(QPalette::Text));
+
     // Notify the other widgets (Dark-/Light-Mode switching)
     emit styleChanged();
 }

--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -89,6 +89,9 @@ ActivityWidget::ActivityWidget(AccountState *accountState, QWidget *parent)
         this, &ActivityWidget::addError);
 
     _removeTimer.setInterval(1000);
+
+    // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
+    connect(this, &ActivityWidget::styleChanged, delegate, &ActivityItemDelegate::slotStyleChanged);
 }
 
 ActivityWidget::~ActivityWidget()
@@ -548,6 +551,12 @@ void ActivityWidget::slotNotifyServerFinished(const QString &reply, int replyCod
     qCInfo(lcActivity) << "Server Notification reply code" << replyCode << reply;
 }
 
+void ActivityWidget::slotStyleChanged()
+{
+    // Notify the other widgets (Dark-/Light-Mode switching)
+    emit styleChanged();
+}
+
 /* ==================================================================== */
 
 ActivitySettings::ActivitySettings(AccountState *accountState, QWidget *parent)
@@ -570,6 +579,9 @@ ActivitySettings::ActivitySettings(AccountState *accountState, QWidget *parent)
     // connect a model signal to stop the animation
     connect(_activityWidget, &ActivityWidget::rowsInserted, _progressIndicator, &QProgressIndicator::stopAnimation);
     connect(_activityWidget, &ActivityWidget::rowsInserted, this, &ActivitySettings::slotDisplayActivities);
+
+    // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
+    connect(this, &ActivitySettings::styleChanged, _activityWidget, &ActivityWidget::slotStyleChanged);
 }
 
 void ActivitySettings::slotDisplayActivities(){
@@ -628,4 +640,11 @@ bool ActivitySettings::event(QEvent *e)
 ActivitySettings::~ActivitySettings()
 {
 }
+
+void ActivitySettings::slotStyleChanged()
+{
+    // Notify the other widgets (Dark-/Light-Mode switching)
+    emit styleChanged();
+}
+
 }

--- a/src/gui/activitywidget.h
+++ b/src/gui/activitywidget.h
@@ -78,12 +78,14 @@ public slots:
     void addError(const QString &folderAlias, const QString &message, ErrorCategory category);
     void slotProgressInfo(const QString &folder, const ProgressInfo &progress);
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);
+    void slotStyleChanged();
 
 signals:
     void guiLog(const QString &, const QString &);
     void rowsInserted();
     void hideActivityTab(bool);
     void sendNotificationRequest(const QString &accountName, const QString &link, const QByteArray &verb, int row);
+    void styleChanged();
 
 private slots:
     void slotBuildNotificationDisplay(const ActivityList &list);
@@ -96,6 +98,7 @@ private slots:
     void slotSecondaryButtonClickedOnListView(const QModelIndex &index);
 
 private:
+    void customizeStyle();
     void showLabels();
     QString timeString(QDateTime dt, QLocale::FormatType format) const;
     Ui::ActivityWidget *_ui;
@@ -137,6 +140,7 @@ public slots:
     void slotRefresh();
     void slotRemoveAccount();
     void setNotificationRefreshInterval(std::chrono::milliseconds interval);
+    void slotStyleChanged();
 
 private slots:
     void slotRegularNotificationCheck();
@@ -144,6 +148,7 @@ private slots:
 
 signals:
     void guiLog(const QString &, const QString &);
+    void styleChanged();
 
 private:
     bool event(QEvent *e) override;

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -40,7 +40,7 @@ namespace OCC {
 FolderStatusDelegate::FolderStatusDelegate()
     : QStyledItemDelegate()
 {
-    m_moreIcon = QIcon(QLatin1String(":/client/resources/more.svg"));
+    customizeStyle();
 }
 
 QString FolderStatusDelegate::addFolderText()
@@ -349,7 +349,7 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         btnOpt.arrowType = Qt::NoArrow;
         btnOpt.subControls = QStyle::SC_ToolButton;
         btnOpt.rect = optionsButtonVisualRect;
-        btnOpt.icon = m_moreIcon;
+        btnOpt.icon = _iconMore;
         int e = QApplication::style()->pixelMetric(QStyle::PM_ButtonIconSize);
         btnOpt.iconSize = QSize(e,e);
         QApplication::style()->drawComplexControl(QStyle::CC_ToolButton, &btnOpt, painter);
@@ -423,5 +423,14 @@ QRect FolderStatusDelegate::errorsListRect(QRect within)
     return within;
 }
 
+void FolderStatusDelegate::slotStyleChanged()
+{
+    customizeStyle();
+}
+
+void FolderStatusDelegate::customizeStyle()
+{
+    _iconMore = Theme::createColorAwareIcon(QLatin1String(":/client/resources/more.svg"));
+}
 
 } // namespace OCC

--- a/src/gui/folderstatusdelegate.h
+++ b/src/gui/folderstatusdelegate.h
@@ -26,7 +26,6 @@ class FolderStatusDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 public:
-    QIcon m_moreIcon;
     FolderStatusDelegate();
 
     enum datarole { FolderAliasRole = Qt::UserRole + 100,
@@ -62,9 +61,16 @@ public:
     static QRect errorsListRect(QRect within);
     static int rootFolderHeightWithoutErrors(const QFontMetrics &fm, const QFontMetrics &aliasFm);
 
+public slots:
+    void slotStyleChanged();
+
 private:
+    void customizeStyle();
+
     static QString addFolderText();
     QPersistentModelIndex _pressedIndex;
+
+    QIcon _iconMore;
 };
 
 } // namespace OCC

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -254,9 +254,6 @@ void SettingsDialog::accountAdded(AccountState *s)
     _actionGroupWidgets.insert(accountAction, accountSettings);
     _actionForAccount.insert(s->account().data(), accountAction);
     accountAction->trigger();
-    
-    // Connect styleChanged event, to adapt (Dark-/Light-Mode switching)
-    connect(this, &SettingsDialog::styleChanged, accountSettings, &AccountSettings::slotStyleChanged);
 
     connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotFoldersChanged);
     connect(accountSettings, &AccountSettings::openFolderAlias,
@@ -267,6 +264,10 @@ void SettingsDialog::accountAdded(AccountState *s)
 
     // Refresh immediatly when getting online
     connect(s, &AccountState::isConnectedChanged, this, &SettingsDialog::slotRefreshActivityAccountStateSender);
+
+    // Connect styleChanged event, to adapt (Dark-/Light-Mode switching)
+    connect(this, &SettingsDialog::styleChanged, accountSettings, &AccountSettings::slotStyleChanged);
+    connect(this, &SettingsDialog::styleChanged, _activitySettings[s], &ActivitySettings::slotStyleChanged);
 
     activityAdded(s);
     slotRefreshActivity(s);

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -573,6 +573,8 @@ void ShareLinkWidget::customizeStyle()
     _ui->confirmNote->setIcon(Theme::createColorAwareIcon(":/client/resources/confirm.svg"));
     _ui->confirmPassword->setIcon(Theme::createColorAwareIcon(":/client/resources/confirm.svg"));
     _ui->confirmExpirationDate->setIcon(Theme::createColorAwareIcon(":/client/resources/confirm.svg"));
+
+    _ui->progressIndicator->setColor(QGuiApplication::palette().color(QPalette::Text));
 }
 
 }

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -380,6 +380,12 @@ void ShareUserGroupWidget::slotStyleChanged()
 void ShareUserGroupWidget::customizeStyle()
 {
     _ui->confirmShare->setIcon(Theme::createColorAwareIcon(":/client/resources/confirm.svg"));
+
+    _pi_sharee.setColor(QGuiApplication::palette().color(QPalette::Text));
+
+    foreach (auto pi, _parentScrollArea->findChildren<QProgressIndicator *>()) {
+        pi->setColor(QGuiApplication::palette().color(QPalette::Text));;
+    }
 }
 
 ShareUserLine::ShareUserLine(QSharedPointer<Share> share,

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -396,6 +396,8 @@ void OwncloudAdvancedSetupPage::slotStyleChanged()
 
 void OwncloudAdvancedSetupPage::customizeStyle()
 {
+    if(_progressIndi)
+        _progressIndi->setColor(QGuiApplication::palette().color(QPalette::Text));
 }
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -389,4 +389,13 @@ QString OwncloudAdvancedSetupPage::checkLocalSpace(qint64 remoteSize) const
     return (availableLocalSpace()>remoteSize) ? QString() : tr("There isn't enough free space in the local folder!");
 }
 
+void OwncloudAdvancedSetupPage::slotStyleChanged()
+{
+    customizeStyle();
+}
+
+void OwncloudAdvancedSetupPage::customizeStyle()
+{
+}
+
 } // namespace OCC

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -51,6 +51,7 @@ signals:
 
 public slots:
     void setErrorString(const QString &);
+    void slotStyleChanged();
 
 private slots:
     void slotSelectFolder();
@@ -67,6 +68,7 @@ private:
     QUrl serverUrl() const;
     qint64 availableLocalSpace() const;
     QString checkLocalSpace(qint64 remoteSize) const;
+    void customizeStyle();
 
     Ui_OwncloudAdvancedSetupPage _ui;
     bool _checking;

--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -194,5 +194,13 @@ AbstractCredentials *OwncloudHttpCredsPage::getCredentials() const
     return new HttpCredentialsGui(_ui.leUsername->text(), _ui.lePassword->text(), _ocWizard->_clientSslCertificate, _ocWizard->_clientSslKey);
 }
 
+void OwncloudHttpCredsPage::slotStyleChanged()
+{
+    customizeStyle();
+}
+
+void OwncloudHttpCredsPage::customizeStyle()
+{
+}
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -201,6 +201,8 @@ void OwncloudHttpCredsPage::slotStyleChanged()
 
 void OwncloudHttpCredsPage::customizeStyle()
 {
+    if(_progressIndi)
+        _progressIndi->setColor(QGuiApplication::palette().color(QPalette::Text));
 }
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudhttpcredspage.h
+++ b/src/gui/wizard/owncloudhttpcredspage.h
@@ -46,10 +46,14 @@ public:
 Q_SIGNALS:
     void connectToOCUrl(const QString &);
 
+public slots:
+    void slotStyleChanged();
+
 private:
     void startSpinner();
     void stopSpinner();
     void setupCustomization();
+    void customizeStyle();
 
     Ui_OwncloudHttpCredsPage _ui;
     bool _connected;

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -89,29 +89,15 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     connect(_ui.nextButton, &QPushButton::clicked, _ui.slideShow, &SlideShow::nextSlide);
     connect(_ui.prevButton, &QPushButton::clicked, _ui.slideShow, &SlideShow::prevSlide);
 
-	auto widgetBgLightness = OwncloudSetupPage::palette().color(OwncloudSetupPage::backgroundRole()).lightness();
-	bool widgetHasDarkBg =
-        (widgetBgLightness >= 125)
-        ? false
-        : true;
-	_ui.nextButton->setIcon(theme->uiThemeIcon(QString("control-next.svg"), widgetHasDarkBg));
-    _ui.prevButton->setIcon(theme->uiThemeIcon(QString("control-prev.svg"), widgetHasDarkBg));
-
-	// QPushButtons are a mess when it comes to consistent background coloring without stylesheets,
-	// so we do it here even though this is an exceptional styling method here
-    _ui.createAccountButton->setStyleSheet("QPushButton {background-color: #0082C9; color: white}");
-
     _ui.slideShow->startShow();
-
-    QPalette pal = _ui.slideShow->palette();
-    pal.setColor(QPalette::WindowText, theme->wizardHeaderBackgroundColor());
-    _ui.slideShow->setPalette(pal);
 #else
     _ui.createAccountButton->hide();
     _ui.loginButton->hide();
     _ui.installLink->hide();
     _ui.slideShow->hide();
 #endif
+
+    customizeStyle();
 }
 
 void OwncloudSetupPage::setServerUrl(const QString &newUrl)
@@ -432,6 +418,30 @@ void OwncloudSetupPage::slotCertificateAccepted()
 
 OwncloudSetupPage::~OwncloudSetupPage()
 {
+}
+
+void OwncloudSetupPage::slotStyleChanged()
+{
+    customizeStyle();
+}
+
+void OwncloudSetupPage::customizeStyle()
+{
+#ifdef WITH_PROVIDERS
+    Theme *theme = Theme::instance();
+
+    bool widgetHasDarkBg = Theme::isDarkColor(QGuiApplication::palette().base().color());
+    _ui.nextButton->setIcon(theme->uiThemeIcon(QString("control-next.svg"), widgetHasDarkBg));
+    _ui.prevButton->setIcon(theme->uiThemeIcon(QString("control-prev.svg"), widgetHasDarkBg));
+
+    // QPushButtons are a mess when it comes to consistent background coloring without stylesheets,
+    // so we do it here even though this is an exceptional styling method here
+    _ui.createAccountButton->setStyleSheet("QPushButton {background-color: #0082C9; color: white}");
+
+    QPalette pal = _ui.slideShow->palette();
+    pal.setColor(QPalette::WindowText, theme->wizardHeaderBackgroundColor());
+    _ui.slideShow->setPalette(pal);
+#endif
 }
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -442,6 +442,9 @@ void OwncloudSetupPage::customizeStyle()
     pal.setColor(QPalette::WindowText, theme->wizardHeaderBackgroundColor());
     _ui.slideShow->setPalette(pal);
 #endif
+
+    if(_progressIndi)
+        _progressIndi->setColor(QGuiApplication::palette().color(QPalette::Text));
 }
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -62,6 +62,7 @@ public slots:
     void startSpinner();
     void stopSpinner();
     void slotCertificateAccepted();
+    void slotStyleChanged();
 
 protected slots:
     void slotUrlChanged(const QString &);
@@ -78,6 +79,7 @@ signals:
 
 private:
     bool urlHasChanged();
+    void customizeStyle();
 
     Ui_OwncloudSetupPage _ui;
 

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -100,6 +100,13 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     setTitleFormat(Qt::RichText);
     setSubTitleFormat(Qt::RichText);
     setButtonText(QWizard::CustomButton1, tr("Skip folders configuration"));
+
+
+    // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
+    connect(this, &OwncloudWizard::styleChanged, _setupPage, &OwncloudSetupPage::slotStyleChanged);
+    connect(this, &OwncloudWizard::styleChanged, _advancedSetupPage, &OwncloudAdvancedSetupPage::slotStyleChanged);
+
+    customizeStyle();
 }
 
 void OwncloudWizard::setAccount(AccountPtr account)
@@ -275,6 +282,29 @@ AbstractCredentials *OwncloudWizard::getCredentials() const
     }
 
     return nullptr;
+}
+
+void OwncloudWizard::changeEvent(QEvent *e)
+{
+    switch (e->type()) {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::ThemeChange:
+        customizeStyle();
+
+        // Notify the other widgets (Dark-/Light-Mode switching)
+        emit styleChanged();
+        break;
+    default:
+        break;
+    }
+
+    QWizard::changeEvent(e);
+}
+
+void OwncloudWizard::customizeStyle()
+{
+    // HINT: Customize wizard's own style here, if necessary in the future (Dark-/Light-Mode switching)
 }
 
 } // end namespace

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -96,8 +96,14 @@ signals:
     void basicSetupFinished(int);
     void skipFolderConfiguration();
     void needCertificate();
+    void styleChanged();
+
+protected:
+    void changeEvent(QEvent *) override;
 
 private:
+    void customizeStyle();
+
     AccountPtr _account;
     OwncloudSetupPage *_setupPage;
     OwncloudHttpCredsPage *_httpCredsPage;

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -574,7 +574,7 @@ bool Theme::isDarkColor(const QColor &color)
 
 QColor Theme::getBackgroundAwareLinkColor(const QColor &backgroundColor)
 {
-    return QColor((isDarkColor(backgroundColor) ? QColor("#aabdff") : QGuiApplication::palette().color(QPalette::Link)));
+    return QColor((isDarkColor(backgroundColor) ? QColor("#6193dc") : QGuiApplication::palette().color(QPalette::Link)));
 }
 
 QColor Theme::getBackgroundAwareLinkColor()

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -584,12 +584,17 @@ QColor Theme::getBackgroundAwareLinkColor()
 
 void Theme::replaceLinkColorStringBackgroundAware(QString &linkString, const QColor &backgroundColor)
 {
-    linkString.replace(QRegularExpression("(<a href|<a style='color:#([a-zA-Z0-9]{6});' href)"), QString::fromLatin1("<a style='color:%1;' href").arg(getBackgroundAwareLinkColor(backgroundColor).name()));
+    replaceLinkColorString(linkString, getBackgroundAwareLinkColor(backgroundColor));
 }
 
 void Theme::replaceLinkColorStringBackgroundAware(QString &linkString)
 {
     replaceLinkColorStringBackgroundAware(linkString, QGuiApplication::palette().color(QPalette::Base));
+}
+
+void Theme::replaceLinkColorString(QString &linkString, const QColor &newColor)
+{
+    linkString.replace(QRegularExpression("(<a href|<a style='color:#([a-zA-Z0-9]{6});' href)"), QString::fromLatin1("<a style='color:%1;' href").arg(newColor.name()));
 }
 
 QIcon Theme::createColorAwareIcon(const QString &name, const QPalette &palette)

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -403,6 +403,15 @@ public:
     static void replaceLinkColorStringBackgroundAware(QString &linkString);
 
     /**
+     * @brief Appends a CSS-style colour value to all HTML link tags in a given string, as specified by newColor.
+     *
+     * 2019/12/19: Implemented for the Dark Mode on macOS, because the app palette can not account for that (Qt 5.12.5).
+     *
+     * This way we also avoid having certain strings re-translated on Transifex.
+     */
+    static void replaceLinkColorString(QString &linkString, const QColor &newColor);
+
+    /**
      * @brief Creates a colour-aware icon based on the specified palette's base colour.
      *
      * @return QIcon, colour-aware (inverted on dark backgrounds).


### PR DESCRIPTION
- Adjust error link colour in `AccountSettings::showConnectionLabel` to ease readability

- Dark-/Light-Mode switching: 
  - Make `AccountSettings` and `ActivitySettings` background-aware

  - Make `ActivityItemDelegate` background- and **selection**-aware
    - Also implement cached member icons in `ActivityListModel` and return their `enum`'s to
    `ActivityItemDelegate` instead of always recreating them for each call to `paint()`.

  - Make `OwncloudWizard` and its pages background-aware
  - Make all `ProgressIndicator`'s background-aware
- Mac and high-dpi displays: Add workaround in `ActivityItemDelegate` to show full uncropped activity's `actionText` and `timeText`
- Change Dark Mode link colour
- Some refactoring