### PR TITLE
Fix missing subdirectory discovery on move operations in macOS

### DIFF
--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -19,6 +19,7 @@
 
 
 #include <cerrno>
+#include <QDirIterator>
 #include <QStringList>
 
 
@@ -90,8 +91,6 @@ void FolderWatcherPrivate::startWatching()
 
     FSEventStreamContext ctx = { 0, this, nullptr, nullptr, nullptr };
 
-    // TODO: Add kFSEventStreamCreateFlagFileEvents ?
-
     _stream = FSEventStreamCreate(nullptr,
         &callback,
         &ctx,
@@ -105,9 +104,27 @@ void FolderWatcherPrivate::startWatching()
     FSEventStreamStart(_stream);
 }
 
+QStringList FolderWatcherPrivate::addCoalescedPaths(const QStringList &paths) const
+{
+    QStringList coalescedPaths;
+    for (const auto &eventPath : paths) {
+        if (QDir(eventPath).exists()) {
+            QDirIterator it(eventPath, QDir::AllDirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+            while (it.hasNext()) {
+                auto subfolder = it.next();
+                if (!paths.contains(subfolder)) {
+                    coalescedPaths.append(subfolder);
+                }
+            }
+        }
+    }
+    return (paths + coalescedPaths);
+}
+
 void FolderWatcherPrivate::doNotifyParent(const QStringList &paths)
 {
-    _parent->changeDetected(paths);
+    const QStringList totalPaths = addCoalescedPaths(paths);
+    _parent->changeDetected(totalPaths);
 }
 
 

--- a/src/gui/folderwatcher_mac.h
+++ b/src/gui/folderwatcher_mac.h
@@ -37,6 +37,7 @@ public:
     void removePath(const QString &) {}
 
     void startWatching();
+    QStringList addCoalescedPaths(const QStringList &) const;
     void doNotifyParent(const QStringList &);
 
 private:


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Fixes #2176 (and I think I remember similar issues, may or may not be closed duplicates already).
Fixes #1681 
Fixes #1630
Fixes #1083 

Summary:

- On macOS, [FSEventStreamCreate](https://developer.apple.com/documentation/coreservices/1443980-fseventstreamcreate?language=objc) is used for monitoring folder changes
- In general, move and copy operations are handled differently in terms of IO on most unxoids
- Due to the way FSEventStreamCreate works, move operations of folders into the NC folder may coalesce into a single event (means: Only the moved folder path is contained within the event stream)
- Due to the way NC code works, the path list passed from the folderwatcher_xxx.cpp is assumed to be complete for the upcoming traversal (e.g. all folder paths including subfolders are present in the list)

I chose to solve this by modifying the mac-specific folder watcher implementation as this is the way with the smallest overall code impact. Following a FSEventStreamCreate event notification, the contained pathlist is first passed to a new function that checks for possibly coalesced subfolder paths for every entry. If found, they are added to the pathlist and finally passed as const to doNotifyParent, just as before.

Even though one could perftune this with a lower-level iterator, I do not expect a noticable impact from this even for moderately large folder movements, thus the Qt-way was chosen for recursive traversal checks.