### PR TITLE
Resolve symlinks when checking for registered paths.

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -191,11 +191,12 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
     def check_registered_paths(self, filename):
         topLevelFolder = False
         internalFile = False
+        absfilename = os.path.realpath(filename)
         for reg_path in socketConnect.registered_paths:
-            if filename == reg_path:
+            if absfilename == reg_path:
                 topLevelFolder = True
                 break
-            if filename.startswith(reg_path):
+            if absfilename.startswith(reg_path):
                 internalFile = True
                 # you can't have a registered path below another so it is save to break here
                 break
@@ -447,6 +448,7 @@ class SyncStateExtension(GObject.GObject, Nautilus.InfoProvider):
             return
 
         filename = get_local_path(item.get_uri())
+        filename = os.path.realpath(filename)
         if item.is_directory():
             filename += os.sep
 

--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -209,6 +209,7 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         all_internal_files = True
         for i, file_uri in enumerate(files):
             filename = get_local_path(file_uri.get_uri())
+            filename = os.path.realpath(filename)
 
             # Check if its a folder (ends with an /), if yes add a "/"
             # otherwise it will not find the entry in the table


### PR DESCRIPTION
Fixes issue #1948
The client already resolves symlinks when adding new paths to the
sync-list, but the Nautilus plugin did not do this yet, causing it
to not recognise synced folders if they were accessed via a symlink.