### PR TITLE
Fix pause sync states

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -79,7 +79,7 @@ ownCloudGui::ownCloudGui(Application *parent)
     connect(_tray.data(), &Systray::pauseSync,
         this, &ownCloudGui::slotPauseAllFolders);
 
-    connect(_tray.data(), &Systray::pauseSync,
+    connect(_tray.data(), &Systray::resumeSync,
         this, &ownCloudGui::slotUnpauseAllFolders);
 
     connect(_tray.data(), &Systray::openHelp,

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -105,6 +105,11 @@ void Systray::create()
     }
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
+    foreach (Folder *f, FolderMan::instance()->map()) {
+        if (!f->syncPaused()) {
+            _syncIsPaused = false;
+        }
+    }
 }
 
 void Systray::slotNewUserSelected()

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -105,8 +105,8 @@ void Systray::create()
     }
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
-    foreach (Folder *f, FolderMan::instance()->map()) {
-        if (!f->syncPaused()) {
+    for (const auto *folderMap : FolderMan::instance()->map()) {
+        if(!folderMap->syncPaused()) {
             _syncIsPaused = false;
         }
     }

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -105,8 +105,10 @@ void Systray::create()
     }
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
-    for (const auto *folderMap : FolderMan::instance()->map()) {
-        if(!folderMap->syncPaused()) {
+
+    const auto folderMap = FolderMan::instance()->map();
+    for (const auto *folder : folderMap) {
+        if(!folder->syncPaused()) {
             _syncIsPaused = false;
         }
     }

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -108,8 +108,9 @@ void Systray::create()
 
     const auto folderMap = FolderMan::instance()->map();
     for (const auto *folder : folderMap) {
-        if(!folder->syncPaused()) {
+        if (!folder->syncPaused()) {
             _syncIsPaused = false;
+            break;
         }
     }
 }

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -91,7 +91,7 @@ private:
     QPoint computeWindowPosition(int width, int height) const;
 
     bool _isOpen = false;
-    bool _syncIsPaused = false;
+    bool _syncIsPaused = true;
     QPointer<QQmlApplicationEngine> _trayEngine;
 };
 


### PR DESCRIPTION
Fixes #2207 
Fixes #2206 

Changes:

1. Fix of a (apparently) copy/paste bug where the same signal (pause) was used for resume and pause slots.
2. Proper initial setting of _syncIsPaused state variable on Systray creation method (e.g. when accounts are populated and set up, if existing) to ensure correct qml gui dropdown entry text