### PR TITLE
Do not build for Xenial anymore

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -14,7 +14,7 @@ OBS_PROJECT_ALPHA=home:ivaradi:alpha
 OBS_PROJECT_BETA=home:ivaradi:beta
 OBS_PACKAGE=nextcloud-desktop
 
-UBUNTU_DISTRIBUTIONS="xenial bionic eoan focal groovy"
+UBUNTU_DISTRIBUTIONS="bionic eoan focal groovy"
 DEBIAN_DISTRIBUTIONS="buster stretch"
 
 pull_request=${DRONE_PULL_REQUEST:=master}


### PR DESCRIPTION
With the recently introduced QQC2, Qt 5.5 and thus Xenial cannot be supported anymore. This patch removes the build for Xenial.