### PR TITLE
Windows MSI: Update Docs & add SKIPAUTOUPDATE property

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -60,6 +60,9 @@
         </DirectorySearch>
     </Property>
 
+    <!-- Property to disable update checks -->
+    <Property Id="SKIPAUTOUPDATE" Value="0" />
+
     <!-- Quit / restart application -->
     <util:RestartResource ProcessName="$(var.AppExe)" />
 
@@ -163,8 +166,8 @@
     </Directory>
 
     <DirectoryRef Id="TARGETDIR">
-        <Component Id="RegistryEntries" Guid="*" Win64="no">
-            <!-- Version numbers used to detect existing installation (use 32-bit registry like NSIS does) -->
+        <!-- Version numbers used to detect existing installation (use 32-bit registry like NSIS does) -->
+        <Component Id="RegistryVersionInfo" Guid="*" Win64="no">
             <RegistryKey Root="HKLM" Key="Software\$(var.AppVendor)\$(var.AppName)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
                 <RegistryValue Type="string" Value="[INSTALLDIR]" />
                 <RegistryValue Type="integer" Name="VersionMajor" Value="$(var.VerMajor)" />
@@ -176,6 +179,14 @@
                 <RegistryValue Type="string" Name="InstallerProductCode" Value="[ProductCode]" />
             </RegistryKey>
         </Component>
+
+        <!-- Platform bitness-dependent settings -->
+        <Component Id="RegistryDefaultSettings" Guid="*" Win64="$(var.PlatformWin64)">
+            <RegistryKey Root="HKLM" Key="Software\$(var.AppVendor)\$(var.AppName)">
+                <!-- Property to disable update checks -->
+                <RegistryValue Type="integer" Name="skipUpdateCheck" Value="[SKIPAUTOUPDATE]" />
+            </RegistryKey>
+        </Component>
     </DirectoryRef>
 
     <!-- Features -->
@@ -183,7 +194,8 @@
         Description="$(var.AppName) $(var.VerDesc)">
         <ComponentGroupRef Id="ClientFiles" />
 
-        <ComponentRef Id="RegistryEntries" />
+        <ComponentRef Id="RegistryVersionInfo" />
+        <ComponentRef Id="RegistryDefaultSettings" />
 
         <Feature Id="ShellExtensions" Title="Integration for Windows Explorer"
             Description="This feature requires a reboot." >

--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -192,7 +192,7 @@
             <Condition Level="0">(NO_SHELL_EXTENSIONS=1)</Condition>
         </Feature>
 
-        <Feature Id="StartMenuShortcut" Title="Start Menu Shortcut">
+        <Feature Id="StartMenuShortcuts" Title="Start Menu Shortcut">
             <ComponentRef Id="StartMenuIcon" />
             <Condition Level="0">(NO_START_MENU_SHORTCUTS=1)</Condition>
         </Feature>

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -2,7 +2,7 @@
 Installing the Desktop Synchronization Client
 =============================================
 
-You can download the  latest version of the Nextcloud Desktop Synchronization
+You can download the latest version of the Nextcloud Desktop Synchronization
 Client from the `Nextcloud download page`_.
 There are clients for Linux, macOs, and Microsoft Windows.
 
@@ -42,7 +42,7 @@ System Requirements
 Customizing the Windows Installation
 ------------------------------------
 
-If you just want to install ownCloud Desktop Synchronization Client on your local
+If you just want to install Nextcloud Desktop Synchronization Client on your local
 system, you can simply launch the `.msi` file and configure it in the wizard
 that pops up.
 
@@ -53,13 +53,13 @@ The MSI installer provides several features that can be installed or removed
 individually, which you can also control via command-line, if you are automating
 the installation, then run the following command::
 
-   msiexec /passive /i ownCloud-x.y.z.msi
+   msiexec /passive /i Nextcloud-x.y.z.msi
 
-The command will install the ownCloud Desktop Synchronization Client into the default location
+The command will install the Nextcloud Desktop Synchronization Client into the default location
 with the default features enabled.
 If you want to disable, e.g., desktop shortcut icons you can simply change the above command to the following::
 
