### PR TITLE
Windows: Enable CFG and SafeSEH linker security flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,9 +34,15 @@ if(NOT MSVC)
 endif()
 
 if(WIN32)
-  # Enable DEP & ASLR
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /nxcompat /dynamicbase")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /nxcompat /dynamicbase")
+  # Enable DEP, ASLR and CFG
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /nxcompat /dynamicbase /guard:cf")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /nxcompat /dynamicbase /guard:cf")
+
+  # x86 only: Enable SafeSEH
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /safeseh")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /safeseh")
+  endif()
 elseif(UNIX AND NOT APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro -Wl,-z,now")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro -Wl,-z,now")


### PR DESCRIPTION
See:
https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
https://docs.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers

Also interesting to play around with for verifying security flags:
https://blog.netspi.com/verifying-aslr-dep-and-safeseh-with-powershell/ (<- [Repo](https://github.com/NetSPI/PESecurity))

For running in processes (in _PowerShell_):
`Get-ProcessMitigation -Name .\nextcloud.exe -RunningProcesses`
