### PR TITLE
Make sure we don't assert when calling fileStatus

### DIFF
--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -290,8 +290,14 @@ void SyncFileStatusTracker::slotSyncFinished()
     // Clear the sync counts to reduce the impact of unsymetrical inc/dec calls (e.g. when directory job abort)
     QHash<QString, int> oldSyncCount;
     std::swap(_syncCount, oldSyncCount);
-    for (auto it = oldSyncCount.begin(); it != oldSyncCount.end(); ++it)
+    for (auto it = oldSyncCount.begin(); it != oldSyncCount.end(); ++it) {
+        // Don't announce folders, fileStatus expect only paths without '/', otherwise it asserts
+        if (it.key().endsWith('/')) {
+            continue;
+        }
+
         emit fileStatusChanged(getSystemDestination(it.key()), fileStatus(it.key()));
+    }
 }
 
 void SyncFileStatusTracker::slotSyncEngineRunningChanged()


### PR DESCRIPTION
It happens that sometimes we leak a directory path ending with a slash,
but that violates fileStatus' precondition so let's catch it early and
skip such path.

Of course the right fix would be a larger swipe in the sync engine and
around it to not use naked strings anymore but rely on the typesystem.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>