### PR TITLE
Fix build with Qt 5.15

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -31,6 +31,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPainter>
+#include <QPainterPath>
 
 #include "networkjobs.h"
 #include "account.h"


### PR DESCRIPTION
QPainterPath is no longer included via qtransform.h (since
5.15.0-beta2, 50d2acdc93b4de2ba56eb67787e2bdcb21dd4bea in
qtbase.git).