### PR TITLE
Make QML code more declarative by using properties

### DIFF
--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -67,7 +67,7 @@ MenuItem {
                         Layout.leftMargin: 4
                         verticalAlignment: Qt.AlignCenter
                         cache: false
-                        source: ("image://avatars/" + id)
+                        source: model.avatar != "" ? model.avatar : "image://avatars/fallbackBlack"
                         Layout.preferredHeight: (userLineLayout.height -16)
                         Layout.preferredWidth: (userLineLayout.height -16)
                         Rectangle {

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -21,6 +21,7 @@ class User : public QObject
     Q_PROPERTY(QString server READ server CONSTANT)
     Q_PROPERTY(bool hasLocalFolder READ hasLocalFolder NOTIFY hasLocalFolderChanged)
     Q_PROPERTY(bool serverHasTalk READ serverHasTalk NOTIFY serverHasTalkChanged)
+    Q_PROPERTY(QString avatar READ avatarUrl NOTIFY avatarChanged)
 public:
     User(AccountStatePtr &account, const bool &isCurrent = false, QObject* parent = nullptr);
 
@@ -39,17 +40,18 @@ public:
     AccountApp *talkApp() const;
     bool hasActivities() const;
     AccountAppList appList() const;
-    QImage avatar(bool whiteBg = false) const;
-    QString id() const;
+    QImage avatar() const;
     void login() const;
     void logout() const;
     void removeAccount() const;
+    QString avatarUrl() const;
 
 signals:
     void guiLog(const QString &, const QString &);
     void nameChanged();
     void hasLocalFolderChanged();
     void serverHasTalkChanged();
+    void avatarChanged();
 
 public slots:
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);
@@ -89,6 +91,7 @@ class UserModel : public QAbstractListModel
 {
     Q_OBJECT
     Q_PROPERTY(User* currentUser READ currentUser NOTIFY newUserSelected)
+    Q_PROPERTY(int currentUserId READ currentUserId NOTIFY newUserSelected)
 public:
     static UserModel *instance();
     virtual ~UserModel() = default;
@@ -108,12 +111,11 @@ public:
     Q_INVOKABLE void openCurrentAccountLocalFolder();
     Q_INVOKABLE void openCurrentAccountTalk();
     Q_INVOKABLE void openCurrentAccountServer();
-    Q_INVOKABLE QImage currentUserAvatar();
     Q_INVOKABLE int numUsers();
     Q_INVOKABLE QString currentUserServer();
     Q_INVOKABLE bool currentUserHasActivities();
     Q_INVOKABLE bool currentUserHasLocalFolder();
-    Q_INVOKABLE int currentUserId() const;
+    int currentUserId() const;
     Q_INVOKABLE bool isUserConnected(const int &id);
     Q_INVOKABLE void switchCurrentUser(const int &id);
     Q_INVOKABLE void login(const int &id);

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -33,10 +33,8 @@ Window {
     }
 
     onVisibleChanged: {
-        currentAccountAvatar.source = ""
-        currentAccountAvatar.source = "image://avatars/currentUser"
         currentAccountStateIndicator.source = ""
-        currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId()) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+        currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
 
         // HACK: reload account Instantiator immediately by restting it - could be done better I guess
         // see also id:accountMenu below
@@ -47,10 +45,8 @@ Window {
     Connections {
         target: UserModel
         onRefreshCurrentUserGui: {
-            currentAccountAvatar.source = ""
-            currentAccountAvatar.source = "image://avatars/currentUser"
             currentAccountStateIndicator.source = ""
-            currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId()) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+            currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
         }
         onNewUserSelected: {
             accountMenu.close();
@@ -336,7 +332,7 @@ Window {
                             Layout.leftMargin: 8
                             verticalAlignment: Qt.AlignCenter
                             cache: false
-                            source: "image://avatars/currentUser"
+                            source: UserModel.currentUser.avatar != "" ? UserModel.currentUser.avatar : "image://avatars/fallbackWhite"
                             Layout.preferredHeight: Style.accountAvatarSize
                             Layout.preferredWidth: Style.accountAvatarSize
 
@@ -355,7 +351,7 @@ Window {
 
                             Image {
                                 id: currentAccountStateIndicator
-                                source: UserModel.isUserConnected(UserModel.currentUserId()) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+                                source: UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
                                 cache: false
                                 x: currentAccountStateIndicatorBackground.x + 1
                                 y: currentAccountStateIndicatorBackground.y + 1


### PR DESCRIPTION
By using properties and property bindings the QML code gets more declarative rather than imperative, which is considered better.

This patch:
- Introduces a currentUserId property in UserModel that replaces the equivalent Q_INVOKABLE call
- Introduces an avatar property in User that contains the avatar's image provider url without any fallback
- Introduces new image provider urls for fallback images
- Moves the fallback image selection to QML since we want different fallbacks according to where it is used
- Wires up the necessary signals to propagate a changing avatar

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>