### PR TITLE
macOS: Display Dock icon and use its context menu

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -14,6 +14,8 @@
         <string>@APPLICATION_REV_DOMAIN@</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>@APPLICATION_NAME_XML_ESCAPED@</string>
         <key>CFBundleLongVersionString</key>
         <string>@APPLICATION_NAME_XML_ESCAPED@ @MIRALL_VERSION_STRING@</string>
         <key>CFBundlePackageType</key>

--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -4,8 +4,6 @@
 <dict>
         <key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>CFBundleDevelopmentRegion</key>
         <string>English</string>
         <key>CFBundleExecutable</key>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -152,7 +152,8 @@ IF( APPLE )
     list(APPEND client_SRCS cocoainitializer_mac.mm
                             socketapisocket_mac.mm
                             systray.mm
-                            owncloudgui_mac.mm)
+                            owncloudgui_mac.mm
+                            dockwatcher_mac.mm)
 
     if(SPARKLE_FOUND AND BUILD_UPDATER)
        # Define this, we need to check in updater.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -149,9 +149,10 @@ IF(BUILD_UPDATER)
 endif()
 
 IF( APPLE )
-    list(APPEND client_SRCS cocoainitializer_mac.mm)
-    list(APPEND client_SRCS socketapisocket_mac.mm)
-    list(APPEND client_SRCS systray.mm)
+    list(APPEND client_SRCS cocoainitializer_mac.mm
+                            socketapisocket_mac.mm
+                            systray.mm
+                            settingsdialog_mac.mm)
 
     if(SPARKLE_FOUND AND BUILD_UPDATER)
        # Define this, we need to check in updater.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -152,7 +152,7 @@ IF( APPLE )
     list(APPEND client_SRCS cocoainitializer_mac.mm
                             socketapisocket_mac.mm
                             systray.mm
-                            settingsdialog_mac.mm)
+                            owncloudgui_mac.mm)
 
     if(SPARKLE_FOUND AND BUILD_UPDATER)
        # Define this, we need to check in updater.cpp

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -136,7 +136,11 @@ Application::Application(int &argc, char **argv)
 #endif
 
     setApplicationName(_theme->appName());
+#ifndef Q_OS_MAC
+    // For macOS the icon is set in the MacOSXBundleInfo.plist file. Setting it here lead to Dock display
+    // errors, shortly drawing an opaque background while the icon is bouncing at app launch.
     setWindowIcon(_theme->applicationIcon());
+#endif
     setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
     auto confDir = ConfigFile().configPath();

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -42,8 +42,6 @@
 #include "owncloudsetupwizard.h"
 #include "version.h"
 
-#include "config.h"
-
 #if defined(Q_OS_WIN)
 #include <windows.h>
 #endif
@@ -103,7 +101,7 @@ namespace {
 
 Application::Application(int &argc, char **argv)
     : SharedTools::QtSingleApplication(Theme::instance()->appName(), argc, argv)
-    , _gui(nullptr)
+    , _gui(ownCloudGui::instance(this))
     , _theme(Theme::instance())
     , _helpOnly(false)
     , _versionOnly(false)
@@ -223,7 +221,7 @@ Application::Application(int &argc, char **argv)
 
     // Setting up the gui class will allow tray notifications for the
     // setup that follows, like folder setup
-    _gui = new ownCloudGui(this);
+    _gui->init();
     if (_showLogWindow) {
         _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
     }
@@ -270,9 +268,6 @@ Application::Application(int &argc, char **argv)
 
     // Cleanup at Quit.
     connect(this, &QCoreApplication::aboutToQuit, this, &Application::slotCleanup);
-
-    // Allow other classes to hook into isShowingSettingsDialog() signals (re-auth widgets, for example)
-    connect(_gui.data(), &ownCloudGui::isShowingSettingsDialog, this, &Application::slotGuiIsShowingSettings);
 
     _gui->createTray();
 }
@@ -665,11 +660,6 @@ bool Application::versionOnly()
 void Application::showMainDialog()
 {
     _gui->slotOpenMainDialog();
-}
-
-void Application::slotGuiIsShowingSettings()
-{
-    emit isShowingSettingsDialog();
 }
 
 } // namespace OCC

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -82,7 +82,6 @@ protected:
 signals:
     void folderRemoved();
     void folderStateChanged(Folder *);
-    void isShowingSettingsDialog();
 
 protected slots:
     void slotParseMessage(const QString &, QObject *);
