### PR TITLE
Simplify nullptr comparisons where appropriate

### DIFF
--- a/shell_integration/windows/OCContextMenu/OCContextMenuFactory.cpp
+++ b/shell_integration/windows/OCContextMenu/OCContextMenuFactory.cpp
@@ -65,7 +65,7 @@ IFACEMETHODIMP OCContextMenuFactory::CreateInstance(IUnknown *pUnkOuter, REFIID 
     HRESULT hr = CLASS_E_NOAGGREGATION;
 
     // pUnkOuter is used for aggregation. We do not support it in the sample.
-    if (pUnkOuter == nullptr) {
+    if (!pUnkOuter) {
         hr = E_OUTOFMEMORY;
 
         // Create the COM component.

--- a/shell_integration/windows/OCContextMenu/OCContextMenuRegHandler.cpp
+++ b/shell_integration/windows/OCContextMenu/OCContextMenuRegHandler.cpp
@@ -33,7 +33,7 @@ HRESULT SetHKCRRegistryKeyAndValue(PCWSTR pszSubKey, PCWSTR pszValueName, PCWSTR
 
     if (SUCCEEDED(hr))
     {
-        if (pszData != nullptr)
+        if (pszData)
         {
             // Set the specified value of the key.
             DWORD cbData = lstrlen(pszData) * sizeof(*pszData);
@@ -72,7 +72,7 @@ HRESULT GetHKCRRegistryKeyAndValue(PCWSTR pszSubKey, PCWSTR pszValueName, PWSTR 
 
 HRESULT OCContextMenuRegHandler::RegisterInprocServer(PCWSTR pszModule, const CLSID& clsid, PCWSTR pszFriendlyName, PCWSTR pszThreadModel)
 {
-    if (pszModule == nullptr || pszThreadModel == nullptr)
+    if (!pszModule || !pszThreadModel)
     {
         return E_INVALIDARG;
     }
@@ -136,7 +136,7 @@ HRESULT OCContextMenuRegHandler::UnregisterInprocServer(const CLSID& clsid)
 HRESULT OCContextMenuRegHandler::RegisterShellExtContextMenuHandler(
     PCWSTR pszFileType, const CLSID& clsid, PCWSTR pszFriendlyName)
 {
-    if (pszFileType == nullptr)
+    if (!pszFileType)
     {
         return E_INVALIDARG;
     }
@@ -180,7 +180,7 @@ HRESULT OCContextMenuRegHandler::RegisterShellExtContextMenuHandler(
 HRESULT OCContextMenuRegHandler::UnregisterShellExtContextMenuHandler(
     PCWSTR pszFileType, PCWSTR pszFriendlyName)
 {
-    if (pszFileType == nullptr)
+    if (!pszFileType)
     {
         return E_INVALIDARG;
     }

--- a/shell_integration/windows/OCOverlays/OCOverlayFactory.cpp
+++ b/shell_integration/windows/OCOverlays/OCOverlayFactory.cpp
@@ -70,7 +70,7 @@ IFACEMETHODIMP OCOverlayFactory::CreateInstance(
 {
     HRESULT hResult = CLASS_E_NOAGGREGATION;
 
-    if (pUnkOuter != nullptr) { return hResult; }
+    if (pUnkOuter) { return hResult; }
 
     hResult = E_OUTOFMEMORY;
     OCOverlay *lrOverlay = new (std::nothrow) OCOverlay(_state);

--- a/shell_integration/windows/OCOverlays/OCOverlayRegistrationHandler.cpp
+++ b/shell_integration/windows/OCOverlays/OCOverlayRegistrationHandler.cpp
@@ -73,7 +73,7 @@ HRESULT OCOverlayRegistrationHandler::RemoveRegistryEntries(PCWSTR friendlyName)
 
 HRESULT OCOverlayRegistrationHandler::RegisterCOMObject(PCWSTR modulePath, PCWSTR friendlyName, const CLSID& clsid)
 {
-    if (modulePath == nullptr) {
+    if (!modulePath) {
         return E_FAIL;
     }
 

--- a/src/common/utility_mac.cpp
+++ b/src/common/utility_mac.cpp
@@ -124,7 +124,7 @@ static bool hasDarkSystray_private()
     CFStringRef darkInterfaceStyle = CFSTR("Dark");
     interfaceStyle = (CFStringRef)CFPreferencesCopyAppValue(interfaceStyleKey,
         kCFPreferencesCurrentApplication);
-    if (interfaceStyle != nullptr) {
+    if (interfaceStyle) {
         returnValue = (kCFCompareEqualTo == CFStringCompare(interfaceStyle, darkInterfaceStyle, 0));
         CFRelease(interfaceStyle);
     }

--- a/src/csync/csync.cpp
+++ b/src/csync/csync.cpp
@@ -67,7 +67,7 @@ csync_s::csync_s(const char *localUri, OCC::SyncJournalDb *statedb)
 int csync_update(CSYNC *ctx) {
   int rc = -1;
 
-  if (ctx == nullptr) {
+  if (!ctx) {
     errno = EBADF;
     return -1;
   }
@@ -256,14 +256,14 @@ csync_s::~csync_s() {
 }
 
 void *csync_get_userdata(CSYNC *ctx) {
-  if (ctx == nullptr) {
+  if (!ctx) {
     return nullptr;
   }
   return ctx->callbacks.userdata;
 }
 
 int csync_set_userdata(CSYNC *ctx, void *userdata) {
-  if (ctx == nullptr) {
+  if (!ctx) {
     return -1;
   }
 
@@ -273,7 +273,7 @@ int csync_set_userdata(CSYNC *ctx, void *userdata) {
 }
 
 csync_auth_callback csync_get_auth_callback(CSYNC *ctx) {
-  if (ctx == nullptr) {
+  if (!ctx) {
     return nullptr;
   }
 
@@ -281,7 +281,7 @@ csync_auth_callback csync_get_auth_callback(CSYNC *ctx) {
 }
 
 int csync_set_status(CSYNC *ctx, int status) {
-  if (ctx == nullptr || status < 0) {
+  if (!ctx || status < 0) {
     return -1;
   }
 
@@ -291,7 +291,7 @@ int csync_set_status(CSYNC *ctx, int status) {
 }
 
 CSYNC_STATUS csync_get_status(CSYNC *ctx) {
-  if (ctx == nullptr) {
+  if (!ctx) {
     return CSYNC_STATUS_ERROR;
   }
 
@@ -305,21 +305,21 @@ const char *csync_get_status_string(CSYNC *ctx)
 
 void csync_request_abort(CSYNC *ctx)
 {
-  if (ctx != nullptr) {
+  if (ctx) {
     ctx->abort = true;
   }
 }
 
 void csync_resume(CSYNC *ctx)
 {
-  if (ctx != nullptr) {
+  if (ctx) {
     ctx->abort = false;
   }
 }
 
 int  csync_abort_requested(CSYNC *ctx)
 {
-  if (ctx != nullptr) {
+  if (ctx) {
     return ctx->abort;
   } else {
     return (1 == 0);

--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -617,7 +617,7 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
   // if the etag of this dir is still the same, its content is restored from the
   // database.
   if( do_read_from_db ) {
-      if( ! fill_tree_from_db(ctx, db_uri) ) {
+      if(!fill_tree_from_db(ctx, db_uri)) {
         errno = ENOENT;
         ctx->status_code = CSYNC_STATUS_OPENDIR_ERROR;
         goto error;
@@ -625,7 +625,7 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
       return 0;
   }
 
-  if ((dh = csync_vio_opendir(ctx, uri)) == nullptr) {
+  if (!(dh = csync_vio_opendir(ctx, uri))) {
       if (ctx->abort) {
           qCDebug(lcUpdate, "Aborted!");
           ctx->status_code = CSYNC_STATUS_ABORTED;
@@ -783,7 +783,7 @@ int csync_ftw(CSYNC *ctx, const char *uri, csync_walker_fn fn,
 
 error:
   ctx->remote.read_from_db = read_from_db;
-  if (dh != nullptr) {
+  if (dh) {
     csync_vio_closedir(ctx, dh);
   }
   return -1;

--- a/src/csync/csync_util.cpp
+++ b/src/csync/csync_util.cpp
@@ -74,7 +74,7 @@ const char *csync_instruction_str(enum csync_instructions_e instr)
 {
   int idx = 0;
 
-  while (_instr[idx].instr_str != nullptr) {
+  while (_instr[idx].instr_str) {
     if (_instr[idx].instr_code == instr) {
       return _instr[idx].instr_str;
     }
@@ -92,7 +92,7 @@ void csync_memstat_check() {
 
   /* get process memory stats */
   fp = fopen("/proc/self/statm","r");
-  if (fp == nullptr) {
+  if (!fp) {
     return;
   }
   s = fscanf(fp, "%d%d%d%d%d%d%d", &m.size, &m.resident, &m.shared, &m.trs,

--- a/src/csync/std/c_utf8.cpp
+++ b/src/csync/std/c_utf8.cpp
@@ -43,7 +43,7 @@
 /* Convert a locale String to UTF8 */
 QByteArray c_utf8_from_locale(const mbchar_t *wstr)
 {
-  if (wstr == nullptr) {
+  if (!wstr) {
     return QByteArray();
   }
 
@@ -87,7 +87,7 @@ extern "C" {
 /* Convert a an UTF8 string to locale */
 mbchar_t* c_utf8_string_to_locale(const char *str)
 {
-    if (str == nullptr ) {
+    if (!str) {
         return nullptr;
     }
 #ifdef _WIN32
@@ -111,7 +111,7 @@ mbchar_t* c_utf8_string_to_locale(const char *str)
 
  mbchar_t* c_utf8_path_to_locale(const char *str)
  {
-     if( str == nullptr ) {
+     if(!str) {
          return nullptr;
      } else {
  #ifdef _WIN32

--- a/src/csync/vio/csync_vio.cpp
+++ b/src/csync/vio/csync_vio.cpp
@@ -53,7 +53,7 @@ csync_vio_handle_t *csync_vio_opendir(CSYNC *ctx, const char *name) {
 int csync_vio_closedir(CSYNC *ctx, csync_vio_handle_t *dhandle) {
   int rc = -1;
 
-  if (dhandle == nullptr) {
+  if (!dhandle) {
     errno = EBADF;
     return -1;
   }

--- a/src/csync/vio/csync_vio_local_unix.cpp
+++ b/src/csync/vio/csync_vio_local_unix.cpp
@@ -59,7 +59,7 @@ csync_vio_handle_t *csync_vio_local_opendir(const char *name) {
   dirname = c_utf8_path_to_locale(name);
 
   handle->dh = _topendir( dirname );
-  if (handle->dh == nullptr) {
+  if (!handle->dh) {
     c_free_locale_string(dirname);
     SAFE_FREE(handle);
     return nullptr;
@@ -75,7 +75,7 @@ int csync_vio_local_closedir(csync_vio_handle_t *dhandle) {
   dhandle_t *handle = nullptr;
   int rc = -1;
 
-  if (dhandle == nullptr) {
+  if (!dhandle) {
     errno = EBADF;
     return -1;
   }
@@ -99,7 +99,7 @@ std::unique_ptr<csync_file_stat_t> csync_vio_local_readdir(csync_vio_handle_t *d
 
   do {
       dirent = _treaddir(handle->dh);
-      if (dirent == nullptr)
+      if (!dirent)
           return {};
   } while (qstrcmp(dirent->d_name, ".") == 0 || qstrcmp(dirent->d_name, "..") == 0);
 

--- a/src/csync/vio/csync_vio_local_win.cpp
+++ b/src/csync/vio/csync_vio_local_win.cpp
@@ -100,7 +100,7 @@ int csync_vio_local_closedir(csync_vio_handle_t *dhandle) {
   dhandle_t *handle = nullptr;
   int rc = -1;
 
-  if (dhandle == nullptr) {
+  if (!dhandle) {
     errno = EBADF;
     return -1;
   }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -495,7 +495,7 @@ void AccountSettings::slotLockForDecryptionError(const QByteArray& fileId, int h
 void AccountSettings::slotEditCurrentIgnoredFiles()
 {
     Folder *f = FolderMan::instance()->folder(selectedFolderAlias());
-    if (f == nullptr)
+    if (!f)
         return;
     openIgnoredFilesDialog(f->path());
 }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -593,7 +593,7 @@ void FolderMan::slotRunOneEtagJob()
             //qCDebug(lcFolderMan) << "No more remote ETag check jobs to schedule.";
 
             /* now it might be a good time to check for restarting... */
-            if (_currentSyncFolder == nullptr && _appRestartRequired) {
+            if (!_currentSyncFolder && _appRestartRequired) {
                 restartApplication();
             }
         } else {
@@ -973,7 +973,7 @@ QStringList FolderMan::findFileInLocalFolders(const QString &relPath, const Acco
     QStringList re;
 
     foreach (Folder *folder, this->map().values()) {
-        if (acc != nullptr && folder->accountState()->account() != acc) {
+        if (acc && folder->accountState()->account() != acc) {
             continue;
         }
         QString path = folder->cleanPath();

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -158,7 +158,7 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
     while (i + sizeof(struct inotify_event) < static_cast<unsigned int>(len)) {
         // cast an inotify_event
         event = (struct inotify_event *)&buffer[i];
-        if (event == nullptr) {
+        if (!event) {
             qCDebug(lcFolderWatcher) << "NULL event";
             i += sizeof(struct inotify_event);
             continue;

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -600,7 +600,7 @@ void ownCloudGui::slotHelp()
 
 void ownCloudGui::raiseDialog(QWidget *raiseWidget)
 {
-    if (raiseWidget && raiseWidget->parentWidget() == nullptr) {
+    if (raiseWidget && !raiseWidget->parentWidget()) {
         // Qt has a bug which causes parent-less dialogs to pop-under.
         raiseWidget->showNormal();
         raiseWidget->raise();

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -40,7 +40,7 @@ Systray *Systray::_instance = nullptr;
 
 Systray *Systray::instance()
 {
-    if (_instance == nullptr) {
+    if (!_instance) {
         _instance = new Systray();
     }
     return _instance;

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -419,7 +419,7 @@ void User::openLocalFolder()
 {
     const auto folder = getFolder();
 
-    if (folder != nullptr) {
+    if (folder) {
         QDesktopServices::openUrl(QUrl::fromLocalFile(folder->path()));
     }
 }
@@ -509,7 +509,7 @@ UserModel *UserModel::_instance = nullptr;
 
 UserModel *UserModel::instance()
 {
-    if (_instance == nullptr) {
+    if (!_instance) {
         _instance = new UserModel();
     }
     return _instance;
@@ -808,7 +808,7 @@ UserAppsModel *UserAppsModel::_instance = nullptr;
 
 UserAppsModel *UserAppsModel::instance()
 {
-    if (_instance == nullptr) {
+    if (!_instance) {
         _instance = new UserAppsModel();
     }
     return _instance;

--- a/src/libsync/bandwidthmanager.cpp
+++ b/src/libsync/bandwidthmanager.cpp
@@ -153,7 +153,7 @@ void BandwidthManager::relativeUploadMeasuringTimerExpired()
         _relativeUploadDelayTimer.start();
         return;
     }
-    if (_relativeLimitCurrentMeasuredDevice == nullptr) {
+    if (!_relativeLimitCurrentMeasuredDevice) {
         qCDebug(lcBandwidthManager) << "No device set, just waiting 1 sec";
         _relativeUploadDelayTimer.setInterval(1000);
         _relativeUploadDelayTimer.start();
@@ -247,7 +247,7 @@ void BandwidthManager::relativeDownloadMeasuringTimerExpired()
         _relativeDownloadDelayTimer.start();
         return;
     }
-    if (_relativeLimitCurrentMeasuredJob == nullptr) {
+    if (!_relativeLimitCurrentMeasuredJob) {
         qCDebug(lcBandwidthManager) << "No job set, just waiting 1 sec";
         _relativeDownloadDelayTimer.setInterval(1000);
         _relativeDownloadDelayTimer.start();

--- a/test/csync/encoding_tests/check_encoding.cpp
+++ b/test/csync/encoding_tests/check_encoding.cpp
@@ -93,17 +93,17 @@ static void check_to_multibyte(void **state)
 {
     int rc = -1;
 
-    mbchar_t *mb_string = c_utf8_path_to_locale( TESTSTRING );
-    mbchar_t *mb_null   = c_utf8_path_to_locale( nullptr );
+    mbchar_t *mb_string = c_utf8_path_to_locale(TESTSTRING);
+    mbchar_t *mb_null   = c_utf8_path_to_locale(nullptr);
 
     (void) state;
 
 #ifdef _WIN32
-    assert_int_equal( wcscmp( LTESTSTRING, mb_string), 0 );
+    assert_int_equal(wcscmp(LTESTSTRING, mb_string), 0);
 #else
     assert_string_equal(mb_string, TESTSTRING);
 #endif
-    assert_true( mb_null == nullptr );
+    assert_false(mb_null);
     assert_int_equal(rc, -1);
 
     c_free_locale_string(mb_string);
@@ -159,12 +159,12 @@ static void check_long_win_path(void **state)
             "olonglonglonglong\\file.txt";
 
     QByteArray new_long = OCC::FileSystem::pathtoUNC(QByteArray::fromRawData(longPath, strlen(longPath)));
-    // printf( "XXXXXXXXXXXX %s %d\n", new_long, mem_reserved);
+    // printf("XXXXXXXXXXXX %s %d\n", new_long, mem_reserved);
 
     assert_string_equal(new_long, longPathConv);
 
-    // printf( "YYYYYYYYYYYY %ld\n", strlen(new_long));
-    assert_int_equal( strlen(new_long), 286);
+    // printf("YYYYYYYYYYYY %ld\n", strlen(new_long));
+    assert_int_equal(strlen(new_long), 286);
 }
 
 int torture_run_tests(void)


### PR DESCRIPTION
This is a continuation of #1988 and #2057.

Make the codebase consistent, we already have a lot of implicit pointer comparisons.

Exception: Stay explicit on `return`'s, example:
`return _db != nullptr;`