### PR TITLE
Connection wizard improvements

### DIFF
--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -240,9 +240,9 @@
            </layout>
           </item>
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="addressDescriptionLabel">
             <property name="text">
-             <string>This is the link to your Nextcloud web interface when you open it in the browser.&lt;br/&gt; It looks like https://cloud.example.com or https://example.com/cloud</string>
+             <string>This is the link to your %1 web interface when you open it in the browser.&lt;br/&gt;It looks like https://cloud.example.com or https://example.com/cloud</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -378,7 +378,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Log in to your Nextcloud</string>
+        <string>Log in to your %1</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>
@@ -488,8 +488,6 @@
    <header>wizard/slideshow.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../../theme.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -221,10 +221,16 @@
             <item>
              <widget class="QLabel" name="urlLabel">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>24</width>
+                <height>24</height>
+               </size>
               </property>
               <property name="text">
                <string/>

--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -234,6 +234,16 @@
            </layout>
           </item>
           <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>This is the link to your Nextcloud web interface when you open it in the browser.&lt;br/&gt; It looks like https://cloud.example.com or https://example.com/cloud</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="errorLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">

--- a/src/gui/wizard/owncloudsetupnocredspage.ui
+++ b/src/gui/wizard/owncloudsetupnocredspage.ui
@@ -340,7 +340,7 @@
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>Register with a provider</string>
+        <string>Sign up with a provider</string>
        </property>
        <property name="default">
         <bool>false</bool>
@@ -362,7 +362,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Log in</string>
+        <string>Log in to your Nextcloud</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -175,14 +175,15 @@ void OwncloudSetupPage::slotUrlChanged(const QString &url)
         _ui.leUrl->setText(newUrl);
     }
 
-    if (!url.startsWith(QLatin1String("https://"))) {
-        _ui.urlLabel->setPixmap(QPixmap(Theme::hidpiFileName(":/client/theme/lock-http.svg")));
-        _ui.urlLabel->setToolTip(tr("This URL is NOT secure as it is not encrypted.\n"
-                                    "It is not advisable to use it."));
-    } else {
-        _ui.urlLabel->setPixmap(QPixmap(Theme::hidpiFileName(":/client/theme/lock-https.svg")));
-        _ui.urlLabel->setToolTip(tr("This URL is secure. You can use it."));
-    }
+    const auto isSecure = url.startsWith(QLatin1String("https://"));
+    const auto toolTip = isSecure ? tr("This URL is secure. You can use it.")
+                                  : tr("This URL is NOT secure as it is not encrypted.\n"
+                                       "It is not advisable to use it.");
+    const auto pixmap = isSecure ? QPixmap(Theme::hidpiFileName(":/client/theme/lock-https.svg"))
+                                 : QPixmap(Theme::hidpiFileName(":/client/theme/lock-http.svg"));
+
+    _ui.urlLabel->setToolTip(toolTip);
+    _ui.urlLabel->setPixmap(pixmap.scaled(_ui.urlLabel->size(), Qt::KeepAspectRatio));
 }
 
 void OwncloudSetupPage::slotUrlEditFinished()

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -91,6 +91,11 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
     _ui.slideShow->hide();
 #endif
 
+    const auto appName = Theme::instance()->appNameGUI();
+    _ui.loginButton->setText(tr("Log in to your %1").arg(appName));
+    _ui.addressDescriptionLabel->setText(tr("This is the link to your %1 web interface when you open it in the browser.<br/>"
+                                            "It looks like https://cloud.example.com or https://example.com/cloud").arg(appName));
+
     customizeStyle();
 }
 

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -125,6 +125,10 @@ void OwncloudSetupPage::setupCustomization()
 #ifdef WITH_PROVIDERS
 void OwncloudSetupPage::slotLogin()
 {
+    _ui.slideShow->hide();
+    _ui.nextButton->hide();
+    _ui.prevButton->hide();
+
     _ocWizard->setRegistration(false);
     _ui.login->setMaximumHeight(0);
     auto *animation = new QPropertyAnimation(_ui.login, "maximumHeight");


### PR DESCRIPTION
Fix #1158
Fix #1160

This now looks like this:

![Screenshot_20201008_174152](https://user-images.githubusercontent.com/1411800/95481693-8fa62080-098d-11eb-806e-e8855828d985.png)

And on the login page:

![Screenshot_20201008_174230](https://user-images.githubusercontent.com/1411800/95481762-a51b4a80-098d-11eb-84f9-5b16542f359e.png)

When an error happens (didn't really change that behavior but previously it was doing weird things with the lock icon):

![Screenshot_20201008_174311](https://user-images.githubusercontent.com/1411800/95481834-bebc9200-098d-11eb-83eb-cdd275de8daf.png)

