### PR TITLE
Updater: Add query-parameter 'updatesegment' to the update check

### DIFF
--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -25,6 +25,7 @@
 #include "version.h"
 
 #include "config.h"
+#include "configfile.h"
 
 namespace OCC {
 
@@ -74,6 +75,11 @@ QUrlQuery Updater::getQueryParams()
         // FIXME: Provide a checkbox in UI to enable regular versions to switch
         // to beta channel
     }
+
+    // updateSegment (see configfile.h)
+    ConfigFile cfg;
+    auto updateSegment = cfg.updateSegment();
+    query.addQueryItem(QLatin1String("updatesegment"), QString::number(updateSegment));
 
     return query;
 }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -64,6 +64,7 @@ static const char optionalServerNotificationsC[] = "optionalServerNotifications"
 static const char showInExplorerNavigationPaneC[] = "showInExplorerNavigationPane";
 static const char skipUpdateCheckC[] = "skipUpdateCheck";
 static const char updateCheckIntervalC[] = "updateCheckInterval";
+static const char updateSegmentC[] = "updateSegment";
 static const char geometryC[] = "geometry";
 static const char timeoutC[] = "timeout";
 static const char chunkSizeC[] = "chunkSize";
@@ -574,6 +575,21 @@ void ConfigFile::setSkipUpdateCheck(bool skip, const QString &connection)
 
     settings.setValue(QLatin1String(skipUpdateCheckC), QVariant(skip));
     settings.sync();
+}
+
+int ConfigFile::updateSegment() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    int segment = settings.value(QLatin1String(updateSegmentC), -1).toInt();
+
+    // Invalid? (Unset at the very first launch)
+    if(segment < 0 || segment > 99) {
+        // Save valid segment value, normally has to be done only once.
+        segment = qrand() % 99;
+        settings.setValue(QLatin1String(updateSegmentC), segment);
+    }
+
+    return segment;
 }
 
 int ConfigFile::maxLogLines() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -149,6 +149,11 @@ public:
     bool skipUpdateCheck(const QString &connection = QString()) const;
     void setSkipUpdateCheck(bool, const QString &);
 
+    /** Query-parameter 'updatesegment' for the update check, value between 0 and 99.
+        Used to throttle down desktop release rollout in order to keep the update servers alive at peak times.
+        See: https://github.com/nextcloud/client_updater_server/pull/36 */
+    int updateSegment() const;
+
     void saveGeometryHeader(QHeaderView *header);
     void restoreGeometryHeader(QHeaderView *header);
 


### PR DESCRIPTION
Used to throttle down desktop release rollout in order to keep the update servers alive at peak times.

See: https://github.com/nextcloud/client_updater_server/pull/36

Targeted issues: #1795, #1800