### PR TITLE
Heavy refactoring: Windows workaround for >= 4k (4096 bit) client-cert SSL keys and large certs

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -109,6 +109,7 @@ set(client_SRCS
     creds/httpcredentialsgui.cpp
     creds/oauth.cpp
     creds/flow2auth.cpp
+    creds/keychainchunk.cpp
     creds/webflowcredentials.cpp
     creds/webflowcredentialsdialog.cpp
     wizard/postfixlineedit.cpp

--- a/src/gui/creds/keychainchunk.cpp
+++ b/src/gui/creds/keychainchunk.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) by Michael Schuster <michael@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "account.h"
+#include "keychainchunk.h"
+#include "theme.h"
+#include "networkjobs.h"
+#include "configfile.h"
+#include "creds/abstractcredentials.h"
+
+using namespace QKeychain;
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcKeychainChunk, "nextcloud.sync.credentials.keychainchunk", QtInfoMsg)
+
+namespace KeychainChunk {
+
+#if defined(KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK)
+static void addSettingsToJob(Account *account, QKeychain::Job *job)
+{
+    Q_UNUSED(account)
+    auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
+    settings->setParent(job); // make the job parent to make setting deleted properly
+    job->setSettings(settings.release());
+}
+#endif
+
+/*
+* Job
+*/
+Job::Job(QObject *parent)
+    : QObject(parent)
+{
+    _serviceName = Theme::instance()->appName();
+}
+
+/*
+* WriteJob
+*/
+WriteJob::WriteJob(Account *account, const QString &key, const QByteArray &data, QObject *parent)
+    : Job(parent)
+{
+    _account = account;
+    _key = key;
+
+    // Windows workaround: Split the private key into chunks of 2048 bytes,
+    // to allow 4k (4096 bit) keys to be saved (obey Windows's limits)
+    _chunkBuffer = data;
+    _chunkCount = 0;
+}
+
+void WriteJob::start()
+{
+    slotWriteJobDone(nullptr);
+}
+
+void WriteJob::slotWriteJobDone(QKeychain::Job *incomingJob)
+{
+    QKeychain::WritePasswordJob *writeJob = static_cast<QKeychain::WritePasswordJob *>(incomingJob);
+
+    // errors?
+    if (writeJob) {
+        _error = writeJob->error();
+        _errorString = writeJob->errorString();
+
+        if (writeJob->error() != NoError) {
+            qCWarning(lcKeychainChunk) << "Error while writing" << writeJob->key() << "chunk" << writeJob->errorString();
+            _chunkBuffer.clear();
+        }
+    }
+
+    // write a chunk if there is any in the buffer
+    if (!_chunkBuffer.isEmpty()) {
+#if defined(Q_OS_WIN)
+        // Windows workaround: Split the data into chunks of 2048 bytes,
+        // to allow 4k (4096 bit) keys to be saved (obey Windows's limits)
+        auto chunk = _chunkBuffer.left(KeychainChunk::ChunkSize);
+
+        _chunkBuffer = _chunkBuffer.right(_chunkBuffer.size() - chunk.size());
+#else
+        // write full data in one chunk on non-Windows, as usual
+        auto chunk = _chunkBuffer;
+
+        _chunkBuffer.clear();
+#endif
+        auto index = (_chunkCount++);
+
+        // keep the limit
+        if (_chunkCount > KeychainChunk::MaxChunks) {
+            qCWarning(lcKeychainChunk) << "Maximum chunk count exceeded while writing" << writeJob->key() << "chunk" << QString::number(index) << "cutting off after" << QString::number(KeychainChunk::MaxChunks) << "chunks";
+
+            writeJob->deleteLater();
+
+            _chunkBuffer.clear();
+
+            emit finished(this);
+            return;
+        }
+
+        const QString kck = AbstractCredentials::keychainKey(
+            _account->url().toString(),
+            _key + (index > 0 ? (QString(".") + QString::number(index)) : QString()),
+            _account->id());
+
+        QKeychain::WritePasswordJob *job = new QKeychain::WritePasswordJob(_serviceName);
+#if defined(KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK)
+        addSettingsToJob(_account, job);
+#endif
+        job->setInsecureFallback(_insecureFallback);
+        connect(job, &QKeychain::Job::finished, this, &KeychainChunk::WriteJob::slotWriteJobDone);
+        // only add the key's (sub)"index" after the first element, to stay compatible with older versions and non-Windows
+        job->setKey(kck);
+        job->setBinaryData(chunk);
+        job->start();
+
+        chunk.clear();
+    } else {
+        emit finished(this);
+    }
+
+    writeJob->deleteLater();
+}
+
+/*
+* ReadJob
+*/
+ReadJob::ReadJob(Account *account, const QString &key, const bool &keychainMigration, QObject *parent)
+    : Job(parent)
+{
+    _account = account;
+    _key = key;
+
+    _keychainMigration = keychainMigration;
+
+    _chunkCount = 0;
+    _chunkBuffer.clear();
+}
+
+void ReadJob::start()
+{
+    _chunkCount = 0;
+    _chunkBuffer.clear();
+
+    const QString kck = AbstractCredentials::keychainKey(
+        _account->url().toString(),
+        _key,
+        _keychainMigration ? QString() : _account->id());
+
+    QKeychain::ReadPasswordJob *job = new QKeychain::ReadPasswordJob(_serviceName);
+#if defined(KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK)
+    addSettingsToJob(_account, job);
+#endif
+    job->setInsecureFallback(_insecureFallback);
+    job->setKey(kck);
+    connect(job, &QKeychain::Job::finished, this, &KeychainChunk::ReadJob::slotReadJobDone);
+    job->start();
+}
+
+void ReadJob::slotReadJobDone(QKeychain::Job *incomingJob)
+{
+    // Errors or next chunk?
+    QKeychain::ReadPasswordJob *readJob = static_cast<QKeychain::ReadPasswordJob *>(incomingJob);
+
+    if (readJob) {
+        _error = readJob->error();
+        _errorString = readJob->errorString();
+
+        if (readJob->error() == NoError && readJob->binaryData().length() > 0) {
+            _chunkBuffer.append(readJob->binaryData());
+            _chunkCount++;
+
+#if defined(Q_OS_WIN)
+            // try to fetch next chunk
+            if (_chunkCount < KeychainChunk::MaxChunks) {
+                const QString kck = AbstractCredentials::keychainKey(
+                    _account->url().toString(),
+                    _key + QString(".") + QString::number(_chunkCount),
+                    _keychainMigration ? QString() : _account->id());
+
+                QKeychain::ReadPasswordJob *job = new QKeychain::ReadPasswordJob(_serviceName);
+#if defined(KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK)
+                addSettingsToJob(_account, job);
+#endif
+                job->setInsecureFallback(_insecureFallback);
+                job->setKey(kck);
+                connect(job, &QKeychain::Job::finished, this, &KeychainChunk::ReadJob::slotReadJobDone);
+                job->start();
+
+                readJob->deleteLater();
+                return;
+            } else {
+                qCWarning(lcKeychainChunk) << "Maximum chunk count for" << readJob->key() << "reached, ignoring after" << KeychainChunk::MaxChunks;
+            }
+#endif
+        } else {
+                qCWarning(lcKeychainChunk) << "Unable to read" << readJob->key() << "chunk" << QString::number(_chunkCount) << readJob->errorString();
+        }
+
+        readJob->deleteLater();
+    }
+
+    emit finished(this);
+}
+
+} // namespace KeychainChunk
+
+} // namespace OCC

