### PR TITLE
Qt 5.5 compatibility ifdef

### DIFF
--- a/src/gui/iconjob.cpp
+++ b/src/gui/iconjob.cpp
@@ -23,7 +23,9 @@ IconJob::IconJob(const QUrl &url, QObject *parent) :
             this, &IconJob::finished);
 
     QNetworkRequest request(url);
+#if (QT_VERSION >= 0x050600)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+#endif
     _accessManager.get(request);
 }
 


### PR DESCRIPTION
Recent change cd80c749d66596ab13d9c4ffb74509b1ab042eda started to usage symbol `QNetworkRequest::FollowRedirectsAttribute` which is introduced only in Qt 5.6, hence the code stopped compiling for Ubuntu Xenial which has Qt 5.5. 

This patch makes the usage of this symbol conditional on the Qt version.