### PR TITLE
testLaunchOnStartup shouldn't fail on dev setup

### DIFF
--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -20,6 +20,11 @@ class TestUtility : public QObject
     Q_OBJECT
 
 private slots:
+    void initTestCase()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
     void testFormatFingerprint()
     {
         QVERIFY2(formatFingerprint("68ac906495480a3404beee4874ed853a037a7a8f")


### PR DESCRIPTION
This test was failing locally for me. Indeed, through QStandardPaths it
was finding the user settings of my production client and not having the
initial state it expected. Using QStandardPaths test mode then it starts
from a clean slate every time.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>