### PR TITLE
Use default member initialization

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -86,33 +86,19 @@ public:
 
     struct DownloadInfo
     {
-        DownloadInfo()
-            : _errorCount(0)
-            , _valid(false)
-        {
-        }
         QString _tmpfile;
         QByteArray _etag;
-        int _errorCount;
-        bool _valid;
+        int _errorCount = 0;
+        bool _valid = false;
     };
     struct UploadInfo
     {
-        UploadInfo()
-            : _chunk(0)
-            , _transferid(0)
-            , _size(0)
-            , _modtime(0)
-            , _errorCount(0)
-            , _valid(false)
-        {
-        }
-        int _chunk;
-        int _transferid;
-        quint64 _size; //currently unused
-        qint64 _modtime;
-        int _errorCount;
-        bool _valid;
+        int _chunk = 0;
+        int _transferid = 0;
+        quint64 _size = 0; //currently unused
+        qint64 _modtime = 0;
+        int _errorCount = 0;
+        bool _valid = false;
         QByteArray _contentChecksum;
         /**
          * Returns true if this entry refers to a chunked upload that can be continued.

--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -81,31 +81,22 @@ public:
         InsufficientRemoteStorage
     };
 
-    SyncJournalErrorBlacklistRecord()
-        : _retryCount(0)
-        , _errorCategory(Category::Normal)
-        , _lastTryModtime(0)
-        , _lastTryTime(0)
-        , _ignoreDuration(0)
-    {
-    }
-
     /// The number of times the operation was unsuccessful so far.
-    int _retryCount;
+    int _retryCount = 0;
 
     /// The last error string.
     QString _errorString;
     /// The error category. Sometimes used for special actions.
-    Category _errorCategory;
+    Category _errorCategory = Category::Normal;
 
-    qint64 _lastTryModtime;
+    qint64 _lastTryModtime = 0;
     QByteArray _lastTryEtag;
 
     /// The last time the operation was attempted (in s since epoch).
-    qint64 _lastTryTime;
+    qint64 _lastTryTime = 0;
 
     /// The number of seconds the file shall be ignored.
-    qint64 _ignoreDuration;
+    qint64 _ignoreDuration = 0;
 
     QString _file;
     QString _renameTarget;

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -65,8 +65,6 @@ public:
     bool paused;
     /// whether the folder syncs hidden files
     bool ignoreHiddenFiles;
-    /// the folder has client side encryption
-    bool isClientSideEncrypted;
     /// The CLSID where this folder appears in registry for the Explorer navigation pane entry.
     QUuid navigationPaneClsid;
 

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -47,12 +47,6 @@ class FolderWatcher;
 class FolderDefinition
 {
 public:
-    FolderDefinition()
-        : paused(false)
-        , ignoreHiddenFiles(false)
-    {
-    }
-
     /// The name of the folder in the ui and internally
     QString alias;
     /// path on local machine
@@ -62,9 +56,9 @@ public:
     /// path on remote
     QString targetPath;
     /// whether the folder is paused
-    bool paused;
+    bool paused = false;
     /// whether the folder syncs hidden files
-    bool ignoreHiddenFiles;
+    bool ignoreHiddenFiles = false;
     /// The CLSID where this folder appears in registry for the Explorer navigation pane entry.
     QUuid navigationPaneClsid;
 

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -58,35 +58,24 @@ public:
 
     struct SubFolderInfo
     {
-        SubFolderInfo()
-            : _folder(nullptr)
-            , _size(0)
-            , _isExternal(false)
-            , _fetched(false)
-            , _hasError(false)
-            , _fetchingLabel(false)
-            , _isUndecided(false)
-            , _checked(Qt::Checked)
-        {
-        }
-        Folder *_folder;
+        Folder *_folder = nullptr;
         QString _name;
         QString _path;
         QVector<int> _pathIdx;
         QVector<SubFolderInfo> _subs;
-        qint64 _size;
-        bool _isExternal;
+        qint64 _size = 0;
+        bool _isExternal = false;
 
-        bool _fetched; // If we did the LSCOL for this folder already
+        bool _fetched = false; // If we did the LSCOL for this folder already
         QPointer<LsColJob> _fetchingJob; // Currently running LsColJob
-        bool _hasError; // If the last fetching job ended in an error
+        bool _hasError = false; // If the last fetching job ended in an error
         QString _lastErrorString;
-        bool _fetchingLabel; // Whether a 'fetching in progress' label is shown.
+        bool _fetchingLabel = false; // Whether a 'fetching in progress' label is shown.
         // undecided folders are the big folders that the user has not accepted yet
-        bool _isUndecided;
+        bool _isUndecided = false;
         QByteArray _fileId; // the file id for this folder on the server.
 
-        Qt::CheckState _checked;
+        Qt::CheckState _checked = Qt::Checked;
 
         // Whether this has a FetchLabel subrow
         bool hasLabel() const;
@@ -96,19 +85,14 @@ public:
 
         struct Progress
         {
-            Progress()
-                : _warningCount(0)
-                , _overallPercent(0)
-            {
-            }
             bool isNull() const
             {
                 return _progressString.isEmpty() && _warningCount == 0 && _overallSyncString.isEmpty();
             }
             QString _progressString;
             QString _overallSyncString;
-            int _warningCount;
-            int _overallPercent;
+            int _warningCount = 0;
+            int _overallPercent = 0;
         };
         Progress _progress;
     };


### PR DESCRIPTION
This PR introduces default member initialization, a C++
feature available since C++11, in a few locations to
replace the explicit definition of a default constructor.