### PR TITLE
Reorganize Debian build

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -71,7 +71,8 @@ for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
     git merge ${DRONE_COMMIT}
 
     admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution} ${revdate}
-    cp /tmp/tmpchangelog debian/changelog
+    cat /tmp/tmpchangelog debian/changelog > debian/changelog.new
+    mv debian/changelog.new debian/changelog
 
     fullver=`head -1 debian/changelog | sed "s:nextcloud-desktop (\([^)]*\)).*:\1:"`
 

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -14,7 +14,7 @@ OBS_PROJECT_ALPHA=home:ivaradi:alpha
 OBS_PROJECT_BETA=home:ivaradi:beta
 OBS_PACKAGE=nextcloud-desktop
 
-UBUNTU_DISTRIBUTIONS="xenial bionic eoan focal"
+UBUNTU_DISTRIBUTIONS="xenial bionic eoan focal groovy"
 DEBIAN_DISTRIBUTIONS="buster stretch"
 
 pull_request=${DRONE_PULL_REQUEST:=master}

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -3,6 +3,8 @@
 set -xe
 shopt -s extglob
 
+env
+
 PPA=ppa:nextcloud-devs/client
 PPA_ALPHA=ppa:nextcloud-devs/client-alpha
 PPA_BETA=ppa:nextcloud-devs/client-beta
@@ -10,7 +12,10 @@ PPA_BETA=ppa:nextcloud-devs/client-beta
 OBS_PROJECT=home:ivaradi
 OBS_PROJECT_ALPHA=home:ivaradi:alpha
 OBS_PROJECT_BETA=home:ivaradi:beta
-OBS_PACKAGE=nextcloud-client
+OBS_PACKAGE=nextcloud-desktop
+
+UBUNTU_DISTRIBUTIONS="xenial bionic eoan focal"
+DEBIAN_DISTRIBUTIONS="buster stretch"
 
 pull_request=${DRONE_PULL_REQUEST:=master}
 
@@ -33,7 +38,7 @@ fi
 set -x
 
 cd "${DRONE_WORKSPACE}"
-read basever kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
 
 cd "${DRONE_DIR}"
 
@@ -49,55 +54,40 @@ fi
 
 origsourceopt=""
 
-if ! wget http://ppa.launchpad.net/${repo}/ubuntu/pool/main/n/nextcloud-client/nextcloud-client_${basever}.orig.tar.bz2; then
-    cp -a ${DRONE_WORKSPACE} nextcloud-client_${basever}
-    tar cjf nextcloud-client_${basever}.orig.tar.bz2 --exclude .git nextcloud-client_${basever}
-    origsourceopt="-sa"
-fi
+cp -a ${DRONE_WORKSPACE} nextcloud-desktop_${basever}-${revdate}
+tar cjf nextcloud-desktop_${basever}-${revdate}.orig.tar.bz2 --exclude .git --exclude binary nextcloud-desktop_${basever}-${revdate}
 
-for distribution in xenial bionic eoan focal groovy stable oldstable; do
-    rm -rf nextcloud-client_${basever}
-    cp -a ${DRONE_WORKSPACE} nextcloud-client_${basever}
+cd "${DRONE_WORKSPACE}"
+git config --global user.email "drone@noemail.invalid"
+git config --global user.name "Drone User"
 
-    cd nextcloud-client_${basever}
+for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
+    git checkout -- .
+    git clean -xdf
 
-    cp -a admin/linux/debian/debian .
-    if test -d admin/linux/debian/debian.${distribution}; then
-        tar cf - -C admin/linux/debian/debian.${distribution} . | tar xf - -C debian
-    fi
+    git fetch origin debian/dist/${distribution}/${DRONE_TARGET_BRANCH}
+    git checkout origin/debian/dist/${distribution}/${DRONE_TARGET_BRANCH}
 
