### PR TITLE
Connect signal guiLog to slot to display systray message.

### DIFF
--- a/src/gui/tray/NotificationHandler.cpp
+++ b/src/gui/tray/NotificationHandler.cpp
@@ -92,7 +92,7 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         auto json = element.toObject();
         a._type = Activity::NotificationType;
         a._accName = ai->account()->displayName();
-        a._id = json.value("activity_id").toInt();
+        a._id = json.value("notification_id").toInt();
 
         //need to know, specially for remote_share
         a._objectType = json.value("object_type").toString();

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -7,6 +7,7 @@
 #include "ocsjob.h"
 #include "configfile.h"
 #include "notificationconfirmjob.h"
+#include "logger.h"
 
 #include <QDesktopServices>
 #include <QIcon>
@@ -45,6 +46,8 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     connect(_account->account().data(), &Account::accountChangedDisplayName, this, &User::nameChanged);
 
     connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &User::hasLocalFolderChanged);
+
+    connect(this, &User::guiLog, Logger::instance(), &Logger::guiLog);
 }
 
 void User::slotBuildNotificationDisplay(const ActivityList &list)


### PR DESCRIPTION
And correct the object name returned by the api - the id was always 0 so
no new systray messages were displayed.

![notification](https://user-images.githubusercontent.com/241266/94578501-17967700-0278-11eb-92d7-bc959f1ecb3d.png)
