### PR TITLE
Keep the E2EE info message around to allow displaying mnemonic

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -197,11 +197,15 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(_accountState->account()->e2e(), &ClientSideEncryption::showMnemonic, this, &AccountSettings::slotShowMnemonic);
 
     connect(_accountState->account()->e2e(), &ClientSideEncryption::mnemonicGenerated, this, &AccountSettings::slotNewMnemonicGenerated);
-    if (_accountState->account()->e2e()->newMnemonicGenerated())
-    {
+    if (_accountState->account()->e2e()->newMnemonicGenerated()) {
         slotNewMnemonicGenerated();
     } else {
-        _ui->encryptionMessage->hide();
+        _ui->encryptionMessage->setText(tr("This account supports end-to-end encryption"));
+
+        auto *mnemonic = new QAction(tr("Display mnemonic"), this);
+        connect(mnemonic, &QAction::triggered, this, &AccountSettings::requesetMnemonic);
+        _ui->encryptionMessage->addAction(mnemonic);
+        _ui->encryptionMessage->show();
     }
 
     connect(UserModel::instance(), &UserModel::addAccount,


### PR DESCRIPTION
We lost the ability to display the E2EE mnemonic during the GUI
redesign and the info message wasn't displayed again on restart. So now
we display it every time, it still can be dismissed and the button text
is different in such a case to make the intent clearer.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>

Fix #2251 
Fix #2252 