@@ -92,7 +91,6 @@ protected slots:
     void slotAccountStateAdded(AccountState *accountState);
     void slotAccountStateRemoved(AccountState *accountState);
     void slotSystemOnlineConfigurationChanged(QNetworkConfiguration);
-    void slotGuiIsShowingSettings();
 
 private:
     void setHelp();

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -62,8 +62,10 @@ WebFlowCredentialsDialog::WebFlowCredentialsDialog(Account *account, bool useFlo
         connect(_webView, &WebView::urlCatched, this, &WebFlowCredentialsDialog::urlCatched);
     }
 
-    auto app = static_cast<Application *>(qApp);
-    connect(app, &Application::isShowingSettingsDialog, this, &WebFlowCredentialsDialog::slotShowSettingsDialog);
+    connect(ownCloudGui::instance(), &ownCloudGui::isShowingSettingsDialog, this, &WebFlowCredentialsDialog::slotShowSettingsDialog);
+
+    // Dialog visibility
+    connect(this, &WebFlowCredentialsDialog::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
 
     _errorLabel = new QLabel();
     _errorLabel->hide();
@@ -147,6 +149,12 @@ void WebFlowCredentialsDialog::changeEvent(QEvent *e)
 void WebFlowCredentialsDialog::customizeStyle()
 {
     // HINT: Customize dialog's own style here, if necessary in the future (Dark-/Light-Mode switching)
+}
+
+void WebFlowCredentialsDialog::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 void WebFlowCredentialsDialog::slotShowSettingsDialog()

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -64,6 +64,10 @@ WebFlowCredentialsDialog::WebFlowCredentialsDialog(Account *account, bool useFlo
 
     connect(ownCloudGui::instance(), &ownCloudGui::isShowingSettingsDialog, this, &WebFlowCredentialsDialog::slotShowSettingsDialog);
 
+    // Delay between calls to ownCloudGui::raiseDialog, to not annoy the users while they're switching to the Settings dialog
+    _raiseDelayTimer.setInterval(1000);
+    _raiseDelayTimer.setSingleShot(true);
+
     // Dialog visibility
     connect(this, &WebFlowCredentialsDialog::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
 
@@ -159,6 +163,11 @@ void WebFlowCredentialsDialog::setVisible(bool visible)
 
 void WebFlowCredentialsDialog::slotShowSettingsDialog()
 {
+    if (_raiseDelayTimer.isActive())
+        return;
+
+    _raiseDelayTimer.start();
+
     // bring window to top but slightly delay, to avoid being hidden behind the SettingsDialog
     QTimer::singleShot(100, this, [this] {
         ownCloudGui::raiseDialog(this);

--- a/src/gui/creds/webflowcredentialsdialog.h
+++ b/src/gui/creds/webflowcredentialsdialog.h
@@ -33,6 +33,7 @@ public:
 protected:
     void closeEvent(QCloseEvent * e) override;
     void changeEvent(QEvent *) override;
+    void setVisible(bool visible) override;
 
 public slots:
     void slotFlow2AuthResult(Flow2Auth::Result, const QString &errorString, const QString &user, const QString &appPassword);
@@ -43,6 +44,7 @@ signals:
     void styleChanged();
     void onActivate();
     void onClose();
+    void onSetVisible(bool visible);
 
 private:
     void customizeStyle();

--- a/src/gui/creds/webflowcredentialsdialog.h
+++ b/src/gui/creds/webflowcredentialsdialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include <QUrl>
+#include <QTimer>
 
 #include "accountfwd.h"
 #include "creds/flow2auth.h"
@@ -59,6 +60,8 @@ private:
     QVBoxLayout *_layout;
     QVBoxLayout *_containerLayout;
     HeaderBanner *_headerBanner;
+
+    QTimer _raiseDelayTimer;
 };
 
 } // namespace OCC

--- a/src/gui/dockwatcher_mac.h
+++ b/src/gui/dockwatcher_mac.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) by Michael Schuster <michael.schuster@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include <QObject>
+
+namespace OCC {
+
+class FolderWatcher;
+
+namespace Mac {
+
+class DockWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    ~DockWatcher();
+    static DockWatcher *instance(QObject *parent = nullptr);
+
+    void init();
+
+    bool keepInDock() const;
+
+signals:
+    void keepInDockChanged(bool keepInDock);
+
+private:
+    void queryKeepInDock();
+
+    QScopedPointer<FolderWatcher> _folderWatcher;
+    bool _keepInDock = false;
+
+    NSString *_bundleIdentifier;
+    NSString *_plistDock;
+
+    static DockWatcher *_instance;
+    explicit DockWatcher(QObject *parent = nullptr);
+};
+
+} // namespace Mac
+} // namespace OCC

--- a/src/gui/dockwatcher_mac.h
+++ b/src/gui/dockwatcher_mac.h
@@ -33,8 +33,11 @@ public:
 
     bool keepInDock() const;
 
+    void emitDockIconClickEvent();
+
 signals:
     void keepInDockChanged(bool keepInDock);
+    void dockIconClicked();
 
 private:
     void queryKeepInDock();

--- a/src/gui/dockwatcher_mac.mm
+++ b/src/gui/dockwatcher_mac.mm
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) by Michael Schuster <michael.schuster@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "dockwatcher_mac.h"
+
+#import <AppKit/AppKit.h>
+
+#include "folderwatcher.h"
+
+
+namespace OCC {
+namespace Mac {
+
+DockWatcher *DockWatcher::_instance = nullptr;
+
+DockWatcher::DockWatcher(QObject *parent)
+    : QObject(parent)
+{
+    Q_ASSERT(!_instance);
+    _instance = this;
+}
+
+DockWatcher *DockWatcher::instance(QObject *parent)
+{
+    if (!_instance) {
+        _instance = new DockWatcher(parent);
+    }
+    return _instance;
+}
+
+DockWatcher::~DockWatcher()
+{
+    _instance = nullptr;
+}
+
+void DockWatcher::init()
+{
+    // com.nextcloud.desktopclient (Info.plist: CFBundleIdentifier)
+    _bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+
+    // ~/Library/Preferences/com.apple.dock.plist
+    NSString *rootPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory,
+       NSUserDomainMask, YES) firstObject];
+    _plistDock = [rootPath stringByAppendingPathComponent:@"Preferences/com.apple.dock.plist"];
+
+    // Watcher for plist
+    _folderWatcher.reset(new FolderWatcher());
+    QObject::connect(_folderWatcher.data(), &FolderWatcher::pathChanged, [this] {
+        queryKeepInDock();
+    });
+    _folderWatcher->init(QString::fromUtf8([_plistDock UTF8String]));
+
+    // Fetch initial state
+    queryKeepInDock();
+}
+
+bool DockWatcher::keepInDock() const
+{
+    return _keepInDock;
+}
+
+void DockWatcher::queryKeepInDock()
+{
+    NSData *plistXML = [[NSFileManager defaultManager] contentsAtPath:_plistDock];
+
+    if (!plistXML) {
+        return;
+    }
+
+    NSDictionary *dict = (NSDictionary *)[NSPropertyListSerialization
+        propertyListWithData:plistXML
+        options:NSPropertyListImmutable
+        format:nil
+        error:nil];
+
+    if (!dict) {
+        return;
+    }
+
+    /* Example plist's "persistent-apps" element (redacted):
+         "tile-data" =         {
+             "bundle-identifier" = "com.nextcloud.desktopclient";
+         };
+     */
+    NSArray *apps = [dict objectForKey:@"persistent-apps"];
+    bool oldState = _keepInDock;
+    _keepInDock = false;
+
+    for (NSArray *key in apps) {
+        id tile_data = [key valueForKey:@"tile-data"];
+
+        if (tile_data) {
+            id bundle_identifier = [tile_data valueForKey:@"bundle-identifier"];
+
+            if (bundle_identifier &&
+                [bundle_identifier compare:_bundleIdentifier] == NSOrderedSame) {
+                _keepInDock = true;
+                break;
+            }
+        }
+    }
+
+    if (_keepInDock != oldState) {
+        emit keepInDockChanged(_keepInDock);
+    }
+}
+
+} // namespace Mac
+} // namespace OCC

