### PR TITLE
Change width of app menu

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -459,7 +459,7 @@ Window {
                         Menu {
                             id: appsMenu
                             y: (trayWindowAppsButton.y + trayWindowAppsButton.height + 2)
-                            width: (Style.headerButtonIconSize * 3)
+                            width: Math.min(contentItem.childrenRect.width + 4, Style.trayWindowWidth / 2)
                             closePolicy: "CloseOnPressOutside"
 
                             background: Rectangle {
@@ -476,6 +476,7 @@ Window {
                                     text: appName
                                     font.pixelSize: Style.topLinePixelSize
                                     icon.source: appIconUrl
+                                    width: contentItem.implicitWidth + leftPadding + rightPadding
                                     onTriggered: appsMenuModelBackend.openAppUrl(appUrl)
                                 }
                             }


### PR DESCRIPTION
The app menu has a width based on the header button size which is
way too narrow to display its content, see #2012.

This PR changes the width based on the contents (menu items) of
the menu, however, limiting the maximum width to half the window width.