### PR TITLE
Let context menu open wizard if there are no accounts

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -85,6 +85,9 @@ ownCloudGui::ownCloudGui(Application *parent)
     connect(_tray.data(), &Systray::openHelp,
         this, &ownCloudGui::slotHelp);
 
+    connect(_tray.data(), &Systray::openAccountWizard,
+        this, &ownCloudGui::slotNewAccountWizard);
+
     connect(_tray.data(), &Systray::openMainDialog,
         this, &ownCloudGui::slotOpenMainDialog);
 

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -82,8 +82,12 @@ Systray::Systray()
 
 #ifndef Q_OS_MAC
     auto contextMenu = new QMenu();
-    contextMenu->addAction(tr("Open main dialog"), this, &Systray::openMainDialog);
-    contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
+    if (AccountManager::instance()->accounts().isEmpty()) {
+        contextMenu->addAction(tr("Add account"), this, &Systray::openAccountWizard);
+    } else {
+        contextMenu->addAction(tr("Open main dialog"), this, &Systray::openMainDialog);
+        contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
+    }
     contextMenu->addAction(tr("Exit %1").arg(Theme::instance()->appNameGUI()), this, &Systray::shutdown);
     setContextMenu(contextMenu);
 #endif

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -64,6 +64,7 @@ public:
 
 signals:
     void currentUserChanged();
+    void openAccountWizard();
     void openMainDialog();
     void openSettings();
     void openHelp();


### PR DESCRIPTION
The context menu offers to open the main dialog and the settings
even if no accounts are configured.  In this case, the main dialog
is useless and the settings are probably confusing.  Hence, this
commit replaces these actions in the context menu by an action
to open the wizard (which also opens on left click, so this is
the most natural thing to do).