### PR TITLE
Fix wrong encoding when specifying extra header with if-match path

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -286,7 +286,7 @@ void PropagateUploadFileNG::startNextChunk()
         // "If-Match applies to the source, but we are interested in comparing the etag of the destination
         auto ifMatch = headers.take("If-Match");
         if (!ifMatch.isEmpty()) {
-            headers["If"] = "<" + destination.toUtf8() + "> ([" + ifMatch + "])";
+            headers["If"] = "<" + QUrl::toPercentEncoding(destination, "/") + "> ([" + ifMatch + "])";
         }
         if (!_transmissionChecksumHeader.isEmpty()) {
             qCInfo(lcPropagateUpload) << destination << _transmissionChecksumHeader;


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Should fix at least the core issue in #1182 (comments in issue started to furiously mix different use and error cases, so I'm cautious with the "fix" wording here). An If-Match extra header was set with an wrongly encoded path. toUtf8() on the destination resulted in an unreadable path when it contains umlauts, alway resulting in an error when propagating the final MOVE instruction to the server after a file with such umlauts has changed. 