### PR TITLE
Fix crash when clicking on folder with status 403 in the main dialog.

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -1241,7 +1241,7 @@ bool FolderStatusModel::SubFolderInfo::hasLabel() const
 void FolderStatusModel::SubFolderInfo::resetSubs(FolderStatusModel *model, QModelIndex index)
 {
     _fetched = false;
-    delete _fetchingJob;
+    _fetchingJob->deleteLater();
     if (hasLabel()) {
         model->beginRemoveRows(index, 0, 0);
         _fetchingLabel = false;


### PR DESCRIPTION
LsColJob was still being used after delete was called.

![folderview](https://user-images.githubusercontent.com/241266/96599956-bb5fc980-12f0-11eb-9e51-6a74b8562dc9.png)
