### PR TITLE
Fix wrong window position on some linux DEs - worked around invalid g…

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -142,7 +142,29 @@ int Systray::calcTrayWindowX()
     int trayIconTopCenterX = (topRight - ((topRight - topLeft) * 0.5)).x();
     return trayIconTopCenterX - (400 * 0.5);
 #else
-    QScreen *trayScreen = QGuiApplication::primaryScreen();
+QScreen* trayScreen = nullptr;
+#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
+    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+        trayScreen = QGuiApplication::screenAt(QCursor::pos());
+    } else {
+        trayScreen = QGuiApplication::screenAt(this->geometry().topLeft());
+    }
+#else
+    foreach (QScreen* screen, QGuiApplication::screens()) {
+        if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+            if (screen->geometry().contains(QCursor::pos())) {
+                trayScreen = screen;
+            }
+        } else {
+            if (screen->geometry().contains(this->geometry().topLeft())) {
+                trayScreen = screen;
+            }
+        }
+    }
+    if (trayScreen == nullptr) {
+        trayScreen = QGuiApplication::primaryScreen();
+    }
+#endif
     int screenWidth = trayScreen->geometry().width();
     int screenHeight = trayScreen->geometry().height();
     int availableWidth = trayScreen->availableGeometry().width();
@@ -188,7 +210,29 @@ int Systray::calcTrayWindowY()
     // don't use availableGeometry() here, because this also excludes the dock
     return 22+6;
 #else
-    QScreen *trayScreen = QGuiApplication::primaryScreen();
+QScreen* trayScreen = nullptr;
+#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
+    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+    trayScreen = QGuiApplication::screenAt(QCursor::pos());
+    } else {
+        trayScreen = QGuiApplication::screenAt(this->geometry().topLeft());
+    }
+#else
+    foreach (QScreen* screen, QGuiApplication::screens()) {
+        if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+            if (screen->geometry().contains(QCursor::pos())) {
+                trayScreen = screen;
+            }
+        } else {
+            if (screen->geometry().contains(this->geometry().topLeft())) {
+                trayScreen = screen;
+            }
+        }
+    }
+    if (trayScreen == nullptr) {
+        trayScreen = QGuiApplication::primaryScreen();
+    }
+#endif
     int screenWidth = trayScreen->geometry().width();
     int screenHeight = trayScreen->geometry().height();
     int availableHeight = trayScreen->availableGeometry().height();

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -18,6 +18,7 @@
 #include "config.h"
 #include "tray/UserModel.h"
 
+#include <QCursor>
 #include <QDesktopServices>
 #include <QGuiApplication>
 #include <QQmlComponent>
@@ -146,12 +147,21 @@ int Systray::calcTrayWindowX()
     int screenHeight = trayScreen->geometry().height();
     int availableWidth = trayScreen->availableGeometry().width();
     int availableHeight = trayScreen->availableGeometry().height();
-    QPoint topRightDpiAware = this->geometry().topRight() / trayScreen->devicePixelRatio();
-    QPoint topLeftDpiAware = this->geometry().topLeft() / trayScreen->devicePixelRatio();
 
-    // get coordinates from top center point of tray icon
+    QPoint topRightDpiAware = QPoint();
+    QPoint topLeftDpiAware = QPoint();
+    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+        // tray geometry is invalid - QT bug on some linux desktop environments
+        // Use mouse position instead. Cringy, but should work for now
+        topRightDpiAware = QCursor::pos() / trayScreen->devicePixelRatio();
+        topLeftDpiAware = QCursor::pos() / trayScreen->devicePixelRatio();
+    } else {
+        topRightDpiAware = this->geometry().topRight() / trayScreen->devicePixelRatio();
+        topLeftDpiAware = this->geometry().topLeft() / trayScreen->devicePixelRatio();
+    }
+
+    // get x coordinate from top center point of tray icon
     int trayIconTopCenterX = (topRightDpiAware - ((topRightDpiAware - topLeftDpiAware) * 0.5)).x();
