### PR TITLE
Fix clang tidy errors in csync tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: qt-5.12
 
 steps:
 - name: cmake
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -11,7 +11,7 @@ steps:
     - cd /drone/build
     - cmake -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_BUILD_TYPE=Debug -DNO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../src
 - name: compile
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -19,7 +19,7 @@ steps:
     - cd /drone/build
     - make -j$(nproc)
 - name: test
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -46,7 +46,7 @@ name: qt-5.12-clang
 
 steps:
 - name: cmake
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -54,7 +54,7 @@ steps:
     - cd /drone/build
     - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Debug -DNO_SHIBBOLETH=1 -DBUILD_UPDATER=ON -DUNIT_TESTING=1 -DSANITIZE_ADDRESS=ON ../src
 - name: compile
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -62,7 +62,7 @@ steps:
     - cd /drone/build
     - ninja
 - name: test
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build
@@ -72,7 +72,7 @@ steps:
     - chown -R test:test .
     - su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test
 - name: clang-tidy
-  image: nextcloudci/client-5.12:client-5.12-10
+  image: nextcloudci/client-5.12:client-5.12-11
   volumes:
     - name: build
       path: /drone/build

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -73,7 +73,7 @@ static int setup_init(void **state) {
 }
 
 static int teardown(void **state) {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     auto statedb = csync->statedb;

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -642,7 +642,7 @@ static void check_csync_excluded_performance(void **)
     // Being able to use QElapsedTimer for measurement would be nice...
     {
         struct timeval before, after;
-        gettimeofday(&before, 0);
+        gettimeofday(&before, nullptr);
 
         for (i = 0; i < N; ++i) {
             totalRc += check_dir_full("/this/is/quite/a/long/path/with/many/components");
@@ -650,7 +650,7 @@ static void check_csync_excluded_performance(void **)
         }
         assert_int_equal(totalRc, CSYNC_NOT_EXCLUDED); // mainly to avoid optimization
 
-        gettimeofday(&after, 0);
+        gettimeofday(&after, nullptr);
 
         const double total = (after.tv_sec - before.tv_sec)
                 + (after.tv_usec - before.tv_usec) / 1.0e6;
@@ -660,7 +660,7 @@ static void check_csync_excluded_performance(void **)
 
     {
         struct timeval before, after;
-        gettimeofday(&before, 0);
+        gettimeofday(&before, nullptr);
 
         for (i = 0; i < N; ++i) {
             totalRc += check_dir_traversal("/this/is/quite/a/long/path/with/many/components");
@@ -668,7 +668,7 @@ static void check_csync_excluded_performance(void **)
         }
         assert_int_equal(totalRc, CSYNC_NOT_EXCLUDED); // mainly to avoid optimization
 
-        gettimeofday(&after, 0);
+        gettimeofday(&after, nullptr);
 
         const double total = (after.tv_sec - before.tv_sec)
                 + (after.tv_usec - before.tv_usec) / 1.0e6;

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -652,8 +652,8 @@ static void check_csync_excluded_performance(void **)
 
         gettimeofday(&after, nullptr);
 
-        const double total = (after.tv_sec - before.tv_sec)
-                + (after.tv_usec - before.tv_usec) / 1.0e6;
+        const auto total = static_cast<double>(after.tv_sec - before.tv_sec)
+                + static_cast<double>(after.tv_usec - before.tv_usec) / 1.0e6;
         const double perCallMs = total / 2 / N * 1000;
         printf("csync_excluded: %f ms per call\n", perCallMs);
     }
@@ -670,8 +670,8 @@ static void check_csync_excluded_performance(void **)
 
         gettimeofday(&after, nullptr);
 
-        const double total = (after.tv_sec - before.tv_sec)
-                + (after.tv_usec - before.tv_usec) / 1.0e6;
+        const auto total = static_cast<double>(after.tv_sec - before.tv_sec)
+                + static_cast<double>(after.tv_usec - before.tv_usec) / 1.0e6;
         const double perCallMs = total / 2 / N * 1000;
         printf("csync_excluded_traversal: %f ms per call\n", perCallMs);
     }

--- a/test/csync/csync_tests/check_csync_exclude.cpp
+++ b/test/csync/csync_tests/check_csync_exclude.cpp
@@ -18,10 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "config_csync.h"
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 #include <sys/time.h>
-#include <stdio.h>
+#include <cstdio>
 
 #define CSYNC_TEST 1
 #include "csync_exclude.cpp"

--- a/test/csync/csync_tests/check_csync_misc.cpp
+++ b/test/csync/csync_tests/check_csync_misc.cpp
@@ -18,7 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include "common/utility.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include "torture.h"
 
 static void check_csync_normalize_etag(void **state)

--- a/test/csync/csync_tests/check_csync_update.cpp
+++ b/test/csync/csync_tests/check_csync_update.cpp
@@ -146,7 +146,7 @@ static int setup_ftw(void **state)
 
 static int teardown(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
 
     unlink(TESTDB);
     auto statedb = csync->statedb;
@@ -216,7 +216,7 @@ static int failing_fn(CSYNC *ctx,
 /* detect a new file */
 static void check_csync_detect_update(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_file_stat_t *st = nullptr;
     std::unique_ptr<csync_file_stat_t> fs;
     int rc = 0;
@@ -239,7 +239,7 @@ static void check_csync_detect_update(void **state)
  */
 static void check_csync_detect_update_db_none(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_file_stat_t *st = nullptr;
     std::unique_ptr<csync_file_stat_t> fs;
     int rc = 0;
@@ -260,7 +260,7 @@ static void check_csync_detect_update_db_none(void **state)
 
 static void check_csync_detect_update_db_eval(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_file_stat_t *st = nullptr;
     std::unique_ptr<csync_file_stat_t> fs;
     int rc = 0;
@@ -281,7 +281,7 @@ static void check_csync_detect_update_db_eval(void **state)
 
 static void check_csync_detect_update_db_rename(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     // csync_file_stat_t *st;
 
     std::unique_ptr<csync_file_stat_t> fs;
@@ -306,7 +306,7 @@ static void check_csync_detect_update_db_rename(void **state)
 
 static void check_csync_detect_update_db_new(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_file_stat_t *st = nullptr;
     std::unique_ptr<csync_file_stat_t> fs;
     int rc = 0;
@@ -327,7 +327,7 @@ static void check_csync_detect_update_db_new(void **state)
 
 static void check_csync_ftw(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     rc = csync_ftw(csync, "/tmp", csync_walker, MAX_DEPTH);
@@ -336,7 +336,7 @@ static void check_csync_ftw(void **state)
 
 static void check_csync_ftw_empty_uri(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     rc = csync_ftw(csync, "", csync_walker, MAX_DEPTH);
@@ -345,7 +345,7 @@ static void check_csync_ftw_empty_uri(void **state)
 
 static void check_csync_ftw_failing_fn(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     rc = csync_ftw(csync, "/tmp", failing_fn, MAX_DEPTH);

--- a/test/csync/encoding_tests/check_encoding.cpp
+++ b/test/csync/encoding_tests/check_encoding.cpp
@@ -17,7 +17,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#include <stdio.h>
+#include <cstdio>
 #include "c_string.h"
 #include "c_utf8.h"
 #include "common/filesystembase.h"

--- a/test/csync/torture.h
+++ b/test/csync/torture.h
@@ -24,9 +24,9 @@
 extern "C" {
 #endif
 
-#include <stdarg.h>
-#include <stddef.h>
-#include <setjmp.h>
+#include <stdarg.h> // NOLINT sometimes compiled in C mode
+#include <stddef.h> // NOLINT sometimes compiled in C mode
+#include <setjmp.h> // NOLINT sometimes compiled in C mode
 
 #include <cmocka.h>
 

--- a/test/csync/vio_tests/check_vio.cpp
+++ b/test/csync/vio_tests/check_vio.cpp
@@ -75,7 +75,7 @@ static int setup_dir(void **state) {
 }
 
 static int teardown(void **state) {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     auto statedb = csync->statedb;
@@ -99,7 +99,7 @@ static int teardown(void **state) {
 
 static void check_csync_vio_opendir(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_vio_handle_t *dh = nullptr;
     int rc = 0;
 
@@ -112,7 +112,7 @@ static void check_csync_vio_opendir(void **state)
 
 static void check_csync_vio_opendir_perm(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     csync_vio_handle_t *dh = nullptr;
     int rc = 0;
     mbchar_t *dir = c_utf8_path_to_locale(CSYNC_TEST_DIR);
@@ -132,7 +132,7 @@ static void check_csync_vio_opendir_perm(void **state)
 
 static void check_csync_vio_closedir_null(void **state)
 {
-    CSYNC *csync = (CSYNC*)*state;
+    auto *csync = (CSYNC*)*state;
     int rc = 0;
 
     rc = csync_vio_closedir(csync, nullptr);

--- a/test/csync/vio_tests/check_vio.cpp
+++ b/test/csync/vio_tests/check_vio.cpp
@@ -20,8 +20,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <string.h>
-#include <errno.h>
+#include <cstring>
+#include <cerrno>
 
 #include "csync_private.h"
 #include "std/c_utf8.h"

--- a/test/csync/vio_tests/check_vio_ext.cpp
+++ b/test/csync/vio_tests/check_vio_ext.cpp
@@ -20,9 +20,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <string.h>
-#include <errno.h>
-#include <stdio.h>
+#include <cstring>
+#include <cerrno>
+#include <cstdio>
 
 #include "csync_private.h"
 #include "std/c_utf8.h"

--- a/test/csync/vio_tests/check_vio_ext.cpp
+++ b/test/csync/vio_tests/check_vio_ext.cpp
@@ -230,7 +230,7 @@ static void traverse_dir(void **state, const char *dir, int *cnt)
             if( !sv->result ) {
                 sv->result = c_strdup( subdir_out);
             } else {
-                int newlen = 1+strlen(sv->result)+strlen(subdir_out);
+                const auto newlen = 1 + strlen(sv->result)+strlen(subdir_out);
                 char *tmp = sv->result;
                 sv->result = (char*)c_malloc(newlen);
                 strcpy( sv->result, tmp);
@@ -406,7 +406,7 @@ static void check_readdir_longtree(void **state)
 "<DIR> C:/tmp/csync_test/vierzig/mann/auf/des/toten/Mann/kiste/ooooooooooooooooooooooh/and/ne/bottle/voll/rum/und/so/singen/wir/VIERZIG/MANN/AUF/DES/TOTEN/MANNS/KISTE/OOOOOOOOH/AND/NE/BOTTLE/VOLL/RUM/undnochmalallezusammen/VierZig/MannaufDesTotenManns/KISTE/ooooooooooooooooooooooooooohhhhhh/und/BESSER/ZWEI/Butteln/VOLL RUM";
 
     /* assemble the result string ... */
-    int overall_len = 1+strlen(r1)+strlen(r2)+strlen(r3);
+    const auto overall_len = 1 + strlen(r1) + strlen(r2) + strlen(r3);
     int files_cnt = 0;
     char *result = (char*)c_malloc(overall_len);
     *result = '\0';

--- a/test/csync/vio_tests/check_vio_ext.cpp
+++ b/test/csync/vio_tests/check_vio_ext.cpp
@@ -94,7 +94,7 @@ static int setup_testenv(void **state) {
     c_free_locale_string(dir);
 
     /* --- initialize csync */
-    statevar *mystate = (statevar*)malloc( sizeof(statevar) );
+    auto *mystate = (statevar*)malloc( sizeof(statevar) );
     mystate->result = nullptr;
 
     mystate->csync = new CSYNC("/tmp/check_csync1", new OCC::SyncJournalDb(""));
@@ -118,7 +118,7 @@ static void output( const char *text )
 }
 
 static int teardown(void **state) {
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
     CSYNC *csync = sv->csync;
     int rc = 0;
 
@@ -187,7 +187,7 @@ static void traverse_dir(void **state, const char *dir, int *cnt)
 {
     csync_vio_handle_t *dh = nullptr;
     std::unique_ptr<csync_file_stat_t> dirent;
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
     CSYNC *csync = sv->csync;
     char *subdir = nullptr;
     char *subdir_out = nullptr;
@@ -304,7 +304,7 @@ static void create_file( const char *path, const char *name, const char *content
 
 static void check_readdir_shorttree(void **state)
 {
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
 
     const char *t1 = "alibaba/und/die/vierzig/räuber/";
     create_dirs( t1 );
@@ -323,7 +323,7 @@ static void check_readdir_shorttree(void **state)
 
 static void check_readdir_with_content(void **state)
 {
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
     int files_cnt = 0;
 
     const char *t1 = "warum/nur/40/Räuber/";
@@ -347,7 +347,7 @@ static void check_readdir_with_content(void **state)
 
 static void check_readdir_longtree(void **state)
 {
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
 
     /* Strange things here: Compilers only support strings with length of 4k max.
      * The expected result string is longer, so it needs to be split up in r1, r2 and r3
@@ -424,7 +424,7 @@ static void check_readdir_longtree(void **state)
 // https://github.com/owncloud/client/issues/3128 https://github.com/owncloud/client/issues/2777
 static void check_readdir_bigunicode(void **state)
 {
-    statevar *sv = (statevar*) *state;
+    auto *sv = (statevar*) *state;
 //    1: ? ASCII: 239 - EF
 //    2: ? ASCII: 187 - BB
 //    3: ? ASCII: 191 - BF

--- a/test/csync/vio_tests/check_vio_ext.cpp
+++ b/test/csync/vio_tests/check_vio_ext.cpp
@@ -430,7 +430,7 @@ static void check_readdir_bigunicode(void **state)
 //    3: ? ASCII: 191 - BF
 //    4: ASCII: 32    - 20
 
-    char *p = 0;
+    char *p = nullptr;
     asprintf( &p, "%s/%s", CSYNC_TEST_DIR, "goodone/" );
     int rc = _tmkdir(p, MKDIR_MASK);
     assert_int_equal(rc, 0);


### PR DESCRIPTION
This depends on nextcloud/docker-ci#241 being merged and tagged as client-5.12-11 first.