### PR TITLE
Show date and time in activity log (fixes issue #1683)

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -130,7 +130,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case ActivityItemDelegate::AccountRole:
         return a._accName;
     case ActivityItemDelegate::PointInTimeRole:
-        return Utility::timeAgoInWords(a._dateTime);
+        return QString("%1 (%2)").arg(a._dateTime.toLocalTime().toString(Qt::DefaultLocaleShortDate), Utility::timeAgoInWords(a._dateTime.toLocalTime()));
     case ActivityItemDelegate::AccountConnectedRole:
         return (ast && ast->isConnected());
     default:


### PR DESCRIPTION
Adds date and time to the activity log entries:
<img width="805" alt="Screenshot 2019-12-19 at 04 50 37" src="https://user-images.githubusercontent.com/48932272/71209835-d1ee5c00-22ac-11ea-83a4-acdb270ef62e.png">

Takes the local timezone and format into account.

This fixes issue #1683.