--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -101,6 +101,7 @@ void FolderWatcherPrivate::startWatching()
         kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagIgnoreSelf);
 
     CFRelease(pathsToWatch);
+    CFRelease(folderCF);
     FSEventStreamScheduleWithRunLoop(_stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
     FSEventStreamStart(_stream);
 }

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -262,7 +262,8 @@ void GeneralSettings::slotIgnoreFilesEditor()
 
 void GeneralSettings::slotShowLegalNotice()
 {
-    auto notice = new LegalNotice();
+    auto dlg = qobject_cast<QDialog*>(parent()->parent());
+    auto notice = new LegalNotice(dlg);
     notice->exec();
     delete notice;
 }

--- a/src/gui/legalnotice.cpp
+++ b/src/gui/legalnotice.cpp
@@ -15,6 +15,7 @@
 #include "legalnotice.h"
 #include "ui_legalnotice.h"
 #include "theme.h"
+#include "owncloudgui.h"
 
 namespace OCC {
 
@@ -26,6 +27,11 @@ LegalNotice::LegalNotice(QDialog *parent)
     _ui->setupUi(this);
 
     connect(_ui->closeButton, &QPushButton::clicked, this, &LegalNotice::accept);
+
+    if (!parent) {
+        // Dialog visibility
+        connect(this, &LegalNotice::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
+    }
 
     customizeStyle();
 }
@@ -66,6 +72,12 @@ void LegalNotice::customizeStyle()
     _ui->notice->setText(notice);
     _ui->notice->setWordWrap(true);
     _ui->notice->setOpenExternalLinks(true);
+}
+
+void LegalNotice::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 } // namespace OCC

