### PR TITLE
Use qEnvironmentVariableIsEmpty

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -150,7 +150,7 @@ QByteArray contentChecksumType()
 
 static bool checksumComputationEnabled()
 {
-    static bool enabled = qgetenv("OWNCLOUD_DISABLE_CHECKSUM_COMPUTATIONS").isEmpty();
+    static bool enabled = qEnvironmentVariableIsEmpty("OWNCLOUD_DISABLE_CHECKSUM_COMPUTATIONS");
     return enabled;
 }
 


### PR DESCRIPTION
clazy suggests that it is more efficient since it doesn't allocate.

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>