### PR TITLE
Update CI for Qt 5.12.9

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,13 +3,13 @@ name: qt-5.12
 
 steps:
 - name: build and test
-  image: nextcloudci/client-5.12:client-5.12-7
+  image: nextcloudci/client-5.12:client-5.12-9
   commands:
     # Install QtKeyChain
     - /bin/bash -c "
       export CC=gcc-7 &&
       export CXX=g++-7 &&
-      export QT_BASE_DIR=/opt/qt5.12.8 &&
+      export QT_BASE_DIR=/opt/qt5.12.9 &&
       export QTDIR=\$QT_BASE_DIR &&
       export PATH=\$QT_BASE_DIR/bin:\$PATH &&
       export LD_LIBRARY_PATH=\$QT_BASE_DIR/lib/x86_64-linux-gnu:\$QT_BASE_DIR/lib:/usr/local/lib:\$LD_LIBRARY_PATH &&
@@ -27,7 +27,7 @@ steps:
     - /bin/bash -c "
       export CC=gcc-7 &&
       export CXX=g++-7 &&
-      export QT_BASE_DIR=/opt/qt5.12.8 &&
+      export QT_BASE_DIR=/opt/qt5.12.9 &&
       export QTDIR=\$QT_BASE_DIR &&
       export PATH=\$QT_BASE_DIR/bin:\$PATH &&
       export LD_LIBRARY_PATH=\$QT_BASE_DIR/lib/x86_64-linux-gnu:\$QT_BASE_DIR/lib:/usr/local/lib:\$LD_LIBRARY_PATH &&
@@ -52,13 +52,13 @@ name: qt-5.12-clang
 
 steps:
 - name: build and test
-  image: nextcloudci/client-5.12:client-5.12-7
+  image: nextcloudci/client-5.12:client-5.12-9
   commands:
     # Install QtKeyChain
     - /bin/bash -c "
       export CC=clang-6.0 &&
       export CXX=clang++-6.0 &&
-      export QT_BASE_DIR=/opt/qt5.12.8 &&
+      export QT_BASE_DIR=/opt/qt5.12.9 &&
       export QTDIR=\$QT_BASE_DIR &&
       export PATH=\$QT_BASE_DIR/bin:\$PATH &&
       export LD_LIBRARY_PATH=\$QT_BASE_DIR/lib/x86_64-linux-gnu:\$QT_BASE_DIR/lib:/usr/local/lib:\$LD_LIBRARY_PATH &&
@@ -76,7 +76,7 @@ steps:
     - /bin/bash -c "
       export CC=clang-6.0 &&
       export CXX=clang++-6.0 &&
-      export QT_BASE_DIR=/opt/qt5.12.8 &&
+      export QT_BASE_DIR=/opt/qt5.12.9 &&
       export QTDIR=\$QT_BASE_DIR &&
       export PATH=\$QT_BASE_DIR/bin:\$PATH &&
       export LD_LIBRARY_PATH=\$QT_BASE_DIR/lib/x86_64-linux-gnu:\$QT_BASE_DIR/lib:/usr/local/lib:\$LD_LIBRARY_PATH &&
@@ -103,7 +103,7 @@ name: AppImage
 
 steps:
 - name: build
-  image: nextcloudci/client-5.12:client-5.12-7
+  image: nextcloudci/client-5.12:client-5.12-9
   environment:
     CI_UPLOAD_GIT_TOKEN:
       from_secret: CI_UPLOAD_GIT_TOKEN

--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -6,7 +6,7 @@ mkdir /app
 mkdir /build
 
 #Set Qt-5.12
-export QT_BASE_DIR=/opt/qt5.12.8
+export QT_BASE_DIR=/opt/qt5.12.9
 export QTDIR=$QT_BASE_DIR
 export PATH=$QT_BASE_DIR/bin:$PATH
 export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH

--- a/admin/linux/upload-appimage.sh
+++ b/admin/linux/upload-appimage.sh
@@ -32,8 +32,6 @@ fi
 
 echo "Found AppImage: $BASENAME"
 
-apt-get -y install jq
-
 if [ $TAG_NAME != "master" ]; then
     # Delete all old comments in desktop PR, starting with "AppImage file:"
     oldComments=$(curl 2>/dev/null -u $GIT_USERNAME:$GIT_TOKEN -X GET $DESKTOP_API_BASE_URL/issues/$PR/comments | jq '.[] | (.id |tostring) + "|" + (.user.login | test("'${GIT_USERNAME}'") | tostring) + "|" + (.body | test("AppImage file:.*") | tostring)'  | grep "true|true" | tr -d "\"" | cut -f1 -d"|")


### PR DESCRIPTION
Update CI for Qt 5.12.9

Also remove the `jq` package installation from the AppImage upload script because the package is included in the new Docker image (see nextcloud/docker-ci#231 and #2213).