--- a/src/gui/legalnotice.h
+++ b/src/gui/legalnotice.h
@@ -37,8 +37,12 @@ public:
     explicit LegalNotice(QDialog *parent = nullptr);
     ~LegalNotice();
 
+signals:
+    void onSetVisible(bool visible);
+
 protected:
     void changeEvent(QEvent *) override;
+    void setVisible(bool visible) override;
 
 private:
     void customizeStyle();

--- a/src/gui/legalnotice.ui
+++ b/src/gui/legalnotice.ui
@@ -7,28 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>591</width>
-    <height>360</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Legal notice</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QLabel" name="header">
-     <property name="font">
-      <font>
-       <pointsize>13</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Legal notice</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
    <item>
     <widget class="QLabel" name="notice">
      <property name="text">

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -160,9 +160,7 @@ void ownCloudGui::slotOpenSettingsDialog()
 
 void ownCloudGui::slotOpenMainDialog()
 {
-    if (!_tray->isOpen()) {
-        _tray->showWindow();
-    }
+    slotTrayClicked(QSystemTrayIcon::Trigger);
 }
 
 void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
@@ -184,7 +182,6 @@ void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
             } else {
                 _tray->showWindow();
             }
-
         }
     }
     // FIXME: Also make sure that any auto updater dialogue https://github.com/owncloud/client/issues/5613

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -45,7 +45,7 @@
 #if defined(Q_OS_X11)
 #include <QX11Info>
 #elif defined(Q_OS_MAC)
-#include "settingsdialog_mac.h"
+#include "owncloudgui_mac.h"
 #include "legalnotice.h"
 #include <QMenuBar>
 #endif
@@ -767,6 +767,15 @@ void ownCloudGui::slotDialogVisibilityChanged(bool visible)
             _visibleDialogs.removeAt(index);
         }
     }
+
+#ifdef Q_OS_MAC
+    // Dock icon visibility
+    if (!_visibleDialogs.isEmpty()) {
+        Mac::setActivationPolicy(Mac::ActivationPolicy::Regular);
+    } else {
+        Mac::setActivationPolicy(Mac::ActivationPolicy::Accessory);
+    }
+#endif
 }
 
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -46,6 +46,7 @@
 #include <QX11Info>
 #elif defined(Q_OS_MAC)
 #include "owncloudgui_mac.h"
+#include "dockwatcher_mac.h"
 #include "legalnotice.h"
 #include <QMenuBar>
 #endif
@@ -143,8 +144,12 @@ void ownCloudGui::init()
         this, &ownCloudGui::slotShowGuiMessage);
 
 #ifdef Q_OS_MAC
-    // Initial Dock icon visibility
-    slotDialogVisibilityChanged(false);
+    // "Keep in Dock" Watcher and initial Dock icon visibility
+    auto dockWatcher = Mac::DockWatcher::instance(this);
+    connect(dockWatcher, &Mac::DockWatcher::keepInDockChanged, [this] {
+        slotDialogVisibilityChanged(false);
+    });
+    dockWatcher->init();
 
     // Menu Bar
     auto menuBar = new QMenuBar(nullptr);
@@ -770,7 +775,7 @@ void ownCloudGui::slotDialogVisibilityChanged(bool visible)
 
 #ifdef Q_OS_MAC
     // Dock icon visibility
