### PR TITLE
[stable-3.0] Show the "Display mnemonic" button only when we know e2e is supported

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -205,7 +205,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
         auto *mnemonic = new QAction(tr("Display mnemonic"), this);
         connect(mnemonic, &QAction::triggered, this, &AccountSettings::requesetMnemonic);
         _ui->encryptionMessage->addAction(mnemonic);
-        _ui->encryptionMessage->show();
+        _ui->encryptionMessage->hide();
     }
 
     connect(UserModel::instance(), &UserModel::addAccount,
@@ -841,6 +841,10 @@ void AccountSettings::slotAccountStateChanged()
          */
         qCInfo(lcAccountSettings) << "Account" << accountsState()->account()->displayName()
             << "Client Side Encryption" << accountsState()->account()->capabilities().clientSideEncryptionAvailable();
+
+        if (_accountState->account()->capabilities().clientSideEncryptionAvailable()) {
+            _ui->encryptionMessage->show();
+        }
     }
 }
 


### PR DESCRIPTION
Turns out that showing the button straight from the page ctor is a bit
too early. At that point the account might not be connected yet and thus
we wouldn't have proper information. Currently we were displaying that
button all the time, now we wait for the account to be connected to
decide to show it or not.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>