### PR TITLE
Display the correct default permissions when creating a share.

### DIFF
--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -149,9 +149,6 @@ void OcsShareJob::createShare(const QString &path,
     addParam(QString::fromLatin1("path"), path);
     addParam(QString::fromLatin1("shareType"), QString::number(shareType));
     addParam(QString::fromLatin1("shareWith"), shareWith);
-    if (!(permissions & SharePermissionDefault)) {
-        addParam(QString::fromLatin1("permissions"), QString::number(permissions));
-    }
 
     start();
 }

--- a/src/gui/sharepermissions.h
+++ b/src/gui/sharepermissions.h
@@ -28,7 +28,7 @@ enum SharePermission {
     SharePermissionCreate = 4,
     SharePermissionDelete = 8,
     SharePermissionShare = 16,
-    SharePermissionDefault = 1 << 30
+    SharePermissionDefault = 31
 };
 Q_DECLARE_FLAGS(SharePermissions, SharePermission)
 Q_DECLARE_OPERATORS_FOR_FLAGS(SharePermissions)

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -208,7 +208,7 @@ void ShareUserGroupWidget::slotSharesFetched(const QList<QSharedPointer<Share>> 
         }
 
         // the owner of the file that shared it first
-		// leave out if it's the current user
+        // leave out if it's the current user
         if(x == 0 && !share->getUidOwner().isEmpty() && !(share->getUidOwner() == _account->credentials()->user())) {
             _ui->mainOwnerLabel->setText(QString("Shared with you by ").append(share->getOwnerDisplayName()));
         }
@@ -320,7 +320,8 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex &index)
     } else {
 
         // Default permissions on creation
-        int permissions = SharePermissionRead | SharePermissionUpdate;
+        int permissions = SharePermissionCreate | SharePermissionUpdate
+                | SharePermissionDelete | SharePermissionShare;
         _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
             sharee->shareWith(), SharePermission(permissions));
     }


### PR DESCRIPTION
- The default displayed was not in sync with the server because
the client was setting permissions when creating a share while it
should get the default permissions from the server to display it to the
user first.

server:
![server](https://user-images.githubusercontent.com/241266/86829080-47c4e400-c094-11ea-92c5-24632e02ea7d.png)

client:
![client](https://user-images.githubusercontent.com/241266/86829090-4bf10180-c094-11ea-8f2e-662300babc6d.png)


