### PR TITLE
Direct download share option

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -49,6 +49,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     , _linkShare(nullptr)
     , _passwordRequired(false)
     , _noteRequired(false)
+	, _useDirectDownload(false)
     , _expiryRequired(false)
     , _namesSupported(true)
     , _linkContextMenu(nullptr)
@@ -231,6 +232,10 @@ void ShareLinkWidget::setupUiOptions()
         _expiryRequired = true;
     }
 
+	// Add action to return the direct download link when copying the share link
+    _directDownloadLinkAction = _linkContextMenu->addAction(tr("Use direct download link"));
+    _directDownloadLinkAction->setCheckable(true);
+	
     // Adds action to unshare widget (check box)
     _unshareLinkAction = _linkContextMenu->addAction(QIcon(":/client/theme/delete.svg"),
         tr("Delete share link"));
@@ -283,8 +288,11 @@ void ShareLinkWidget::slotNoteSet()
 void ShareLinkWidget::slotCopyLinkShare(bool clicked)
 {
     Q_UNUSED(clicked);
+	
+	QUrl link = _linkShare->getLink();
+	if (_useDirectDownload) link = _linkShare->getDirectDownloadLink();
 
-    QApplication::clipboard()->setText(_linkShare->getLink().toString());
+    QApplication::clipboard()->setText(link.toString());
 }
 
 void ShareLinkWidget::slotExpireDateSet()
@@ -527,6 +535,9 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
 
     } else if (action == _noteLinkAction) {
         toggleNoteOptions(state);
+
+    } else if (action == _directDownloadLinkAction) {
+		_useDirectDownload = state;
 
     } else if (action == _unshareLinkAction) {
         confirmAndDeleteShare();

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -49,7 +49,7 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
     , _linkShare(nullptr)
     , _passwordRequired(false)
     , _noteRequired(false)
-	, _useDirectDownload(false)
+    , _useDirectDownload(false)
     , _expiryRequired(false)
     , _namesSupported(true)
     , _linkContextMenu(nullptr)
@@ -232,10 +232,10 @@ void ShareLinkWidget::setupUiOptions()
         _expiryRequired = true;
     }
 
-	// Add action to return the direct download link when copying the share link
+    // Add action to return the direct download link when copying the share link
     _directDownloadLinkAction = _linkContextMenu->addAction(tr("Use direct download link"));
     _directDownloadLinkAction->setCheckable(true);
-	
+
     // Adds action to unshare widget (check box)
     _unshareLinkAction = _linkContextMenu->addAction(QIcon(":/client/theme/delete.svg"),
         tr("Delete share link"));
@@ -288,9 +288,9 @@ void ShareLinkWidget::slotNoteSet()
 void ShareLinkWidget::slotCopyLinkShare(bool clicked)
 {
     Q_UNUSED(clicked);
-	
-	QUrl link = _linkShare->getLink();
-	if (_useDirectDownload) link = _linkShare->getDirectDownloadLink();
+
+    QUrl link = _linkShare->getLink();
+    if (_useDirectDownload) link = _linkShare->getDirectDownloadLink();
 
     QApplication::clipboard()->setText(link.toString());
 }
@@ -537,7 +537,7 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
         toggleNoteOptions(state);
 
     } else if (action == _directDownloadLinkAction) {
-		_useDirectDownload = state;
+        _useDirectDownload = state;
 
     } else if (action == _unshareLinkAction) {
         confirmAndDeleteShare();

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -103,7 +103,7 @@ private:
 
     void showExpireDateOptions(bool show);
     void toggleExpireDateOptions(bool enable);
-
+	
     void slotCopyLinkShare(bool clicked);
 
     /** Confirm with the user and then delete the share */
@@ -129,6 +129,7 @@ private:
     bool _expiryRequired;
     bool _namesSupported;
     bool _noteRequired;
+	bool _useDirectDownload;
 
     QMenu *_linkContextMenu;
     QAction *_readOnlyLinkAction;
@@ -137,6 +138,7 @@ private:
     QAction *_allowUploadLinkAction;
     QAction *_passwordProtectLinkAction;
     QAction *_expirationDateLinkAction;
+	QAction *_directDownloadLinkAction;
     QAction *_unshareLinkAction;
     QAction *_addAnotherLinkAction;
     QAction *_noteLinkAction;

--- a/src/gui/sharelinkwidget.h
+++ b/src/gui/sharelinkwidget.h
@@ -103,7 +103,7 @@ private:
 
     void showExpireDateOptions(bool show);
     void toggleExpireDateOptions(bool enable);
-	
+
     void slotCopyLinkShare(bool clicked);
 
     /** Confirm with the user and then delete the share */
@@ -129,7 +129,7 @@ private:
     bool _expiryRequired;
     bool _namesSupported;
     bool _noteRequired;
-	bool _useDirectDownload;
+    bool _useDirectDownload;
 
     QMenu *_linkContextMenu;
     QAction *_readOnlyLinkAction;
@@ -138,7 +138,7 @@ private:
     QAction *_allowUploadLinkAction;
     QAction *_passwordProtectLinkAction;
     QAction *_expirationDateLinkAction;
-	QAction *_directDownloadLinkAction;
+    QAction *_directDownloadLinkAction;
     QAction *_unshareLinkAction;
     QAction *_addAnotherLinkAction;
     QAction *_noteLinkAction;


### PR DESCRIPTION
Add a "direct download" share option (closes #2230).

I'm not sure if this is something the dev team wants, but the code to generate a direct download link was already there with `LinkShare::getDirectDownloadLink()`, so I figured just adding the accompanying menu item wouldn't be too amiss?