### PR TITLE
Updater: Enhance UI, make build optional

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
       source /opt/qt57/bin/qt57-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -59,7 +59,7 @@ steps:
       source /opt/qt58/bin/qt58-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -96,7 +96,7 @@ steps:
       source /opt/qt59/bin/qt59-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON  ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -137,7 +137,7 @@ steps:
       source /opt/qt510/bin/qt510-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -178,7 +178,7 @@ steps:
       source /opt/qt511/bin/qt511-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -219,7 +219,7 @@ steps:
       source /opt/qt511/bin/qt511-env.sh &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -268,7 +268,7 @@ steps:
       export PKG_CONFIG_PATH=\$QT_BASE_DIR/lib/pkgconfig:\$PKG_CONFIG_PATH &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&
@@ -317,7 +317,7 @@ steps:
       export PKG_CONFIG_PATH=\$QT_BASE_DIR/lib/pkgconfig:\$PKG_CONFIG_PATH &&
       mkdir build &&
       cd build &&
-      cmake -D NO_SHIBBOLETH=1 -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
+      cmake -D NO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../ &&
       make &&
       useradd -m -s /bin/bash test &&
       chown -R test:test . &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,15 @@ if(NO_MSG_HANDLER)
    add_definitions(-DNO_MSG_HANDLER=1)
 endif()
 
+# this option builds the updater
+option(BUILD_UPDATER "BUILD_UPDATER" OFF)
+if(BUILD_UPDATER)
+   message("Compiling with updater")
+   add_definitions(-DBUILD_UPDATER=1)
+else()
+   message("Compiling without updater")
+endif()
+
 # this option builds the shell integration
 option(BUILD_SHELL_INTEGRATION "BUILD_SHELL_INTEGRATION" ON)
 
@@ -172,9 +181,9 @@ if(APPLE)
 endif()
 
 if(BUILD_CLIENT)
-    if(APPLE)
+    if(APPLE AND BUILD_UPDATER)
         find_package(Sparkle)
-    endif(APPLE)
+    endif()
 
     if(UNIX)
         find_package(INotify REQUIRED)

--- a/NEXTCLOUD.cmake
+++ b/NEXTCLOUD.cmake
@@ -24,6 +24,9 @@ option( WITH_CRASHREPORTER "Build crashreporter" OFF )
 #set( CRASHREPORTER_SUBMIT_URL "https://crash-reports.owncloud.com/submit" CACHE STRING "URL for crash reporter" )
 #set( CRASHREPORTER_ICON ":/owncloud-icon.png" )
 
+## Updater options
+option( BUILD_UPDATER "Build updater" OFF )
+
 option( WITH_PROVIDERS "Build with providers list" ON )
 
 

--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -38,6 +38,7 @@ mkdir build-client
 cd build-client
 cmake -D CMAKE_INSTALL_PREFIX=/usr \
     -D NO_SHIBBOLETH=1 \
+    -D BUILD_UPDATER=ON \
     -D QTKEYCHAIN_LIBRARY=/app/usr/lib/x86_64-linux-gnu/libqt5keychain.so \
     -D QTKEYCHAIN_INCLUDE_DIR=/app/usr/include/qt5keychain/ \
     -DMIRALL_VERSION_SUFFIX=PR-$DRONE_PULL_REQUEST \

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -3,7 +3,10 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick)
 set(CMAKE_AUTOMOC TRUE)
 set(CMAKE_AUTOUIC TRUE)
 set(CMAKE_AUTORCC TRUE)
-add_subdirectory(updater)
+
+IF(BUILD_UPDATER)
+    add_subdirectory(updater)
+endif()
 
 set(MIRALL_RC_SRC ../../resources.qrc)
 if (EXISTS "${OEM_THEME_DIR}/theme.qrc")
@@ -139,18 +142,20 @@ IF(NOT NO_SHIBBOLETH)
     )
 endif()
 