-    if (!_visibleDialogs.isEmpty()) {
+    if (!_visibleDialogs.isEmpty() || Mac::DockWatcher::instance()->keepInDock()) {
         Mac::setActivationPolicy(Mac::ActivationPolicy::Regular);
     } else {
         Mac::setActivationPolicy(Mac::ActivationPolicy::Accessory);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -44,6 +44,10 @@
 
 #if defined(Q_OS_X11)
 #include <QX11Info>
+#elif defined(Q_OS_MAC)
+#include "settingsdialog_mac.h"
+#include "legalnotice.h"
+#include <QMenuBar>
 #endif
 
 #include <QQmlEngine>
@@ -137,6 +141,33 @@ void ownCloudGui::init()
         this, &ownCloudGui::slotShowOptionalTrayMessage);
     connect(Logger::instance(), &Logger::guiMessage,
         this, &ownCloudGui::slotShowGuiMessage);
+
+#ifdef Q_OS_MAC
+    // Initial Dock icon visibility
+    slotDialogVisibilityChanged(false);
+
+    // Menu Bar
+    auto menuBar = new QMenuBar(nullptr);
+    auto menu = menuBar->addMenu(QString());
+
+    // Preferences
+    auto action = new QAction(this);
+    action->setMenuRole(QAction::PreferencesRole);
+    connect(action, &QAction::triggered, this, &ownCloudGui::slotShowSettings);
+    menu->addAction(action);
+
+    // About
+    action = new QAction(this);
+    action->setMenuRole(QAction::AboutRole);
+    connect(action, &QAction::triggered, [action] {
+        action->setEnabled(false);
+        auto notice = new LegalNotice();
+        notice->exec();
+        delete notice;
+        action->setEnabled(true);
+    });
+    menu->addAction(action);
+#endif
 }
 
 void ownCloudGui::createTray()

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -149,6 +149,8 @@ void ownCloudGui::init()
     connect(dockWatcher, &Mac::DockWatcher::keepInDockChanged, [this] {
         slotDialogVisibilityChanged(false);
     });
+    connect(dockWatcher, &Mac::DockWatcher::dockIconClicked, this,
+            &ownCloudGui::slotOpenMainDialog);
     dockWatcher->init();
 
     // Menu Bar

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -670,9 +670,6 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         return;
     }
 
-    // For https://github.com/owncloud/client/issues/3783
-    _settingsDialog->hide();
-
     const auto accountState = folder->accountState();
 
     const QString file = localPath.mid(folder->cleanPath().length() + 1);

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -109,7 +109,7 @@ public slots:
 
     void slotRemoveDestroyedShareDialogs();
 
-    // List of visible dialogs to raise on re-focus
+    // List of visible dialogs to raise on re-focus (also used for macOS Dock icon visibility)
     void slotDialogVisibilityChanged(bool visible);
 
 private slots:

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -52,7 +52,8 @@ class ownCloudGui : public QObject
 {
     Q_OBJECT
 public:
-    explicit ownCloudGui(Application *parent = nullptr);
+    ~ownCloudGui();
+    static ownCloudGui *instance(Application *parent = nullptr);
 
     bool checkAccountExists(bool openSettings);
 
@@ -64,10 +65,13 @@ public:
     bool cloudProviderApiAvailable();
 #endif
     void createTray();
+    void init();
 
 signals:
     void setupProxy();
     void serverError(int code, const QString &message);
+
+    // Allow other classes to hook into isShowingSettingsDialog() signals (re-auth widgets, for example)
     void isShowingSettingsDialog();
 
 public slots:
@@ -105,6 +109,9 @@ public slots:
 
     void slotRemoveDestroyedShareDialogs();
 
+    // List of visible dialogs to raise on re-focus
+    void slotDialogVisibilityChanged(bool visible);
+
 private slots:
     void slotLogin();
     void slotLogout();
@@ -124,6 +131,7 @@ private:
 #endif
 
     QMap<QString, QPointer<ShareDialog>> _shareDialogs;
+    QList<QPointer<QDialog>> _visibleDialogs;
 
     QAction *_actionNewAccountWizard;
     QAction *_actionSettings;
@@ -132,6 +140,8 @@ private:
 
     QList<QAction *> _recentItemsActions;
     Application *_app;
+    static ownCloudGui *_instance;
+    explicit ownCloudGui(Application *parent = nullptr);
 };
 
 } // namespace OCC

