### PR TITLE
Issues/2219/deprecate foreach

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -293,8 +293,8 @@ void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
     auto oldBlackListSet = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok).toSet();
     if (ok) {
         auto blackListSet = newList.toSet();
-        auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
-        foreach (const auto &it, changes) {
+        const auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
+        for (const auto &it : changes) {
             journal->avoidReadFromDbOnNextSync(it);
         }
 

--- a/src/cmd/simplesslerrorhandler.cpp
+++ b/src/cmd/simplesslerrorhandler.cpp
@@ -27,7 +27,7 @@ bool SimpleSslErrorHandler::handleErrors(QList<QSslError> errors, const QSslConf
         return false;
     }
 
-    foreach (QSslError error, errors) {
+    for (const auto &error : qAsConst(errors)) {
         certs->append(error.certificate());
     }
     return true;

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -372,10 +372,9 @@ void AccountManager::shutdown()
 
 bool AccountManager::isAccountIdAvailable(const QString &id) const
 {
-    const auto it = std::find_if(_accounts.cbegin(), _accounts.cend(), [id](const auto &acc) {
+    return std::none_of(_accounts.cbegin(), _accounts.cend(), [id](const auto &acc) {
         return acc->account()->id() == id;
     });
-    return it == _accounts.cend();
 }
 
 QString AccountManager::generateFreeAccountId() const

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -372,10 +372,10 @@ void AccountManager::shutdown()
 
 bool AccountManager::isAccountIdAvailable(const QString &id) const
 {
-    auto acc = std::find_if(_accounts.cbegin(), _accounts.cend(), [&id](const auto &acc) {
+    const auto it = std::find_if(_accounts.cbegin(), _accounts.cend(), [id](const auto &acc) {
         return acc->account()->id() == id;
     });
-    return acc == _accounts.cend();
+    return it == _accounts.cend();
 }
 
 QString AccountManager::generateFreeAccountId() const

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -65,7 +65,7 @@ bool AccountManager::restore()
         return true;
     }
 
-    foreach (const auto &accountId, settings->childGroups()) {
+    for (const auto &accountId : settings->childGroups()) {
         settings->beginGroup(accountId);
         if (auto acc = loadAccountHelper(*settings)) {
             acc->_id = accountId;
@@ -140,7 +140,7 @@ void AccountManager::save(bool saveCredentials)
 {
     auto settings = ConfigFile::settingsWithGroup(QLatin1String(accountsC));
     settings->setValue(QLatin1String(versionC), 2);
-    foreach (const auto &acc, _accounts) {
+    for (const auto &acc : qAsConst(_accounts)) {
         settings->beginGroup(acc->account()->id());
         saveAccountHelper(acc->account().data(), *settings, saveCredentials);
         acc->writeToSettings(*settings);
@@ -187,7 +187,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
             // re-persisting them)
             acc->_credentials->persist();
         }
-        Q_FOREACH (QString key, acc->_settingsMap.keys()) {
+        for (const auto &key : acc->_settingsMap.keys()) {
             settings.setValue(key, acc->_settingsMap.value(key));
         }
         settings.setValue(QLatin1String(authTypeC), acc->_credentials->authType());
@@ -201,7 +201,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.beginGroup(QLatin1String("General"));
     qCInfo(lcAccountManager) << "Saving " << acc->approvedCerts().count() << " unknown certs.";
     QByteArray certs;
-    Q_FOREACH (const QSslCertificate &cert, acc->approvedCerts()) {
+    for (const auto &cert : acc->approvedCerts()) {
         certs += cert.toPem() + '\n';
     }
     if (!certs.isEmpty()) {
@@ -258,7 +258,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
         authType = "webflow";
         settings.setValue(QLatin1String(authTypeC), authType);
 
-        foreach(QString key, settings.childKeys()) {
+        for (const QString &key : settings.childKeys()) {
             if (!key.startsWith("http_"))
                 continue;
             auto newkey = QString::fromLatin1("webflow_").append(key.mid(5));
@@ -274,7 +274,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));
     QString authTypePrefix = authType + "_";
-    Q_FOREACH (QString key, settings.childKeys()) {
+    for (const auto &key : settings.childKeys()) {
         if (!key.startsWith(authTypePrefix))
             continue;
         acc->_settingsMap.insert(key, settings.value(key));
@@ -292,12 +292,10 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 
 AccountStatePtr AccountManager::account(const QString &name)
 {
-    foreach (const auto &acc, _accounts) {
-        if (acc->account()->displayName() == name) {
-            return acc;
-        }
-    }
-    return AccountStatePtr();
+    const auto it = std::find_if(_accounts.cbegin(), _accounts.cend(), [name](const auto &acc) {
+        return acc->account()->displayName() == name;
+    });
+    return it != _accounts.cend() ? *it : AccountStatePtr();
 }
 
 AccountState *AccountManager::addAccount(const AccountPtr &newAccount)
@@ -364,9 +362,9 @@ void AccountManager::displayMnemonic(const QString& mnemonic)
 
 void AccountManager::shutdown()
 {
-    auto accountsCopy = _accounts;
+    const auto accountsCopy = _accounts;
     _accounts.clear();
-    foreach (const auto &acc, accountsCopy) {
+    for (const auto &acc : accountsCopy) {
         emit accountRemoved(acc.data());
         emit removeAccountFolders(acc.data());
     }
@@ -374,12 +372,10 @@ void AccountManager::shutdown()
 
 bool AccountManager::isAccountIdAvailable(const QString &id) const
 {
-    foreach (const auto &acc, _accounts) {
-        if (acc->account()->id() == id) {
-            return false;
-        }
-    }
-    return true;
+    auto acc = std::find_if(_accounts.cbegin(), _accounts.cend(), [&id](const auto &acc) {
+        return acc->account()->id() == id;
+    });
+    return acc == _accounts.cend();
 }
 
 QString AccountManager::generateFreeAccountId() const

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -761,7 +761,7 @@ void AccountSettings::slotAccountStateChanged()
         AccountPtr account = _accountState->account();
         QUrl safeUrl(account->url());
         safeUrl.setPassword(QString()); // Remove the password from the URL to avoid showing it in the UI
-        const auto &folders = FolderMan::instance()->map().values();
+        const auto folders = FolderMan::instance()->map().values();
         for (Folder *folder : folders) {
             _model->slotUpdateFolderState(folder);
         }
@@ -894,14 +894,14 @@ void AccountSettings::refreshSelectiveSyncStatus()
 
     QString msg;
     int cnt = 0;
-    const auto &folders = FolderMan::instance()->map().values();
+    const auto folders = FolderMan::instance()->map().values();
     for (Folder *folder : folders) {
         if (folder->accountState() != _accountState) {
             continue;
         }
 
         bool ok = false;
-        const auto &undecidedList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
+        const auto undecidedList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
         QString p;
         for (const auto &it : undecidedList) {
             // FIXME: add the folder alias in a hoover hint.

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -761,8 +761,8 @@ void AccountSettings::slotAccountStateChanged()
         AccountPtr account = _accountState->account();
         QUrl safeUrl(account->url());
         safeUrl.setPassword(QString()); // Remove the password from the URL to avoid showing it in the UI
-        FolderMan *folderMan = FolderMan::instance();
-        foreach (Folder *folder, folderMan->map().values()) {
+        const auto &folders = FolderMan::instance()->map().values();
+        for (Folder *folder : folders) {
             _model->slotUpdateFolderState(folder);
         }
 
@@ -894,15 +894,16 @@ void AccountSettings::refreshSelectiveSyncStatus()
 
     QString msg;
     int cnt = 0;
-    foreach (Folder *folder, FolderMan::instance()->map().values()) {
+    const auto &folders = FolderMan::instance()->map().values();
+    for (Folder *folder : folders) {
         if (folder->accountState() != _accountState) {
             continue;
         }
 
         bool ok = false;
-        auto undecidedList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
+        const auto &undecidedList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
         QString p;
-        foreach (const auto &it, undecidedList) {
+        for (const auto &it : undecidedList) {
             // FIXME: add the folder alias in a hoover hint.
             // folder->alias() + QLatin1String("/")
             if (cnt++) {

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -441,7 +441,7 @@ void AccountState::slotNavigationAppsFetched(const QJsonDocument &reply, int sta
 
             if(!reply.isEmpty()){
                 auto element = reply.object().value("ocs").toObject().value("data");
-                const auto &navLinks = element.toArray();
+                const auto navLinks = element.toArray();
 
                 if(navLinks.size() > 0){
                     for (const QJsonValue &value : navLinks) {
@@ -468,7 +468,7 @@ AccountAppList AccountState::appList() const
 AccountApp* AccountState::findApp(const QString &appId) const
 {
     if(!appId.isEmpty()) {
-        const auto &apps = appList();
+        const auto apps = appList();
         const auto it = std::find_if(apps.cbegin(), apps.cend(), [appId](const auto &app) {
             return app->id() == appId;
         });

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -441,10 +441,10 @@ void AccountState::slotNavigationAppsFetched(const QJsonDocument &reply, int sta
 
             if(!reply.isEmpty()){
                 auto element = reply.object().value("ocs").toObject().value("data");
-                auto navLinks = element.toArray();
+                const auto &navLinks = element.toArray();
 
                 if(navLinks.size() > 0){
-                    foreach (const QJsonValue &value, navLinks) {
+                    for (const QJsonValue &value : navLinks) {
                         auto navLink = value.toObject();
 
                         auto *app = new AccountApp(navLink.value("name").toString(), QUrl(navLink.value("href").toString()),
@@ -468,9 +468,12 @@ AccountAppList AccountState::appList() const
 AccountApp* AccountState::findApp(const QString &appId) const
 {
     if(!appId.isEmpty()) {
-        foreach(AccountApp *app, appList()) {
-            if(app->id() == appId)
-                return app;
+        const auto &apps = appList();
+        const auto it = std::find_if(apps.cbegin(), apps.cend(), [appId](const auto &app) {
+            return app->id() == appId;
+        });
+        if (it != apps.cend()) {
+            return *it;
         }
     }
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -241,7 +241,7 @@ Application::Application(int &argc, char **argv)
         this, &Application::slotAccountStateAdded);
     connect(AccountManager::instance(), &AccountManager::accountRemoved,
         this, &Application::slotAccountStateRemoved);
-    foreach (auto ai, AccountManager::instance()->accounts()) {
+    for (const auto &ai : AccountManager::instance()->accounts()) {
         slotAccountStateAdded(ai.data());
     }
 
@@ -349,8 +349,8 @@ void Application::slotSystemOnlineConfigurationChanged(QNetworkConfiguration cnf
 
 void Application::slotCheckConnection()
 {
-    auto list = AccountManager::instance()->accounts();
-    foreach (const auto &accountState, list) {
+    const auto &list = AccountManager::instance()->accounts();
+    for (const auto &accountState : list) {
         AccountState::State state = accountState->state();
 
         // Don't check if we're manually signed out or
@@ -612,7 +612,7 @@ void Application::setupTranslations()
     auto *qtTranslator = new QTranslator(this);
     auto *qtkeychainTranslator = new QTranslator(this);
 
-    foreach (QString lang, uiLanguages) {
+    for (QString lang : qAsConst(uiLanguages)) {
         lang.replace(QLatin1Char('-'), QLatin1Char('_')); // work around QTBUG-25973
         lang = substLang(lang);
         const QString trPath = applicationTrPath();

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -349,7 +349,7 @@ void Application::slotSystemOnlineConfigurationChanged(QNetworkConfiguration cnf
 
 void Application::slotCheckConnection()
 {
-    const auto &list = AccountManager::instance()->accounts();
+    const auto list = AccountManager::instance()->accounts();
     for (const auto &accountState : list) {
         AccountState::State state = accountState->state();
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -529,11 +529,10 @@ void Folder::saveToSettings() const
     // where two folders for different accounts point at the same
     // local folders.
     const auto folderMap = FolderMan::instance()->map();
-    const auto it = std::find_if(folderMap.cbegin(), folderMap.cend(), [this](const auto *other) {
+    const auto oneAccountOnly = std::none_of(folderMap.cbegin(), folderMap.cend(), [this](const auto *other) {
         return other != this && other->cleanPath() == this->cleanPath();
     });
 
-    bool oneAccountOnly = it == folderMap.cend();
     bool compatible = _saveBackwardsCompatible || oneAccountOnly;
 
     if (compatible) {

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -528,7 +528,7 @@ void Folder::saveToSettings() const
     // This ensures that older clients will not read a configuration
     // where two folders for different accounts point at the same
     // local folders.
-    const auto &folderMap = FolderMan::instance()->map();
+    const auto folderMap = FolderMan::instance()->map();
     const auto it = std::find_if(folderMap.cbegin(), folderMap.cend(), [this](const auto *other) {
         return other != this && other->cleanPath() == this->cleanPath();
     });

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -280,7 +280,7 @@ int FolderMan::setupFoldersMigration()
     QDir dir(_folderConfigPath);
     //We need to include hidden files just in case the alias starts with '.'
     dir.setFilter(QDir::Files | QDir::Hidden);
-    const auto &list = dir.entryList();
+    const auto list = dir.entryList();
 
     // Normally there should be only one account when migrating.
     AccountState *accountState = AccountManager::instance()->accounts().value(0).data();
@@ -913,7 +913,7 @@ Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition 
 
     // Migration: The first account that's configured for a local folder shall
     // be saved in a backwards-compatible way.
-    const auto &folderList = FolderMan::instance()->map();
+    const auto folderList = FolderMan::instance()->map();
     const auto it = std::find_if(folderList.cbegin(), folderList.cend(), [this, folder](const auto *other) {
         return other != folder && other->cleanPath() == folder->cleanPath();
     });
@@ -975,7 +975,7 @@ Folder *FolderMan::folderForPath(const QString &path)
 {
     QString absolutePath = QDir::cleanPath(path) + QLatin1Char('/');
 
-    const auto &folders = this->map().values();
+    const auto folders = this->map().values();
     const auto it = std::find_if(folders.cbegin(), folders.cend(), [absolutePath](const auto *folder) {
         const QString folderPath = folder->cleanPath() + QLatin1Char('/');
         return absolutePath.startsWith(folderPath, (Utility::isWindows() || Utility::isMac()) ? Qt::CaseInsensitive : Qt::CaseSensitive);

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -914,11 +914,10 @@ Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition 
     // Migration: The first account that's configured for a local folder shall
     // be saved in a backwards-compatible way.
     const auto folderList = FolderMan::instance()->map();
-    const auto it = std::find_if(folderList.cbegin(), folderList.cend(), [this, folder](const auto *other) {
+    const auto oneAccountOnly = std::none_of(folderList.cbegin(), folderList.cend(), [this, folder](const auto *other) {
         return other != folder && other->cleanPath() == folder->cleanPath();
     });
 
-    bool oneAccountOnly = it == folderList.cend();
     folder->setSaveBackwardsCompatible(oneAccountOnly);
 
     if (folder) {


### PR DESCRIPTION
A different take on issue #2219 replacing previous PR #2240.

As #2240 would become a bit unwieldly trying to get all instances of `foreach`/`Q_FOREACH` fixed in one go, I've split the patches here along source/module boundaries. Hopefully this will make it easier to review, test and merge, as it can be merged before every instance is converted.

I'll keep pushing to this branch for now, but feel free to merge at any time once you're happy with it. I'll just make a new PR for the next batch of convertions. 

For the most part, I've replaced `foreach` with range based for statements, but in some instances where I think it made more sense I've replaced with the `std::find_if`algorithm instead.

I think I've avoided any unneccessary detaching of Qcontainers, but let me know if you see anything suspicious.