### PR TITLE
Don't call method on potentially null object

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -799,7 +799,6 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
     FileData fileData = hasSeveralFiles ? FileData{} : FileData::get(argument);
     bool isOnTheServer = fileData.journalRecord().isValid();
     auto flagString = isOnTheServer ? QLatin1String("::") : QLatin1String(":d:");
-    auto capabilities = fileData.folder->accountState()->account()->capabilities();
 
     if (fileData.folder && fileData.folder->accountState()->isConnected()) {
         DirectEditor* editor = getDirectEditorForLocalFile(fileData.localPath);


### PR DESCRIPTION
We were calling accountState() on a "folder" member which could be
nullptr. In fact this would happen any time one right click on a file
outside of a sync dir under Windows, this thus led to a crash.

Since the capabilities variable was unused anyway, we just removed it.

This should fix #1804 and fix #2054.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>