--- a/src/gui/owncloudgui_mac.h
+++ b/src/gui/owncloudgui_mac.h
@@ -12,8 +12,18 @@
  * for more details.
  */
 
+#pragma once
+
+namespace OCC {
+namespace Mac {
+
 enum class ActivationPolicy {
     Regular,
     Accessory,
     Prohibited
 };
+
+void setActivationPolicy(ActivationPolicy policy);
+
+} // namespace Mac
+} // namespace OCC

--- a/src/gui/owncloudgui_mac.mm
+++ b/src/gui/owncloudgui_mac.mm
@@ -12,10 +12,13 @@
  * for more details.
  */
 
-#include "settingsdialog_mac.h"
+#include "owncloudgui_mac.h"
 
 #import <AppKit/AppKit.h>
 #include <QDebug>
+
+namespace OCC {
+namespace Mac {
 
 void setActivationPolicy(ActivationPolicy policy)
 {
@@ -35,3 +38,6 @@ void setActivationPolicy(ActivationPolicy policy)
         qWarning() << "setActivationPolicy" << static_cast<int>(policy) << "failed";
     }
 }
+
+} // namespace Mac
+} // namespace OCC

--- a/src/gui/proxyauthdialog.cpp
+++ b/src/gui/proxyauthdialog.cpp
@@ -15,6 +15,8 @@
 #include "proxyauthdialog.h"
 #include "ui_proxyauthdialog.h"
 
+#include "owncloudgui.h"
+
 namespace OCC {
 
 ProxyAuthDialog::ProxyAuthDialog(QWidget *parent)
@@ -22,6 +24,11 @@ ProxyAuthDialog::ProxyAuthDialog(QWidget *parent)
     , ui(new Ui::ProxyAuthDialog)
 {
     ui->setupUi(this);
+
+    if (!parent) {
+        // Dialog visibility
+        connect(this, &ProxyAuthDialog::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
+    }
 }
 
 ProxyAuthDialog::~ProxyAuthDialog()
@@ -49,6 +56,12 @@ void ProxyAuthDialog::reset()
     ui->usernameEdit->setFocus();
     ui->usernameEdit->clear();
     ui->passwordEdit->clear();
+}
+
+void ProxyAuthDialog::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 } // namespace OCC

--- a/src/gui/proxyauthdialog.h
+++ b/src/gui/proxyauthdialog.h
@@ -44,6 +44,12 @@ public:
     /// Resets the dialog for new credential entry.
     void reset();
 
+signals:
+    void onSetVisible(bool visible);
+
+protected:
+    void setVisible(bool visible) override;
+
 private:
     Ui::ProxyAuthDialog *ui;
 };

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -40,6 +40,12 @@
 #include <QPainter>
 #include <QPainterPath>
 
+#ifdef Q_OS_MAC
+#include "settingsdialog_mac.h"
+
+void setActivationPolicy(ActivationPolicy policy);
+#endif
+
 namespace {
 const char TOOLBAR_CSS[] =
     "QToolBar { background: %1; margin: 0; padding: 0; border: none; border-bottom: 0 solid %2; spacing: 0; } "
@@ -134,6 +140,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     customizeStyle();
 
     cfg.restoreGeometry(this);
+
+#ifdef Q_OS_MAC
+    setActivationPolicy(ActivationPolicy::Accessory);
+#endif
 }
 
 SettingsDialog::~SettingsDialog()
@@ -180,6 +190,13 @@ void SettingsDialog::changeEvent(QEvent *e)
 
 void SettingsDialog::setVisible(bool visible)
 {
+#ifdef Q_OS_MAC
+    if (visible) {
+        setActivationPolicy(ActivationPolicy::Regular);
+    } else {
+        setActivationPolicy(ActivationPolicy::Accessory);
+    }
+#endif
     emit onSetVisible(visible);
     QDialog::setVisible(visible);
 }

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -40,12 +40,6 @@
 #include <QPainter>
 #include <QPainterPath>
 
-#ifdef Q_OS_MAC
-#include "settingsdialog_mac.h"
-
-void setActivationPolicy(ActivationPolicy policy);
-#endif
-
 namespace {
 const char TOOLBAR_CSS[] =
     "QToolBar { background: %1; margin: 0; padding: 0; border: none; border-bottom: 0 solid %2; spacing: 0; } "
@@ -140,10 +134,6 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     customizeStyle();
 
     cfg.restoreGeometry(this);
-
-#ifdef Q_OS_MAC
-    setActivationPolicy(ActivationPolicy::Accessory);
-#endif
 }
 
 SettingsDialog::~SettingsDialog()