-    int trayIconTopCenterY = (topRightDpiAware - ((topRightDpiAware - topLeftDpiAware) * 0.5)).y();
 
     if (availableHeight < screenHeight) {
         // taskbar is on top or bottom
@@ -182,11 +192,19 @@ int Systray::calcTrayWindowY()
     int screenWidth = trayScreen->geometry().width();
     int screenHeight = trayScreen->geometry().height();
     int availableHeight = trayScreen->availableGeometry().height();
-    QPoint topRightDpiAware = this->geometry().topRight() / trayScreen->devicePixelRatio();
-    QPoint topLeftDpiAware = this->geometry().topLeft() / trayScreen->devicePixelRatio();
 
-    // get coordinates from top center point of tray icon
-    int trayIconTopCenterX = (topRightDpiAware - ((topRightDpiAware - topLeftDpiAware) * 0.5)).x();
+    QPoint topRightDpiAware = QPoint();
+    QPoint topLeftDpiAware = QPoint();
+    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
+        // tray geometry is invalid - QT bug on some linux desktop environments
+        // Use mouse position instead. Cringy, but should work for now
+        topRightDpiAware = QCursor::pos() / trayScreen->devicePixelRatio();
+        topLeftDpiAware = QCursor::pos() / trayScreen->devicePixelRatio();
+    } else {
+        topRightDpiAware = this->geometry().topRight() / trayScreen->devicePixelRatio();
+        topLeftDpiAware = this->geometry().topLeft() / trayScreen->devicePixelRatio();
+    }
+    // get y coordinate from top center point of tray icon
     int trayIconTopCenterY = (topRightDpiAware - ((topRightDpiAware - topLeftDpiAware) * 0.5)).y();
 
     if (availableHeight < screenHeight) {

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -95,6 +95,17 @@ bool Systray::isOpen()
     return _isOpen;
 }
 
