### PR TITLE
Fix hover cutoff in apps menu

### DIFF
--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -22,6 +22,7 @@ MenuItem {
                 Layout.preferredWidth: (userLineLayout.width * (5/6))
                 Layout.preferredHeight: (userLineLayout.height)
                 display: AbstractButton.IconOnly
+                hoverEnabled: true
                 flat: true
 
                 MouseArea {
@@ -39,8 +40,15 @@ MenuItem {
                     }
                 }
 
-                background: Rectangle {
-                    color: "transparent"
+
+                background: Item {
+                    height: parent.height
+                    width: parent.menu.width
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 1
+                        color: parent.parent.hovered ? Style.lightHover : "transparent"
+                    }
                 }
 
                 RowLayout {
@@ -140,18 +148,40 @@ MenuItem {
                     MenuItem {
                         text: isConnected ? qsTr("Log out") : qsTr("Log in")
                         font.pixelSize: Style.topLinePixelSize
+                        hoverEnabled: true
                         onClicked: {
                             isConnected ? UserModel.logout(index) : UserModel.login(index)
                             accountMenu.close()
+                        }
+
+                        background: Item {
+                            height: parent.height
+                            width: parent.menu.width
+                            Rectangle {
+                                anchors.fill: parent
+                                anchors.margins: 1
+                                color: parent.parent.hovered ? Style.lightHover : "transparent"
+                            }
                         }
                     }
 
                     MenuItem {
                         text: qsTr("Remove Account")
                         font.pixelSize: Style.topLinePixelSize
+                        hoverEnabled: true
                         onClicked: {
                             UserModel.removeAccount(index)
                             accountMenu.close()
+                        }
+
+                        background: Item {
+                            height: parent.height
+                            width: parent.menu.width
+                            Rectangle {
+                                anchors.fill: parent
+                                anchors.margins: 1
+                                color: parent.parent.hovered ? Style.lightHover : "transparent"
+                            }
                         }
                     }
                 }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -170,6 +170,17 @@ Window {
                             MenuItem {
                                 id: addAccountButton
                                 height: Style.addAccountButtonHeight
+                                hoverEnabled: true
+
+                                background: Item {
+                                    height: parent.height
+                                    width: parent.menu.width
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        anchors.margins: 1
+                                        color: parent.parent.hovered ? Style.lightHover : "transparent"
+                                    }
+                                }
 
                                 RowLayout {
                                     anchors.fill: parent
@@ -207,19 +218,52 @@ Window {
                             MenuItem {
                                 id: syncPauseButton
                                 font.pixelSize: Style.topLinePixelSize
+                                hoverEnabled: true
                                 onClicked: Systray.pauseResumeSync()
+
+                                background: Item {
+                                    height: parent.height
+                                    width: parent.menu.width
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        anchors.margins: 1
+                                        color: parent.parent.hovered ? Style.lightHover : "transparent"
+                                    }
+                                }
                             }
 
                             MenuItem {
                                 text: qsTr("Settings")
                                 font.pixelSize: Style.topLinePixelSize
+                                hoverEnabled: true
                                 onClicked: Systray.openSettings()
+
+                                background: Item {
+                                    height: parent.height
+                                    width: parent.menu.width
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        anchors.margins: 1
+                                        color: parent.parent.hovered ? Style.lightHover : "transparent"
+                                    }
+                                }
                             }
 
                             MenuItem {
                                 text: qsTr("Exit");
                                 font.pixelSize: Style.topLinePixelSize
+                                hoverEnabled: true
                                 onClicked: Systray.shutdown()
+
+                                background: Item {
+                                    height: parent.height
+                                    width: parent.menu.width
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        anchors.margins: 1
+                                        color: parent.parent.hovered ? Style.lightHover : "transparent"
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -405,11 +405,24 @@ Window {
                             onObjectAdded: appsMenu.insertItem(index, object)
                             onObjectRemoved: appsMenu.removeItem(object)
                             delegate: MenuItem {
+                                id: appEntry
                                 text: appName
                                 font.pixelSize: Style.topLinePixelSize
                                 icon.source: appIconUrl
                                 width: contentItem.implicitWidth + leftPadding + rightPadding
                                 onTriggered: UserAppsModel.openAppUrl(appUrl)
+                                hoverEnabled: true
+
+                                background: Item {
+                                    width: appsMenu.width
+                                    height: parent.height
+
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        anchors.margins: 1
+                                        color: appEntry.hovered ? Style.lightHover : "transparent"
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Could also be done in other ways, this seemed to be the most consistent regarding the other hover adjustments in Window.qml.

before:
![before](https://user-images.githubusercontent.com/32204802/84930998-686fce80-b0d2-11ea-92da-5af9c00744e5.gif)

after:
![after](https://user-images.githubusercontent.com/32204802/84931001-6ad22880-b0d2-11ea-96e7-af2febd38563.gif)