@@ -190,13 +180,6 @@ void SettingsDialog::changeEvent(QEvent *e)
 
 void SettingsDialog::setVisible(bool visible)
 {
-#ifdef Q_OS_MAC
-    if (visible) {
-        setActivationPolicy(ActivationPolicy::Regular);
-    } else {
-        setActivationPolicy(ActivationPolicy::Accessory);
-    }
-#endif
     emit onSetVisible(visible);
     QDialog::setVisible(visible);
 }

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -128,6 +128,9 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
 
     connect(this, &SettingsDialog::onActivate, gui, &ownCloudGui::slotSettingsDialogActivated);
 
+    // Dialog visibility
+    connect(this, &SettingsDialog::onSetVisible, gui, &ownCloudGui::slotDialogVisibilityChanged);
+
     customizeStyle();
 
     cfg.restoreGeometry(this);
@@ -173,6 +176,12 @@ void SettingsDialog::changeEvent(QEvent *e)
     }
 
     QDialog::changeEvent(e);
+}
+
+void SettingsDialog::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 void SettingsDialog::slotSwitchPage(QAction *action)

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -62,11 +62,13 @@ public slots:
 signals:
     void styleChanged();
     void onActivate();
+    void onSetVisible(bool visible);
 
 protected:
     void reject() override;
     void accept() override;
     void changeEvent(QEvent *) override;
+    void setVisible(bool visible) override;
 
 private slots:
     void accountAdded(AccountState *);

--- a/src/gui/settingsdialog_mac.h
+++ b/src/gui/settingsdialog_mac.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+enum class ActivationPolicy {
+    Regular,
+    Accessory,
+    Prohibited
+};

--- a/src/gui/settingsdialog_mac.mm
+++ b/src/gui/settingsdialog_mac.mm
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) by Hannah von Reth <hannah.vonreth@owncloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "settingsdialog_mac.h"
+
+#import <AppKit/AppKit.h>
+#include <QDebug>
+
+void setActivationPolicy(ActivationPolicy policy)
+{
+    NSApplicationActivationPolicy mode = NSApplicationActivationPolicyRegular;
+    switch (policy) {
+    case ActivationPolicy::Regular:
+        mode = NSApplicationActivationPolicyRegular;
+        break;
+    case ActivationPolicy::Accessory:
+        mode = NSApplicationActivationPolicyAccessory;
+        break;
+    case ActivationPolicy::Prohibited:
+        mode = NSApplicationActivationPolicyProhibited;
+        break;
+    }
+    if (![NSApp setActivationPolicy:mode]) {
+        qWarning() << "setActivationPolicy" << static_cast<int>(policy) << "failed";
+    }
+}

--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -62,6 +62,9 @@ ShareDialog::ShareDialog(QPointer<AccountState> accountState,
     // We want to act on account state changes
     connect(_accountState.data(), &AccountState::stateChanged, this, &ShareDialog::slotAccountStateChanged);
 
+    // Dialog visibility
+    connect(this, &ShareDialog::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
+
     // Set icon
     QFileInfo f_info(_localPath);
     QFileIconProvider icon_provider;
@@ -381,6 +384,12 @@ void ShareDialog::changeEvent(QEvent *e)
     }
 
     QDialog::changeEvent(e);
+}
+
+void ShareDialog::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 } // namespace OCC

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -70,9 +70,11 @@ private slots:
 signals:
     void toggleAnimation(bool);
     void styleChanged();
+    void onSetVisible(bool visible);
 
 protected:
     void changeEvent(QEvent *) override;
+    void setVisible(bool visible) override;
 
 private:
     void showSharingUi();

--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -13,6 +13,7 @@
  */
 #include "configfile.h"
 #include "sslerrordialog.h"
+#include "owncloudgui.h"
 
 #include <QtGui>
 #include <QtNetwork>
@@ -75,6 +76,11 @@ SslErrorDialog::SslErrorDialog(AccountPtr account, QWidget *parent)
         okButton->setDefault(true);
         connect(okButton, &QAbstractButton::clicked, this, &QDialog::accept);
         connect(cancelButton, &QAbstractButton::clicked, this, &QDialog::reject);
+    }
+
+    if (!parent) {
+        // Dialog visibility
+        connect(this, &SslErrorDialog::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
     }
 }
 
