### PR TITLE
Add direct editing to the file manager extension

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -249,6 +249,11 @@ void ConnectionValidator::slotCapabilitiesRecieved(const QJsonDocument &json)
         return;
     }
 
+    // Check for the directEditing capability
+    QUrl directEditingURL = QUrl(caps["files"].toObject()["directEditing"].toObject()["url"].toString());
+    QString directEditingETag = caps["files"].toObject()["directEditing"].toObject()["etag"].toString();
+    _account->fetchDirectEditors(directEditingURL, directEditingETag);
+
     fetchUser();
 }
 

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -37,6 +37,7 @@ namespace OCC {
 class SyncFileStatus;
 class Folder;
 class SocketListener;
+class DirectEditor;
 
 /**
  * @brief The SocketApi class
@@ -122,6 +123,10 @@ private:
      * and ends with GET_MENU_ITEMS:END
      */
     Q_INVOKABLE void command_GET_MENU_ITEMS(const QString &argument, SocketListener *listener);
+
+    /// Direct Editing
+    Q_INVOKABLE void command_EDIT(const QString &localFile, SocketListener *listener);
+    DirectEditor* getDirectEditorForLocalFile(const QString &localFile);
 
     QString buildRegisterPathMessage(const QString &path);
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -246,6 +246,10 @@ public:
     void writeAppPasswordOnce(QString appPassword);
     void deleteAppPassword();
 
+    /// Direct Editing
+    // Check for the directEditing capability
+    void fetchDirectEditors(const QUrl &directEditingURL, const QString &directEditingETag);
+
 public slots:
     /// Used when forgetting credentials
     void clearQNAMCache();
@@ -278,6 +282,7 @@ signals:
 protected Q_SLOTS:
     void slotCredentialsFetched();
     void slotCredentialsAsked();
+    void slotDirectEditingRecieved(const QJsonDocument &json);
 
 private:
     Account(QObject *parent = nullptr);
@@ -323,6 +328,9 @@ private:
     bool _wroteAppPassword = false;
 
     friend class AccountManager;
+
+    // Direct Editing
+    QString _lastDirectEditingETag;
 
     /* IMPORTANT - remove later - FIXME MS@2019-12-07 -->
      * TODO: For "Log out" & "Remove account": Remove client CA certs and KEY!

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -176,4 +176,85 @@ bool Capabilities::uploadConflictFiles() const
 
     return _capabilities["uploadConflictFiles"].toBool();
 }
+
+/*-------------------------------------------------------------------------------------*/
+
+// Direct Editing
+void Capabilities::addDirectEditor(DirectEditor* directEditor)
+{
+    if(directEditor)
+        _directEditors.append(directEditor);
+}
+
+DirectEditor* Capabilities::getDirectEditorForMimetype(const QMimeType &mimeType)
+{
+    foreach(DirectEditor* editor, _directEditors) {
+        if(editor->hasMimetype(mimeType))
+            return editor;
+    }
+
+    return nullptr;
+}
+
+DirectEditor* Capabilities::getDirectEditorForOptionalMimetype(const QMimeType &mimeType)
+{
+    foreach(DirectEditor* editor, _directEditors) {
+        if(editor->hasOptionalMimetype(mimeType))
+            return editor;
+    }
+
+    return nullptr;
+}
+
+/*-------------------------------------------------------------------------------------*/
+
+DirectEditor::DirectEditor(const QString &id, const QString &name, QObject* parent)
+    : QObject(parent)
+    , _id(id)
+    , _name(name)
+{
+}
+
+QString DirectEditor::id() const
+{
+    return _id;
+}
+
+QString DirectEditor::name() const
+{
+    return _name;
+}
+
+void DirectEditor::addMimetype(const QByteArray &mimeType)
+{
+    _mimeTypes.append(mimeType);
+}
+
+void DirectEditor::addOptionalMimetype(const QByteArray &mimeType)
+{
+    _optionalMimeTypes.append(mimeType);
+}
+
+QList<QByteArray> DirectEditor::mimeTypes() const
+{
+    return _mimeTypes;
+}
+
+QList<QByteArray> DirectEditor::optionalMimeTypes() const
+{
+    return _optionalMimeTypes;
+}
+
+bool DirectEditor::hasMimetype(const QMimeType &mimeType)
+{
+    return _mimeTypes.contains(mimeType.name().toLatin1());
+}
+
+bool DirectEditor::hasOptionalMimetype(const QMimeType &mimeType)
+{
+    return _optionalMimeTypes.contains(mimeType.name().toLatin1());
+}
+
+/*-------------------------------------------------------------------------------------*/
+
 }

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -20,8 +20,11 @@
 
 #include <QVariantMap>
 #include <QStringList>
