### PR TITLE
Fix nullptr regression in RegistryUtil::ReadRegistry

### DIFF
--- a/shell_integration/windows/OCUtil/RegistryUtil.cpp
+++ b/shell_integration/windows/OCUtil/RegistryUtil.cpp
@@ -40,7 +40,7 @@ bool RegistryUtil::ReadRegistry(const wchar_t* key, const wchar_t* name, wstring
 
     HKEY rootKey = nullptr;
 
-    hResult = HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, (LPCWSTR)key, nullptr, KEY_READ, &rootKey));
+    hResult = HRESULT_FROM_WIN32(RegOpenKeyEx(HKEY_CURRENT_USER, (LPCWSTR)key, 0, KEY_READ, &rootKey));
 
     if(!SUCCEEDED(hResult))
     {


### PR DESCRIPTION
Merging PR #2057 caused the Windows build to fail:

`shell_integration\windows\OCUtil\RegistryUtil.cpp(43): error C2664: 'LSTATUS RegOpenKeyExW(HKEY,LPCWSTR,DWORD,REGSAM,PHKEY)': cannot convert argument 3 from 'nullptr' to 'DWORD'`

The previous implementation prior the PR supplied NULL as the argument 3 to RegOpenKeyEx, so it was silently accepted and translated to zero, satisfying the DWORD's type requirement.

See also: https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexw

```
LSTATUS RegOpenKeyExW(
  HKEY    hKey,
  LPCWSTR lpSubKey,
  DWORD   ulOptions,
  REGSAM  samDesired,
  PHKEY   phkResult
);
```