### PR TITLE
l10n: Changed spelling of "user name" to "username"

### DIFF
--- a/src/gui/shareuserline.ui
+++ b/src/gui/shareuserline.ui
@@ -54,7 +54,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>User name</string>
+      <string>Username</string>
      </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>


### PR DESCRIPTION
Using "username" like on > 200 strings over the whole Nextcloud project.

Signed-off-by: rakekniven mark.ziegler@rakekniven.de