### PR TITLE
Remove "This includes" due to tooltip order

### DIFF
--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -344,7 +344,7 @@ void ActivityListModel::addIgnoredFileToList(Activity newActivity)
     bool duplicate = false;
     if (_listOfIgnoredFiles.size() == 0) {
         _notificationIgnoredFiles = newActivity;
-        _notificationIgnoredFiles._subject = tr("Files from the ignore list as well as symbolic links are not synced. This includes:");
+        _notificationIgnoredFiles._subject = tr("Files from the ignore list as well as symbolic links are not synced.");
         _listOfIgnoredFiles.append(newActivity);
         return;
     }


### PR DESCRIPTION
After the tooltip update, I noticed that the "info" message tooltip has "This Includes:" as the info text, which looks a bit odd now.

![Screenshot_20200915_170859](https://user-images.githubusercontent.com/2388657/93269521-1e53c300-f77d-11ea-912f-04e3ea7b503f.png)

I thus removed the text. However, I'm not sure about other places this could happen.

One possible other way to fix this would be to switch the info and title in the tooltip, but then that wouldn't match the list view unless that was also swapped as well.

(I'm not sure how this should be designed, or if this current fix is ok)