### PR TITLE
Use QGuiApplication::primaryScreen() as fallback for Systray::currentScreen()

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -211,7 +211,9 @@ QScreen *Systray::currentScreen() const
         }
     }
 
-    return nullptr;
+    // Didn't find anything matching the cursor position,
+    // falling back to the primary screen
+    return QGuiApplication::primaryScreen();
 }
 
 Systray::TaskBarPosition Systray::taskbarOrientation() const


### PR DESCRIPTION
Under Wayland QCursor::pos() is unlikely to give us anything meaningful,
so fallback to the primary screen information.

Fix #2405

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>