### PR TITLE
Fix avatar errors

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -653,20 +653,20 @@ QImage AvatarJob::makeCircularAvatar(const QImage &baseAvatar)
 
     QImage avatar(dim, dim, QImage::Format_ARGB32);
 
-	//Let User::avatar() handle a faulty avatar, just prevent errors here
-	if (!avatar.isNull()) {
-	    avatar.fill(Qt::transparent);
+    //Let User::avatar() handle a faulty avatar, just prevent errors here
+    if (!avatar.isNull()) {
+        avatar.fill(Qt::transparent);
 
-		QPainter painter(&avatar);
-		painter.setRenderHint(QPainter::Antialiasing);
+        QPainter painter(&avatar);
+        painter.setRenderHint(QPainter::Antialiasing);
 
-		QPainterPath path;
-		path.addEllipse(0, 0, dim, dim);
-		painter.setClipPath(path);
+        QPainterPath path;
+        path.addEllipse(0, 0, dim, dim);
+        painter.setClipPath(path);
 
-		painter.drawImage(0, 0, baseAvatar);
-		painter.end();
-	}
+        painter.drawImage(0, 0, baseAvatar);
+        painter.end();
+    }
 
     return avatar;
 }

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -652,17 +652,21 @@ QImage AvatarJob::makeCircularAvatar(const QImage &baseAvatar)
     int dim = baseAvatar.width();
 
     QImage avatar(dim, dim, QImage::Format_ARGB32);
-    avatar.fill(Qt::transparent);
 
-    QPainter painter(&avatar);
-    painter.setRenderHint(QPainter::Antialiasing);
+	//Let User::avatar() handle a faulty avatar, just prevent errors here
+	if (!avatar.isNull()) {
+	    avatar.fill(Qt::transparent);
 
-    QPainterPath path;
-    path.addEllipse(0, 0, dim, dim);
-    painter.setClipPath(path);
+		QPainter painter(&avatar);
+		painter.setRenderHint(QPainter::Antialiasing);
 
-    painter.drawImage(0, 0, baseAvatar);
-    painter.end();
+		QPainterPath path;
+		path.addEllipse(0, 0, dim, dim);
+		painter.setClipPath(path);
+
+		painter.drawImage(0, 0, baseAvatar);
+		painter.end();
+	}
 
     return avatar;
 }


### PR DESCRIPTION
The following lines show up in my logfile:

```
[unknown 	QPainter::begin: Paint device returned engine == 0, type: 3
[unknown 	QPainter::setRenderHint: Painter must be active to set rendering hints
[unknown 	QPainter::setClipPath: Painter not active
[unknown 	QPainter::end: Painter not active, aborted
```

This was caused by a retrieved baseAvatar that was much too large (21845 px wide), causing QImage to return the null image. This eventuality, however, was only tested for in `User::avatar()`, and not in `AvatarJob::makeCircularAvatar()`. Fixed by only attempting to use the avatar image if it isn't null.