### PR TITLE
Fix e2e moves handling

### DIFF
--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -65,6 +65,7 @@ public:
     bool _serverHasIgnoredFiles = false;
     QByteArray _checksumHeader;
     QByteArray _e2eMangledName;
+    bool _isE2eEncrypted = false;
 };
 
 bool OCSYNC_EXPORT

--- a/src/csync/csync.cpp
+++ b/src/csync/csync.cpp
@@ -340,5 +340,6 @@ std::unique_ptr<csync_file_stat_t> csync_file_stat_s::fromSyncJournalFileRecord(
     st->has_ignored_files = rec._serverHasIgnoredFiles;
     st->checksumHeader = rec._checksumHeader;
     st->e2eMangledName = rec._e2eMangledName;
+    st->isE2eEncrypted = rec._isE2eEncrypted;
     return st;
 }

--- a/src/csync/csync.h
+++ b/src/csync/csync.h
@@ -173,6 +173,7 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   // In both cases, the format is "SHA1:baff".
   QByteArray checksumHeader;
   QByteArray e2eMangledName;
+  bool isE2eEncrypted;
 
   CSYNC_STATUS error_status = CSYNC_STATUS_OK;
 
@@ -183,6 +184,7 @@ struct OCSYNC_EXPORT csync_file_stat_s {
     , child_modified(false)
     , has_ignored_files(false)
     , is_hidden(false)
+    , isE2eEncrypted(false)
   { }
 
   static std::unique_ptr<csync_file_stat_t> fromSyncJournalFileRecord(const OCC::SyncJournalFileRecord &rec);

--- a/src/csync/csync_reconcile.cpp
+++ b/src/csync/csync_reconcile.cpp
@@ -178,8 +178,21 @@ static void _csync_merge_algorithm_visitor(csync_file_stat_t *cur, CSYNC * ctx) 
                         basePath.constData(), other ? "found" : "not found");
                 }
 
