### PR TITLE
Fix clang-tidy issues on Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -89,9 +89,7 @@ steps:
       chown -R test:test . &&
       su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
     # Static analysis with clang-tidy
-    - /bin/bash -c "
-      ln -s build/compile_commands.json . &&
-      run-clang-tidy-6.0"
+    - run-clang-tidy-6.0 -p build
 trigger:
   branch:
     - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,7 +89,7 @@ steps:
       chown -R test:test . &&
       su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test"
     # Static analysis with clang-tidy
-    - run-clang-tidy-6.0 -p build
+    - "! run-clang-tidy-6.0 -p build -quiet | grep -A 5 ': error:'"
 trigger:
   branch:
     - master

--- a/src/csync/csync.h
+++ b/src/csync/csync.h
@@ -158,6 +158,7 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   bool child_modified BITFIELD(1);
   bool has_ignored_files BITFIELD(1); // Specify that a directory, or child directory contains ignored files.
   bool is_hidden BITFIELD(1); // Not saved in the DB, only used during discovery for local files.
+  bool isE2eEncrypted BITFIELD(1);
 
   QByteArray path;
   QByteArray rename_path;
@@ -173,7 +174,6 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   // In both cases, the format is "SHA1:baff".
   QByteArray checksumHeader;
   QByteArray e2eMangledName;
-  bool isE2eEncrypted;
 
   CSYNC_STATUS error_status = CSYNC_STATUS_OK;
 

--- a/src/gui/elidedlabel.cpp
+++ b/src/gui/elidedlabel.cpp
@@ -26,7 +26,6 @@ ElidedLabel::ElidedLabel(QWidget *parent)
 ElidedLabel::ElidedLabel(const QString &text, QWidget *parent)
     : QLabel(text, parent)
     , _text(text)
-    , _elideMode(Qt::ElideNone)
 {
 }
 

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -156,23 +156,23 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     }
     painter->save();
 
-    QIcon statusIcon = qvariant_cast<QIcon>(index.data(FolderStatusIconRole));
-    QString aliasText = qvariant_cast<QString>(index.data(HeaderRole));
-    QString pathText = qvariant_cast<QString>(index.data(FolderPathRole));
-    QString remotePath = qvariant_cast<QString>(index.data(FolderSecondPathRole));
-    QStringList conflictTexts = qvariant_cast<QStringList>(index.data(FolderConflictMsg));
-    QStringList errorTexts = qvariant_cast<QStringList>(index.data(FolderErrorMsg));
+    auto statusIcon = qvariant_cast<QIcon>(index.data(FolderStatusIconRole));
+    auto aliasText = qvariant_cast<QString>(index.data(HeaderRole));
+    auto pathText = qvariant_cast<QString>(index.data(FolderPathRole));
+    auto remotePath = qvariant_cast<QString>(index.data(FolderSecondPathRole));
+    auto conflictTexts = qvariant_cast<QStringList>(index.data(FolderConflictMsg));
+    auto errorTexts = qvariant_cast<QStringList>(index.data(FolderErrorMsg));
 
-    int overallPercent = qvariant_cast<int>(index.data(SyncProgressOverallPercent));
-    QString overallString = qvariant_cast<QString>(index.data(SyncProgressOverallString));
-    QString itemString = qvariant_cast<QString>(index.data(SyncProgressItemString));
-    int warningCount = qvariant_cast<int>(index.data(WarningCount));
-    bool syncOngoing = qvariant_cast<bool>(index.data(SyncRunning));
-    QDateTime syncDate = qvariant_cast<QDateTime>(index.data(SyncDate));
-    bool syncEnabled = qvariant_cast<bool>(index.data(FolderAccountConnected));
+    auto overallPercent = qvariant_cast<int>(index.data(SyncProgressOverallPercent));
+    auto overallString = qvariant_cast<QString>(index.data(SyncProgressOverallString));
+    auto itemString = qvariant_cast<QString>(index.data(SyncProgressItemString));
+    auto warningCount = qvariant_cast<int>(index.data(WarningCount));
+    auto syncOngoing = qvariant_cast<bool>(index.data(SyncRunning));
+    auto syncDate = qvariant_cast<QDateTime>(index.data(SyncDate));
+    auto syncEnabled = qvariant_cast<bool>(index.data(FolderAccountConnected));
 