-set(updater_SRCS
-    updater/ocupdater.cpp
-    updater/updateinfo.cpp
-    updater/updater.cpp
-)
+IF(BUILD_UPDATER)
+    set(updater_SRCS
+        updater/ocupdater.cpp
+        updater/updateinfo.cpp
+        updater/updater.cpp
+    )
+endif()
 
 IF( APPLE )
     list(APPEND client_SRCS cocoainitializer_mac.mm)
     list(APPEND client_SRCS socketapisocket_mac.mm)
     list(APPEND client_SRCS systray.mm)
 
-    if(SPARKLE_FOUND)
+    if(SPARKLE_FOUND AND BUILD_UPDATER)
        # Define this, we need to check in updater.cpp
        add_definitions( -DHAVE_SPARKLE )
        list(APPEND updater_SRCS updater/sparkleupdater_mac.mm)
@@ -298,9 +303,11 @@ else()
     install(FILES ${qtkeychain_I18N} DESTINATION ${QM_DIR})
 endif()
 
-add_library(updater STATIC ${updater_SRCS})
-target_link_libraries(updater ${synclib_NAME} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml Qt5::WebEngineWidgets)
-target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+IF(BUILD_UPDATER)
+    add_library(updater STATIC ${updater_SRCS})
+    target_link_libraries(updater ${synclib_NAME} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml)
+    target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY  ${BIN_OUTPUT_DIRECTORY}
@@ -309,9 +316,11 @@ set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
 set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/${APPLICATION_EXECUTABLE};${CMAKE_INSTALL_RPATH}" )
 
-target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml Qt5::Qml Qt5::Quick)
+target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml Qt5::Qml Qt5::Quick Qt5::WebEngineWidgets)
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${synclib_NAME} )
-target_link_libraries( ${APPLICATION_EXECUTABLE} updater )
+IF(BUILD_UPDATER)
+    target_link_libraries( ${APPLICATION_EXECUTABLE} updater )
+endif()
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${OS_SPECIFIC_LINK_LIBRARIES} )
 IF( LIBCLOUDPROVIDERS_FOUND )
     string(TOLOWER "${APPLICATION_VENDOR}" DBUS_VENDOR)
@@ -334,6 +343,7 @@ target_include_directories(${APPLICATION_EXECUTABLE} PRIVATE
     ${CMAKE_SOURCE_DIR}/src/3rdparty/qtsingleapplication
     ${CMAKE_SOURCE_DIR}/src/3rdparty/kmessagewidget
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 ## handle DBUS for Fdo notifications

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -34,7 +34,11 @@
 #include "sharedialog.h"
 #include "accountmanager.h"
 #include "creds/abstractcredentials.h"
+
+#if defined(BUILD_UPDATER)
 #include "updater/ocupdater.h"
+#endif
+
 #include "owncloudsetupwizard.h"
 #include "version.h"
 
@@ -254,12 +258,14 @@ Application::Application(int &argc, char **argv)
     connect(&_networkConfigurationManager, &QNetworkConfigurationManager::configurationChanged,
         this, &Application::slotSystemOnlineConfigurationChanged);
 
+#if defined(BUILD_UPDATER)
     // Update checks
     UpdaterScheduler *updaterScheduler = new UpdaterScheduler(this);
     connect(updaterScheduler, &UpdaterScheduler::updaterAnnouncement,
         _gui.data(), &ownCloudGui::slotShowTrayMessage);
     connect(updaterScheduler, &UpdaterScheduler::requestRestart,
         _folderManager.data(), &FolderMan::slotScheduleAppRestart);
+#endif
 
     // Cleanup at Quit.
     connect(this, &QCoreApplication::aboutToQuit, this, &Application::slotCleanup);

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -23,8 +23,11 @@
 #include "accountmanager.h"
 #include "synclogdialog.h"
 
+#if defined(BUILD_UPDATER)
 #include "updater/updater.h"
 #include "updater/ocupdater.h"
+#endif
+
 #include "ignorelisteditor.h"
 #include "common/utility.h"
 
@@ -150,6 +153,7 @@ void GeneralSettings::loadMiscSettings()
     _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
 }
 
