### PR TITLE
Added Qt version check >= 5.9

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,11 @@
 project(gui)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick)
+if (Qt5Widgets_VERSION VERSION_LESS 5.9.0 
+    OR Qt5Svg_VERSION VERSION_LESS 5.9.0 
+    OR Qt5Qml_VERSION VERSION_LESS 5.9.0 
+    OR Qt5Quick_VERSION VERSION_LESS 5.9.0)
+    message(FATAL_ERROR "Starting with Nextcloud client version 2.7 GUI building requires Qt >= 5.9.")
+endif()
 set(CMAKE_AUTOMOC TRUE)
 set(CMAKE_AUTOUIC TRUE)
 set(CMAKE_AUTORCC TRUE)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,9 +1,6 @@
 project(gui)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick)
-if (Qt5Widgets_VERSION VERSION_LESS 5.9.0 
-    OR Qt5Svg_VERSION VERSION_LESS 5.9.0 
-    OR Qt5Qml_VERSION VERSION_LESS 5.9.0 
-    OR Qt5Quick_VERSION VERSION_LESS 5.9.0)
+if (Qt5Widgets_VERSION VERSION_LESS 5.9.0)
     message(FATAL_ERROR "Starting with Nextcloud client version 2.7 GUI building requires Qt >= 5.9.")
 endif()
 set(CMAKE_AUTOMOC TRUE)


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Because the new tray interface will silently fail by Qt's design without specific interface tests (meaning: no build errors, failing at runtime if the necessary qml/qtquick modules aren't provided), I propose to ensure that requirement on build time via cmake when the gui project is built. Otherwise, users will probably run into confusion when building the project on older Qt versions.