### PR TITLE
Put filename in quotes

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -424,7 +424,7 @@ void PropagateDownloadFile::startDownload()
 
     // do a klaas' case clash check.
     if (propagator()->localFileNameClash(_item->_file)) {
-        done(SyncFileItem::NormalError, tr("File %1 can not be downloaded because of a local file name clash!").arg(QDir::toNativeSeparators(_item->_file)));
+        done(SyncFileItem::NormalError, tr("File '%1' cannot be downloaded because of a local file name clash!").arg(QDir::toNativeSeparators(_item->_file)));
         return;
     }
 

--- a/translations/client_bg.ts
+++ b/translations/client_bg.ts
@@ -2242,7 +2242,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_ca.ts
+++ b/translations/client_ca.ts
@@ -2262,7 +2262,7 @@ No és aconsellable fer-la servir.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>El fitxer %1 no es pot descarregar a causa d’un conflicte de nom amb un fitxer local.</translation>
     </message>
     <message>

--- a/translations/client_cs.ts
+++ b/translations/client_cs.ts
@@ -2259,7 +2259,7 @@ Nedoporučuje se jí používat.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Soubor %1 nemohl být stažen z důvodu kolize názvu se souborem v místním systému!</translation>
     </message>
     <message>

--- a/translations/client_da.ts
+++ b/translations/client_da.ts
@@ -2239,7 +2239,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -2259,8 +2259,8 @@ Es ist nicht ratsam, sie zu benutzen.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
-        <translation>Die Datei %1 kann aufgrund eines Konfliktes mit dem lokalen Dateinamen nicht herunter geladen werden!</translation>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
+        <translation>Die Datei '%1' kann aufgrund eines Konfliktes mit dem lokalen Dateinamen nicht herunter geladen werden!</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="477"/>

--- a/translations/client_el.ts
+++ b/translations/client_el.ts
@@ -2254,7 +2254,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Το αρχείο %1 δεν είναι δυνατό να ληφθεί λόγω διένεξης με το όνομα ενός τοπικού αρχείου!</translation>
     </message>
     <message>

--- a/translations/client_en.ts
+++ b/translations/client_en.ts
@@ -2268,7 +2268,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/client_en_GB.ts
+++ b/translations/client_en_GB.ts
@@ -2253,8 +2253,8 @@ It is not advisable to use it.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
-        <translation>File %1 can not be downloaded because of a local file name clash!</translation>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
+        <translation>File '%1' cannot be downloaded because of a local file name clash!</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="477"/>

--- a/translations/client_eo.ts
+++ b/translations/client_eo.ts
@@ -2259,7 +2259,7 @@ Uzi ĝin ne konsilindas.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Dosiero %1 ne elŝuteblis, ĉar estas konflikto kun loka dosiernomo!</translation>
     </message>
     <message>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -2259,7 +2259,7 @@ No se recomienda usarla.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no se puede descargar a causa de un conflicto con el nombre de un archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_AR.ts
+++ b/translations/client_es_AR.ts
@@ -2239,7 +2239,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_es_CL.ts
+++ b/translations/client_es_CL.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_CO.ts
+++ b/translations/client_es_CO.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_CR.ts
+++ b/translations/client_es_CR.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_DO.ts
+++ b/translations/client_es_DO.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_EC.ts
+++ b/translations/client_es_EC.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_GT.ts
+++ b/translations/client_es_GT.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_HN.ts
+++ b/translations/client_es_HN.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_MX.ts
+++ b/translations/client_es_MX.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_es_SV.ts
+++ b/translations/client_es_SV.ts
@@ -2246,7 +2246,7 @@ No es recomendable usarlo. </translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>¡El archivo %1 no puede ser descargado porque hay un conflicto con el nombre del archivo local!</translation>
     </message>
     <message>

--- a/translations/client_et.ts
+++ b/translations/client_et.ts
@@ -2240,7 +2240,7 @@ Selle kasutamine pole soovitatav.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Faili %1 ei saa alla laadida kuna on konflikt kohaliku faili nimega.</translation>
     </message>
     <message>

--- a/translations/client_eu.ts
+++ b/translations/client_eu.ts
@@ -2253,7 +2253,7 @@ Ez da gomendagarria erabltzea.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_fa.ts
+++ b/translations/client_fa.ts
@@ -2244,7 +2244,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>پرونده 1% بخاطر یک پرونده محلی به نام برخورد دانلود نمی شود!</translation>
     </message>
     <message>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -2242,7 +2242,7 @@ Osoitteen käyttäminen ei ole suositeltavaa.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -2262,7 +2262,7 @@ Il est déconseillé de l&apos;utiliser.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Le fichier %1 ne peut pas être téléchargé en raison d&apos;un conflit sur le nom de fichier local. </translation>
     </message>
     <message>

--- a/translations/client_gl.ts
+++ b/translations/client_gl.ts
@@ -2260,7 +2260,7 @@ Recomendámoslle que non o use.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Non é posíbel descargar o ficheiro %1 por mor dunha colisión co nome dun ficheiro local!</translation>
     </message>
     <message>

--- a/translations/client_he.ts
+++ b/translations/client_he.ts
@@ -2241,7 +2241,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_hr.ts
+++ b/translations/client_hr.ts
@@ -2260,7 +2260,7 @@ Nije preporučljivo koristiti ga.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Datoteka %1 ne može se preuzeti zbog nepodudaranja naziva lokalne datoteke!</translation>
     </message>
     <message>

--- a/translations/client_hu.ts
+++ b/translations/client_hu.ts
@@ -2254,7 +2254,7 @@ Használata nem ajánlott.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>A(z) %1 fájl nem tölthető le, mert ütközik egy helyi fájl nevével.</translation>
     </message>
     <message>

