### PR TITLE
Enhance Version info display (minimal info, hide details)

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -65,6 +65,7 @@ namespace {
     static const char optionsC[] =
         "Options:\n"
         "  -h --help            : show this help screen.\n"
+        "  --version            : show version information.\n"
         "  --logwindow          : open a window to show log output.\n"
         "  --logfile <filename> : write log output to file <filename>.\n"
         "  --logdir <name>      : write each sync log output in a new file\n"

--- a/src/gui/legalnotice.cpp
+++ b/src/gui/legalnotice.cpp
@@ -14,6 +14,7 @@
 
 #include "legalnotice.h"
 #include "ui_legalnotice.h"
+#include "theme.h"
 
 namespace OCC {
 
@@ -24,16 +25,9 @@ LegalNotice::LegalNotice(QDialog *parent)
 {
     _ui->setupUi(this);
 
-    QString notice = tr("<p>Copyright 2017-2020 Nextcloud GmbH<br />"
-                        "Copyright 2012-2018 ownCloud GmbH</p>");
-
-    notice += tr("<p>Licensed under the GNU General Public License (GPL) Version 2.0 or any later version.</p>");
-
-    _ui->notice->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextBrowserInteraction);
-    _ui->notice->setText(notice);
-    _ui->notice->setWordWrap(true);
-
     connect(_ui->closeButton, &QPushButton::clicked, this, &LegalNotice::accept);
+
+    customizeStyle();
 }
 
 LegalNotice::~LegalNotice()
@@ -41,4 +35,37 @@ LegalNotice::~LegalNotice()
     delete _ui;
 }
 
+void LegalNotice::changeEvent(QEvent *e)
+{
+    switch (e->type()) {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::ThemeChange:
+        customizeStyle();
+        break;
+    default:
+        break;
+    }
+
+    QDialog::changeEvent(e);
 }
+
+void LegalNotice::customizeStyle()
+{
+    QString notice = tr("<p>Copyright 2017-2020 Nextcloud GmbH<br />"
+                        "Copyright 2012-2018 ownCloud GmbH</p>");
+
+    notice += tr("<p>Licensed under the GNU General Public License (GPL) Version 2.0 or any later version.</p>");
+
+    notice += "<p>&nbsp;</p>";
+    notice += Theme::instance()->aboutDetails();
+
+    Theme::replaceLinkColorStringBackgroundAware(notice);
+
+    _ui->notice->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextBrowserInteraction);
+    _ui->notice->setText(notice);
+    _ui->notice->setWordWrap(true);
+    _ui->notice->setOpenExternalLinks(true);
+}
+
+} // namespace OCC

--- a/src/gui/legalnotice.h
+++ b/src/gui/legalnotice.h
@@ -37,7 +37,12 @@ public:
     explicit LegalNotice(QDialog *parent = nullptr);
     ~LegalNotice();
 
+protected:
+    void changeEvent(QEvent *) override;
+
 private:
+    void customizeStyle();
+
     Ui::LegalNotice *_ui;
 };
 

--- a/src/gui/legalnotice.ui
+++ b/src/gui/legalnotice.ui
@@ -11,15 +11,14 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Dialog</string>
+   <string>Legal notice</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QLabel" name="header">
      <property name="font">
       <font>
-       <family>Arabic Newspaper</family>
-       <pointsize>11</pointsize>
+       <pointsize>13</pointsize>
       </font>
      </property>
      <property name="text">

--- a/src/gui/legalnotice.ui
+++ b/src/gui/legalnotice.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>260</height>
+    <width>591</width>
+    <height>360</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -550,7 +550,9 @@ QString Theme::versionSwitchOutput() const
     stream << "Git revision " << GIT_SHA1 << endl;
 #endif
     stream << "Using Qt " << qVersion() << ", built against Qt " << QT_VERSION_STR << endl;
+    stream << "Using Qt platform plugin '" << QGuiApplication::platformName() << "'" << endl;
     stream << "Using '" << QSslSocket::sslLibraryVersionString() << "'" << endl;
+    stream << "Running on " << Utility::platformName() << ", " << QSysInfo::currentCpuArchitecture() << endl;
     return helpText;
 }
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -337,6 +337,24 @@ QString Theme::gitSHA1() const
 
 QString Theme::about() const
 {
+    // Shorten Qt's OS name: "macOS Mojave (10.14)" -> "macOS"
+    QStringList osStringList = Utility::platformName().split(QLatin1Char(' '));
+    QString osName = osStringList.at(0);
+
+    QString devString;
+    //: Example text: "<p>Nextcloud Desktop Client</p>"   (%1 is the application name)
+    devString = tr("<p>%1 Desktop Client</p>")
+              .arg(APPLICATION_NAME);
+
+    devString += tr("<p>Version %1. For more information please click <a href='%2'>here</a>.</p>")
+              .arg(QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION)) + QString(" (%1)").arg(osName))
+              .arg(helpUrl());
+
+    return devString;
+}
+
+QString Theme::aboutDetails() const
+{
     QString devString;
     devString = tr("<p>Version %1. For more information please click <a href='%2'>here</a>.</p>")
               .arg(MIRALL_VERSION_STRING)

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -206,6 +206,11 @@ public:
     virtual QString about() const;
 
     /**
+     * Legal notice dialog version detail contents
+     */
+    virtual QString aboutDetails() const;
+
+    /**
      * Define if the systray icons should be using mono design
      */
     void setSystrayUseMonoIcons(bool mono);


### PR DESCRIPTION
### Settings dialog: About section
<img width="691" alt="Screenshot 2020-03-07 at 06 14 26" src="https://user-images.githubusercontent.com/48932272/76137760-c48d7600-6040-11ea-994a-072b474e1e6e.png">

### Detail info moved to Legal notice dialog
<img width="703" alt="Screenshot 2020-03-07 at 06 14 37" src="https://user-images.githubusercontent.com/48932272/76137769-e0911780-6040-11ea-94ee-ab4ddf022a2f.png">

### Further improvements

- Show missing `--version` syntax in `--help` screen:
  ```
  [...]

  Options:
    -h --help            : show this help screen.
    --version            : show version information.
    --logwindow          : open a window to show log output.

  [...]
  ```

- Show Qt platform plugin, OS and CPU arch in `--version` output:
  ```
  Nextcloud version 2.7.0daily (build 20200306)
  Git revision aa5556b7d077a5854d7baf49e96cf4a90291ec4d
  Using Qt 5.12.5, built against Qt 5.12.5
  Using Qt platform plugin 'cocoa'
  Using 'OpenSSL 1.1.1d  10 Sep 2019'
  Running on macOS Mojave (10.14), x86_64
  ```