### PR TITLE
Make sure the tray icon point is in screen coordinates

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -279,8 +279,8 @@ QRect Systray::taskbarGeometry() const
 QRect Systray::currentScreenRect() const
 {
     const auto screen = currentScreen();
-    const auto rect = screen->geometry();
-    return rect.translated(screen->virtualGeometry().topLeft());
+    Q_ASSERT(screen);
+    return screen->geometry();
 }
 
 QPoint Systray::computeWindowReferencePoint() const
@@ -378,7 +378,7 @@ QPoint Systray::calcTrayIconCenter() const
     return trayIconCenter;
 #else
     // On Linux, fall back to mouse position (assuming tray icon is activated by mouse click)
-    return QCursor::pos();
+    return QCursor::pos(currentScreen());
 #endif
 }
 


### PR DESCRIPTION
Fix #2166 

Previously we were using QCursor::pos() in the Linux case, which is a
fair heuristic except it will always be relative to the primary screen
and not the current screen. This explains why we had to adjust with the
virtual geometry.

In the Windows and Mac case we got the position out of QSystemTrayIcon
and that one was already relative to the current screen.

So now we use QCursor::pos(currentScreen()) which ensures we give the
coordinates relatively to the current screen also in the Linux case.

Since all platforms are now having that point in the same coordinate
system we don't need to mess around with the virtual geometry to
compensate.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>