### PR TITLE
[stable-2.6] Prevent empty FileMap in local csync to be processed if folder not empty

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -973,6 +973,16 @@ void SyncEngine::slotDiscoveryJobFinished(int discoveryResult)
         _journal->commitIfNeededAndStartNewTransaction("Post discovery");
     }
 
+    // FIXME: This is a reasonable safety check, but specifically just a hotfix.
+    // See: https://github.com/nextcloud/desktop/issues/1433
+    // It's still unclear why we can get an empty FileMap even though folder isn't empty
+    // For now: Re-check if folder is really empty, if not bail out
+    if (_csync_ctx.data()->local.files.empty() && QDir(_localPath).entryInfoList(QDir::NoDotAndDotDot).count() > 0) {
+        qCWarning(lcEngine) << "Received local tree with empty FileMap but sync folder isn't empty. Won't reconcile.";
+        finalize(false);
+        return;
+    }
+
     _progressInfo->_currentDiscoveredRemoteFolder.clear();
     _progressInfo->_currentDiscoveredLocalFolder.clear();
     _progressInfo->_status = ProgressInfo::Reconcile;


### PR DESCRIPTION
Backport of #2183 

(cherry picked from commit d47e570ff3562b9d5d5e9178269b297775626746)
(cherry picked from commit f8920f969fc4aeb90e5b50ec1c7aa087150cbc04)
