### PR TITLE
macOS: Opt In to Dark Mode for building against older macOS SDKs < 10.14

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -30,6 +30,8 @@
         <string>(C) 2014-2020 @APPLICATION_VENDOR@</string>
         <key>NSSupportsAutomaticGraphicsSwitching</key>
         <true/>
+        <key>NSRequiresAquaSystemAppearance</key>
+        <false/>
         <key>SUShowReleaseNotes</key>
         <false/>
         <key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
Required for our build server that uses an older SDK to support previous macOS versions.

See: https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app