+#if defined(BUILD_UPDATER)
 void GeneralSettings::slotUpdateInfo()
 {
     // Note: the sparkle-updater is not an OCUpdater
@@ -202,6 +206,7 @@ void GeneralSettings::slotToggleAutoUpdateCheck()
     bool isChecked = _ui->autoCheckForUpdatesCheckBox->isChecked();
     cfgFile.setAutoUpdateCheck(isChecked, QString());
 }
+#endif // defined(BUILD_UPDATER)
 
 void GeneralSettings::saveMiscSettings()
 {
@@ -269,8 +274,12 @@ void GeneralSettings::customizeStyle()
     Theme::replaceLinkColorStringBackgroundAware(about);
     _ui->aboutLabel->setText(about);
 
+#if defined(BUILD_UPDATER)
     // updater info
     slotUpdateInfo();
+#else
+    _ui->updatesGroupBox->setVisible(false);
+#endif
 }
 
 } // namespace OCC

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -47,10 +47,12 @@ private slots:
     void slotToggleLaunchOnStartup(bool);
     void slotToggleOptionalServerNotifications(bool);
     void slotShowInExplorerNavigationPane(bool);
-    void slotUpdateInfo();
     void slotIgnoreFilesEditor();
     void loadMiscSettings();
     void slotShowLegalNotice();
+    void slotUpdateInfo();
+    void slotUpdateCheckNow();
+    void slotToggleAutoUpdateCheck();
 
 private:
     void customizeStyle();

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -50,9 +50,11 @@ private slots:
     void slotIgnoreFilesEditor();
     void loadMiscSettings();
     void slotShowLegalNotice();
+#if defined(BUILD_UPDATER)
     void slotUpdateInfo();
     void slotUpdateCheckNow();
     void slotToggleAutoUpdateCheck();
+#endif
 
 private:
     void customizeStyle();

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -98,48 +98,95 @@
      <property name="title">
       <string>Updates</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="updateStateLabel">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QCheckBox" name="autoCheckForUpdatesCheckBox">
+          <property name="text">
+           <string>&amp;Automatically check for Updates</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="updateButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Check for Update now</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
-      <item>
-       <widget class="QPushButton" name="restartButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>&amp;Restart &amp;&amp; Update</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Preferred</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="updateStateLabel">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="restartButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Restart &amp;&amp; Update</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -283,6 +330,8 @@
   <tabstop>newFolderLimitCheckBox</tabstop>
   <tabstop>newFolderLimitSpinBox</tabstop>
   <tabstop>crashreporterCheckBox</tabstop>
+  <tabstop>autoCheckForUpdatesCheckBox</tabstop>
+  <tabstop>updateButton</tabstop>
   <tabstop>restartButton</tabstop>
  </tabstops>
  <resources/>

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -26,7 +26,9 @@
 #include "common/utility.h"
 #include "cocoainitializer.h"
 
+#if defined(BUILD_UPDATER)
 #include "updater/updater.h"
+#endif
 
 #include <QTimer>
 #include <QMessageBox>
@@ -103,6 +105,8 @@ int main(int argc, char **argv)
         }
     }
 #endif
+
+#if defined(BUILD_UPDATER)
     // if handleStartup returns true, main()
     // needs to terminate here, e.g. because
     // the updater is triggered
@@ -110,6 +114,7 @@ int main(int argc, char **argv)
     if (updater && updater->handleStartup()) {
         return 1;
     }
+#endif
 
     // if the application is already running, notify it.
     if (app.isRunning()) {

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -68,8 +68,8 @@ void UpdaterScheduler::slotTimerFired()
         qCInfo(lcUpdater) << "Setting new update check interval " << checkInterval;
     }
 
