### PR TITLE
Change ownCloud reference to Nextcloud

### DIFF
--- a/doc/conflicts.rst
+++ b/doc/conflicts.rst
@@ -7,7 +7,7 @@ Conflicts
 Overview
 --------
 
-The ownCloud desktop client uploads local changes and downloads remote changes.
+The Nextcloud desktop client uploads local changes and downloads remote changes.
 When a file has changed on the local side and on the remote between synchronization
 runs the client will be unable to resolve the situation on its own. It will
 create a conflict file with the local version, download the remote version and


### PR DESCRIPTION
Signed-off-by: Jacob Neplokh <me@jacobneplokh.com>

Resolves nextcloud/documentation#2171

--
This changes an ownCloud reference in the docs to Nextcloud.