### PR TITLE
Disable http2 for now due to Qt bug

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -93,12 +93,12 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
     qInfo(lcAccessManager) << op << verb << newRequest.url().toString() << "has X-Request-ID" << requestId;
     newRequest.setRawHeader("X-Request-ID", requestId);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 4)
-    // only enable HTTP2 with Qt 5.9.4 because old Qt have too many bugs (e.g. QTBUG-64359 is fixed in >= Qt 5.9.4)
+
+    // Disable http2 for now due to Qt bug
     if (newRequest.url().scheme() == "https") { // Not for "http": QTBUG-61397
-        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, true);
+        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, false);
     }
-#endif
+
 
     return QNetworkAccessManager::createRequest(op, newRequest, outgoingData);
 }


### PR DESCRIPTION
  So that user may continue to use http2 on their webpage

Signed-off-by: XNG <Milokita@users.noreply.github.com>