@@ -221,6 +227,12 @@ bool SslErrorDialog::trustConnection()
     qCInfo(lcSslErrorDialog) << "SSL-Connection is trusted: " << stat;
 
     return stat;
+}
+
+void SslErrorDialog::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QDialog::setVisible(visible);
 }
 
 } // end namespace

--- a/src/gui/sslerrordialog.h
+++ b/src/gui/sslerrordialog.h
@@ -54,6 +54,12 @@ public:
     bool trustConnection();
     QList<QSslCertificate> unknownCerts() const { return _unknownCerts; }
 
+signals:
+    void onSetVisible(bool visible);
+
+protected:
+    void setVisible(bool visible) override;
+
 private:
     QString styleSheet() const;
     bool _allTrusted;

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -80,12 +80,15 @@ Systray::Systray()
         }
     );
 
-#ifndef Q_OS_MAC
     auto contextMenu = new QMenu();
     contextMenu->addAction(tr("Open main dialog"), this, &Systray::openMainDialog);
     contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
+#ifndef Q_OS_MAC
     contextMenu->addAction(tr("Exit %1").arg(Theme::instance()->appNameGUI()), this, &Systray::shutdown);
     setContextMenu(contextMenu);
+#else
+    // On macOS this will be the Dock menu.
+    contextMenu->setAsDockMenu();
 #endif
 
     connect(UserModel::instance(), &UserModel::newUserSelected,

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -109,6 +109,9 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
 
     // allow Flow2 page to poll on window activation
     connect(this, &OwncloudWizard::onActivate, _flow2CredsPage, &Flow2AuthCredsPage::slotPollNow);
+
+    // Dialog visibility
+    connect(this, &OwncloudWizard::onSetVisible, ownCloudGui::instance(), &ownCloudGui::slotDialogVisibilityChanged);
 }
 
 void OwncloudWizard::setAccount(AccountPtr account)
@@ -317,6 +320,12 @@ void OwncloudWizard::bringToTop()
 {
     // bring wizard to top
     ownCloudGui::raiseDialog(this);
+}
+
+void OwncloudWizard::setVisible(bool visible)
+{
+    emit onSetVisible(visible);
+    QWizard::setVisible(visible);
 }
 
 } // end namespace

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -100,9 +100,11 @@ signals:
     void needCertificate();
     void styleChanged();
     void onActivate();
+    void onSetVisible(bool visible);
 
 protected:
     void changeEvent(QEvent *) override;
+    void setVisible(bool visible) override;
 
 private:
     void customizeStyle();


### PR DESCRIPTION
### Important:

#2197 needs to be merged first, then I can rebase this one.

### macOS: Show the Dock icon when Settings or any other dialog is visible

This also allows the user to reach the window(s) using the Application Switcher (Command + Tab).

More:
- Monitor the Dock for changes to the `Keep in Dock` option. This leaves the context menu intact while the icon is pinned to the Dock.
- Register a native Click Handler to track clicks on the active Dock icon, treat them like clicks on the Tray icon.

### Use the Systray context menu as the Dock menu

The native way on macOS for an app context menu is to add it to the Dock icon. A right-click on the Dock icon reveals the standard menu, e.g. featuring "_Quit_". This commit adds the "_Open main dialog_" and "_Settings_" actions to the Dock menu:

<img width="214" alt="Screenshot 2020-07-04 at 02 06 24" src="https://user-images.githubusercontent.com/48932272/86504599-b8c97a80-bdba-11ea-9ded-db20dead5abb.png">

The system then automatically shows the app menu bar too (with system's fixed standard menu actions):

<img width="242" alt="Screenshot 2020-07-06 at 11 33 18" src="https://user-images.githubusercontent.com/48932272/86578861-c4fd3580-bf7c-11ea-9414-8fcd3d89de39.png">

Other small improvements:
- Add `CFBundleName` to `MacOSXBundleInfo.plist` to use our real app name (Finder and Menu bar)
  - `nextcloud -> Nextcloud`
- Fix an animation issue with the Dock icon background transparency on app launch (caused by `setWindowIcon`)
- `LegalNotice` dialog:
  - Ensure correct parenting in `GeneralSettings` (`SettingsDialog`)
  - Remove additional "_Legal notice_" label in UI widget (duplicate of `windowTitle`)
- Fix memory leak in `FolderWatcherPrivate::startWatching`

Continuation of #2136.