+Q_INVOKABLE int Systray::screenIndex()
+{
+    auto qPos = QCursor::pos();
+    for (int i = 0; i < QGuiApplication::screens().count(); i++) {
+        if (QGuiApplication::screens().at(i)->geometry().contains(qPos)) {
+            return i;
+        }
+    }
+    return 0;
+}
+
 Q_INVOKABLE void Systray::setOpened()
 {
     _isOpen = true;
@@ -142,29 +153,13 @@ int Systray::calcTrayWindowX()
     int trayIconTopCenterX = (topRight - ((topRight - topLeft) * 0.5)).x();
     return trayIconTopCenterX - (400 * 0.5);
 #else
-QScreen* trayScreen = nullptr;
-#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
-    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
-        trayScreen = QGuiApplication::screenAt(QCursor::pos());
+    QScreen* trayScreen = nullptr;
+    if (QGuiApplication::screens().count() > 1) {
+        trayScreen = QGuiApplication::screens().at(screenIndex());
     } else {
-        trayScreen = QGuiApplication::screenAt(this->geometry().topLeft());
-    }
-#else
-    foreach (QScreen* screen, QGuiApplication::screens()) {
-        if (this->geometry().left() == 0 || this->geometry().top() == 0) {
-            if (screen->geometry().contains(QCursor::pos())) {
-                trayScreen = screen;
-            }
-        } else {
-            if (screen->geometry().contains(this->geometry().topLeft())) {
-                trayScreen = screen;
-            }
-        }
-    }
-    if (trayScreen == nullptr) {
         trayScreen = QGuiApplication::primaryScreen();
     }
-#endif
+
     int screenWidth = trayScreen->geometry().width();
     int screenHeight = trayScreen->geometry().height();
     int availableWidth = trayScreen->availableGeometry().width();
@@ -210,30 +205,13 @@ int Systray::calcTrayWindowY()
     // don't use availableGeometry() here, because this also excludes the dock
     return 22+6;
 #else
-QScreen* trayScreen = nullptr;
-#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
-    if (this->geometry().left() == 0 || this->geometry().top() == 0) {
-    trayScreen = QGuiApplication::screenAt(QCursor::pos());
+    QScreen* trayScreen = nullptr;
+    if (QGuiApplication::screens().count() > 1) {
+        trayScreen = QGuiApplication::screens().at(screenIndex());
     } else {
-        trayScreen = QGuiApplication::screenAt(this->geometry().topLeft());
-    }
-#else
-    foreach (QScreen* screen, QGuiApplication::screens()) {
-        if (this->geometry().left() == 0 || this->geometry().top() == 0) {
-            if (screen->geometry().contains(QCursor::pos())) {
-                trayScreen = screen;
-            }
-        } else {
-            if (screen->geometry().contains(this->geometry().topLeft())) {
-                trayScreen = screen;
-            }
-        }
-    }
-    if (trayScreen == nullptr) {
         trayScreen = QGuiApplication::primaryScreen();
     }
-#endif
-    int screenWidth = trayScreen->geometry().width();
+
     int screenHeight = trayScreen->geometry().height();
     int availableHeight = trayScreen->availableGeometry().height();
 

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -57,6 +57,7 @@ public:
     Q_INVOKABLE bool syncIsPaused();
     Q_INVOKABLE void setOpened();
     Q_INVOKABLE void setClosed();
+    Q_INVOKABLE int screenIndex();
 
 signals:
     void currentUserChanged();

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.9
-import QtQuick.Window 2.2
+import QtQuick.Window 2.3
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -1,7 +1,7 @@
 import QtQml 2.1
 import QtQml.Models 2.1
 import QtQuick 2.9
-import QtQuick.Window 2.2
+import QtQuick.Window 2.3
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
 import QtGraphicalEffects 1.0
@@ -58,8 +58,8 @@ Window {
             trayWindow.show();
             trayWindow.raise();
             trayWindow.requestActivate();
-            trayWindow.setX( systrayBackend.calcTrayWindowX());
-            trayWindow.setY( systrayBackend.calcTrayWindowY());
+            trayWindow.setX( Qt.application.screens[systrayBackend.screenIndex()].virtualX + systrayBackend.calcTrayWindowX());
+            trayWindow.setY( Qt.application.screens[systrayBackend.screenIndex()].virtualY + systrayBackend.calcTrayWindowY());
             systrayBackend.setOpened();
             userModelBackend.fetchCurrentActivityModel();
         }


### PR DESCRIPTION
…eometry() returned by QT

Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Reason is UGLY. Qt's geometry() returns invalid QRect/QPoint (0, 0 / 0, -1) when called on tray icon objects on several linux desktop environments. There has already been major discussion throughout several places over this the last years, but it seems like at Qt one has given up (or never cared about this) as the whole topic with desktop environments is a mess anyway on linux.

Long story short: If geometry() return value is invalid (origin point (0,0)), use the current mouse position instead. Logically this is very ugly and only a workaround, but in practice should work out b/c mouse trigger is the only legitimate way for the tray window to pop up right now. Only exception I could think of is opening this by accessibility methods of the current system, but positioning should not be that important in this case. 

Windows and macOS not affected (tested). Current openSUSE Leap:

![4](https://user-images.githubusercontent.com/32204802/72792298-1026c480-3c39-11ea-87b9-7d8e079dabde.png)
![3](https://user-images.githubusercontent.com/32204802/72792299-10bf5b00-3c39-11ea-8c62-53f60c2c25cb.png)
![2](https://user-images.githubusercontent.com/32204802/72792300-10bf5b00-3c39-11ea-8c7f-bebb4ec88948.png)
![1](https://user-images.githubusercontent.com/32204802/72792301-10bf5b00-3c39-11ea-8aa4-79aa8c1d3332.png)


