### PR TITLE
refactor_useQCommandLineParser

### DIFF
--- a/doc/options.rst
+++ b/doc/options.rst
@@ -1,16 +1,16 @@
 You have the option of starting your Nextcloud desktop client with the 
 ``nextcloud`` command. The following options are supported:
 
-``nextcloud -h`` or ``nextcloud --help``
+``nextcloud --help``, ``nextcloud -h`` or ``nextcloud -?``, 
         Displays all command options.
 
 The other options are:
 
-``--logwindow``
+``--logwindow``, ``-l``
         Opens a window displaying log output.
 
 ``--logfile`` `<filename>`
-        Write log output to the file specified. To write to stdout, specify `-` 
+        Writes log output to the file specified. To write to stdout, specify `-` 
         as the filename.
 
 ``--logdir`` `<name>`
@@ -25,10 +25,13 @@ The other options are:
         Clears (flushes) the log file after each write action.
 
 ``--logdebug``
-        Also output debug-level messages in the log (equivalent to setting the env var QT_LOGGING_RULES="qt.*=true;*.debug=true").
+        Also outputs debug-level messages in the log (equivalent to setting the env var QT_LOGGING_RULES="qt.*=true;*.debug=true").
 
 ``--confdir`` `<dirname>`
         Uses the specified configuration directory.
 
 ``--background``
-        Launch the application in the background (i.e. without opening the main dialog).
+        Launches the application in the background (i.e. without opening the main dialog).
+
+``--quit``, ``-q``
+        Quits the running instance.

--- a/man/nextcloudcmd.1.rst
+++ b/man/nextcloudcmd.1.rst
@@ -32,38 +32,48 @@ OPTIONS
 ``--path``
        Overrides default remote root folder to a specific subfolder on the server(e.g.: /Documents would sync the Documents subfolder on the server)
 
-``—user``, ``-u`` ``[user]``
+``--user``, ``-u`` ``[user]``
        Use ``user`` as the login name.
 
-``—password``, ``-p`` ``[password]``
+``--password``, ``-p`` ``[password]``
        Use ``password`` as the password.
 
-``-n``
+``--netrc``, ``-n``
        Use ``netrc (5)`` for login.
 
-``—non-interactive``
+``--non-interactive``
        Do not prompt for questions.
 
-``—silent``, ``—s``
+``--silent``, ``-s``
        Inhibits verbose log output.
 
-``—trust``
+``--trust``
        Trust any SSL certificate, including invalid ones.
 
-``—httpproxy  http://[user@pass:]<server>:<port>``
+``--httpproxy  http://[user@pass:]<server>:<port>``
       Uses ``server`` as HTTP proxy.
 
-``—exclude [file]``
+``--exclude [file]``
       Exclude list file
 
-``—unsyncedfolders [file]``
+``--unsyncedfolders [file]``
       File containing the list of unsynced folders (selective sync)
 
-``—max-sync-retries [n]``
+``--max-sync-retries [n]``
       Retries maximum n times (defaults to 3)
 
-``-h``
-      Sync hidden files,do not ignore them
+``--ignore-hidden``, ``-i``
+      Ignores hidden files, do not sync them
+
+``--uplimit``
+      Limit the upload speed of files to n KB/s
+
+``--downlimit``
+      Limit the download speed of files to n KB/s
+
+``--logdebug``
+      More verbose logging
+
 
 Example
 =======
@@ -71,7 +81,7 @@ To synchronize the nextCloud directory ``Music`` to the local directory ``media/
 through a proxy listening on port ``8080`` on the gateway machine ``192.168.178.1``,
 the command line would be::
 
-  $ nextcloudcmd —httpproxy http://192.168.178.1:8080 --path /Music \
+  $ nextcloudcmd --httpproxy http://192.168.178.1:8080 --path /Music \
                 $HOME/media/music \
                 https://server/nextcloud
 
@@ -80,7 +90,7 @@ been specified on the command line or ``-n`` (see `netrc(5)`) has been passed.
 
 Using the legacy scheme, it would be::
 
-  $ nextcloudcmd —httpproxy http://192.168.178.1:8080 --path /Music \
+  $ nextcloudcmd --httpproxy http://192.168.178.1:8080 --path /Music \
                 $HOME/media/music \
                 ownclouds://server/nextcloud
 

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -217,22 +217,22 @@ Usage: %3 [OPTION] <source_dir> <server_url>
 #endif
 
     QString source_dir = args.at(0);
