### PR TITLE
Add -no-strip cmd line arg to macdeployqt if when building with Debug…

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -395,12 +395,19 @@ if(BUILD_OWNCLOUD_OSX_BUNDLE AND NOT BUILD_LIBRARIES_ONLY)
 
     set(cmd_NAME ${APPLICATION_EXECUTABLE}cmd)
 
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(NO_STRIP "-no-strip")
+    else()
+        set(NO_STRIP "")
+    endif()
+
     add_custom_command(TARGET ${APPLICATION_EXECUTABLE} POST_BUILD
         COMMAND "${MACDEPLOYQT_EXECUTABLE}"
             "$<TARGET_FILE_DIR:${APPLICATION_EXECUTABLE}>/../.."
             -qmldir=${CMAKE_SOURCE_DIR}/src/gui
             -always-overwrite
             -executable="$<TARGET_FILE_DIR:${APPLICATION_EXECUTABLE}>/${cmd_NAME}"
+            ${NO_STRIP}
         COMMENT "Running macdeployqt..."
     )
 endif()


### PR DESCRIPTION
… profile

Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Why the change? -> Otherwise prevents debugging related stuff on macOS (including ability to use breakpoints) when building with a clean tree. This can be very confusing for new users digging into the code & client-building for the first time. Just went full retard for about half an hour not realizing why can't debug with a fresh repo clone despite I'm definitely using the cmake Debug profile.

Why not let the user handle this b/c this is local build env stuff? -> Because the macdeployqt call is already in the code / cmake chain src so this isn't about setting appropriate command line arguments that have to be set anyways. Having the user to provide args that complement hardcoded chain src that should work without it is bananas.

(Note: This is only an issue on macOS b/c only here we have this src-based call of the deploy tool)