### PR TITLE
Adjust to makeDbName returning an absolute path

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -499,7 +499,7 @@ restart_sync:
     }
 
     Cmd cmd;
-    QString dbPath = options.source_dir + SyncJournalDb::makeDbName(credentialFreeUrl, folder, user);
+    QString dbPath = SyncJournalDb::makeDbName(credentialFreeUrl, folder, user);
     SyncJournalDb db(dbPath);
 
     if (!selectiveSyncList.empty()) {


### PR DESCRIPTION
PR #1451 changed the behavior of makeDbName which now returns an
absolute path. This obviously then failed in nextcloudcmd which
prepended to it the path to the local folder to sync. We just stop doing
this to have the journal db end up at the right place in that case as
well.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>