### PR TITLE
Include list info in tooltip

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -540,9 +540,9 @@ Window {
 
                     ToolTip {
                         visible: activityMouseArea.containsMouse
-                        text: activityTextTitle.text
+                        text: activityTextTitle.text + ((activityTextInfo.text !== "") ? "\n\n" + activityTextInfo.text : "")
                         delay: 250
-                        timeout: 3000
+                        timeout: 10000
                     }
                 }
                 Button {


### PR DESCRIPTION
The info text is now included in the tooltip.

The tooltip timeout was also removed.
I dislike when the tooltips close themselves when I'm reading them. Many frameworks seem to recommend tooltips to show for as long as possible - while also making them easy to disappear when the mouse moves away - which Qt seems to handle well.