### PR TITLE
syncjournaldb: index e2eMangledName column in metadata

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -745,6 +745,15 @@ bool SyncJournalDb::updateMetadataTableStructure()
         commitInternal("update database structure: add contentChecksum col for uploadinfo");
     }
 
+    if (true) {
+        SqlQuery query(_db);
+        query.prepare("CREATE INDEX IF NOT EXISTS metadata_e2e_id ON metadata(e2eMangledName);");
+        if (!query.exec()) {
+            sqlFail("updateMetadataTableStructure: create index e2eMangledName", query);
+            re = false;
+        }
+        commitInternal("update database structure: add e2eMangledName index");
+    }
 
     return re;
 }


### PR DESCRIPTION
Add an index on the e2eMangledName column in the metadata table
to speed up file sync by orders of magnitude on directories with
a large number of files.

Signed-off-by: Jan Schmidt <jan@centricular.com>


-- Someone in our house dropped 1.4 million files / 800GB into their Nextcloud directory, and the desktop client spent the next few days chewing 100% CPU, almost entirely doing lookups on e2eMangledName in the metadata table. With this index, it was up and synching in a few minutes.