+                const auto curParentPath = [=]{
+                    const auto slashPosition = cur->path.lastIndexOf('/');
+                    if (slashPosition >= 0) {
+                        return cur->path.left(slashPosition);
+                    } else {
+                        return QByteArray();
+                    }
+                }();
+                auto curParent = our_tree->findFile(curParentPath);
+
                 if(!other) {
                     // Stick with the NEW
+                    return;
+                } else if (!other->e2eMangledName.isEmpty() || (curParent && curParent->isE2eEncrypted)) {
+                    // Stick with the NEW as well, we want to always issue delete + upload in such cases
                     return;
                 } else if (other->instruction == CSYNC_INSTRUCTION_RENAME) {
                     // Some other EVAL_RENAME already claimed other.

--- a/src/csync/csync_update.cpp
+++ b/src/csync/csync_update.cpp
@@ -203,7 +203,8 @@ static int _csync_detect_update(CSYNC *ctx, std::unique_ptr<csync_file_stat_t> f
 
   if(base.isValid()) { /* there is an entry in the database */
       // When the file is loaded from the file system it misses
-      // the e2e mangled name
+      // the e2e mangled name and e2e encryption status
+      fs->isE2eEncrypted = base._isE2eEncrypted;
       if (fs->e2eMangledName.isEmpty() && !base._e2eMangledName.isEmpty()) {
           fs->e2eMangledName = base._e2eMangledName;
           fs->path = base._path;

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1228,14 +1228,14 @@ void ClientSideEncryption::folderEncryptedStatusFetched(const QHash<QString, boo
     _refreshingEncryptionStatus = false;
     _folder2encryptedStatus = result;
     qCDebug(lcCse) << "Retrieved correctly the encrypted status of the folders." << result;
-    emit folderEncryptedStatusFetchDone();
+    emit folderEncryptedStatusFetchDone(result);
 }
 
 void ClientSideEncryption::folderEncryptedStatusError(int error)
 {
     _refreshingEncryptionStatus = false;
     qCDebug(lcCse) << "Failed to retrieve the status of the folders." << error;
-    emit folderEncryptedStatusFetchDone();
+    emit folderEncryptedStatusFetchDone({});
 }
 
 FolderMetadata::FolderMetadata(AccountPtr account, const QByteArray& metadata, int statusCode) : _account(account)

--- a/src/libsync/clientsideencryption.h
+++ b/src/libsync/clientsideencryption.h
@@ -105,7 +105,7 @@ signals:
     void initializationFinished();
     void mnemonicGenerated(const QString& mnemonic);
     void showMnemonic(const QString& mnemonic);
-    void folderEncryptedStatusFetchDone();
+    void folderEncryptedStatusFetchDone(const QHash<QString, bool> &values);
 
 private:
     void getPrivateKeyFromServer();

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -510,15 +510,7 @@ void OwncloudPropagator::start(const SyncFileItemVector &items,
 
     connect(_rootJob.data(), &PropagatorJob::finished, this, &OwncloudPropagator::emitFinished);
 
-    // If needed, make sure we have up to date E2E information before scheduling the first job
-    // otherwise we start right away
-    if (_account->capabilities().clientSideEncryptionAvailable()) {
-        connect(_account->e2e(), &ClientSideEncryption::folderEncryptedStatusFetchDone,
-                this, &OwncloudPropagator::onFolderEncryptedStatusFetchDone);
-        _account->e2e()->fetchFolderEncryptedStatus();
-    } else {
-        scheduleNextJob();
-    }
+    scheduleNextJob();
 }
 
 const SyncOptions &OwncloudPropagator::syncOptions() const
@@ -614,13 +606,6 @@ bool OwncloudPropagator::hasCaseClashAccessibilityProblem(const QString &relfile
 QString OwncloudPropagator::getFilePath(const QString &tmp_file_name) const
 {
     return _localDir + tmp_file_name;
-}
-
-void OwncloudPropagator::onFolderEncryptedStatusFetchDone()
-{
-    disconnect(_account->e2e(), &ClientSideEncryption::folderEncryptedStatusFetchDone,
-               this, &OwncloudPropagator::onFolderEncryptedStatusFetchDone);
-    scheduleNextJob();
 }
 
 void OwncloudPropagator::scheduleNextJob()

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -527,8 +527,6 @@ private slots:
         _finishedEmited = true;
     }
 
-    void onFolderEncryptedStatusFetchDone();
-
     void scheduleNextJobImpl();
 
 signals:

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -858,6 +858,11 @@ void SyncEngine::startSync()
         return shouldDiscoverLocally(path);
     };
 
+    slotStartDiscovery();
+}
+
+void SyncEngine::slotStartDiscovery()
+{
     bool ok = false;
     auto selectiveSyncBlackList = _journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
     if (ok) {

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -858,6 +858,21 @@ void SyncEngine::startSync()
         return shouldDiscoverLocally(path);
     };
 
+    // If needed, make sure we have up to date E2E information before the
+    // discovery phase, otherwise we start right away
+    if (_account->capabilities().clientSideEncryptionAvailable()) {
+        connect(_account->e2e(), &ClientSideEncryption::folderEncryptedStatusFetchDone,
+                this, &SyncEngine::onFolderEncryptedStatusFetchDone);
+        _account->e2e()->fetchFolderEncryptedStatus();
+    } else {
+        slotStartDiscovery();
+    }
+}
+
+void SyncEngine::onFolderEncryptedStatusFetchDone()
+{
+    disconnect(_account->e2e(), &ClientSideEncryption::folderEncryptedStatusFetchDone,
+               this, &SyncEngine::onFolderEncryptedStatusFetchDone);
     slotStartDiscovery();
 }
 

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -168,6 +168,7 @@ signals:
     void seenLockedFile(const QString &fileName);
 
 private slots:
+    void onFolderEncryptedStatusFetchDone();
     void slotStartDiscovery();
 
     void slotFolderDiscovered(bool local, const QString &folder);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -168,7 +168,7 @@ signals:
     void seenLockedFile(const QString &fileName);
 
 private slots:
-    void onFolderEncryptedStatusFetchDone();
+    void onFolderEncryptedStatusFetchDone(const QHash<QString, bool> &values);
     void slotStartDiscovery();
 
     void slotFolderDiscovered(bool local, const QString &folder);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -168,6 +168,8 @@ signals:
     void seenLockedFile(const QString &fileName);
 
 private slots:
+    void slotStartDiscovery();
+
     void slotFolderDiscovered(bool local, const QString &folder);
     void slotRootEtagReceived(const QString &);
 


### PR DESCRIPTION
This deals with all types of move involving E2E which are now treated as delete + upload. Unfortunately that includes also renames local to the same folder, but that would require further changes, I'll consider that as an optimization we can keep for later.

Fix #940 