### PR TITLE
Debug gui errors

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -462,7 +462,7 @@ Window {
                         Menu {
                             id: appsMenu
                             y: (trayWindowAppsButton.y + trayWindowAppsButton.height + 2)
-                            width: Math.min(contentItem.childrenRect.width + 4, Style.trayWindowWidth / 2)
+                            width: Style.trayWindowWidth / 2
                             closePolicy: "CloseOnPressOutside"
 
                             background: Rectangle {

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -462,7 +462,17 @@ Window {
                         Menu {
                             id: appsMenu
                             y: (trayWindowAppsButton.y + trayWindowAppsButton.height + 2)
-                            width: Style.trayWindowWidth / 2
+                            width: {
+                                var result = 0;
+                                for (var i = 0; i < count; ++i) {
+                                    var item = itemAt(i);
+                                    var width = item.contentItem.implicitWidth +
+                                                item.leftPadding + item.rightPadding;
+                                    result = Math.max(width, result);
+                                }
+
+                                return Math.min(result + 4, Style.trayWindowWidth / 2);
+                            }
                             closePolicy: "CloseOnPressOutside"
 
                             background: Rectangle {
@@ -479,7 +489,6 @@ Window {
                                     text: appName
                                     font.pixelSize: Style.topLinePixelSize
                                     icon.source: appIconUrl
-                                    width: contentItem.implicitWidth + leftPadding + rightPadding
                                     onTriggered: appsMenuModelBackend.openAppUrl(appUrl)
                                 }
                             }

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -652,17 +652,21 @@ QImage AvatarJob::makeCircularAvatar(const QImage &baseAvatar)
     int dim = baseAvatar.width();
 
     QImage avatar(dim, dim, QImage::Format_ARGB32);
-    avatar.fill(Qt::transparent);
 
-    QPainter painter(&avatar);
-    painter.setRenderHint(QPainter::Antialiasing);
+	//Let User::avatar() handle a faulty avatar, just prevent errors here
+	if (!avatar.isNull()) {
+	    avatar.fill(Qt::transparent);
 
-    QPainterPath path;
-    path.addEllipse(0, 0, dim, dim);
-    painter.setClipPath(path);
+		QPainter painter(&avatar);
+		painter.setRenderHint(QPainter::Antialiasing);
 
-    painter.drawImage(0, 0, baseAvatar);
-    painter.end();
+		QPainterPath path;
+		path.addEllipse(0, 0, dim, dim);
+		painter.setClipPath(path);
+
+		painter.drawImage(0, 0, baseAvatar);
+		painter.end();
+	}
 
     return avatar;
 }


### PR DESCRIPTION
### Problem

The following lines showed up in my log file after compiling from source:

```
[unknown 	qrc:/qml/src/gui/tray/Window.qml:462:25: QML Menu: Binding loop detected for property "width"
[unknown 	QPainter::begin: Paint device returned engine == 0, type: 3
[unknown 	QPainter::setRenderHint: Painter must be active to set rendering hints
[unknown 	QPainter::setClipPath: Painter not active
[unknown 	QPainter::end: Painter not active, aborted
```

### Solution 1

The first error message was introduced by commit 2946c335ba443983a6018ca0f9ba9745d5e1c44a. I temporarily fixed it by removing the offending statement, but @sbeyer should take another look at it.

### Solution 2

The other error messages were caused by a retrieved `baseAvatar` that was much too large (21845 px wide), causing [QImage](https://doc.qt.io/qt-5/qimage.html#QImage-2) to return the null image. This eventuality, however, was only tested for in `User::avatar()`, not locally. Fixed by only attempting to use the avatar image if it isn't null.
