### PR TITLE
Install libcloudproviders files by default on debian

### DIFF
--- a/admin/linux/debian/debian/nextcloud-client.install
+++ b/admin/linux/debian/debian/nextcloud-client.install
@@ -1,4 +1,6 @@
 usr/bin
 usr/share/applications
+usr/share/cloud-providers/
+usr/share/dbus-1/services/
 usr/share/icons
 debian/101-sync-inotify.conf etc/sysctl.d


### PR DESCRIPTION
These two files were missing from the packaging making libcloudproviders unaware of nextcloud service