### PR TITLE
WebFlowCredentials: Make username comparison case-insensitive (fix #1741)

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -183,7 +183,11 @@ void WebFlowCredentials::askFromUser() {
 void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user, const QString &pass, const QString &host) {
     Q_UNUSED(host)
 
-    if (_user != user) {
+    // Compare the re-entered username case-insensitive and save the new value (avoid breaking the account)
+    // See issue: https://github.com/nextcloud/desktop/issues/1741
+    if (QString::compare(_user, user, Qt::CaseInsensitive) == 0) {
+        _user = user;
+    } else {
         qCInfo(lcWebFlowCredentials()) << "Authed with the wrong user!";
 
         QString msg = tr("Please login with the user: %1")


### PR DESCRIPTION
Fixes issue #1741

cc @rullzer @camilasan 