### PR TITLE
Use native text rendering for qml windows

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -14,6 +14,7 @@
  */
 #include <QtGlobal>
 
+#include <cmath>
 #include <csignal>
 
 #ifdef Q_OS_UNIX
@@ -34,6 +35,7 @@
 #include <QMessageBox>
 #include <QDebug>
 #include <QQuickStyle>
+#include <QQuickWindow>
 
 using namespace OCC;
 
@@ -98,6 +100,15 @@ int main(int argc, char **argv)
         app.showVersion();
         return 0;
     }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
+#else
+    // See https://bugreports.qt.io/browse/QTBUG-70481
+    if (std::fmod(app.devicePixelRatio(), 1) == 0) {
+        QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
+    }
+#endif
 
 // check a environment variable for core dumps
 #ifdef Q_OS_UNIX


### PR DESCRIPTION
This makes the text renderer use the same text rendering as the rest of the OS. I find the way Qt renders QML text to be "blurrier" than how the OS handles text rendering. 

It is mostly noticeable on the top part of the text.

Before (Arch KDE and Windows):
![before-linux](https://user-images.githubusercontent.com/2388657/92834480-132d1b80-f3a8-11ea-9439-261a6bc47a45.png)

After (Arch KDE):
![after-linux](https://user-images.githubusercontent.com/2388657/92834490-16280c00-f3a8-11ea-9531-a969d797dc46.png)

Note: depending on the Qt version, there [have been issues](https://bugreports.qt.io/browse/QTBUG-67007) with native text rendering at non-integer scaling. This has been [fixed in Qt 5.14](https://bugreports.qt.io/browse/QTBUG-70481), so the version check could be higher as a quick fix to avoid issues with older qt versions. [A similar fix like KDE](https://invent.kde.org/frameworks/qqc2-desktop-style/-/blob/f8e56a22721057107bccdf319da36ff82ca2a804/org.kde.desktop/Label.qml#L25) could also be applied for lower than 5.14.

Fix  #2419