### PR TITLE
Add Groovy-specific files

### DIFF
--- a/admin/linux/debian/debian.groovy/changelog
+++ b/admin/linux/debian/debian.groovy/changelog
@@ -1,0 +1,23 @@
+nextcloud-client (2.3.3-1.0~groovy1) groovy; urgency=medium
+
+  * Debian build support for the forked client.
+
+ -- István Váradi <ivaradi@varadiistvan.hu>  Mon, 6 Nov 2017 20:20:04 +0100
+
+nextcloud-client (2.3.1-1.0~groovy1) groovy; urgency=medium
+
+  * New upstream version
+
+ -- István Váradi <ivaradi@varadiistvan.hu>  Thu, 23 Mar 2017 19:07:36 +0100
+
+nextcloud-client (2.3.0-1.0~groovy1) groovy; urgency=medium
+
+  * New upstream version
+
+ -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 21 Mar 2017 19:34:13 +0100
+
+nextcloud-client (2.2.4-1.4~groovy1) groovy; urgency=medium
+
+  * The locale-specific icon names are correct too
+
+ -- István Váradi <ivaradi@varadiistvan.hu>  Tue, 7 Feb 2017 19:55:40 +0100

--- a/admin/linux/debian/debian.groovy/control
+++ b/admin/linux/debian/debian.groovy/control
@@ -1,0 +1,90 @@
+Source: nextcloud-client
+Section: contrib/devel
+Priority: optional
+Maintainer: István Váradi <ivaradi@varadiistvan.hu>
+Build-Depends: cmake,
+               debhelper,
+               cdbs,
+               dh-python,
+               extra-cmake-modules (>= 5.16),
+               libkf5kio-dev,
+               libcmocka-dev,
+               libcloudproviders-dev,
+               libdbus-1-dev,
+               libhttp-dav-perl,
+               libinotify-dev [kfreebsd-any],
+               libqt5svg5-dev,
+               libqt5webkit5-dev,
+               libsqlite3-dev,
+               libssl-dev (>= 1.1.0),
+               zlib1g-dev,
+               optipng,
+               pkg-kde-tools,
+               python3-sphinx,
+               python3-all,
+               qt5keychain-dev,
+               qtwebengine5-dev,
+               qtdeclarative5-dev,
+               qttools5-dev,
+               qttools5-dev-tools,
+               xvfb
+Standards-Version: 3.9.8
+Homepage: https://github.com/nextcloud/client_theming
+#Vcs-Git: git://anonscm.debian.org/collab-maint/nextcloud-client.git
+#Vcs-Browser: https://anonscm.debian.org/cgit/collab-maint/nextcloud-client.git
+
+Package: nextcloud-client
+Architecture: any
+Depends: libnextcloudsync0 (=${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, nextcloud-client-l10n
+Description: Nextcloud desktop sync client
+ Use the desktop client to keep your files synchronized
+ between your Nextcloud server and your desktop. Select
+ one or more directories on your local machine and always
+ have access to your latest files wherever you are.
+
+Package: libnextcloudsync0
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Nextcloud sync library
+ Used by the Nextcloud desktop client as the synchronization engine.
+
+Package: libnextcloudsync-dev
+Architecture: any
+Section: contrib/libdevel
+Depends: libnextcloudsync0 (=${binary:Version}), ${misc:Depends}
+Description: Nextcloud sync library development files
+ The headers and development library for the Nextcloud sync library.
+
+Package: nextcloud-client-l10n
+Architecture: all
+Depends: ${misc:Depends}
+Description: Nextcloud client internatialization files
+ The translation files.
+
+Package: nextcloud-client-nautilus
+Architecture: all
+Depends: nextcloud-client (>=${binary:Version}), libnextcloudsync0, python3-nautilus, nautilus, ${misc:Depends}
+Description: Nautilus plugin for Nextcloud
+ This package contains a Nautilus plugin to display
+ synchronization status icons for Nextcloud files.
+
+Package: nextcloud-client-nemo
+Architecture: all
+Depends: nextcloud-client (>=${binary:Version}), libnextcloudsync0, python-nemo | nemo-python, nemo, ${misc:Depends}
+Description: Nemo plugin for Nextcloud
+ This package contains a Nemo plugin to display
+ synchronization status icons for Nextcloud files.
+
+Package: nextcloud-client-caja
+Architecture: all
+Depends: nextcloud-client (>=${binary:Version}), libnextcloudsync0, python3-caja, caja, ${misc:Depends}
+Description: Caja plugin for Nextcloud
+ This package contains a Caja plugin to display
+ synchronization status icons for Nextcloud files.
+
+Package: nextcloud-client-dolphin
+Architecture: any
+Depends: dolphin (>= 4:15.12.1), libnextcloudsync0 (= ${binary:Version}), nextcloud-client, ${misc:Depends}, ${shlibs:Depends}
+Description: Dolphin plugin for Nextcloud
+ This package contains a Dolphin plugin to display
+ synchronization status icons for Nextcloud files.


### PR DESCRIPTION
Some Debian control files must be updated for Groovy to build the binary packages successfully.