### PR TITLE
Qt 5.5 compatibility #ifdef

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -326,6 +326,11 @@ void SyncEngine::deleteStaleErrorBlacklistEntries(const SyncFileItemVector &sync
     _journal->deleteStaleErrorBlacklistEntries(blacklist_file_paths);
 }
 
+#if (QT_VERSION < 0x050600)
+template <typename T>
+constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
+#endif
+
 void SyncEngine::conflictRecordMaintenance()
 {
     // Remove stale conflict entries from the database


### PR DESCRIPTION
Xenial uses Qt 5.5 which does not yet support qAsConst. This patch adds a definition for it if Qt is earlier than 5.6.