### PR TITLE
Remove timeout parameter from showMessage

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -117,7 +117,7 @@ Q_INVOKABLE void Systray::setClosed()
     _isOpen = false;
 }
 
-void Systray::showMessage(const QString &title, const QString &message, MessageIcon icon, int millisecondsTimeoutHint)
+void Systray::showMessage(const QString &title, const QString &message, MessageIcon icon)
 {
 #ifdef USE_FDO_NOTIFICATIONS
     if (QDBusInterface(NOTIFICATIONS_SERVICE, NOTIFICATIONS_PATH, NOTIFICATIONS_IFACE).isValid()) {
@@ -134,7 +134,7 @@ void Systray::showMessage(const QString &title, const QString &message, MessageI
     } else
 #endif
     {
-        QSystemTrayIcon::showMessage(title, message, icon, millisecondsTimeoutHint);
+        QSystemTrayIcon::showMessage(title, message, icon);
     }
 }
 

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -47,7 +47,7 @@ public:
     virtual ~Systray() {};
 
     void create();
-    void showMessage(const QString &title, const QString &message, MessageIcon icon = Information, int millisecondsTimeoutHint = 10000);
+    void showMessage(const QString &title, const QString &message, MessageIcon icon = Information);
     void setToolTip(const QString &tip);
     bool isOpen();
 


### PR DESCRIPTION
It it never set by calling code so the default value of 10000 is used. It is only used in the call to QSystemTrayIcon, which uses 10000 as default value too.

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>