+#include <QMimeDatabase>
 
 namespace OCC {
+
+class DirectEditor;
 
 /**
  * @brief The Capabilities class represents the capabilities of an ownCloud
@@ -127,9 +130,47 @@ public:
      */
     bool uploadConflictFiles() const;
 
+    // Direct Editing
+    void addDirectEditor(DirectEditor* directEditor);
+    DirectEditor* getDirectEditorForMimetype(const QMimeType &mimeType);
+    DirectEditor* getDirectEditorForOptionalMimetype(const QMimeType &mimeType);
+
 private:
     QVariantMap _capabilities;
+
+    QList<DirectEditor*> _directEditors;
 };
+
+/*-------------------------------------------------------------------------------------*/
+
+class OWNCLOUDSYNC_EXPORT DirectEditor : public QObject
+{
+    Q_OBJECT
+public:
+    DirectEditor(const QString &id, const QString &name, QObject* parent = 0);
+
+    void addMimetype(const QByteArray &mimeType);
+    void addOptionalMimetype(const QByteArray &mimeType);
+
+    bool hasMimetype(const QMimeType &mimeType);
+    bool hasOptionalMimetype(const QMimeType &mimeType);
+
+    QString id() const;
+    QString name() const;
+
+    QList<QByteArray> mimeTypes() const;
+    QList<QByteArray> optionalMimeTypes() const;
+
+private:
+    QString _id;
+    QString _name;
+
+    QList<QByteArray> _mimeTypes;
+    QList<QByteArray> _optionalMimeTypes;
+};
+
+/*-------------------------------------------------------------------------------------*/
+
 }
 
 #endif //CAPABILITIES_H

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -801,7 +801,7 @@ void JsonApiJob::start()
     auto query = _additionalParams;
     query.addQueryItem(QLatin1String("format"), QLatin1String("json"));
     QUrl url = Utility::concatUrlPath(account()->url(), path(), query);
-    sendRequest("GET", url, _request);
+    sendRequest(_usePOST ? "POST" : "GET", url, _request);
     AbstractNetworkJob::start();
 }
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -373,6 +373,16 @@ public:
     void addQueryParams(const QUrlQuery &params);
     void addRawHeader(const QByteArray &headerName, const QByteArray &value);
 
+    /**
+     * @brief usePOST - allow job to do an anonymous POST request instead of GET
+     * @param params: (optional) true for POST, false for GET (default).
+     *
+     * This function needs to be called before start() obviously.
+     */
+    void usePOST(bool usePOST = true) {
+        _usePOST = usePOST;
+    }
+
 public slots:
     void start() override;
 
@@ -398,6 +408,8 @@ signals:
 private:
     QUrlQuery _additionalParams;
     QNetworkRequest _request;
+
+    bool _usePOST = false;
 };
 
 /**


### PR DESCRIPTION
### Share context menu: Use `directEditing` capability in `SocketApi`

- Allow direct editing _"Edit"_ when an editor is available for the mime type
- Show _"Open in browser"_ if editing is unavailable (as previously, both now on top of the menu list)
- Rename the menu title to the app name, _"Nextcloud"_ instead of _"Share via ..."_

### Add support for the `directEditing` capability

- Fetch in `ConnectionValidator::slotCapabilitiesRecieved`
- Add editors to a list made of the new `DirectEditor` class

**TODO:**
- Add support for re-fetch and continuously check for changes (ETag)

### Further improvements:
- `JsonApiJob`: Add method `usePOST` to allow anonymous `POST` requests

Thanks to @tobiasKaminsky and @juliushaertl for guidance! ❤️ 
And to @camilasan for the super helpful PR #1442 🚀 