### PR TITLE
Add desktop-entry hint to notifications

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -121,8 +121,9 @@ void Systray::showMessage(const QString &title, const QString &message, MessageI
 {
 #ifdef USE_FDO_NOTIFICATIONS
     if (QDBusInterface(NOTIFICATIONS_SERVICE, NOTIFICATIONS_PATH, NOTIFICATIONS_IFACE).isValid()) {
+        const QVariantMap hints = {{QStringLiteral("desktop-entry"), QStringLiteral("com.nextcloud.desktopclient.nextcloud")}};
         QList<QVariant> args = QList<QVariant>() << APPLICATION_NAME << quint32(0) << APPLICATION_ICON_NAME
-                                                 << title << message << QStringList() << QVariantMap() << qint32(-1);
+                                                 << title << message << QStringList() << hints << qint32(-1);
         QDBusMessage method = QDBusMessage::createMethodCall(NOTIFICATIONS_SERVICE, NOTIFICATIONS_PATH, NOTIFICATIONS_IFACE, "Notify");
         method.setArguments(args);
         QDBusConnection::sessionBus().asyncCall(method);

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -121,7 +121,7 @@ void Systray::showMessage(const QString &title, const QString &message, MessageI
 {
 #ifdef USE_FDO_NOTIFICATIONS
     if (QDBusInterface(NOTIFICATIONS_SERVICE, NOTIFICATIONS_PATH, NOTIFICATIONS_IFACE).isValid()) {
-        const QVariantMap hints = {{QStringLiteral("desktop-entry"), QStringLiteral("com.nextcloud.desktopclient.nextcloud")}};
+        const QVariantMap hints = {{QStringLiteral("desktop-entry"), LINUX_APPLICATION_ID}};
         QList<QVariant> args = QList<QVariant>() << APPLICATION_NAME << quint32(0) << APPLICATION_ICON_NAME
                                                  << title << message << QStringList() << hints << qint32(-1);
         QDBusMessage method = QDBusMessage::createMethodCall(NOTIFICATIONS_SERVICE, NOTIFICATIONS_PATH, NOTIFICATIONS_IFACE, "Notify");


### PR DESCRIPTION
This allows the notification server to map a notification to the program's desktop file, which allows the server to do extra things. For example KDE Plasma adds the Nextcloud icon to the notification and allows to configure notifications from Nextcloud.

This is a standard hint from https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#hints