### PR TITLE
Don't use a confusing "royal you" in the sync messages

### DIFF
--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -364,18 +364,19 @@ void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
             activity._fileAction = "file_changed";
         }
 
-
         if (item->_status == SyncFileItem::NoStatus || item->_status == SyncFileItem::Success) {
             qCWarning(lcActivity) << "Item " << item->_file << " retrieved successfully.";
-            
-            if (activity._fileAction == "file_renamed") {
-                activity._message.prepend(tr("You renamed") + " ");
+
+            if (item->_direction != SyncFileItem::Up) {
+                activity._message = tr("Synced %1").arg(item->_originalFile);
+            } else if (activity._fileAction == "file_renamed") {
+                activity._message = tr("You renamed %1").arg(item->_originalFile);
             } else if (activity._fileAction == "file_deleted") {
-                activity._message.prepend(tr("You deleted") + " ");
+                activity._message = tr("You deleted %1").arg(item->_originalFile);
             } else if (activity._fileAction == "file_created") {
-                activity._message.prepend(tr("You created") + " ");
+                activity._message = tr("You created %1").arg(item->_originalFile);
             } else {
-                activity._message.prepend(tr("You changed") + " ");
+                activity._message = tr("You changed %1").arg(item->_originalFile);
             }
 
             _activityModel->addSyncFileItemToActivityList(activity);


### PR DESCRIPTION
Users get rightfully confused with the "You changed ..." messages in the
activity list for syncs. Indeed, some of those changes might be coming
from the server in which case we don't really know who did the change.

So now we use the old "Synced ..." messages for changes pulled from the
server and we have a more precise "You changed ..." (renamed, deleted,
created) when the changes were initiated locally (since there we know
the user reading the message did it).

Also changed how the messages are constructed so that they can be
properly translated.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>