### PR TITLE
Handle redirects when downloading updates

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -304,7 +304,9 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
             if (QFile(_targetFile).exists()) {
                 setDownloadState(DownloadComplete);
             } else {
-                QNetworkReply *reply = qnam()->get(QNetworkRequest(QUrl(url)));
+                auto request = QNetworkRequest(QUrl(url));
+                request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+                QNetworkReply *reply = qnam()->get(request);
                 connect(reply, &QIODevice::readyRead, this, &NSISUpdater::slotWriteFile);
                 connect(reply, &QNetworkReply::finished, this, &NSISUpdater::slotDownloadFinished);
                 setDownloadState(Downloading);


### PR DESCRIPTION
This is necessary for downloads coming from Github for instance. They
are systematically redirected and we'd just fail the download.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>