### PR TITLE
Implemented account-setting for masking WebDAV commands

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -36,6 +36,7 @@ static const char caCertsKeyC[] = "CaCertificates";
 static const char accountsC[] = "Accounts";
 static const char versionC[] = "version";
 static const char serverVersionC[] = "serverVersion";
+static const char maskWebDAVC[] = "maskWebDAV";
 }
 
 
@@ -179,6 +180,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
 {
     settings.setValue(QLatin1String(urlC), acc->_url.toString());
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
+    settings.setValue(QLatin1String(maskWebDAVC), acc->maskWebDAVCommands());
     if (acc->_credentials) {
         if (saveCredentials) {
             // Only persist the credentials if the parameter is set, on migration from 1.8.x
@@ -266,6 +268,8 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
             settings.remove(key);
         }
     }
+
+    acc->setMaskWebDAVCommands(settings.value(QLatin1String(maskWebDAVC)).toBool());
 
     qCInfo(lcAccountManager) << "Account for" << acc->url() << "using auth type" << authType;
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -161,6 +161,8 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     refreshSelectiveSyncStatus();
     connect(_model, &QAbstractItemModel::rowsInserted,
         this, &AccountSettings::refreshSelectiveSyncStatus);
+    _ui->allowMaskingWebDAV->setChecked(_accountState->account()->maskWebDAVCommands());
+    connect(_ui->allowMaskingWebDAV, &QAbstractButton::toggled, this, &AccountSettings::slotToggleMaskWebDAV);
 
     QAction *syncNowAction = new QAction(this);
     syncNowAction->setShortcut(QKeySequence(Qt::Key_F6));
@@ -247,6 +249,12 @@ void AccountSettings::slotNewMnemonicGenerated()
 
     _ui->encryptionMessage->addAction(mnemonic);
     _ui->encryptionMessage->show();
+}
+
+void AccountSettings::slotToggleMaskWebDAV(bool enable)
+{
+    _accountState->account()->setMaskWebDAVCommands(enable);
+    AccountManager::instance()->save();
 }
 
 void AccountSettings::slotMenuBeforeShow() {

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -99,6 +99,7 @@ protected slots:
     void slotFolderListClicked(const QModelIndex &indx);
     void doExpand();
     void slotLinkActivated(const QString &link);
+    void slotToggleMaskWebDAV(bool);
 
     void slotMenuBeforeShow();
 

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -249,6 +249,23 @@
     </layout>
    </item>
    <item row="3" column="0">
+    <layout class="QHBoxLayout" name="maskGroupBox">
+     <item>
+      <widget class="QCheckBox" name="allowMaskingWebDAV">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Allow masking WebDAV</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
     <widget class="OCC::FolderStatusView" name="_folderList">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -109,6 +109,10 @@ public:
     void setUrl(const QUrl &url);
     QUrl url() const { return _url; }
 
+    // allowing masking of WebDAV commands
+    bool maskWebDAVCommands();
+    void setMaskWebDAVCommands(bool);
+
     /// Adjusts _userVisibleUrl once the host to use is discovered.
     void setUserVisibleHost(const QString &host);
 
@@ -319,6 +323,9 @@ private:
 
     /// Used in RemoteWipe
     bool _wroteAppPassword = false;
+
+    /// Attempt to mask WebDAV commands in supported servers
+    bool _maskWebDAV = false;
 
     friend class AccountManager;
 


### PR DESCRIPTION
Some service providers specifically disallow (some) WebDAV request methods. To allow Nextcloud to run properly at such hosting parties, masking the request method using a generally allowed method (i.e. POST) allows passing the more uncommon methods like MOVE and PROPFIND. 

This PR adds a setting for each account, allowing the user to indicate whether masking of the WebDAV commands should be allowed. I did not find a proper place to put such a checkbox, so I added it on the account settings screen in between the account information (connected user @) and the folder sync pane.
Alternatively, this setting could be hidden and activated automatically if the server has a proper version AND it returns a 'method not allowed' response on methods like MOVE, PROPFIND, etc. However, such a response can also be generated under different circumstances in which different error situations arise.

This PR makes the account instance add an X-WebDAV header with the original request method and perform a POST operation to the remote. It works in tandem with the PR I'm submitting for the PHP server.

I was not able to find out how to add a test case. If you want that and can give me some pointers, I can extend the PR.
