### PR TITLE
Do not install files related to cloud providers under Xenial

### DIFF
--- a/admin/linux/debian/debian.xenial/nextcloud-client.install
+++ b/admin/linux/debian/debian.xenial/nextcloud-client.install
@@ -1,0 +1,4 @@
+usr/bin
+usr/share/applications
+usr/share/icons
+debian/101-sync-inotify.conf etc/sysctl.d


### PR DESCRIPTION
Since `libcloudproviders` does not exist on Xenial, the related code is not compiled there. Hence the associated directories are also missing and trying to install them into the package causes a build failure. 

This patch adds a Xenial-specific `nextcloud-client.install` file to fix this problem.