### PR TITLE
Disable context menu actions for E2EE files and folders

### DIFF
--- a/src/gui/socketapi.h
+++ b/src/gui/socketapi.h
@@ -120,7 +120,7 @@ private:
     Q_INVOKABLE void command_GET_STRINGS(const QString &argument, SocketListener *listener);
 
     // Sends the context menu options relating to sharing to listener
-    void sendSharingContextMenuOptions(const FileData &fileData, SocketListener *listener);
+    void sendSharingContextMenuOptions(const FileData &fileData, SocketListener *listener, bool enabled);
 
     /** Send the list of menu item. (added in version 1.1)
      * argument is a list of files for which the menu should be shown, separated by '\x1e'


### PR DESCRIPTION
Those files and folders are not shareable and the "Edit" or "Open in
browser" actions will lead to showing an error in the web GUI. No need
to lead users there so just disable them.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>