-   msiexec /passive /i ownCloud-x.y.z.msi REMOVE=DesktopShortcut
+   msiexec /passive /i Nextcloud-x.y.z.msi REMOVE=DesktopShortcut
 
 See the following table for a list of available features:
 
@@ -80,20 +80,20 @@ Installation
 
 You can also choose to only install the client itself by using the following command::
 
-  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT=Client
+  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT=Client
 
 If you for instance want to install everything but the ``DesktopShortcut`` and the ``ShellExtensions`` feature, you have two possibilities:
 
 1. You explicitly name all the features you actually want to install (whitelist) where `Client` is always installed anyway::
 
-  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT=StartMenuShortcuts
+  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT=StartMenuShortcuts
 
 2. You pass the `NO_DESKTOP_SHORTCUT` and `NO_SHELL_EXTENSIONS` properties::
 
-  msiexec /passive /i ownCloud-x.y.z.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
+  msiexec /passive /i Nextcloud-x.y.z.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
 
 .. NOTE::
-The ownCloud `.msi` remembers these properties, so you don't need to specify them on upgrades.
+The Nextcloud `.msi` remembers these properties, so you don't need to specify them on upgrades.
 
 .. NOTE::
 You cannot use these to change the installed features, if you want to do that, see the next section.
@@ -105,11 +105,11 @@ You can change the installed features later by using `REMOVE` and `ADDDEFAULT` p
 
 1. If you want to add the the desktop shortcut later, run the following command::
 
-  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT="DesktopShortcut"
+  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT="DesktopShortcut"
 
 2. If you want to remove it, simply run the following command::
 
-  msiexec /passive /i ownCloud-x.y.z.msi REMOVE="DesktopShortcut"
+  msiexec /passive /i Nextcloud-x.y.z.msi REMOVE="DesktopShortcut"
 
 Windows keeps track of the installed features and using `REMOVE` or `ADDDEFAULT` will only affect the mentioned features.
 
@@ -126,7 +126,7 @@ Installation Folder
 You can adjust the installation folder by specifying the `INSTALLDIR`
 property like this::
 
-  msiexec /passive /i ownCloud-x.y.z.msi INSTALLDIR="C:\Program Files (x86)\Non Standard ownCloud Client Folder"
+  msiexec /passive /i Nextcloud-x.y.z.msi INSTALLDIR="C:\Program Files (x86)\Non Standard Nextcloud Client Folder"
 
 Be careful when using PowerShell instead of `cmd.exe`, it can be tricky to get
 the whitespace escaping right there.
@@ -137,14 +137,14 @@ Disabling Automatic Updates
 
 To disable automatic updates, you can pass the `SKIPAUTOUPDATE` property.::
 
-    msiexec /passive /i ownCloud-x.y.z.msi SKIPAUTOUPDATE="1"
+    msiexec /passive /i Nextcloud-x.y.z.msi SKIPAUTOUPDATE="1"
 
 Launch After Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To launch the client automatically after installation, you can pass the `LAUNCH` property.::
 
-    msiexec /i ownCloud-x.y.z.msi LAUNCH="1"
+    msiexec /i Nextcloud-x.y.z.msi LAUNCH="1"
 
 This option also removes the checkbox to let users decide if they want to launch the client
 for non passive/quiet mode.
@@ -155,15 +155,15 @@ This option does not have any effect without GUI.
 No Reboot After Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ownCloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.
+The Nextcloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.
 If you're taking care of the reboot yourself, you can set the `REBOOT` property::
 
-    msiexec /i ownCloud-x.y.z.msi REBOOT=ReallySuppress
+    msiexec /i Nextcloud-x.y.z.msi REBOOT=ReallySuppress
 
 This will make `msiexec` exit with error `ERROR_SUCCESS_REBOOT_REQUIRED` (3010).
 If your deployment tooling interprets this as an actual error and you want to avoid that, you may want to set the `DO_NOT_SCHEDULE_REBOOT` instead::
 