-    QString target_url = args.at(1);
-    QString options_user = parser.value("user");
-    QString options_password = parser.value("password");
-    QString proxy = parser.value("httpproxy");
-    bool silent = parser.isSet("silent");
-    bool trustSSL = parser.isSet("trust");
-    bool useNetrc = parser.isSet("netrc");
-    bool interactive = !parser.isSet("non-interactive");
-    bool ignoreHiddenFiles = parser.isSet("ignore-hidden");
-    QString exclude = parser.value("exclude");
-    QString unsyncedfolders = parser.value("unsyncedfolders");
-    int restartTimes = parser.value("max-sync-retries").toInt();
-    int uplimit = parser.value("uplimit").toInt() * 1000;
-    int downlimit = parser.value("downlimit").toInt() * 1000;
-    bool logdebug = parser.isSet("logdebug");
-    QString remotePath = parser.value("path");
+    const QString target_url = args.at(1);
+    const QString options_user = parser.value("user");
+    const QString options_password = parser.value("password");
+    const QString proxy = parser.value("httpproxy");
+    const bool silent = parser.isSet("silent");
+    const bool trustSSL = parser.isSet("trust");
+    const bool useNetrc = parser.isSet("netrc");
+    const bool interactive = !parser.isSet("non-interactive");
+    const bool ignoreHiddenFiles = parser.isSet("ignore-hidden");
+    const QString exclude = parser.value("exclude");
+    const QString unsyncedfolders = parser.value("unsyncedfolders");
+    const int restartTimes = parser.value("max-sync-retries").toInt();
+    const int uplimit = parser.value("uplimit").toInt() * 1000;
+    const int downlimit = parser.value("downlimit").toInt() * 1000;
+    const bool logdebug = parser.isSet("logdebug");
+    const QString remotePath = parser.value("path");
 
     if (logdebug) {
         Logger::instance()->setLogFile("-");

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -533,9 +533,9 @@ void Application::slotownCloudWizardDone(int res)
 
 void Application::setupLogging()
 {
-    QString logDir = _parser.value("logdir");
-    QString logFile = _parser.value("logfile");
-    int logExpire = _parser.value("logexpire").toInt();
+    const QString logDir = _parser.value("logdir");
+    const QString logFile = _parser.value("logfile");
+    const int logExpire = _parser.value("logexpire").toInt();
 
     // might be called from second instance
     auto logger = Logger::instance();

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -16,6 +16,7 @@
 #define APPLICATION_H
 
 #include <QApplication>
+#include <QCommandLineParser>
 #include <QPointer>
 #include <QQueue>
 #include <QTimer>
@@ -60,13 +61,8 @@ public:
     explicit Application(int &argc, char **argv);
     ~Application() override;
 
-    bool giveHelp();
-    void showHelp();
     void showHint(std::string errorHint);
-    bool debugMode();
     bool backgroundMode() const;
-    bool versionOnly(); // only display the version?
-    void showVersion();
 
     void showMainDialog();
 
@@ -86,7 +82,6 @@ public slots:
     void tryTrayAgain();
 
 protected:
-    void parseOptions(const QStringList &);
     void setupTranslations();
     void setupLogging();
     bool event(QEvent *event) override;
@@ -107,7 +102,7 @@ protected slots:
     void slotGuiIsShowingSettings();
 
 private:
-    void setHelp();
+    void virtualFileFromArguments();
 
     /**
      * Maybe a newer version of the client was used with this config file:
@@ -116,28 +111,10 @@ private:
     bool configVersionMigration();
 
     QPointer<ownCloudGui> _gui;
-
+    QCommandLineParser _parser;
     Theme *_theme;
-
-    bool _helpOnly;
-    bool _versionOnly;
-
     QElapsedTimer _startedAt;
-
-    // options from command line:
-    bool _showLogWindow;
-    bool _quitInstance = false;
-    QString _logFile;
-    QString _logDir;
-    int _logExpire;
-    bool _logFlush;
-    bool _logDebug;
-    bool _userTriggeredConnect;
-    bool _debugMode;
-    bool _backgroundMode;
-
     ClientProxy _proxy;
-
     QNetworkConfigurationManager _networkConfigurationManager;
     QTimer _checkConnectionTimer;
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -117,14 +117,6 @@ int main(int argc, char **argv)
 #ifndef Q_OS_WIN
     signal(SIGPIPE, SIG_IGN);
 #endif
-    if (app.giveHelp()) {
-        app.showHelp();
-        return 0;
-    }
-    if (app.versionOnly()) {
-        app.showVersion();
-        return 0;
-    }
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -763,8 +763,7 @@ QString Theme::versionSwitchOutput() const
 {
     QString helpText;
     QTextStream stream(&helpText);
-    stream << appName()
-           << QLatin1String(" version ")
+    stream << QLatin1String("version ")
            << version() << Qt::endl;
 #ifdef GIT_SHA1
     stream << "Git revision " << GIT_SHA1 << Qt::endl;


### PR DESCRIPTION
Hey Guys, maybe you like this refactoring. It comes with a small issue. In <Windows e.g. 10> the window for showing the help information does not look identically. However I prefer using Qt-Mechanism instead of parsing it free will. Furthermore, if you say it's not direcly necessary to print an information in case the Config-Directory is not valid. It would allow to remove functions like showHint. 

Best Regards