### PR TITLE
Move existing syncjournal db files from client ver <2.7

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -219,9 +219,16 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 auto settings = account->settings();
 
                 auto journalFileMoveSuccess = true;
-                journalFileMoveSuccess = oldJournal.rename(folderDefinition.journalPath);
-                journalFileMoveSuccess = oldJournalShm.rename(folderDefinition.journalPath.append("-shm"));
-                journalFileMoveSuccess = oldJournalWal.rename(folderDefinition.journalPath.append("-wal"));
+                // Due to db logic can't be sure which of these file exist.
+                if (oldJournal.exists()) {
+                    journalFileMoveSuccess = oldJournal.rename(folderDefinition.journalPath);
+                }
+                if (oldJournalShm.exists()) {
+                    journalFileMoveSuccess = oldJournalShm.rename(folderDefinition.journalPath.append("-shm"));
+                }
+                if (oldJournalWal.exists()) {
+                    journalFileMoveSuccess = oldJournalWal.rename(folderDefinition.journalPath.append("-wal"));
+                }
 
                 if (!journalFileMoveSuccess) {
                     qCWarning(lcFolderMan) << "Wasn't able to move pre-2.7 syncjournal databse files to new location. One-time loss off sync settings possible.";

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -221,17 +221,17 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 auto journalFileMoveSuccess = true;
                 // Due to db logic can't be sure which of these file exist.
                 if (oldJournal.exists()) {
-                    journalFileMoveSuccess = oldJournal.rename(folderDefinition.journalPath);
+                    journalFileMoveSuccess &= oldJournal.rename(folderDefinition.journalPath);
                 }
                 if (oldJournalShm.exists()) {
-                    journalFileMoveSuccess = oldJournalShm.rename(folderDefinition.journalPath.append("-shm"));
+                    journalFileMoveSuccess &= oldJournalShm.rename(folderDefinition.journalPath.append("-shm"));
                 }
                 if (oldJournalWal.exists()) {
-                    journalFileMoveSuccess = oldJournalWal.rename(folderDefinition.journalPath.append("-wal"));
+                    journalFileMoveSuccess &= oldJournalWal.rename(folderDefinition.journalPath.append("-wal"));
                 }
 
                 if (!journalFileMoveSuccess) {
-                    qCWarning(lcFolderMan) << "Wasn't able to move pre-2.7 syncjournal databse files to new location. One-time loss off sync settings possible.";
+                    qCWarning(lcFolderMan) << "Wasn't able to move pre-2.7 syncjournal database files to new location. One-time loss off sync settings possible.";
                 } else {
                     qCInfo(lcFolderMan) << "Successfully migrated syncjournal database.";
                 }


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Attempt to fix #2186 

When the changes to the syncjournal db file locations to rely in OS specific AppData folders where implemented in #1451 , no migration of possibly existing db files was considered. As these files may contain persistent settings and states like sync settings seen in the issue above, this should be the case.

This PR implements a simple, conditional move (`QFile::rename`) of old files to the new ones within existing migration functions.

Testing needed, this is a first draft.

Regarding the downgrade-comment on the issue: No, they were not hanging around, but deleted (which is generally what makes sense, leaving cleaned up files as trash behind just in case a downgrade will happen can't be a solution IMO). Whit this routine, they are not delete but renamed (which has the same result obviously regarding the old location). So what is your opinion on this? Shall we introduce another routine to handle a possibly reversed situation after a downgrade? If this is what's wanted, one would have to find a way to programmatically catch that. Right now I'm only aware of the hard-coded (cmake compile time insertion) git revision / version string, which is only partially useful for a check like `(if db files on new location and current clien version belongs to the range that uses the old one)`