-    msiexec /i ownCloud-x.y.z.msi DO_NOT_SCHEDULE_REBOOT="1"
+    msiexec /i Nextcloud-x.y.z.msi DO_NOT_SCHEDULE_REBOOT="1"
 
 Installation Wizard
 -------------------

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -53,13 +53,13 @@ The MSI installer provides several features that can be installed or removed
 individually, which you can also control via command-line, if you are automating
 the installation, then run the following command::
 
-   msiexec /passive /i Nextcloud-x.y.z.msi
+   msiexec /passive /i Nextcloud-x.y.z-x64.msi
 
 The command will install the Nextcloud Desktop Synchronization Client into the default location
 with the default features enabled.
 If you want to disable, e.g., desktop shortcut icons you can simply change the above command to the following::
 
-   msiexec /passive /i Nextcloud-x.y.z.msi REMOVE=DesktopShortcut
+   msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE=DesktopShortcut
 
 See the following table for a list of available features:
 
@@ -80,17 +80,17 @@ Installation
 
 You can also choose to only install the client itself by using the following command::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT=Client
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=Client
 
 If you for instance want to install everything but the ``DesktopShortcut`` and the ``ShellExtensions`` feature, you have two possibilities:
 
 1. You explicitly name all the features you actually want to install (whitelist) where `Client` is always installed anyway::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT=StartMenuShortcuts
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT=StartMenuShortcuts
 
 2. You pass the `NO_DESKTOP_SHORTCUT` and `NO_SHELL_EXTENSIONS` properties::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
 
 .. NOTE::
 The Nextcloud `.msi` remembers these properties, so you don't need to specify them on upgrades.
@@ -105,11 +105,11 @@ You can change the installed features later by using `REMOVE` and `ADDDEFAULT` p
 
 1. If you want to add the the desktop shortcut later, run the following command::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi ADDDEFAULT="DesktopShortcut"
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi ADDDEFAULT="DesktopShortcut"
 
 2. If you want to remove it, simply run the following command::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi REMOVE="DesktopShortcut"
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi REMOVE="DesktopShortcut"
 
 Windows keeps track of the installed features and using `REMOVE` or `ADDDEFAULT` will only affect the mentioned features.
 
@@ -126,7 +126,7 @@ Installation Folder
 You can adjust the installation folder by specifying the `INSTALLDIR`
 property like this::
 
-  msiexec /passive /i Nextcloud-x.y.z.msi INSTALLDIR="C:\Program Files (x86)\Non Standard Nextcloud Client Folder"
+  msiexec /passive /i Nextcloud-x.y.z-x64.msi INSTALLDIR="C:\Program Files\Non Standard Nextcloud Client Folder"
 
 Be careful when using PowerShell instead of `cmd.exe`, it can be tricky to get
 the whitespace escaping right there.
@@ -137,14 +137,14 @@ Disabling Automatic Updates
 
 To disable automatic updates, you can pass the `SKIPAUTOUPDATE` property.::
 
-    msiexec /passive /i Nextcloud-x.y.z.msi SKIPAUTOUPDATE="1"
+    msiexec /passive /i Nextcloud-x.y.z-x64.msi SKIPAUTOUPDATE="1"
 
 Launch After Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To launch the client automatically after installation, you can pass the `LAUNCH` property.::
 
-    msiexec /i Nextcloud-x.y.z.msi LAUNCH="1"
+    msiexec /i Nextcloud-x.y.z-x64.msi LAUNCH="1"
 
 This option also removes the checkbox to let users decide if they want to launch the client
 for non passive/quiet mode.
@@ -158,12 +158,12 @@ No Reboot After Installation
 The Nextcloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.
 If you're taking care of the reboot yourself, you can set the `REBOOT` property::
 
-    msiexec /i Nextcloud-x.y.z.msi REBOOT=ReallySuppress
+    msiexec /i Nextcloud-x.y.z-x64.msi REBOOT=ReallySuppress
 
 This will make `msiexec` exit with error `ERROR_SUCCESS_REBOOT_REQUIRED` (3010).
 If your deployment tooling interprets this as an actual error and you want to avoid that, you may want to set the `DO_NOT_SCHEDULE_REBOOT` instead::
 
