### PR TITLE
Add photothumb.db to sync-exclude.lst

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -10,6 +10,7 @@
 ].ds_store
 ._*
 ]Thumbs.db
+]photothumb.db
 System Volume Information
 
 .*.sw?


### PR DESCRIPTION
Add photothumb.db file that is thumbnails generated by Photoscape application (generated in every folder with graphic files).