### PR TITLE
Free IconJob after use

### DIFF
--- a/src/gui/iconjob.cpp
+++ b/src/gui/iconjob.cpp
@@ -32,6 +32,7 @@ void IconJob::finished(QNetworkReply *reply)
         return;
 
     reply->deleteLater();
+    this->deleteLater();
     emit jobFinished(reply->readAll());
 }
 }


### PR DESCRIPTION
I have been experiencing the following two issues with the desktop client on linux:

https://github.com/nextcloud/desktop/issues/1769
https://github.com/nextcloud/desktop/issues/1876

After a bit of digging, I can that the IconJob class is creating a new QNetworkAccessManager every time an icon is downloaded (as part of the activity widget and servernotificationhandler.cpp.

Technically, only one QNetworkAccessManager should be needed per application, so creating one per download is not great. However, the IconJob class is also never explicitly freed and does not have a QObject parent, so cannot be freed by Qt.

So we have a memory leak. Over time more and more QNetworkAccessManagers are created and never freed, eventually leading to the errors experienced in the named tickets.

This PR is a "quick fix" for the current implementation of the IconJob class. It simply marks the class to be freed, also freeing the corresponding QNetworkAccessManager. This prevents the memory leak, but a better fix would be to use a shared QNetworkAccessManager