### PR TITLE
Force the default QQC2 style

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(gui)
-find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick)
+find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2)
 set(CMAKE_AUTOMOC TRUE)
 set(CMAKE_AUTOUIC TRUE)
 set(CMAKE_AUTORCC TRUE)
@@ -316,7 +316,7 @@ set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
 set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
         INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/${APPLICATION_EXECUTABLE};${CMAKE_INSTALL_RPATH}" )
 
-target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml Qt5::Qml Qt5::Quick Qt5::WebEngineWidgets)
+target_link_libraries( ${APPLICATION_EXECUTABLE} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml Qt5::Qml Qt5::Quick Qt5::QuickControls2 Qt5::WebEngineWidgets)
 target_link_libraries( ${APPLICATION_EXECUTABLE} ${synclib_NAME} )
 IF(BUILD_UPDATER)
     target_link_libraries( ${APPLICATION_EXECUTABLE} updater )

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -33,6 +33,7 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QDebug>
+#include <QQuickStyle>
 
 using namespace OCC;
 
@@ -49,6 +50,13 @@ void warnSystray()
 int main(int argc, char **argv)
 {
     Q_INIT_RESOURCE(resources);
+
+    // Work around a bug in KDE's qqc2-desktop-style which breaks
+    // buttons with icons not based on a name, by forcing a style name
+    // the platformtheme plugin won't try to force qqc2-desktops-style
+    // anymore.
+    // Can be removed once the bug in qqc2-desktop-style is gone.
+    QQuickStyle::setStyle("Default");
 
     // OpenSSL 1.1.0: No explicit initialisation or de-initialisation is necessary.
 


### PR DESCRIPTION
This works around a bug in KDE's qqc2-desktop-style which breaks buttons
with icons not based on a name. By forcing a style name the KDE Plasma
platformtheme plugin won't try to force qqc2-desktops-style anymore.

Can be removed once the bug in qqc2-desktop-style is gone.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>