### PR TITLE
Debian versioning updates

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -4,9 +4,11 @@ set -xe
 shopt -s extglob
 
 PPA=ppa:nextcloud-devs/client
+PPA_ALPHA=ppa:nextcloud-devs/client-alpha
 PPA_BETA=ppa:nextcloud-devs/client-beta
 
 OBS_PROJECT=home:ivaradi
+OBS_PROJECT_ALPHA=home:ivaradi:alpha
 OBS_PROJECT_BETA=home:ivaradi:beta
 OBS_PACKAGE=nextcloud-client
 
@@ -37,7 +39,9 @@ cd "${DRONE_DIR}"
 
 echo "$kind" > kind
 
-if test "$kind" = "beta"; then
+if test "$kind" = "alpha"; then
+    repo=nextcloud-devs/client-alpha
+elif test "$kind" = "beta"; then
     repo=nextcloud-devs/client-beta
 else
     repo=nextcloud-devs/client
@@ -94,7 +98,10 @@ done
 if test "${pull_request}" = "master"; then
     kind=`cat kind`
 
-    if test "$kind" = "beta"; then
+    if test "$kind" = "alpha"; then
+        PPA=$PPA_ALPHA
+        OBS_PROJECT=$OBS_PROJECT_ALPHA
+    elif test "$kind" = "beta"; then
         PPA=$PPA_BETA
         OBS_PROJECT=$OBS_PROJECT_BETA
     fi

--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -83,7 +83,7 @@ def collectEntries(baseCommit, baseVersion, kind):
         revdate = datetime.datetime.utcfromtimestamp(long(revdate)).strftime("%Y%m%d.%H%M%S")
         revdate += "." + commit
 
-        kind = "beta"
+        kind = "alpha"
 
         if commit==newVersionCommit:
             result = processVersionTag(newVersionTag)

--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -79,7 +79,9 @@ def collectEntries(baseCommit, baseVersion, kind):
         words = line.split("\t")
         (commit, name, email, date, revdate) = words[0:5]
         subject = "\t".join(words[5:])
+
         revdate = datetime.datetime.utcfromtimestamp(long(revdate)).strftime("%Y%m%d.%H%M%S")
+        revdate += "." + commit
 
         kind = "beta"
 
@@ -112,6 +114,11 @@ def collectEntries(baseCommit, baseVersion, kind):
 
         entries.append((commit, name, email, date, revdate, subject,
                         baseVersion, kind))
+
+    if entries:
+        (commit, name, email, date, revdate, subject, baseVersion, kind) = entries[-1]
+        revdate = datetime.datetime.now().strftime("%Y%m%d.%H%M%S")+ "." + commit
+        entries[-1] = (commit, name, email, date, revdate, subject, baseVersion, kind)
 
     entries.reverse()
 


### PR DESCRIPTION
Two major changes are introduced by this PR related to the Debian builds:

- Currenty the version numbers are generated from the timestamps of commits. However, it sometimes happens that an older commit is merged later than a newer one, in which case the version number of the commit merged later is smaller than that of the commit merged earlier. This is then rejected by Launchpad. The first commit makes the version to be generated from the build's timestamp. It also adds the commit ID in case two builds were run at exactly the same time and also for an easier identification of the commit the build was generated from.

- Currently there are two PPAs: one for stable builds and another for "beta" ones. The "beta" here means the builds from the master branch, which are arguably more like "alpha" versions. The second commit makes the builds from the master branch go to an "alpha" PPA. The "beta" PPA will be used for the release candidate versions.