### PR TITLE
Fix Explorer pinning: Add fallbacks for Shell commands (fixes #1599)

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -52,6 +52,7 @@
 #include <QInputDialog>
 
 #include <QClipboard>
+#include <QDesktopServices>
 
 #include <QStandardPaths>
 
@@ -291,6 +292,12 @@ void SocketApi::slotReadSocket()
         int indexOfMethod = staticMetaObject.indexOfMethod(functionWithArguments);
 
         QString argument = line.remove(0, command.length() + 1);
+        if (indexOfMethod == -1) {
+            // Fallback: Try upper-case command
+            functionWithArguments = "command_" + command.toUpper() + "(QString,SocketListener*)";
+            indexOfMethod = staticMetaObject.indexOfMethod(functionWithArguments);
+        }
+
         if (indexOfMethod != -1) {
             staticMetaObject.method(indexOfMethod).invoke(this, Q_ARG(QString, argument), Q_ARG(SocketListener *, listener));
         } else {
@@ -620,6 +627,24 @@ void SocketApi::command_COPY_PUBLIC_LINK(const QString &localFile, SocketListene
     auto job = new GetOrCreatePublicLinkShare(account, fileData.accountRelativePath, [](const QString &url) { copyUrlToClipboard(url); }, this);
     job->run();
 }
+
+// Windows Shell / Explorer pinning fallbacks, see issue: https://github.com/nextcloud/desktop/issues/1599
+#ifdef Q_OS_WIN
+void SocketApi::command_COPYASPATH(const QString &localFile, SocketListener *)
+{
+    QApplication::clipboard()->setText(localFile);
+}
+
+void SocketApi::command_OPENNEWWINDOW(const QString &localFile, SocketListener *)
+{
+    QDesktopServices::openUrl(QUrl::fromLocalFile(localFile));
+}
+
+void SocketApi::command_OPEN(const QString &localFile, SocketListener *socketListener)
+{
+    command_OPENNEWWINDOW(localFile, socketListener);
+}
+#endif
 
 // Fetches the private link url asynchronously and then calls the target slot
 void SocketApi::fetchPrivateLinkUrlHelper(const QString &localFile, const std::function<void(const QString &url)> &targetFun)

--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -106,6 +106,13 @@ private:
     Q_INVOKABLE void command_EMAIL_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
     Q_INVOKABLE void command_OPEN_PRIVATE_LINK(const QString &localFile, SocketListener *listener);
 
+    // Windows Shell / Explorer pinning fallbacks, see issue: https://github.com/nextcloud/desktop/issues/1599
+#ifdef Q_OS_WIN
+    Q_INVOKABLE void command_COPYASPATH(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_OPENNEWWINDOW(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_OPEN(const QString &localFile, SocketListener *listener);
+#endif
+
     // Fetch the private link and call targetFun
     void fetchPrivateLinkUrlHelper(const QString &localFile, const std::function<void(const QString &url)> &targetFun);
 


### PR DESCRIPTION
Fixes #1599

- Add fallbacks for Explorer Shell commands
- Incorporate upstream patch: https://github.com/owncloud/client/pull/7056