-    msiexec /i Nextcloud-x.y.z.msi DO_NOT_SCHEDULE_REBOOT="1"
+    msiexec /i Nextcloud-x.y.z-x64.msi DO_NOT_SCHEDULE_REBOOT="1"
 
 Installation Wizard
 -------------------

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -39,11 +39,11 @@ System Requirements
 .. note::
    For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous LTS.
 
-Customizing the Windows installation
+Customizing the Windows Installation
 ------------------------------------
 
 If you just want to install ownCloud Desktop Synchronization Client on your local
-system, you can simply launch the .msi file and configure it in the wizard
+system, you can simply launch the `.msi` file and configure it in the wizard
 that pops up.
 
 Features
@@ -51,13 +51,13 @@ Features
 
 The MSI installer provides several features that can be installed or removed
 individually, which you can also control via command-line, if you are automating
-the installation::
+the installation, then run the following command::
 
    msiexec /passive /i ownCloud-x.y.z.msi
 
-will install the ownCloud Desktop Synchronization Client into the default location
-with the default features enabled. If you want to disable, e.g., desktop shortcut
-icons you can simply change the above command to::
+The command will install the ownCloud Desktop Synchronization Client into the default location
+with the default features enabled.
+If you want to disable, e.g., desktop shortcut icons you can simply change the above command to the following::
 
    msiexec /passive /i ownCloud-x.y.z.msi REMOVE=DesktopShortcut
 
@@ -93,21 +93,21 @@ If you for instance want to install everything but the ``DesktopShortcut`` and t
   msiexec /passive /i ownCloud-x.y.z.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
 
 .. NOTE::
-The ownCloud .msi remembers these properties, so you don't need to specify them on upgrades.
+The ownCloud `.msi` remembers these properties, so you don't need to specify them on upgrades.
 
 .. NOTE::
 You cannot use these to change the installed features, if you want to do that, see the next section.
 
-Changing installed features
+Changing Installed Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can change the installed features later by using `REMOVE` and `ADDDEFAULT` properties.
 
-1. If you want to add the the desktop shortcut later::
+1. If you want to add the the desktop shortcut later, run the following command::
 
   msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT="DesktopShortcut"
 
-2. If you want to remove it, simply do::
+2. If you want to remove it, simply run the following command::
 
   msiexec /passive /i ownCloud-x.y.z.msi REMOVE="DesktopShortcut"
 
@@ -120,7 +120,7 @@ on the Windows Installer Guide.
 .. NOTE::
 You cannot specify `REMOVE` on initial installation as it will disable all features.
 
-Installation folder
+Installation Folder
 ^^^^^^^^^^^^^^^^^^^
 
 You can adjust the installation folder by specifying the `INSTALLDIR`
@@ -129,18 +129,17 @@ property like this::
   msiexec /passive /i ownCloud-x.y.z.msi INSTALLDIR="C:\Program Files (x86)\Non Standard ownCloud Client Folder"
 
 Be careful when using PowerShell instead of `cmd.exe`, it can be tricky to get
-the whitespace escaping right there. Specifying the `INSTALLDIR` like this
-only works on first installation, you cannot simply reinvoke the .msi with a
-different path. If you still need to change it, uninstall it first and reinstall
-it with the new path.
+the whitespace escaping right there.
+Specifying the `INSTALLDIR` like this only works on first installation, you cannot simply re-invoke the `.msi` with a different path. If you still need to change it, uninstall it first and reinstall it with the new path.
 
-Disabling automatic updates
+Disabling Automatic Updates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 To disable automatic updates, you can pass the `SKIPAUTOUPDATE` property.::
 
     msiexec /passive /i ownCloud-x.y.z.msi SKIPAUTOUPDATE="1"
 
-Launch after installation
+Launch After Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To launch the client automatically after installation, you can pass the `LAUNCH` property.::
@@ -153,7 +152,7 @@ for non passive/quiet mode.
 .. NOTE::
 This option does not have any effect without GUI.
 
-No reboot after installation
+No Reboot After Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ownCloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -63,17 +63,17 @@ If you want to disable, e.g., desktop shortcut icons you can simply change the a
 
 See the following table for a list of available features:
 