--- a/src/gui/creds/keychainchunk.h
+++ b/src/gui/creds/keychainchunk.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) by Michael Schuster <michael@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+#ifndef KEYCHAINCHUNK_H
+#define KEYCHAINCHUNK_H
+
+#include <QObject>
+#include <keychain.h>
+#include "accountfwd.h"
+
+// We don't support insecure fallback
+// #define KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK
+
+namespace OCC {
+
+namespace KeychainChunk {
+
+/*
+* Workaround for Windows:
+*
+* Split the keychain entry's data into chunks of 2048 bytes,
+* to allow 4k (4096 bit) keys / large certs to be saved (see limits in webflowcredentials.h)
+*/
+static constexpr int ChunkSize = 2048;
+static constexpr int MaxChunks = 10;
+
+/*
+ * @brief: Abstract base class for KeychainChunk jobs.
+ */
+class Job : public QObject {
+    Q_OBJECT
+public:
+    Job(QObject *parent = nullptr);
+
+    const QKeychain::Error error() const {
+        return _error;
+    }
+    const QString errorString() const {
+        return _errorString;
+    }
+
+    QByteArray binaryData() const {
+        return _chunkBuffer;
+    }
+
+    const bool insecureFallback() const {
+        return _insecureFallback;
+    }
+
+// If we use it but don't support insecure fallback, give us nice compilation errors ;p
+#if defined(KEYCHAINCHUNK_ENABLE_INSECURE_FALLBACK)
+    void setInsecureFallback(const bool &insecureFallback)
+    {
+        _insecureFallback = insecureFallback;
+    }
+#endif
+
+protected:
+    QString _serviceName;
+    Account *_account;
+    QString _key;
+    bool _insecureFallback = false;
+    bool _keychainMigration = false;
+
+    QKeychain::Error _error = QKeychain::NoError;
+    QString _errorString;
+
+    int _chunkCount = 0;
+    QByteArray _chunkBuffer;
+}; // class Job
+
+/*
+* @brief: Simple wrapper class for QKeychain::WritePasswordJob, splits too large keychain entry's data into chunks on Windows
+*/
+class WriteJob : public KeychainChunk::Job {
+    Q_OBJECT
+public:
+    WriteJob(Account *account, const QString &key, const QByteArray &data, QObject *parent = nullptr);
+    void start();
+
+signals:
+    void finished(KeychainChunk::WriteJob *incomingJob);
+
+private slots:
+    void slotWriteJobDone(QKeychain::Job *incomingJob);
+}; // class WriteJob
+
+/*
+* @brief: Simple wrapper class for QKeychain::ReadPasswordJob, splits too large keychain entry's data into chunks on Windows
+*/
+class ReadJob : public KeychainChunk::Job {
+    Q_OBJECT
+public:
+    ReadJob(Account *account, const QString &key, const bool &keychainMigration, QObject *parent = nullptr);
+    void start();
+
+signals:
+    void finished(KeychainChunk::ReadJob *incomingJob);
+
+private slots:
+    void slotReadJobDone(QKeychain::Job *incomingJob);
+}; // class ReadJob
+
+} // namespace KeychainChunk
+
+} // namespace OCC
+
+#endif // KEYCHAINCHUNK_H

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -19,6 +19,11 @@ namespace QKeychain {
 
 namespace OCC {
 
+namespace KeychainChunk {
+    class ReadJob;
+    class WriteJob;
+}
+
 class WebFlowCredentialsDialog;
 
 class WebFlowCredentials : public AbstractCredentials
@@ -62,14 +67,14 @@ private slots:
 
     void slotAskFromUserCredentialsProvided(const QString &user, const QString &pass, const QString &host);
 
-    void slotReadClientCertPEMJobDone(QKeychain::Job *incomingJob);
-    void slotReadClientKeyPEMJobDone(QKeychain::Job *incomingJob);
-    void slotReadClientCaCertsPEMJobDone(QKeychain::Job *incommingJob);
+    void slotReadClientCertPEMJobDone(KeychainChunk::ReadJob *readJob);
+    void slotReadClientKeyPEMJobDone(KeychainChunk::ReadJob *readJob);
+    void slotReadClientCaCertsPEMJobDone(KeychainChunk::ReadJob *readJob);
     void slotReadPasswordJobDone(QKeychain::Job *incomingJob);
 
-    void slotWriteClientCertPEMJobDone();
-    void slotWriteClientKeyPEMJobDone();
-    void slotWriteClientCaCertsPEMJobDone(QKeychain::Job *incomingJob);
+    void slotWriteClientCertPEMJobDone(KeychainChunk::WriteJob *writeJob);
+    void slotWriteClientKeyPEMJobDone(KeychainChunk::WriteJob *writeJob);
+    void slotWriteClientCaCertsPEMJobDone(KeychainChunk::WriteJob *writeJob);
     void slotWriteJobDone(QKeychain::Job *);
 
 private:
@@ -90,19 +95,6 @@ private:
      */
     static constexpr int _clientSslCaCertificatesMaxCount = 10;
     QQueue<QSslCertificate> _clientSslCaCertificatesWriteQueue;
-
-    /*
-     * Workaround: ...and this time only on Windows:
-     *
-     * Split the private key into chunks of 2048 bytes,
-     * to allow 4k (4096 bit) keys to be saved (see limits above)
-     */
-    void writeSingleClientKeyChunkPEM(QKeychain::Job *incomingJob);
-
-    static constexpr int _clientSslKeyChunkSize = 2048;
-    static constexpr int _clientSslKeyMaxChunks = 10;
-    int _clientSslKeyChunkCount = 0;
-    QByteArray _clientSslKeyChunkBufferPEM;
 
 protected:
     /** Reads data from keychain locations
@@ -134,6 +126,6 @@ protected:
     WebFlowCredentialsDialog *_askDialog;
 };
 
-}
+} // namespace OCC
 
 #endif // WEBFLOWCREDENTIALS_H


### PR DESCRIPTION
### Heavy refactoring: Windows workaround for >= 4k (4096 bit) client-cert SSL keys and large certs

With `QtKeychain` on Windows, storing larger keys or certs in one keychain entry causes the following error due to limits in the Windows APIs:
    `Error: "Credential size exceeds maximum size of 2560"`

This fix implements the new wrapper class `KeychainChunk` with wrapper jobs `ReadJob` and `WriteJob` to encapsulate the `QKeychain` handling of `ReadPasswordJob` and `WritePasswordJob` with `binaryData` but split every supplied keychain entry's data into 2048 byte chunks, on Windows only.

The wrapper is used for all keychain operations in `WebFlowCredentials`, except for the server password.

For reference also see previous fixes:
- https://github.com/nextcloud/desktop/pull/1389
- https://github.com/nextcloud/desktop/pull/1394

This should finally fix the re-opened issue:
- https://github.com/nextcloud/desktop/issues/863

Hopefully this solves it once for all 😄 
cc @rullzer @camilasan 