### PR TITLE
Disable bugprone-forward-declaration-namespace check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: '-*,
     bugprone-*,
+    -bugprone-forward-declaration-namespace,
     cppcoreguidelines-init-variables,
     misc-*,
     -misc-non-private-member-variables-in-classes,


### PR DESCRIPTION
Turns out this clang-tidy check can give false positives coming from
headers outside the project while it shouldn't.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>