### PR TITLE
Fix libsync exports for proxy changes in #1886

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -76,7 +76,7 @@ void ConnectionValidator::systemProxyLookupDone(const QNetworkProxy &proxy)
     }
 
     if (proxy.type() != QNetworkProxy::NoProxy) {
-        qCInfo(lcConnectionValidator) << "Setting QNAM proxy to be system proxy" << printQNetworkProxy(proxy);
+        qCInfo(lcConnectionValidator) << "Setting QNAM proxy to be system proxy" << ClientProxy::printQNetworkProxy(proxy);
     } else {
         qCInfo(lcConnectionValidator) << "No system proxy set by OS";
     }

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -170,7 +170,7 @@ void OwncloudSetupWizard::slotCheckServer(const QString &urlString)
 void OwncloudSetupWizard::slotSystemProxyLookupDone(const QNetworkProxy &proxy)
 {
     if (proxy.type() != QNetworkProxy::NoProxy) {
-        qCInfo(lcWizard) << "Setting QNAM proxy to be system proxy" << printQNetworkProxy(proxy);
+        qCInfo(lcWizard) << "Setting QNAM proxy to be system proxy" << ClientProxy::printQNetworkProxy(proxy);
     } else {
         qCInfo(lcWizard) << "No system proxy set by OS";
     }

--- a/src/libsync/clientproxy.cpp
+++ b/src/libsync/clientproxy.cpp
@@ -56,7 +56,7 @@ bool ClientProxy::isUsingSystemDefault()
     return true;
 }
 
-const char *proxyTypeToCStr(QNetworkProxy::ProxyType type)
+const char *ClientProxy::proxyTypeToCStr(QNetworkProxy::ProxyType type)
 {
     switch (type) {
     case QNetworkProxy::NoProxy:
@@ -76,7 +76,7 @@ const char *proxyTypeToCStr(QNetworkProxy::ProxyType type)
     }
 }
 
-QString printQNetworkProxy(const QNetworkProxy &proxy)
+QString ClientProxy::printQNetworkProxy(const QNetworkProxy &proxy)
 {
     return QString("%1://%2:%3").arg(proxyTypeToCStr(proxy.type())).arg(proxy.hostName()).arg(proxy.port());
 }

--- a/src/libsync/clientproxy.h
+++ b/src/libsync/clientproxy.h
@@ -41,6 +41,9 @@ public:
     static bool isUsingSystemDefault();
     static void lookupSystemProxyAsync(const QUrl &url, QObject *dst, const char *slot);
 
+    static QString printQNetworkProxy(const QNetworkProxy &proxy);
+    static const char *proxyTypeToCStr(QNetworkProxy::ProxyType type);
+
 public slots:
     void setupQtProxyFromConfig();
 };
@@ -58,7 +61,6 @@ private:
     QUrl _url;
 };
 
-QString printQNetworkProxy(const QNetworkProxy &proxy);
 }
 
 #endif // CLIENTPROXY_H


### PR DESCRIPTION
Build failed on Windows, missing `libsync` export for `printQNetworkProxy` after moving `ClientProxy` class from `gui` to `libsync` in #1886.