-+--------------------+--------------------+----------------------------------+---------------------------+
-| Feature            | Enabled by default | Description                      |Property to disable        |
-+====================+====================+==================================+===========================+
-| Client             | Yes, required      | The actual client                |                           |
-+--------------------+--------------------+----------------------------------+---------------------------+
-| DesktopShortcut    | Yes                | Adds a shortcut to the desktop   |``NO_DESKTOP_SHORTCUT``    |
-+--------------------+--------------------+----------------------------------+---------------------------+
-| StartMenuShortcuts | Yes                | Adds shortcuts to the start menu |``NO_START_MENU_SHORTCUTS``|
-+--------------------+--------------------+----------------------------------+---------------------------+
-| ShellExtensions    | Yes                | Adds Explorer integration        |``NO_SHELL_EXTENSIONS``    |
-+--------------------+--------------------+----------------------------------+---------------------------+
++--------------------+--------------------+-----------------------------------+---------------------------+
+| Feature            | Enabled by default | Description                       |Property to disable        |
++====================+====================+===================================+===========================+
+| Client             | Yes, required      | The actual client                 |                           |
++--------------------+--------------------+-----------------------------------+---------------------------+
+| DesktopShortcut    | Yes                | Adds a shortcut to the desktop    |``NO_DESKTOP_SHORTCUT``    |
++--------------------+--------------------+-----------------------------------+---------------------------+
+| StartMenuShortcuts | Yes                | Adds a shortcut to the start menu |``NO_START_MENU_SHORTCUTS``|
++--------------------+--------------------+-----------------------------------+---------------------------+
+| ShellExtensions    | Yes                | Adds Explorer integration         |``NO_SHELL_EXTENSIONS``    |
++--------------------+--------------------+-----------------------------------+---------------------------+
 
 Installation
 ~~~~~~~~~~~~

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -28,7 +28,8 @@ System Requirements
 ----------------------------------
 
 - Windows 8.1+
-- macOS 10.7+ (**64-bit only**)
+- macOS 10.12+ (**64-bit only**)
+- macOS 10.10 & 10.11 (**64-bit and up to client legacy version 2.6.5 only**)
 - CentOS 6 & 7 (64-bit only)
 - Debian 8.0 & 9.0
 - Fedora 25 & 26 & 27

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -39,6 +39,133 @@ System Requirements
 .. note::
    For Linux distributions, we support, if technically feasible, the latest 2 versions per platform and the previous LTS.
 
