### PR TITLE
Set maximum height of account and app menu

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -19,6 +19,8 @@ Window {
     color:      "transparent"
     flags:      Qt.Dialog | Qt.FramelessWindowHint
 
+    readonly property int maxMenuHeight: Style.trayWindowHeight - Style.trayWindowHeaderHeight - 2 * Style.trayWindowBorderWidth
+
     // Close tray window when focus is lost (e.g. click somewhere else on the screen)
     onActiveChanged: {
         if(!active) {
@@ -145,6 +147,7 @@ Window {
                             y: (currentAccountButton.y + Style.trayWindowHeaderHeight + 2)
 
                             width: (Style.currentAccountButtonWidth - 2)
+                            height: Math.min(implicitHeight, maxMenuHeight)
                             closePolicy: "CloseOnPressOutside"
 
                             background: Rectangle {
@@ -437,6 +440,7 @@ Window {
                         y: (trayWindowAppsButton.y + trayWindowAppsButton.height + 2)
                         readonly property Item listContentItem: contentItem.contentItem
                         width: Math.min(listContentItem.childrenRect.width + 4, Style.trayWindowWidth / 2)
+                        height: Math.min(implicitHeight, maxMenuHeight)
                         closePolicy: "CloseOnPressOutside"
 
                         background: Rectangle {


### PR DESCRIPTION
The menus may become too large if they have too many items
(the account menu has this in case of many accounts, the apps
menu in case of many apps).  This commit limits the maximum
height such that the menus do not hide the header.

Fixes #2160.