### PR TITLE
Always show Settings in the context menu (amends #2164)

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -86,8 +86,8 @@ Systray::Systray()
         contextMenu->addAction(tr("Add account"), this, &Systray::openAccountWizard);
     } else {
         contextMenu->addAction(tr("Open main dialog"), this, &Systray::openMainDialog);
-        contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
     }
+    contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
     contextMenu->addAction(tr("Exit %1").arg(Theme::instance()->appNameGUI()), this, &Systray::shutdown);
     setContextMenu(contextMenu);
 #endif


### PR DESCRIPTION
The context menu should allow access to the Settings even when no accounts are configured.

Users may specify proxy / startup / update and other settings at any time.

This slipped through in #2164.