+Customizing the Windows installation
+------------------------------------
+
+If you just want to install ownCloud Desktop Synchronization Client on your local
+system, you can simply launch the .msi file and configure it in the wizard
+that pops up.
+
+Features
+^^^^^^^^
+
+The MSI installer provides several features that can be installed or removed
+individually, which you can also control via command-line, if you are automating
+the installation::
+
+   msiexec /passive /i ownCloud-x.y.z.msi
+
+will install the ownCloud Desktop Synchronization Client into the default location
+with the default features enabled. If you want to disable, e.g., desktop shortcut
+icons you can simply change the above command to::
+
+   msiexec /passive /i ownCloud-x.y.z.msi REMOVE=DesktopShortcut
+
+See the following table for a list of available features:
+
++--------------------+--------------------+----------------------------------+---------------------------+
+| Feature            | Enabled by default | Description                      |Property to disable        |
++====================+====================+==================================+===========================+
+| Client             | Yes, required      | The actual client                |                           |
++--------------------+--------------------+----------------------------------+---------------------------+
+| DesktopShortcut    | Yes                | Adds a shortcut to the desktop   |``NO_DESKTOP_SHORTCUT``    |
++--------------------+--------------------+----------------------------------+---------------------------+
+| StartMenuShortcuts | Yes                | Adds shortcuts to the start menu |``NO_START_MENU_SHORTCUTS``|
++--------------------+--------------------+----------------------------------+---------------------------+
+| ShellExtensions    | Yes                | Adds Explorer integration        |``NO_SHELL_EXTENSIONS``    |
++--------------------+--------------------+----------------------------------+---------------------------+
+
+Installation
+~~~~~~~~~~~~
+
+You can also choose to only install the client itself by using the following command::
+
+  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT=Client
+
+If you for instance want to install everything but the ``DesktopShortcut`` and the ``ShellExtensions`` feature, you have two possibilities:
+
+1. You explicitly name all the features you actually want to install (whitelist) where `Client` is always installed anyway::
+
+  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT=StartMenuShortcuts
+
+2. You pass the `NO_DESKTOP_SHORTCUT` and `NO_SHELL_EXTENSIONS` properties::
+
+  msiexec /passive /i ownCloud-x.y.z.msi NO_DESKTOP_SHORTCUT="1" NO_SHELL_EXTENSIONS="1"
+
+.. NOTE::
+The ownCloud .msi remembers these properties, so you don't need to specify them on upgrades.
+
+.. NOTE::
+You cannot use these to change the installed features, if you want to do that, see the next section.
+
+Changing installed features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can change the installed features later by using `REMOVE` and `ADDDEFAULT` properties.
+
+1. If you want to add the the desktop shortcut later::
+
+  msiexec /passive /i ownCloud-x.y.z.msi ADDDEFAULT="DesktopShortcut"
+
+2. If you want to remove it, simply do::
+
+  msiexec /passive /i ownCloud-x.y.z.msi REMOVE="DesktopShortcut"
+
+Windows keeps track of the installed features and using `REMOVE` or `ADDDEFAULT` will only affect the mentioned features.
+
+Compare `REMOVE <https://msdn.microsoft.com/en-us/library/windows/desktop/aa371194(v=vs.85).aspx>`_
+and `ADDDEFAULT <https://msdn.microsoft.com/en-us/library/windows/desktop/aa367518(v=vs.85).aspx>`_
+on the Windows Installer Guide.
+
+.. NOTE::
+You cannot specify `REMOVE` on initial installation as it will disable all features.
+
+Installation folder
+^^^^^^^^^^^^^^^^^^^
+
+You can adjust the installation folder by specifying the `INSTALLDIR`
+property like this::
+
+  msiexec /passive /i ownCloud-x.y.z.msi INSTALLDIR="C:\Program Files (x86)\Non Standard ownCloud Client Folder"
+
+Be careful when using PowerShell instead of `cmd.exe`, it can be tricky to get
+the whitespace escaping right there. Specifying the `INSTALLDIR` like this
+only works on first installation, you cannot simply reinvoke the .msi with a
+different path. If you still need to change it, uninstall it first and reinstall
+it with the new path.
+
+Disabling automatic updates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To disable automatic updates, you can pass the `SKIPAUTOUPDATE` property.::
+
+    msiexec /passive /i ownCloud-x.y.z.msi SKIPAUTOUPDATE="1"
+
+Launch after installation
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To launch the client automatically after installation, you can pass the `LAUNCH` property.::
+
+    msiexec /i ownCloud-x.y.z.msi LAUNCH="1"
+
+This option also removes the checkbox to let users decide if they want to launch the client
+for non passive/quiet mode.
+
+.. NOTE::
+This option does not have any effect without GUI.
+
+No reboot after installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ownCloud Client schedules a reboot after installation to make sure the Explorer extension is correctly (un)loaded.
+If you're taking care of the reboot yourself, you can set the `REBOOT` property::
+
+    msiexec /i ownCloud-x.y.z.msi REBOOT=ReallySuppress
+
+This will make `msiexec` exit with error `ERROR_SUCCESS_REBOOT_REQUIRED` (3010).
+If your deployment tooling interprets this as an actual error and you want to avoid that, you may want to set the `DO_NOT_SCHEDULE_REBOOT` instead::
+
+    msiexec /i ownCloud-x.y.z.msi DO_NOT_SCHEDULE_REBOOT="1"
+
 Installation Wizard
 -------------------
 


### PR DESCRIPTION
- Adopt MSI docs from upstream
  Even though we had to start from scratch with MSI, our implementation is compatible ;-)

- Add the `SKIPAUTOUPDATE` property for the `skipUpdateCheck` registry setting

- Minor tweak: Update macOS system requirement info