### PR TITLE
Ask for password on password protected link shares

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -28,6 +28,7 @@
 
 #include <QFileInfo>
 #include <QFileIconProvider>
+#include <QInputDialog>
 #include <QPointer>
 #include <QPushButton>
 #include <QFrame>
@@ -137,6 +138,7 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
         _manager = new ShareManager(accountState->account(), this);
         connect(_manager, &ShareManager::sharesFetched, this, &ShareDialog::slotSharesFetched);
         connect(_manager, &ShareManager::linkShareCreated, this, &ShareDialog::slotAddLinkShareWidget);
+        connect(_manager, &ShareManager::linkShareRequiresPassword, this, &ShareDialog::slotLinkShareRequiresPassword);
     }
 }
 
@@ -302,6 +304,24 @@ void ShareDialog::slotCreateLinkShare()
     _manager->createLinkShare(_sharePath, QString(), QString());
 }
 
+void ShareDialog::slotLinkShareRequiresPassword()
+{
+    bool ok;
+    QString password = QInputDialog::getText(this,
+                                             tr("Password for share required"),
+                                             tr("Please enter a password for your link share:"),
+                                             QLineEdit::Normal,
+                                             QString(),
+                                             &ok);
+
+    if (!ok) {
+        // The dialog was canceled so no need to do anything
+        return;
+    }
+
+    // Try to create the link share again with the newly entered password
+    _manager->createLinkShare(_sharePath, QString(), password);
+}
 
 void ShareDialog::slotDeleteShare()
 {

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -64,6 +64,7 @@ private slots:
     void slotAddLinkShareWidget(const QSharedPointer<LinkShare> &linkShare);
     void slotDeleteShare();
     void slotCreateLinkShare();
+    void slotLinkShareRequiresPassword();
     void slotAdjustScrollWidgetSize();
 
 signals:

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -49,6 +49,7 @@
 #include <QLocalSocket>
 #include <QStringBuilder>
 #include <QMessageBox>
+#include <QInputDialog>
 
 #include <QClipboard>
 
@@ -477,6 +478,8 @@ public:
             this, &GetOrCreatePublicLinkShare::linkShareCreated);
         connect(&_shareManager, &ShareManager::serverError,
             this, &GetOrCreatePublicLinkShare::serverError);
+        connect(&_shareManager, &ShareManager::linkShareRequiresPassword,
+            this, &GetOrCreatePublicLinkShare::passwordRequired);
     }
 
     void run()
@@ -510,6 +513,24 @@ private slots:
     {
         qCDebug(lcPublicLink) << "New share created";
         success(share->getLink().toString());
+    }
+
+    void passwordRequired() {
+        bool ok;
+        QString password = QInputDialog::getText(nullptr,
+                                                 tr("Password for share required"),
+                                                 tr("Please enter a password for your link share:"),
+                                                 QLineEdit::Normal,
+                                                 QString(),
+                                                 &ok);
+
+        if (!ok) {
+            // The dialog was canceled so no need to do anything
+            return;
+        }
+
+        // Try to create the link share again with the newly entered password
+        _shareManager.createLinkShare(_localFile, QString(), password);
     }
 
     void serverError(int code, const QString &message)


### PR DESCRIPTION
Fixes #1485

This was missed when creating the new share dialog.
Now it pops up with a nice share password dialog to enter for your link
share.

To test. Just enforce password protection on your system.
Before: :boom:
Now: :rocket: 