### PR TITLE
Ensure to raise all visible dialogs on app focus

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -229,6 +229,9 @@ Application::Application(int &argc, char **argv)
     _gui->setupCloudProviders();
 #endif
 
+    // Install event filter to keep track of visible dialogs
+    installEventFilter(this);
+
     FolderMan::instance()->setupFolders();
     _proxy.setupQtProxyFromConfig(); // folders have to be defined first, than we set up the Qt proxy.
 
@@ -670,6 +673,21 @@ void Application::showMainDialog()
 void Application::slotGuiIsShowingSettings()
 {
     emit isShowingSettingsDialog();
+}
+
+bool Application::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched && watched->isWidgetType()
+        && (event->type() == QEvent::Show || event->type() == QEvent::Hide)) {
+        auto dialog = qobject_cast<QDialog*>(watched);
+        const auto visible = (event->type() == QEvent::Show);
+
+        // Let ownCloudGui manage visible dialogs
+        Q_ASSERT(_gui);
+        _gui->updateDialogVisibility(dialog, visible);
+    }
+
+    return QObject::eventFilter(watched, event);
 }
 
 } // namespace OCC

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -42,8 +42,6 @@
 #include "owncloudsetupwizard.h"
 #include "version.h"
 
-#include "config.h"
-
 #if defined(Q_OS_WIN)
 #include <windows.h>
 #endif

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -78,6 +78,7 @@ protected:
     void parseOptions(const QStringList &);
     void setupTranslations();
     void setupLogging();
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 signals:
     void folderRemoved();

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -173,11 +173,13 @@ void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
     if (reason == QSystemTrayIcon::Trigger) {
         if (OwncloudSetupWizard::bringWizardToFrontIfVisible()) {
             // brought wizard to front
-        } else if (_shareDialogs.size() > 0) {
-            // Share dialog(s) be hidden by other apps, bring them back
-            Q_FOREACH (const QPointer<ShareDialog> &shareDialog, _shareDialogs) {
-                Q_ASSERT(shareDialog.data());
-                raiseDialog(shareDialog);
+        } else if (!_visibleDialogs.isEmpty()) {
+            // Dialog(s) be hidden by other apps, bring them back (e.g. Share / Settings / Auth dialogs)
+            for (const QPointer<QDialog> &dialog : qAsConst(_visibleDialogs)) {
+                if (!dialog) {
+                    continue;
+                }
+                raiseDialog(dialog);
             }
         } else if (_tray->isOpen()) {
             _tray->hideWindow();
@@ -571,7 +573,6 @@ void ownCloudGui::slotSettingsDialogActivated()
 void ownCloudGui::slotShowSyncProtocol()
 {
     slotShowSettings();
-    //_settingsDialog->showActivityPage();
 }
 
 
@@ -713,5 +714,18 @@ void ownCloudGui::slotRemoveDestroyedShareDialogs()
     }
 }
 
+void ownCloudGui::updateDialogVisibility(QDialog *dialog, bool visible)
+{
+    if (dialog) {
+        const auto index = _visibleDialogs.indexOf(dialog);
+        const auto found = (index >= 0);
+
+        if (visible && !found) {
+            _visibleDialogs.append(dialog);
+        } else if (!visible && found) {
+            _visibleDialogs.removeAt(index);
+        }
+    }
+}
 
 } // end namespace

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -65,9 +65,13 @@ public:
 #endif
     void createTray();
 
+    void updateDialogVisibility(QDialog *dialog, bool visible);
+
 signals:
     void setupProxy();
     void serverError(int code, const QString &message);
+
+    // Allow other classes to hook into isShowingSettingsDialog() signals (re-auth widgets, for example)
     void isShowingSettingsDialog();
 
 public slots:
@@ -124,6 +128,7 @@ private:
 #endif
 
     QMap<QString, QPointer<ShareDialog>> _shareDialogs;
+    QList<QPointer<QDialog>> _visibleDialogs;
 
     QAction *_actionNewAccountWizard;
     QAction *_actionSettings;


### PR DESCRIPTION
Let `ownCloudGui` keep track of the visibility of every open dialog, to ensure raising all of them when the user brings the app to the foreground. This way dialogs never get hidden, that's been really annoying from time to time.

- Use event filter in `Application` to track visible dialogs

  Filter Show and Hide events to update `ownCloudGui`:
    - Keep track of visible dialogs in `_visibleDialogs`
    - `slotTrayClicked`: Ensure to raise all visible dialogs on app focus

Other improvements:
- Remove duplicate include in `application.cpp`

This also forms the basis for #2155