### PR TITLE
Remove Ubuntu Disco, add Groovy

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -51,7 +51,7 @@ if ! wget http://ppa.launchpad.net/${repo}/ubuntu/pool/main/n/nextcloud-client/n
     origsourceopt="-sa"
 fi
 
-for distribution in xenial bionic disco eoan focal stable oldstable; do
+for distribution in xenial bionic eoan focal groovy stable oldstable; do
     rm -rf nextcloud-client_${basever}
     cp -a ${DRONE_WORKSPACE} nextcloud-client_${basever}
 


### PR DESCRIPTION
Ubuntu Disco is no longer supported by Launchpad, and the next Ubuntu release, Groovy is available.