### PR TITLE
Use httpd/unix-directory mimetype for E2EE folders

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1361,6 +1361,11 @@ void FolderMetadata::setupExistingMetadata(const QByteArray& metadata)
         file.mimetype = decryptedFileObj["mimetype"].toString().toLocal8Bit();
         file.fileVersion = decryptedFileObj["version"].toInt();
 
+        // In case we wrongly stored "inode/directory" we try to recover from it
+        if (file.mimetype == QByteArrayLiteral("inode/directory")) {
+            file.mimetype = QByteArrayLiteral("httpd/unix-directory");
+        }
+
         _files.push_back(file);
     }
 }

--- a/src/libsync/propagateuploadencrypted.cpp
+++ b/src/libsync/propagateuploadencrypted.cpp
@@ -175,6 +175,12 @@ void PropagateUploadEncrypted::slotFolderEncryptedMetadataReceived(const QJsonDo
 
       QMimeDatabase mdb;
       encryptedFile.mimetype = mdb.mimeTypeForFile(info).name().toLocal8Bit();
+
+      // Other clients expect "httpd/unix-directory" instead of "inode/directory"
+      // Doesn't matter much for us since we don't do much about that mimetype anyway
+      if (encryptedFile.mimetype == QByteArrayLiteral("inode/directory")) {
+          encryptedFile.mimetype = QByteArrayLiteral("httpd/unix-directory");
+      }
   }
 
   _item->_encryptedFileName = _remoteParentPath + QLatin1Char('/') + encryptedFile.encryptedFilename;


### PR DESCRIPTION
We don't do much with that mimetype on our end, but other clients
somehow don't expect inode/directory to let's lie. ;-)

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>

Fix #2319