--- a/translations/client_id.ts
+++ b/translations/client_id.ts
@@ -2252,7 +2252,7 @@ Tidak disarankan untuk digunakan.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_is.ts
+++ b/translations/client_is.ts
@@ -2255,7 +2255,7 @@ Ekki er mælt með því að hún sé notuð.
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -2260,7 +2260,7 @@ Non è consigliabile utilizzarlo.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Il file %1 non può essere scaricato a causa di un conflitto con un file locale.</translation>
     </message>
     <message>

--- a/translations/client_ja.ts
+++ b/translations/client_ja.ts
@@ -2255,7 +2255,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>ファイル %1 はローカルファイル名が衝突しているためダウンロードできません！</translation>
     </message>
     <message>

--- a/translations/client_ko.ts
+++ b/translations/client_ko.ts
@@ -2261,7 +2261,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>로컬 파일 이름 충돌로 인해 %1 파일을 다운로드 할 수 없습니다!</translation>
     </message>
     <message>

--- a/translations/client_lt_LT.ts
+++ b/translations/client_lt_LT.ts
@@ -2248,7 +2248,7 @@ Patariama jo nenaudoti.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Failo %1 nepavyko atsisiųsti dėl kompiuterio failo nesuderinamumo!</translation>
     </message>
     <message>

--- a/translations/client_lv.ts
+++ b/translations/client_lv.ts
@@ -2241,7 +2241,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_nb_NO.ts
+++ b/translations/client_nb_NO.ts
@@ -2246,7 +2246,7 @@ Det er ikke tilrådelig å bruke den.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Fil %1 kan ikke lastes ned på grunn av lokalt sammenfall av filnavn!</translation>
     </message>
     <message>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -2265,7 +2265,7 @@ We adviseren deze site niet te gebruiken.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Bestand %1 kan niet worden gedownload, omdat de naam conflicteert met een lokaal bestand</translation>
     </message>
     <message>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -2260,7 +2260,7 @@ Niezalecane jest jego użycie.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Nie można pobrać pliku %1 ze względu na konflikt nazwy pliku lokalnego!</translation>
     </message>
     <message>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -2247,7 +2247,7 @@ Não é aconselhada a sua utilização.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Não foi possível transferir o ficheiro %1 devido a um conflito com o nome de ficheiro local!</translation>
     </message>
     <message>

--- a/translations/client_pt_BR.ts
+++ b/translations/client_pt_BR.ts
@@ -2260,7 +2260,7 @@ Não é aconselhável usá-la.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>O arquivo %1 não pode ser baixado devido a um conflito local no nome do arquivo!</translation>
     </message>
     <message>

--- a/translations/client_ro.ts
+++ b/translations/client_ro.ts
@@ -2239,7 +2239,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/translations/client_ru.ts
+++ b/translations/client_ru.ts
@@ -2252,7 +2252,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Файл «%1» не может быть загружен из-за локального конфликта имён.</translation>
     </message>
     <message>

--- a/translations/client_sk.ts
+++ b/translations/client_sk.ts
@@ -2260,7 +2260,7 @@ Nie je vhodné ju používať.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Súbor %1 nie je možné stiahnuť, pretože súbor s rovnakým menom už existuje!</translation>
     </message>
     <message>

--- a/translations/client_sl.ts
+++ b/translations/client_sl.ts
@@ -2247,7 +2247,7 @@ Uporaba ni priporočljiva.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Datoteke %1 ni mogoče prejeti zaradi neskladja z imenom krajevne datoteke!</translation>
     </message>
     <message>

--- a/translations/client_sr.ts
+++ b/translations/client_sr.ts
@@ -2260,7 +2260,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Фајл %1 се не може преузети јер се судара са називом локалног фајла!</translation>
     </message>
     <message>

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -2260,7 +2260,7 @@ Det är inte lämpligt att använda den.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Filen %1 kan inte hämtas på grund av namnkonflikt med en lokal fil!</translation>
     </message>
     <message>

--- a/translations/client_th.ts
+++ b/translations/client_th.ts
@@ -2244,7 +2244,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>ไฟล์ %1 ไม่สามารถดาวน์โหลดได้เพราะชื่อไฟล์ต้นทางเหมือนกัน!</translation>
     </message>
     <message>

--- a/translations/client_tr.ts
+++ b/translations/client_tr.ts
@@ -2258,7 +2258,7 @@ Kullanmanız önerilmez.</translation>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>%1 dosyası, adının yerel bir dosya ile çakışması nedeniyle indirilemedi!</translation>
     </message>
     <message>

--- a/translations/client_uk.ts
+++ b/translations/client_uk.ts
@@ -2240,7 +2240,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>Файл %1 не може бути завантажено через локальний конфлікт назви файлу! </translation>
     </message>
     <message>

--- a/translations/client_zh_CN.ts
+++ b/translations/client_zh_CN.ts
@@ -2258,7 +2258,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>由于本地文件名冲突，文件 %1 无法下载。</translation>
     </message>
     <message>

--- a/translations/client_zh_TW.ts
+++ b/translations/client_zh_TW.ts
@@ -2259,7 +2259,7 @@ It is not advisable to use it.</source>
     </message>
     <message>
         <location filename="../src/libsync/propagatedownload.cpp" line="427"/>
-        <source>File %1 can not be downloaded because of a local file name clash!</source>
+        <source>File '%1' cannot be downloaded because of a local file name clash!</source>
         <translation>檔案 %1 無法被下載，因為本地端的檔案名稱已毀損!</translation>
     </message>
     <message>


### PR DESCRIPTION
This will give you a better error message, in case a filename starts or ends with a space character