### PR TITLE
Handle properly null avatar

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -649,6 +649,10 @@ void AvatarJob::start()
 
 QImage AvatarJob::makeCircularAvatar(const QImage &baseAvatar)
 {
+    if (baseAvatar.isNull()) {
+        return {};
+    }
+
     int dim = baseAvatar.width();
 
     QImage avatar(dim, dim, QImage::Format_ARGB32);


### PR DESCRIPTION
If we try to produce the avatar before we managed to connect we'd end up
trying to paint in a null image. Just return early, which will allow the
caller to do something else instead.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>