### PR TITLE
[stable-2.6] Use APPLICATION_ICON_NAME for autostart icon

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -72,7 +72,7 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
            << QLatin1String("Exec=") << QCoreApplication::applicationFilePath() << endl
            << QLatin1String("Terminal=") << "false" << endl
-           << QLatin1String("Icon=") << appName.toLower() << endl // always use lowercase for icons
+           << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
            << QLatin1String("Categories=") << QLatin1String("Network") << endl
            << QLatin1String("Type=") << QLatin1String("Application") << endl
            << QLatin1String("StartupNotify=") << "false" << endl


### PR DESCRIPTION
Backport of #2065

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>
(cherry picked from commit bce93b052b24c23d76a9f9b8864d71b0ad5b040e)
Signed-off-by: Michael Schuster <michael@schuster.ms>