### PR TITLE
Fix incomplete journal upgrade from 2.x to 3.x

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -239,7 +239,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
                 Folder *f = addFolderInternal(folderDefinition, account.data());
                 f->saveToSettings();
 
-                return;
+                continue;
             }
 
             // Migration: ._ files sometimes don't work


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Reason: Silly _return_ within upgrade routine, breaking the overall folder iteration. Assuming this is caused because a "break" is indeed needed within this branch, but _continue_ is the way to go here.

Fixes #2279 