### PR TITLE
Fetch tags for Debian build

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -38,6 +38,7 @@ fi
 set -x
 
 cd "${DRONE_WORKSPACE}"
+git fetch --tags
 read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
 
 cd "${DRONE_DIR}"


### PR DESCRIPTION
The changelog generator used for Debian builds depends on tags being present. However, it seems Drone does not fetch the tags, so the patch adds a command to the build script to do so.

(Automatic backport failed for #2187, doing manually. Is there a better way for manual backporting than opening a new PR?)