### PR TITLE
Force tooltip wrap mode because it's not enabled in Qt 5.12...

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -539,10 +539,18 @@ Window {
                     }
 
                     ToolTip {
+                        id: toolTip
                         visible: activityMouseArea.containsMouse
                         text: activityTextTitle.text + ((activityTextInfo.text !== "") ? "\n\n" + activityTextInfo.text : "")
                         delay: 250
                         timeout: 10000
+                        // Can be dropped on more recent Qt, but on 5.12 it doesn't wrap...
+                        contentItem: Text {
+                            text: toolTip.text
+                            font: toolTip.font
+                            wrapMode: Text.Wrap
+                            color: toolTip.palette.toolTipText
+                        }
                     }
                 }
                 Button {


### PR DESCRIPTION
Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>