### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -1,11 +1,17 @@
 #!//usr/bin/env python2.7
 
+from __future__ import print_function
 import subprocess
 import re
 import sys
 import datetime
 import os
 import ConfigParser
+
+try:
+    long
+except NameError:
+    long = int
 
 distribution="yakkety"
 
@@ -123,12 +129,12 @@ def genChangeLogEntries(f, entries, distribution):
             version = upstreamVersion
         else:
             version = upstreamVersion + "~" + distribution + "1"
-        print >> f, "nextcloud-client (%s) %s; urgency=medium" % (version, distribution)
-        print >> f
-        print >> f, "  * " + subject
-        print >> f
-        print >> f, " -- %s <%s>  %s" % (name, email, date)
-        print >> f
+        print("nextcloud-client (%s) %s; urgency=medium" % (version, distribution), file=f)
+        print(file=f)
+        print("  * " + subject, file=f)
+        print(file=f)
+        print(" -- %s <%s>  %s" % (name, email, date), file=f)
+        print(file=f)
     return (latestBaseVersion, latestKind)
 
 if __name__ == "__main__":
@@ -141,4 +147,4 @@ if __name__ == "__main__":
 
     with open(sys.argv[1], "wt") as f:
         (baseVersion, kind) = genChangeLogEntries(f, entries, distribution)
-        print baseVersion, kind
+        print(baseVersion, kind)

--- a/admin/osx/macdeployqt.py
+++ b/admin/osx/macdeployqt.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with ownCloud.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 import os
 import re
 import subprocess
@@ -74,7 +75,7 @@ class CouldNotFindFrameworkError(Error):
   pass
 
 if len(sys.argv) < 3:
-  print 'Usage: %s <bundle.app> <path-to-qmake>' % sys.argv[0]
+  print('Usage: %s <bundle.app> <path-to-qmake>' % sys.argv[0])
   exit()
 
 def is_exe(fpath):
@@ -96,13 +97,13 @@ plugins_dir = os.path.join(bundle_dir, 'Contents', 'PlugIns')
 binaries = [i for i in glob(os.path.join(bundle_dir, 'Contents', 'MacOS', "*")) if is_exe(i)];
 
 qt_version = QueryQMake('QT_VERSION')
-print "Using Qt", qt_version
+print("Using Qt", qt_version)
 
 fixed_libraries = []
 fixed_frameworks = []
 
 def WriteQtConf():
-  print "Writing qt.conf..."
+  print("Writing qt.conf...")
   with open(os.path.join(resources_dir, 'qt.conf'), 'w') as f:
     f.write("[Paths]\nPlugins = PlugIns\n");
     f.close()
@@ -206,7 +207,7 @@ def FixLibrary(path):
     fixed_libraries.append(path)
   abs_path = FindLibrary(path)
   if abs_path == "":
-    print "Could not resolve %s, not fixing!" % path
+    print("Could not resolve %s, not fixing!" % path)
     return
   broken_libs = GetBrokenLibraries(abs_path)
   FixAllLibraries(broken_libs)
@@ -256,7 +257,7 @@ def CopyPlugin(path, subdir):
 
 def CopyFramework(source_dylib):
   parts = source_dylib.split(os.sep)
-  print "CopyFramework:", source_dylib
+  print("CopyFramework:", source_dylib)
   for i, part in enumerate(parts):
     matchObj = re.match(r'(\w+\.framework)', part)
     if matchObj:
@@ -354,9 +355,9 @@ else:
   commands.append(args)
 
 if len(sys.argv) <= 2:
-  print 'Will run %d commands:' % len(commands)
+  print('Will run %d commands:' % len(commands))
   for command in commands:
-    print ' '.join(command)
+    print(' '.join(command))
 
 for command in commands:
   p = subprocess.Popen(command)

--- a/admin/win/nsi/l10n/bin/build_locale_nsi.py
+++ b/admin/win/nsi/l10n/bin/build_locale_nsi.py
@@ -9,6 +9,11 @@ import os
 import polib
 from optparse import OptionParser
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 parser = OptionParser()
 parser.add_option("-o", "--output", dest="output",
                   help="Directory for localized output", default="../Shared/installer/nightly_localized.nsi")
@@ -126,7 +131,7 @@ for root,dirs,files in os.walk(options.podir):
             if filename in localeToName:
                 language = localeToName[filename]
                 translationCache[language] = collections.OrderedDict()
-                
+
                 po = polib.pofile(os.path.join(root,file))
                 for entry in po.translated_entries():
                     # Loop through all our labels and add translation (each translation may have multiple labels)
@@ -165,14 +170,14 @@ for language,translations in translationCache.iteritems():
     for label,value in translations.iteritems():
         NSINewLines.append( tostr('StrCpy $%s "%s"\n' % (label,value)) )
         if language.upper() == options.lang.upper():
-	    NSIDeclarations.append( tostr('Var %s\n' % label) )
+            NSIDeclarations.append( tostr('Var %s\n' % label) )
 
         count += 1
     NSIWorkingFile = open('%s/%s.nsh' % (options.output, language),"w")
     NSIWorkingFile.writelines(NSINewLines)
     NSIWorkingFile.close()
     print ( "%i translations merged for language '%s'"%(count,language) )
-    
+
 # Finally, let's write languages.nsh and declarations.nsh
 NSIWorkingFile = open('%s/languages.nsh' % options.output,"w")
 NSIWorkingFile.writelines(NSILanguages)
@@ -181,5 +186,5 @@ NSIWorkingFile.close()
 NSIWorkingFile = open('%s/declarations.nsh' % options.output,"w")
 NSIWorkingFile.writelines(NSIDeclarations)
 NSIWorkingFile.close()
-    
+
 print ( "NSI Localization Operation Complete" )

--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -296,6 +296,7 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         state = entry['state']
         state_ok = state.startswith('OK')
         state_sync = state.startswith('SYNC')
+        isDir = os.path.isdir(filename + os.sep)
         if state_ok:
             shareable = True
         elif state_sync and isDir:


### PR DESCRIPTION
Fix some Python 3 related syntax errors, undefined names, etc.

[flake8](http://flake8.pycqa.org) testing of https://github.com/nextcloud/desktop on Python 3.8.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./shell_integration/nautilus/syncstate.py:301:29: F821 undefined name 'isDir'
        elif state_sync and isDir:
                            ^
./admin/win/nsi/l10n/bin/build_locale_nsi.py:168:56: E999 TabError: inconsistent use of tabs and spaces in indentation
	    NSIDeclarations.append( tostr('Var %s\n' % label) )
                                                       ^
./admin/linux/debian/scripts/git2changelog.py:144:15: E999 SyntaxError: invalid syntax
        print baseVersion, kind
              ^
./admin/osx/macdeployqt.py:77:9: E999 SyntaxError: invalid syntax
  print 'Usage: %s <bundle.app> <path-to-qmake>' % sys.argv[0]
        ^
3     E999 SyntaxError: invalid syntax
1     F821 undefined name 'isDir'
4
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
