### PR TITLE
Activity List: Fix crash and folder opening

### DIFF
--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -64,11 +64,18 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case ActivityItemDelegate::PathRole:
         if(!a._file.isEmpty()){
             auto folder = FolderMan::instance()->folder(a._folder);
-            if(!folder)
-                return QVariant();
-            list = FolderMan::instance()->findFileInLocalFolders(folder->remotePath(), ast->account());
+            QString relPath(a._file);
+            if(folder) relPath.prepend(folder->remotePath());
+            list = FolderMan::instance()->findFileInLocalFolders(relPath, ast->account());
             if (list.count() > 0) {
                 return QVariant(list.at(0));
+            }
+            // File does not exist anymore? Let's try to open its path
+            if(QFileInfo(relPath).exists()) {
+                list = FolderMan::instance()->findFileInLocalFolders(QFileInfo(relPath).path(), ast->account());
+                if (list.count() > 0) {
+                    return QVariant(list.at(0));
+                }
             }
         }
         return QVariant();

--- a/src/gui/activitylistmodel.cpp
+++ b/src/gui/activitylistmodel.cpp
@@ -64,6 +64,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case ActivityItemDelegate::PathRole:
         if(!a._file.isEmpty()){
             auto folder = FolderMan::instance()->folder(a._folder);
+            if(!folder)
+                return QVariant();
             list = FolderMan::instance()->findFileInLocalFolders(folder->remotePath(), ast->account());
             if (list.count() > 0) {
                 return QVariant(list.at(0));


### PR DESCRIPTION
- Fixes a crash when double-clicking on Activity list rows (#1693).

- After fixing the crash in the previous commit, double-clicking on Activity list rows still didn't work.

  This fix partly reverts commit 8546d53 in `ActivityItemDelegate::PathRole` of `ActivityListModel::data`, but adds a new check for `relPath`'s existence in line 74.

  I'm assuming the previous change there has been done to shorten the code and avoid opening the user's home folder upon clicking entries which file value is "`App Password`". The new path-check takes care of that too now.