### PR TITLE
Include cstdint only when compiling C++ code

### DIFF
--- a/src/common/c_jhash.h
+++ b/src/common/c_jhash.h
@@ -24,7 +24,7 @@
 #ifndef _C_JHASH_H
 #define _C_JHASH_H
 
-#include <cstdint>
+#include <stdint.h> // NOLINT
 
 #define c_hashsize(n) ((uint8_t) 1 << (n))
 #define c_hashmask(n) (xhashsize(n) - 1)


### PR DESCRIPTION
The file ```src/common/c_jhash.h``` is included from a C file, ```test/csync/std_tests/check_std_c_jhash.c```. As this file is C code, when it is compiled, ```stdint.h``` should be used instead of ```cstdint```.