### PR TITLE
Fix build of Dolphin integration

### DIFF
--- a/shell_integration/dolphin/ownclouddolphinpluginhelper.cpp
+++ b/shell_integration/dolphin/ownclouddolphinpluginhelper.cpp
@@ -22,7 +22,6 @@
 #include <QStandardPaths>
 #include <QFile>
 #include "ownclouddolphinpluginhelper.h"
-#include "config.h"
 
 OwncloudDolphinPluginHelper* OwncloudDolphinPluginHelper::instance()
 {

--- a/shell_integration/dolphin/ownclouddolphinpluginhelper.h
+++ b/shell_integration/dolphin/ownclouddolphinpluginhelper.h
@@ -23,6 +23,7 @@
 #include <QLocalSocket>
 #include <QRegularExpression>
 #include "ownclouddolphinpluginhelper_export.h"
+#include "config.h"
 
 class OWNCLOUDDOLPHINPLUGINHELPER_EXPORT OwncloudDolphinPluginHelper : public QObject {
     Q_OBJECT


### PR DESCRIPTION
config.h needs to be included in the header already since we use APPLICATION_ICON_NAME there. This got introduced in 6fc877577c84e2ed3b175ee1425255e52d1d37b4

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>