### PR TITLE
Fix/improve use case without local folder

### DIFF
--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -96,8 +96,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
                 relPath.prepend(folder->remotePath());
             list = FolderMan::instance()->findFileInLocalFolders(relPath, ast->account());
             if (list.count() > 0) {
-                QString path = "file:///" + QString(list.at(0));
-                return QUrl(path);
+                return QUrl::fromLocalFile(list.at(0));
             }
             // File does not exist anymore? Let's try to open its path
             if (QFileInfo(relPath).exists()) {

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -417,12 +417,16 @@ ActivityListModel *User::getActivityModel()
 
 void User::openLocalFolder()
 {
+    const auto folder = getFolder();
+
+    if (folder != nullptr) {
 #ifdef Q_OS_WIN
-    QString path = "file:///" + this->getFolder()->path();
+        QString path = "file:///" + folder->path();
 #else
-    QString path = "file://" + this->getFolder()->path();
+        QString path = "file://" + folder->path();
 #endif
-    QDesktopServices::openUrl(path);
+        QDesktopServices::openUrl(path);
+    }
 }
 
 void User::login() const

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -768,6 +768,11 @@ bool UserModel::currentUserHasActivities()
     return _users[currentUserIndex()]->hasActivities();
 }
 
+bool UserModel::currentUserHasLocalFolder()
+{
+    return _users[currentUserIndex()]->getFolder() != nullptr;
+}
+
 void UserModel::fetchCurrentActivityModel()
 {
     _users[currentUserId()]->slotRefresh();

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -420,12 +420,7 @@ void User::openLocalFolder()
     const auto folder = getFolder();
 
     if (folder != nullptr) {
-#ifdef Q_OS_WIN
-        QString path = "file:///" + folder->path();
-#else
-        QString path = "file://" + folder->path();
-#endif
-        QDesktopServices::openUrl(path);
+        QDesktopServices::openUrl(QUrl::fromLocalFile(folder->path()));
     }
 }
 

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -101,6 +101,7 @@ public:
     Q_INVOKABLE QString currentUserName();
     Q_INVOKABLE QString currentUserServer();
     Q_INVOKABLE bool currentUserHasActivities();
+    Q_INVOKABLE bool currentUserHasLocalFolder();
     Q_INVOKABLE bool currentServerHasTalk();
     Q_INVOKABLE int currentUserId();
     Q_INVOKABLE bool isUserConnected(const int &id);

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -30,6 +30,7 @@ Window {
         currentAccountAvatar.source = "image://avatars/currentUser"
         currentAccountUser.text = userModelBackend.currentUserName();
         currentAccountServer.text = userModelBackend.currentUserServer();
+        openLocalFolderButton.visible = userModelBackend.currentUserHasLocalFolder();
         trayWindowTalkButton.visible = userModelBackend.currentServerHasTalk() ? true : false;
         currentAccountStateIndicator.source = ""
         currentAccountStateIndicator.source = userModelBackend.isUserConnected(userModelBackend.currentUserId()) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
@@ -52,6 +53,7 @@ Window {
         }
         onNewUserSelected: {
             accountMenu.close();
+            openLocalFolderButton.visible = userModelBackend.currentUserHasLocalFolder();
             trayWindowTalkButton.visible = userModelBackend.currentServerHasTalk() ? true : false;
         }
     }
@@ -360,6 +362,7 @@ Window {
                     Layout.preferredWidth:  Style.trayWindowHeaderHeight
                     Layout.preferredHeight: Style.trayWindowHeaderHeight
                     flat: true
+                    visible: userModelBackend.currentUserHasLocalFolder()
 
                     icon.source: "qrc:///client/theme/white/folder.svg"
                     icon.width: Style.headerButtonIconSize


### PR DESCRIPTION
When you use the client for an account without configured local folder,
it crashes when you click on the folder button.

This PR fixes the crash and removes the folder button if no local folder
is configured.