### PR TITLE
Disable HTTP/2 for now due to Qt bug, allow enabling it via env var

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -93,12 +93,12 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
     qInfo(lcAccessManager) << op << verb << newRequest.url().toString() << "has X-Request-ID" << requestId;
     newRequest.setRawHeader("X-Request-ID", requestId);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 4)
-    // only enable HTTP2 with Qt 5.9.4 because old Qt have too many bugs (e.g. QTBUG-64359 is fixed in >= Qt 5.9.4)
+
+    // Disable http2 for now due to Qt bug
     if (newRequest.url().scheme() == "https") { // Not for "http": QTBUG-61397
-        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, true);
+        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, false);
     }
-#endif
+
 
     return QNetworkAccessManager::createRequest(op, newRequest, outgoingData);
 }

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -93,12 +93,19 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
     qInfo(lcAccessManager) << op << verb << newRequest.url().toString() << "has X-Request-ID" << requestId;
     newRequest.setRawHeader("X-Request-ID", requestId);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 4)
+    // only enable HTTP2 with Qt 5.9.4 because old Qt have too many bugs (e.g. QTBUG-64359 is fixed in >= Qt 5.9.4)
 
-    // Disable http2 for now due to Qt bug
+    /* Disable http2 for now due to Qt bug but allow enabling it via env var, see: https://github.com/owncloud/client/pull/7620
+     *   and: https://github.com/nextcloud/desktop/pull/1806
+     * Issue: https://github.com/nextcloud/desktop/issues/1503
+     */
     if (newRequest.url().scheme() == "https") { // Not for "http": QTBUG-61397
-        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, false);
-    }
+        static const bool http2EnabledEnv = qEnvironmentVariableIntValue("OWNCLOUD_HTTP2_ENABLED") == 1;
 
+        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, http2EnabledEnv);
+    }
+#endif
 
     return QNetworkAccessManager::createRequest(op, newRequest, outgoingData);
 }


### PR DESCRIPTION
Disable HTTP/2 for now due to Qt bug but allow enabling it via env var,
see: https://github.com/owncloud/client/pull/7620 and: https://github.com/nextcloud/desktop/pull/1806

Issue: https://github.com/nextcloud/desktop/issues/1503

The build had to be fixed for older Qt versions, so this PR supersedes #1806 to reintroduce the `#if`.