### PR TITLE
Use system proxy by default if no config file is present

### DIFF
--- a/src/gui/clientproxy.cpp
+++ b/src/gui/clientproxy.cpp
@@ -53,7 +53,7 @@ bool ClientProxy::isUsingSystemDefault()
         return cfg.proxyType() == QNetworkProxy::DefaultProxy;
     }
 
-    return false;
+    return true;
 }
 
 QString printQNetworkProxy(const QNetworkProxy &proxy)


### PR DESCRIPTION
If the client has never been setup before and no configuration file is present yet, the client should use the system proxy by default. Otherwise the setup wizard will fail to run the server check when setting up the connection in https://github.com/nextcloud/desktop/blob/master/src/gui/owncloudsetupwizard.cpp#L158-L161
