### PR TITLE
Darken menu border color

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -201,7 +201,12 @@ Window {
                                 onClicked: UserModel.addAccount()
                             }
 
-                            MenuSeparator { id: accountMenuSeparator }
+                            MenuSeparator {
+                                contentItem: Rectangle {
+                                    implicitHeight: 1
+                                    color: Style.menuBorder
+                                }
+                            }
 
                             MenuItem {
                                 id: syncPauseButton

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -8,7 +8,7 @@ QtObject {
     property color ncBlue:      "#0082c9"
     property color ncBlueHover: "#009dd9"
     property color lightHover:  "#f7f7f7"
-    property color menuBorder:  "#ededed"
+    property color menuBorder:  "#bdbdbd"
 
     // Fonts
     // We are using pixel size because this is cross platform comparable, point size isn't


### PR DESCRIPTION
The lightgray menu border color `#ededed` introduced in
commit f147e5a66f43657805542904b43e0b4e662ffe04 (by PR #2095)
is way too light for my display (and probably others).
Thus the menus have no clear border which looks odd and broken.

This commit simply darkens the menu border to `#808080`.