### PR TITLE
Fix share dialog animation for enforced password policy

### DIFF
--- a/src/gui/sharedialog.cpp
+++ b/src/gui/sharedialog.cpp
@@ -184,6 +184,10 @@ void ShareDialog::initLinkShareWidget(){
         _emptyShareLinkWidget = new ShareLinkWidget(_accountState->account(), _sharePath, _localPath, _maxSharingPermissions, this);
         _linkWidgetList.append(_emptyShareLinkWidget);
 
+        if (_manager) {
+            connect(_manager, &ShareManager::linkShareRequiresPassword, _emptyShareLinkWidget, &ShareLinkWidget::slotCreateShareRequiresPassword);
+        }
+
         connect(_emptyShareLinkWidget, &ShareLinkWidget::resizeRequested, this, &ShareDialog::slotAdjustScrollWidgetSize);
 //        connect(this, &ShareDialog::toggleAnimation, _emptyShareLinkWidget, &ShareLinkWidget::slotToggleAnimation);
         connect(_emptyShareLinkWidget, &ShareLinkWidget::createLinkShare, this, &ShareDialog::slotCreateLinkShare);

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -401,7 +401,7 @@ void ShareLinkWidget::slotDeleteAnimationFinished()
 
 void ShareLinkWidget::slotCreateShareRequiresPassword(const QString &message)
 {
-    slotToggleAnimation(true);
+    slotToggleAnimation(message.isEmpty());
 
     showPasswordOptions(true);
     if (!message.isEmpty()) {

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -133,9 +133,8 @@ void Share::deleteShare()
 
 void Share::slotDeleted()
 {
-    emit shareDeleted();
-
     updateFolder(_account, _path);
+    emit shareDeleted();
 }
 
 void Share::slotOcsError(int statusCode, const QString &message)


### PR DESCRIPTION
Without those changes, the spinner would be displayed forever when adding a new link and hitting cancel on the input box asking for the enforced password.