### PR TITLE
Fix SEGV (due to circular ownership) at exit

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -32,6 +32,7 @@
 #include "cloudproviders/cloudprovidermanager.h"
 #endif
 
+#include <QQmlApplicationEngine>
 #include <QDesktopServices>
 #include <QDir>
 #include <QMessageBox>
@@ -66,7 +67,7 @@ ownCloudGui::ownCloudGui(Application *parent)
     , _app(parent)
 {
     _tray = Systray::instance();
-    _tray->setParent(this);
+    _tray->setTrayEngine(new QQmlApplicationEngine(this));
     // for the beginning, set the offline icon until the account was verified
     _tray->setIcon(Theme::instance()->folderOfflineIcon(/*systray?*/ true));
 

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -50,7 +50,8 @@ Systray *Systray::instance()
 }
 
 Systray::Systray()
-    : _trayEngine(new QQmlApplicationEngine(this))
+    : QSystemTrayIcon(nullptr)
+    , _trayEngine(new QQmlApplicationEngine(this))
 {
     _trayEngine->addImportPath("qrc:/qml/theme");
     _trayEngine->addImageProvider("avatars", new ImageProvider);

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -90,7 +90,7 @@ private:
 
     bool _isOpen = false;
     bool _syncIsPaused = false;
-    QQmlApplicationEngine *_trayEngine = nullptr;
+    QPointer<QQmlApplicationEngine> _trayEngine;
 };
 
 } // namespace OCC

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -49,6 +49,7 @@ public:
     enum class TaskBarPosition { Bottom, Left, Top, Right };
     Q_ENUM(TaskBarPosition);
 
+    void setTrayEngine(QQmlApplicationEngine *trayEngine);
     void create();
     void showMessage(const QString &title, const QString &message, MessageIcon icon = Information);
     void setToolTip(const QString &tip);
@@ -89,7 +90,7 @@ private:
 
     bool _isOpen = false;
     bool _syncIsPaused = false;
-    QQmlApplicationEngine *_trayEngine;
+    QQmlApplicationEngine *_trayEngine = nullptr;
 };
 
 } // namespace OCC


### PR DESCRIPTION
Commit a12205f322d43476230881192616e47c9cf786ef (PR #1891) introduced a circular ownership: `qmlRegisterSingletonType<Systray>(...)` makes the `QQmlEngine` own the resulting singleton `Systray` instance, however, the `QQmlEngine _trayEngine` itself is owned by the `Systray` instance. This circular ownership results in a crash when the destructor of `Systray` calls the destructor of `_trayEngine` which attempts to call the destructor of `Systray` again.

This commit solves this problem by making `ownCloudGui`, which is the parent of `Systray`, the parent of `_trayEngine`.