### PR TITLE
Provide specific install file for Debian oldstable

### DIFF
--- a/admin/linux/debian/debian.oldstable/nextcloud-client.install
+++ b/admin/linux/debian/debian.oldstable/nextcloud-client.install
@@ -1,0 +1,4 @@
+usr/bin
+usr/share/applications
+usr/share/icons
+debian/101-sync-inotify.conf etc/sysctl.d


### PR DESCRIPTION
The Debian oldstable distribution does not have libcloudproviders, and the build fails when it wants to install the files in the directories that are present only if libcloudproviders is used.

This patch adds a specific .install file, which does not contain any reference to those directories.