-    QRect iconRect = option.rect;
-    QRect aliasRect = option.rect;
+    auto iconRect = option.rect;
+    auto aliasRect = option.rect;
 
     iconRect.setLeft(option.rect.left() + aliasMargin);
     iconRect.setTop(iconRect.top() + aliasMargin); // (iconRect.height()-iconsize.height())/2);
@@ -183,12 +183,12 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     aliasRect.setRight(aliasRect.right() - aliasMargin);
 
     // remote directory box
-    QRect remotePathRect = aliasRect;
+    auto remotePathRect = aliasRect;
     remotePathRect.setTop(aliasRect.bottom() + margin);
     remotePathRect.setBottom(remotePathRect.top() + subFm.height());
 
     // local directory box
-    QRect localPathRect = remotePathRect;
+    auto localPathRect = remotePathRect;
     localPathRect.setTop(remotePathRect.bottom() + margin);
     localPathRect.setBottom(localPathRect.top() + subFm.height());
 

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -264,14 +264,14 @@ QRect Systray::taskbarGeometry() const
 #elif defined(Q_OS_MACOS)
     // Finder bar is always 22px height on macOS (when treating as effective pixels)
     auto screenWidth = currentScreenRect().width();
-    return QRect(0, 0, screenWidth, 22);
+    return {0, 0, screenWidth, 22};
 #else
     if (taskbarOrientation() == TaskBarPosition::Bottom || taskbarOrientation() == TaskBarPosition::Top) {
         auto screenWidth = currentScreenRect().width();
-        return QRect(0, 0, screenWidth, 32);
+        return {0, 0, screenWidth, 32};
     } else {
         auto screenHeight = currentScreenRect().height();
-        return QRect(0, 0, 32, screenHeight);
+        return {0, 0, 32, screenHeight};
     }
 #endif
 }

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -137,7 +137,6 @@ namespace {
         // and we have a `forKey` static function that returns
         // an instance of this class
         PKeyCtx(PKeyCtx&& other)
-            : _ctx(nullptr)
         {
             std::swap(_ctx, other._ctx);
         }
@@ -159,12 +158,9 @@ namespace {
     private:
         Q_DISABLE_COPY(PKeyCtx)
 
-        PKeyCtx()
-            : _ctx(nullptr)
-        {
-        }
+        PKeyCtx() = default;
 
-        EVP_PKEY_CTX* _ctx;
+        EVP_PKEY_CTX* _ctx = nullptr;
     };
 
     class PKey {
@@ -179,7 +175,6 @@ namespace {
         // and we have a static functions that return
         // an instance of this class
         PKey(PKey&& other)
-            : _pkey(nullptr)
         {
             std::swap(_pkey, other._pkey);
         }
@@ -217,16 +212,10 @@ namespace {
     private:
         Q_DISABLE_COPY(PKey)
 
-        PKey()
-            : _pkey(nullptr)
-        {
-        }
+        PKey() = default;
 
-        EVP_PKEY* _pkey;
+        EVP_PKEY* _pkey = nullptr;
     };
-
-
-
 
     QByteArray BIO2ByteArray(Bio &b) {
         int pending = BIO_ctrl_pending(b);

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -114,7 +114,6 @@ HttpCredentials::HttpCredentials(const QString &user, const QString &password, c
     , _ready(true)
     , _clientSslKey(key)
     , _clientSslCertificate(certificate)
-    , _keychainMigration(false)
     , _retryOnKeyChainError(false)
 {
 }

--- a/src/libsync/syncfilestatus.cpp
+++ b/src/libsync/syncfilestatus.cpp
@@ -21,7 +21,6 @@ SyncFileStatus::SyncFileStatus()
 
 SyncFileStatus::SyncFileStatus(SyncFileStatusTag tag)
     : _tag(tag)
-    , _shared(false)
 {
 }
 


### PR DESCRIPTION
Although clang-tidy was invoked on Drone, its errors were not recognized as errors. This is fixed now. Moreover, the output of clang-tidy is filtered to reduce noise, and the upcoming clang-tidy errors are fixed.