### PR TITLE
Indicate this is a dialog and not a regular window

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -15,7 +15,7 @@ Window {
     width:      Style.trayWindowWidth
     height:     Style.trayWindowHeight
     color:      "transparent"
-    flags:      Qt.FramelessWindowHint
+    flags:      Qt.Dialog | Qt.FramelessWindowHint
 
     // Close tray window when focus is lost (e.g. click somewhere else on the screen)
     onActiveChanged: {


### PR DESCRIPTION
This is necessary with some window managers which would otherwise
consider they can reposition and resize the tray window as they wish
(yes, even though the user can't do it directly).

This is for instance the case if you use the tiling mode scripts of
KWin. It automatically ignores dialogs but might force windows to be
fullscreen (which would badly break the layout in our case).