### PR TITLE
Enable all the misc clang-tidy check except one

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,7 @@
 Checks: '-*,
     cppcoreguidelines-init-variables,
+    misc-*,
+    -misc-non-private-member-variables-in-classes,
     modernize-avoid-bind,
     modernize-concat-nested-namespaces,
     modernize-deprecated-headers,

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -47,6 +47,7 @@ QString getUserAutostartDir_private()
 
 bool hasLaunchOnStartup_private(const QString &appName)
 {
+    Q_UNUSED(appName)
     QString desktopFileLocation = getUserAutostartDir_private()
                                     + QLatin1String(LINUX_APPLICATION_ID)
                                     + QLatin1String(".desktop");
@@ -55,6 +56,7 @@ bool hasLaunchOnStartup_private(const QString &appName)
 
 void setLaunchOnStartup_private(const QString &appName, const QString &guiName, bool enable)
 {
+    Q_UNUSED(appName)
     QString userAutoStartPath = getUserAutostartDir_private();
     QString desktopFileLocation = userAutoStartPath
                                     + QLatin1String(LINUX_APPLICATION_ID)

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -249,6 +249,7 @@ void WebFlowCredentials::persist() {
 
 void WebFlowCredentials::slotWriteClientCertPEMJobDone(KeychainChunk::WriteJob *writeJob)
 {
+    Q_UNUSED(writeJob)
     // write ssl key if there is one
     if (!_clientSslKey.isNull()) {
         auto job = new KeychainChunk::WriteJob(_account,
@@ -295,6 +296,7 @@ void WebFlowCredentials::writeSingleClientCaCertPEM()
 
 void WebFlowCredentials::slotWriteClientKeyPEMJobDone(KeychainChunk::WriteJob *writeJob)
 {
+    Q_UNUSED(writeJob)
     _clientSslCaCertificatesWriteQueue.clear();
 
     // write ca certs if there are any

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -159,6 +159,7 @@ void WebFlowCredentialsDialog::slotShowSettingsDialog()
 
 void WebFlowCredentialsDialog::slotFlow2AuthResult(Flow2Auth::Result r, const QString &errorString, const QString &user, const QString &appPassword)
 {
+    Q_UNUSED(errorString)
     if(r == Flow2Auth::LoggedIn) {
         emit urlCatched(user, appPassword, QString());
     } else {

--- a/src/gui/ocssharejob.cpp
+++ b/src/gui/ocssharejob.cpp
@@ -144,6 +144,7 @@ void OcsShareJob::createShare(const QString &path,
     const QString &shareWith,
     const Share::Permissions permissions)
 {
+    Q_UNUSED(permissions)
     setVerb("POST");
 
     addParam(QString::fromLatin1("path"), path);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -248,6 +248,8 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     bool allDisconnected = true;
     QVector<AccountStatePtr> problemAccounts;
     auto setStatusText = [&](const QString &text) {
+        // FIXME: So this doesn't do anything? Needs to be revisited
+        Q_UNUSED(text)
         // Don't overwrite the status if we're currently syncing
         if (FolderMan::instance()->currentSyncFolder())
             return;

--- a/src/gui/remotewipe.cpp
+++ b/src/gui/remotewipe.cpp
@@ -25,7 +25,8 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcRemoteWipe, "nextcloud.gui.remotewipe", QtInfoMsg)
 
 RemoteWipe::RemoteWipe(AccountPtr account, QObject *parent)
-    : _account(account),
+    : QObject(parent),
+      _account(account),
       _appPassword(QString()),
       _accountRemoved(false),
       _networkManager(nullptr),

--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -469,6 +469,7 @@ void SocketApi::command_SHARE_MENU_TITLE(const QString &, SocketListener *listen
 
 void SocketApi::command_EDIT(const QString &localFile, SocketListener *listener)
 {
+    Q_UNUSED(listener)
     auto fileData = FileData::get(localFile);
     if (!fileData.folder) {
         qCWarning(lcSocketApi) << "Unknown path" << localFile;

--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -35,7 +35,7 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcActivity, "nextcloud.gui.activity", QtInfoMsg)
 
 ActivityListModel::ActivityListModel(AccountState *accountState, QObject *parent)
-    : QAbstractListModel()
+    : QAbstractListModel(parent)
     , _accountState(accountState)
 {
 }

--- a/src/gui/wizard/flow2authcredspage.cpp
+++ b/src/gui/wizard/flow2authcredspage.cpp
@@ -75,6 +75,7 @@ void OCC::Flow2AuthCredsPage::cleanupPage()
 
 void Flow2AuthCredsPage::slotFlow2AuthResult(Flow2Auth::Result r, const QString &errorString, const QString &user, const QString &appPassword)
 {
+    Q_UNUSED(errorString)
     switch (r) {
     case Flow2Auth::NotSupported: {
         /* Flow2Auth not supported (can't open browser) */

--- a/test/stubremotewipe.cpp
+++ b/test/stubremotewipe.cpp
@@ -14,7 +14,7 @@ const QMetaObject OCC::AccountManager::staticMetaObject = QObject::staticMetaObj
 
 OCC::FolderMan *OCC::FolderMan::instance() { return static_cast<FolderMan *>(new QObject); }
 void OCC::FolderMan::wipeDone(OCC::AccountState*, bool) { }
-OCC::Folder* OCC::FolderMan::addFolder(OCC::AccountState* as, OCC::FolderDefinition const &f) { return nullptr; }
+OCC::Folder* OCC::FolderMan::addFolder(OCC::AccountState*, OCC::FolderDefinition const &) { return nullptr; }
 void OCC::FolderMan::slotWipeFolderForAccount(OCC::AccountState*) { }
 QString OCC::FolderMan::unescapeAlias(QString const&){ return QString(); }
 QString OCC::FolderMan::escapeAlias(QString const&){ return QString(); }


### PR DESCRIPTION
This flagged mostly unused parameters. Didn't enable the
misc-non-private-member-variables-in-classes check as we got a lot of
those. Hopefully we'll get to fix them at some point but that feels too
early and too much work for now.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>