### PR TITLE
Make sure we always have a CLSID when Explorer integration is used

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -945,6 +945,11 @@ Folder *FolderMan::addFolderInternal(FolderDefinition folderDefinition,
 
     auto folder = new Folder(folderDefinition, accountState, this);
 
+    if (_navigationPaneHelper.showInExplorerNavigationPane() && folderDefinition.navigationPaneClsid.isNull()) {
+        folder->setNavigationPaneClsid(QUuid::createUuid());
+        folder->saveToSettings();
+    }
+
     qCInfo(lcFolderMan) << "Adding folder to Folder Map " << folder << folder->alias();
     _folderMap[folder->alias()] = folder;
     if (folder->syncPaused()) {


### PR DESCRIPTION
We update properly the CLSID of folders to integrate them with the
Explorer pane when they are added or removed from the GUI. That said,
there might be cases of users adding folders to sync straight from the
GUI. In such a case the CLSID might be missing on config load so now we
assign one on the fly when that happens.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>