### PR TITLE
If there's no description just say nothing

### DIFF
--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -202,9 +202,6 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case ActionTextColorRole:
         return a._id == -1 ? QLatin1String("#808080") : QLatin1String("#222");   // FIXME: This is a temporary workaround for _showMoreActivitiesAvailableEntry
     case MessageRole:
-        if (a._message.isEmpty()) {
-            return QString("No description available.");
-        }
         return a._message;
     case LinkRole: {
         if (a._link.isEmpty()) {


### PR DESCRIPTION
Otherwise we get lots of "No description available" lines in the
activity list which is basically noise. Also trains the user to ignore
the secondary line.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>