### PR TITLE
Leave the implicit uint to int cast

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -105,25 +105,16 @@ public:
 
     void storeHash(uint hash)
     {
-        int bits = bit_cast(hash);
-        hashBits.setBit((bits & 0xFFFF) % NumBits);
-        hashBits.setBit((bits >> 16) % NumBits);
+        hashBits.setBit((hash & 0xFFFF) % NumBits); // NOLINT it's uint all the way and the modulo puts us back in the 0..1023 range
+        hashBits.setBit((hash >> 16) % NumBits); // NOLINT
     }
     bool isHashMaybeStored(uint hash) const
     {
-        int bits = bit_cast(hash);
-        return hashBits.testBit((bits & 0xFFFF) % NumBits)
-            && hashBits.testBit((bits >> 16) % NumBits);
+        return hashBits.testBit((hash & 0xFFFF) % NumBits) // NOLINT
+            && hashBits.testBit((hash >> 16) % NumBits); // NOLINT
     }
 
 private:
-    static int bit_cast(uint input)
-    {
-        int output = 0;
-        std::memcpy(&output, &input, sizeof(int));
-        return output;
-    }
-
     QBitArray hashBits;
 };
 


### PR DESCRIPTION
I wrongly (and stupidly) assumed the int in QBitArray was treated as a
hash as well but it is an index so it must be positive. Also to make
things even worse I misread on which expression clang-tidy was
complaining regarding the implementation specific narrowing
conversion... This is happening after the modulo operator and not
before. We're in a safe range of values at that point, so it's fine to
let the narrowing happen.
    
Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>