-    admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution}
+    git merge ${DRONE_COMMIT}
+
+    admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution} ${revdate}
     cp /tmp/tmpchangelog debian/changelog
-    if test -f admin/linux/debian/debian.${distribution}/changelog; then
-        cat admin/linux/debian/debian.${distribution}/changelog >> debian/changelog
-    else
-        cat admin/linux/debian/debian/changelog >> debian/changelog
-    fi
 
-    for p in debian/post-patches/*.patch; do
-        if test -f "${p}"; then
-            echo "Applying ${p}"
-            patch -p1 < "${p}"
-        fi
-    done
-
-    fullver=`head -1 debian/changelog | sed "s:nextcloud-client (\([^)]*\)).*:\1:"`
+    fullver=`head -1 debian/changelog | sed "s:nextcloud-desktop (\([^)]*\)).*:\1:"`
 
     EDITOR=true dpkg-source --commit . local-changes
 
     dpkg-source --build .
-    dpkg-genchanges -S ${origsourceopt} > "../nextcloud-client_${fullver}_source.changes"
+    dpkg-genchanges -S -sa > "../nextcloud-desktop_${fullver}_source.changes"
 
     if test -f ~/.has_ppa_keys; then
         debsign -k7D14AA7B -S
     fi
-
-    cd ..
 done
+cd ..
+ls -al
 
 if test "${pull_request}" = "master"; then
-    kind=`cat kind`
-
     if test "$kind" = "alpha"; then
         PPA=$PPA_ALPHA
         OBS_PROJECT=$OBS_PROJECT_ALPHA
@@ -107,24 +97,16 @@ if test "${pull_request}" = "master"; then
     fi
 
     if test -f ~/.has_ppa_keys; then
-        for changes in nextcloud-client_*~+([a-z])1_source.changes; do
-            case "${changes}" in
-                *oldstable1*)
-                    ;;
-                *)
-                    dput $PPA $changes > /dev/null
-                    ;;
-            esac
+        for distribution in ${UBUNTU_DISTRIBUTIONS}; do
+            changes=$(ls -1 nextcloud-desktop_*~${distribution}1_source.changes)
+            if test -f "${changes}"; then
+                dput $PPA "${changes}" > /dev/null
+            fi
         done
 
-        for distribution in stable oldstable; do
-            if test "${distribution}" = "oldstable"; then
-                pkgsuffix=".${distribution}"
-                pkgvertag="~${distribution}1"
-            else
-                pkgsuffix=""
-                pkgvertag=""
-            fi
+        for distribution in ${DEBIAN_DISTRIBUTIONS}; do
+            pkgsuffix=".${distribution}"
+            pkgvertag="~${distribution}1"
 
             package="${OBS_PACKAGE}${pkgsuffix}"
             OBS_SUBDIR="${OBS_PROJECT}/${package}"
@@ -136,10 +118,10 @@ if test "${pull_request}" = "master"; then
                 osc delete ${OBS_SUBDIR}/*
             fi
 
-            cp ../nextcloud-client*.orig.tar.* ${OBS_SUBDIR}/
-            cp ../nextcloud-client_*[0-9.][0-9]${pkgvertag}.dsc ${OBS_SUBDIR}/
-            cp ../nextcloud-client_*[0-9.][0-9]${pkgvertag}.debian.tar* ${OBS_SUBDIR}/
-            cp ../nextcloud-client_*[0-9.][0-9]${pkgvertag}_source.changes ${OBS_SUBDIR}/
+            cp ../nextcloud-desktop*.orig.tar.* ${OBS_SUBDIR}/
+            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.dsc ${OBS_SUBDIR}/
+            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.debian.tar* ${OBS_SUBDIR}/
+            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}_source.changes ${OBS_SUBDIR}/
             osc add ${OBS_SUBDIR}/*
 
             cd ${OBS_SUBDIR}

--- a/admin/linux/debian/scripts/git2changelog.cfg
+++ b/admin/linux/debian/scripts/git2changelog.cfg
@@ -6,3 +6,7 @@
 [versionhack]
 commit = bc7e65b39552ac458b2adacf76cbf98735ec29a0
 tag = v2.4.0-beta
+
+[base]
+commit = 56222de768e3def4d504b3f9832d8598b1ec2043
+version = 2.7.0

--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -48,22 +48,17 @@ def getCommitVersion(commit):
     except:
         return None
 
-def collectEntries(baseCommit, baseVersion, kind, finalRevDate):
-    scriptdir = os.path.dirname(__file__)
-    configPath = os.path.join(scriptdir, "git2changelog.cfg")
+def collectEntries(baseCommit, baseVersion, kind, finalRevDate, config):
 
     newVersionCommit = None
     newVersionTag = None
     newVersionOrigTag = None
 
-    if os.path.exists(configPath):
-        config = ConfigParser.SafeConfigParser()
-        config.read(configPath)
-        if config.has_section("versionhack"):
-            if config.has_option("versionhack", "commit") and \
-               config.has_option("versionhack", "tag"):
-                newVersionCommit = config.get("versionhack", "commit")
-                newVersionTag = config.get("versionhack", "tag")
+    if config is not None and config.has_section("versionhack"):
+        if config.has_option("versionhack", "commit") and \
+           config.has_option("versionhack", "tag"):
+            newVersionCommit = config.get("versionhack", "commit")
+            newVersionTag = config.get("versionhack", "tag")
 
     entries = []
 
@@ -153,13 +148,27 @@ def genChangeLogEntries(f, entries, distribution):
     return (latestBaseVersion, latestRevDate, latestKind)
 
 if __name__ == "__main__":
+    scriptdir = os.path.dirname(__file__)
+    configPath = os.path.join(scriptdir, "git2changelog.cfg")
+
+    baseCommit = "f9b1c724d6ab5431e0cd56b7cd834f2dd48cebb1"
+    baseVersion = "2.4.0"
+
+    config = None
+    if os.path.exists(configPath):
+        config = ConfigParser.SafeConfigParser()
+        config.read(configPath)
+
+        if config.has_section("base"):
+            if config.has_option("base", "commit") and \
+               config.has_option("base", "version"):
+                baseCommit = config.get("base", "commit")
+                baseVersion = config.get("base", "version")
 
     distribution = sys.argv[2]
     finalRevDate = sys.argv[3] if len(sys.argv)>3 else None
 
-    #entries = collectEntries("8aade24147b5313f8241a8b42331442b7f40eef9", "2.2.4", "release")
-    entries = collectEntries("f9b1c724d6ab5431e0cd56b7cd834f2dd48cebb1",
-                             "2.4.0", "beta", finalRevDate)
+    entries = collectEntries(baseCommit, baseVersion, "alpha", finalRevDate, config)
 
     with open(sys.argv[1], "wt") as f:
         (baseVersion, revdate, kind) = genChangeLogEntries(f, entries, distribution)


### PR DESCRIPTION
The Debian ownCloud maintainers team (https://salsa.debian.org/owncloud-team) created official Debian packages for the desktop client some time ago. They worked independently of me so they used different package names and a somewhat different package structure as well. It meant that if someone has installed their version and then wanted to upgrade to the PPA version, there were file conflicts.

Because of this and to avoid duplicate work, I have contacted the Debian team and based on our discussions I have updated the build scripts to work with a more Debian-y way to structure the repo. The main difference is that there are now branches for the various distributions and main tracks (e.g. debian/dist/bionic/master or debian/dist/eoan/stable-2.6) which are branched out from the corresponding branches and the Debian control files are added in a proper debian subdirectory.

When building, these Debian branches are checked out one-by-one and the corresponding main branch (i.e. master or stable-2.6) is merged into them locally to get the latest changes and the build is performed. This new method is implemented by this PR.