### PR TITLE
Repair the Windows build

### DIFF
--- a/src/libsync/wordlist.h
+++ b/src/libsync/wordlist.h
@@ -4,10 +4,12 @@
 #include <QList>
 #include <QString>
 
+#include "owncloudlib.h"
+
 namespace OCC {
     namespace WordList {
-        QStringList getRandomWords(int nr);
-        QString getUnifiedString(const QStringList& l);
+        OWNCLOUDSYNC_EXPORT QStringList getRandomWords(int nr);
+        OWNCLOUDSYNC_EXPORT QString getUnifiedString(const QStringList& l);
     }
 }
 


### PR DESCRIPTION
This is due to #2520 which forgot to export the newly used symbols.
This made it to stable-3.0 as #2524 so this one will need to be backported as well.