### PR TITLE
Fix issue 2085

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -85,6 +85,9 @@ ownCloudGui::ownCloudGui(Application *parent)
     connect(_tray.data(), &Systray::openHelp,
         this, &ownCloudGui::slotHelp);
 
+    connect(_tray.data(), &Systray::openMainDialog,
+        this, &ownCloudGui::slotOpenMainDialog);
+
     connect(_tray.data(), &Systray::openSettings,
         this, &ownCloudGui::slotShowSettings);
 
@@ -164,7 +167,7 @@ void ownCloudGui::slotOpenMainDialog()
 
 void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
 {
-    if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::Context) {
+    if (reason == QSystemTrayIcon::Trigger) {
         if (OwncloudSetupWizard::bringWizardToFrontIfVisible()) {
             // brought wizard to front
         } else if (_shareDialogs.size() > 0) {

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -25,6 +25,7 @@
 #include <QQmlContext>
 #include <QQuickWindow>
 #include <QScreen>
+#include <QMenu>
 
 #ifdef USE_FDO_NOTIFICATIONS
 #include <QDBusConnection>
@@ -78,6 +79,14 @@ Systray::Systray()
             return Systray::instance();
         }
     );
+
+#ifndef Q_OS_MAC
+    auto contextMenu = new QMenu();
+    contextMenu->addAction(tr("Open main dialog"), this, &Systray::openMainDialog);
+    contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
+    contextMenu->addAction(tr("Exit %1").arg(Theme::instance()->appNameGUI()), this, &Systray::shutdown);
+    setContextMenu(contextMenu);
+#endif
 
     connect(UserModel::instance(), &UserModel::newUserSelected,
         this, &Systray::slotNewUserSelected);

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -64,6 +64,7 @@ public:
 
 signals:
     void currentUserChanged();
+    void openMainDialog();
     void openSettings();
     void openHelp();
     void shutdown();

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -211,19 +211,13 @@ Window {
                             }
 
                             MenuItem {
-                                text: qsTr("Open settings")
+                                text: qsTr("Settings")
                                 font.pixelSize: Style.topLinePixelSize
                                 onClicked: Systray.openSettings()
                             }
 
                             MenuItem {
-                                text: qsTr("Help")
-                                font.pixelSize: Style.topLinePixelSize
-                                onClicked: Systray.openHelp()
-                            }
-
-                            MenuItem {
-                                text: qsTr("Quit Nextcloud")
+                                text: qsTr("Exit");
                                 font.pixelSize: Style.topLinePixelSize
                                 onClicked: Systray.shutdown()
                             }


### PR DESCRIPTION
Update systray behavior and context menu:
- left click brings up the new QtQuick based dialogs on all latforms
- right click brings up the new QtQuick based dialog on Mac OS only
- right click brings up a context menu on all other platforms than Mac OS
- "Quit Nextcloud" => "Quit"
- Add "Open Main Dialog" option: add new slot to show the main dialog and fix
open settings slot to correctly show the settings.

Fix #2085 

![context menu](https://user-images.githubusercontent.com/241266/86275840-31221700-bbd4-11ea-85fb-30ff279f5765.png)

### to do
- [x] Test on Mac OS. 
- [x] I always run clang now so it found some issues and it fixed it... I can move that last commit to somewhere else if anyone is against it being in the same PR.