-    // consider the skipUpdateCheck flag in the config.
-    if (cfg.skipUpdateCheck()) {
+    // consider the skipUpdateCheck and !autoUpdateCheck flags in the config.
+    if (cfg.skipUpdateCheck() || !cfg.autoUpdateCheck()) {
         qCInfo(lcUpdater) << "Skipping update check because of config file";
         return;
     }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -223,6 +223,7 @@ void OCUpdater::slotVersionInfoArrived()
     reply->deleteLater();
     if (reply->error() != QNetworkReply::NoError) {
         qCWarning(lcUpdater) << "Failed to reach version check url: " << reply->errorString();
+        setDownloadState(DownloadTimedOut);
         return;
     }
 
@@ -234,6 +235,7 @@ void OCUpdater::slotVersionInfoArrived()
         versionInfoArrived(_updateInfo);
     } else {
         qCWarning(lcUpdater) << "Could not parse update information.";
+        setDownloadState(DownloadTimedOut);
     }
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -63,6 +63,7 @@ static const char crashReporterC[] = "crashReporter";
 static const char optionalServerNotificationsC[] = "optionalServerNotifications";
 static const char showInExplorerNavigationPaneC[] = "showInExplorerNavigationPane";
 static const char skipUpdateCheckC[] = "skipUpdateCheck";
+static const char autoUpdateCheckC[] = "autoUpdateCheck";
 static const char updateCheckIntervalC[] = "updateCheckInterval";
 static const char updateSegmentC[] = "updateSegment";
 static const char geometryC[] = "geometry";
@@ -574,6 +575,32 @@ void ConfigFile::setSkipUpdateCheck(bool skip, const QString &connection)
     settings.beginGroup(con);
 
     settings.setValue(QLatin1String(skipUpdateCheckC), QVariant(skip));
+    settings.sync();
+}
+
+bool ConfigFile::autoUpdateCheck(const QString &connection) const
+{
+    QString con(connection);
+    if (connection.isEmpty())
+        con = defaultConnection();
+
+    QVariant fallback = getValue(QLatin1String(autoUpdateCheckC), con, true);
+    fallback = getValue(QLatin1String(autoUpdateCheckC), QString(), fallback);
+
+    QVariant value = getPolicySetting(QLatin1String(autoUpdateCheckC), fallback);
+    return value.toBool();
+}
+
+void ConfigFile::setAutoUpdateCheck(bool autoCheck, const QString &connection)
+{
+    QString con(connection);
+    if (connection.isEmpty())
+        con = defaultConnection();
+
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.beginGroup(con);
+
+    settings.setValue(QLatin1String(autoUpdateCheckC), QVariant(autoCheck));
     settings.sync();
 }
 

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -146,8 +146,13 @@ public:
     // how often the check about new versions runs
     std::chrono::milliseconds updateCheckInterval(const QString &connection = QString()) const;
 
+    // skipUpdateCheck completely disables the updater and hides its UI
     bool skipUpdateCheck(const QString &connection = QString()) const;
     void setSkipUpdateCheck(bool, const QString &);
+
+    // autoUpdateCheck allows the user to make the choice in the UI
+    bool autoUpdateCheck(const QString &connection = QString()) const;
+    void setAutoUpdateCheck(bool, const QString &);
 
     /** Query-parameter 'updatesegment' for the update check, value between 0 and 99.
         Used to throttle down desktop release rollout in order to keep the update servers alive at peak times.


### PR DESCRIPTION
![Screenshot from 2020-03-09 04-23-39](https://user-images.githubusercontent.com/48932272/76180545-88801f80-61be-11ea-95fc-727f64eb3bbb.png)

### UI: Implement auto-update option and update button

- Add checkbox and button to UI
- Add new parameter autoUpdateCheck to ConfigFile

### Bugfix
- Fix OCUpdater: Also change status on network error or invalid XML

### Add _CMake_ option `BUILD_UPDATER` to make the updater optional

- Default: `BUILD_UPDATER` = `NO`

  To ease builds for distro packages and contributors (regardless of the specified update URL)

- Enable updater build for Drone CI and AppImage builds

### Next steps (follow-up PRs)

- Resurrect auto-update functionality (macOS (Sparkle) work in progress, Windows next)
- Add support for update channels: stable, beta