### PR TITLE
Use APPLICATION_ICON_NAME for autostart icon

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -76,7 +76,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
            << QLatin1String("Exec=") << QCoreApplication::applicationFilePath() << endl
            << QLatin1String("Terminal=") << "false" << endl
-           << QLatin1String("Icon=") << appName.toLower() << endl // always use lowercase for icons
+           << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
            << QLatin1String("Categories=") << QLatin1String("Network") << endl
            << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl


### PR DESCRIPTION
Previously we wrote 'nextcloud', but our icon name is 'Nextcloud'.

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>