### PR TITLE
Prevent empty FileMap in local csync to be processed if folder not empty

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1044,7 +1044,6 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
     // See: https://github.com/nextcloud/desktop/issues/1433
     // It's still unclear why we can get an empty FileMap even though folder isn't empty
     // For now: Re-check if folder is really empty, if not bail out
-    auto test = QDir(_localPath).entryInfoList();
     if (_csync_ctx.data()->local.files.empty() && QDir(_localPath).entryInfoList(QDir::NoDotAndDotDot).count() > 0) {
         qCWarning(lcEngine) << "Received local tree with empty FileMap but sync folder isn't empty. Won't reconcile.";
         finalize(false);


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

This is merely a hotfix for https://github.com/nextcloud/desktop/issues/1433 as finding the real cause obviously seems to be a bigger task. However this check shouldn't bring any drawbacks so it's probably a good option for the moment.

Summary of the situation:

- There are reports about the client deleting everything on the server
- Reports are quantitatively low, but exist as independent occurences for a longer time period including current stable release
- After inspecting logs and the csync algorithm it seesm to me that "Deleting everything" happens in the reconciliation phase. Specifically, as those occurrences happen with DELETE instructions in the UP direction (sending deletes for all root folders to the server, leaving local files intact and syncing them again afterwards)the only place where this could happen is the reconciliation loop where local tree (other_tree) is compared to remote tree (current_tree). Then, all the file paths sent to findfile (mapping to the FileMap object in the local tree, ctx) return no result, the Map seems to be empty. This is what the check prevents. If, after a DiscoveryJob signal, a local tree with an empty FileMap is found (this itself isn't checked anywhere until now) and the Nextcloud sync folder is not empty (which is checked by independent QDir functionality, excluding . and ..) reconciliation will not happen.

IMHO, **backport** to last stable would be helpful and reasonable.