### PR TITLE
Fix date in ActivityWidget and remove unnecessary string conversion

### DIFF
--- a/src/gui/activitywidget.cpp
+++ b/src/gui/activitywidget.cpp
@@ -179,7 +179,7 @@ void ActivityWidget::slotItemCompleted(const QString &folder, const SyncFileItem
         Activity activity;
         activity._type = Activity::SyncFileItemType; //client activity
         activity._status = item->_status;
-        activity._dateTime = QDateTime::fromString(QDateTime::currentDateTime().toString(), Qt::ISODate);
+        activity._dateTime = QDateTime::currentDateTime();
         activity._message = item->_originalFile;
         activity._link = folderInstance->accountState()->account()->url();
         activity._accName = folderInstance->accountState()->account()->displayName();


### PR DESCRIPTION
The local date and time value was converted into a string, just to be converted
into another string, to be converted to a value once again, returning zero as
the result. This caused the widget to always display "now". 🤪

Looks like this was a simply copy and paste mistake from this line in
`ActivityListModel::slotActivitiesReceived`:

`a._dateTime = QDateTime::fromString(json.value("date").toString(), Qt::ISODate);
`

This also belongs to issue #1683.

cc @camilasan Funny one ^^