### PR TITLE
Don't display quota information when the user has no quota.

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -969,7 +969,7 @@ void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
         _ui->quotaProgressBar->setVisible(false);
         _ui->quotaInfoLabel->setToolTip(QString());
 
-        /* -1 means not computed; -2 means unknown; -3 means unlimited  (#3940)*/
+        /* -1 means not computed; -2 means unknown; -3 means unlimited  (#owncloud/client/issues/3940)*/
         if (total == 0 || total == -1) {
             _ui->quotaInfoLabel->setText(tr("Currently there is no storage usage information available."));
         } else {

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -68,7 +68,7 @@ signals:
 
 public slots:
     void slotOpenOC();
-    void slotUpdateQuota(qint64, qint64);
+    void slotUpdateQuota(qint64 total, qint64 used);
     void slotAccountStateChanged();
     void slotStyleChanged();
 

--- a/src/gui/userinfo.cpp
+++ b/src/gui/userinfo.cpp
@@ -124,7 +124,7 @@ void UserInfo::slotUpdateLastInfo(const QJsonDocument &json)
     // Quota
     auto objQuota = objData.value("quota").toObject();
     qint64 used = objQuota.value("used").toDouble();
-    qint64 total = objQuota.value("total").toDouble();
+    qint64 total = objQuota.value("quota").toDouble();
 
     if(_lastInfoReceived.isNull() || _lastQuotaUsedBytes != used || _lastQuotaTotalBytes != total) {
         _lastQuotaUsedBytes = used;


### PR DESCRIPTION
- The code handling the api response was not up to date with the latest
api changes.
- Unlimited quota display: use qint64 to avoid data loss
- Change total with quota: total holds the quota total and not the storage total.

Signed-off-by: Camila <hello@camila.codes>