### PR TITLE
Reach out to the contentItem inside of the ListView to find the width

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -435,7 +435,8 @@ Window {
                     Menu {
                         id: appsMenu
                         y: (trayWindowAppsButton.y + trayWindowAppsButton.height + 2)
-                        width: Math.min(contentItem.childrenRect.width + 4, Style.trayWindowWidth / 2)
+                        readonly property Item listContentItem: contentItem.contentItem
+                        width: Math.min(listContentItem.childrenRect.width + 4, Style.trayWindowWidth / 2)
                         closePolicy: "CloseOnPressOutside"
 
                         background: Rectangle {


### PR DESCRIPTION
Turns out that the ListView embedded in the Menu (reachable via
contentItem) would create a binding loop if we're using its
childrenRect. But really we're interested in the total width for the
instantiated delegate *inside* the ListView. That's why we go one level
deeper and get the childrenRect of the inner contentItem instead.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>