### PR TITLE
[stable-2.6] macOS: Fix memory leak in FolderWatcherPrivate::startWatching

### DIFF
--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -101,6 +101,7 @@ void FolderWatcherPrivate::startWatching()
         kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagIgnoreSelf);
 
     CFRelease(pathsToWatch);
+    CFRelease(folderCF);
     FSEventStreamScheduleWithRunLoop(_stream, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
     FSEventStreamStart(_stream);
 }


### PR DESCRIPTION
backport of #2497