### PR TITLE
Avoid depth infinity propfind for e2ee

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1241,19 +1241,23 @@ void ClientSideEncryption::getPublicKeyFromServer()
     job->start();
 }
 
+void ClientSideEncryption::scheduleFolderEncryptedStatusJob(const QString &path)
+{
+    auto getEncryptedStatus = new GetFolderEncryptStatusJob(_account, path);
+    connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusReceived,
+            this, &ClientSideEncryption::folderEncryptedStatusFetched);
+    connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusError,
+            this, &ClientSideEncryption::folderEncryptedStatusError);
+    getEncryptedStatus->start();
+
+    _folderStatusJobs.append(getEncryptedStatus);
+}
+
 void ClientSideEncryption::fetchFolderEncryptedStatus()
 {
     _refreshingEncryptionStatus = true;
     _folder2encryptedStatus.clear();
-
-    auto getEncryptedStatus = new GetFolderEncryptStatusJob(_account, QString());
-    connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusReceived,
-                    this, &ClientSideEncryption::folderEncryptedStatusFetched);
-    connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusError,
-                    this, &ClientSideEncryption::folderEncryptedStatusError);
-    getEncryptedStatus->start();
-
-    _folderStatusJobs.append(getEncryptedStatus);
+    scheduleFolderEncryptedStatusJob(QString());
 }
 
 void ClientSideEncryption::folderEncryptedStatusFetched(const QHash<QString, bool>& result)

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1243,7 +1243,7 @@ void ClientSideEncryption::getPublicKeyFromServer()
 
 void ClientSideEncryption::scheduleFolderEncryptedStatusJob(const QString &path)
 {
-    auto getEncryptedStatus = new GetFolderEncryptStatusJob(_account, path);
+    auto getEncryptedStatus = new GetFolderEncryptStatusJob(_account, path, this);
     connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusReceived,
             this, &ClientSideEncryption::folderEncryptedStatusFetched);
     connect(getEncryptedStatus, &GetFolderEncryptStatusJob::encryptStatusError,

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1274,8 +1274,17 @@ void ClientSideEncryption::folderEncryptedStatusFetched(const QHash<QString, boo
         _folder2encryptedStatus.insert((*it).first, (*it).second);
     }
 
-    _refreshingEncryptionStatus = false;
-    emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
+    for (const auto &folder : result.keys()) {
+        if (folder == job->folder()) {
+            continue;
+        }
+        scheduleFolderEncryptedStatusJob(folder);
+    }
+
+    if (_folderStatusJobs.isEmpty()) {
+        _refreshingEncryptionStatus = false;
+        emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
+    }
 }
 
 void ClientSideEncryption::folderEncryptedStatusError(int error)
@@ -1287,8 +1296,10 @@ void ClientSideEncryption::folderEncryptedStatusError(int error)
 
     _folderStatusJobs.removeAll(job);
 
-    _refreshingEncryptionStatus = false;
-    emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
+    if (_folderStatusJobs.isEmpty()) {
+        _refreshingEncryptionStatus = false;
+        emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
+    }
 }
 
 FolderMetadata::FolderMetadata(AccountPtr account, const QByteArray& metadata, int statusCode) : _account(account)

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1263,13 +1263,14 @@ void ClientSideEncryption::folderEncryptedStatusFetched(const QHash<QString, boo
 
     _folderStatusJobs.removeAll(job);
 
+    qCDebug(lcCse) << "Retrieved correctly the encrypted status of the folders for" << job->folder() << result;
+
     // FIXME: Can be replaced by _folder2encryptedStatus.insert(result); once we depend on Qt 5.15
     for (auto it = result.constKeyValueBegin(); it != result.constKeyValueEnd(); ++it) {
         _folder2encryptedStatus.insert((*it).first, (*it).second);
     }
 
     _refreshingEncryptionStatus = false;
-    qCDebug(lcCse) << "Retrieved correctly the encrypted status of the folders." << result;
     emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
 }
 
@@ -1278,10 +1279,11 @@ void ClientSideEncryption::folderEncryptedStatusError(int error)
     auto job = static_cast<GetFolderEncryptStatusJob *>(sender());
     Q_ASSERT(job);
 
+    qCDebug(lcCse) << "Failed to retrieve the status of the folders for" << job->folder() << error;
+
     _folderStatusJobs.removeAll(job);
 
     _refreshingEncryptionStatus = false;
-    qCDebug(lcCse) << "Failed to retrieve the status of the folders." << error;
     emit folderEncryptedStatusFetchDone(_folder2encryptedStatus);
 }
 

--- a/src/libsync/clientsideencryption.h
+++ b/src/libsync/clientsideencryption.h
@@ -111,6 +111,7 @@ signals:
     void folderEncryptedStatusFetchDone(const QHash<QString, bool> &values);
 
 private:
+    void scheduleFolderEncryptedStatusJob(const QString &path);
     void getPrivateKeyFromServer();
     void getPublicKeyFromServer();
     void decryptPrivateKey(const QByteArray &key);

--- a/src/libsync/clientsideencryption.h
+++ b/src/libsync/clientsideencryption.h
@@ -23,6 +23,8 @@ class ReadPasswordJob;
 
 namespace OCC {
 
+class GetFolderEncryptStatusJob;
+
 QString baseUrl();
 
 namespace EncryptionHelper {
@@ -125,6 +127,7 @@ private:
     //TODO: Save this on disk.
     QHash<QByteArray, QByteArray> _folder2token;
     QHash<QString, bool> _folder2encryptedStatus;
+    QVector<GetFolderEncryptStatusJob*> _folderStatusJobs;
 
 public:
     //QSslKey _privateKey;

--- a/src/libsync/clientsideencryptionjobs.cpp
+++ b/src/libsync/clientsideencryptionjobs.cpp
@@ -29,6 +29,11 @@ GetFolderEncryptStatusJob::GetFolderEncryptStatusJob(const AccountPtr& account, 
 {
 }
 
+QString GetFolderEncryptStatusJob::folder() const
+{
+    return _folder;
+}
+
 void GetFolderEncryptStatusJob::start()
 {
 	QNetworkRequest req;

--- a/src/libsync/clientsideencryptionjobs.cpp
+++ b/src/libsync/clientsideencryptionjobs.cpp
@@ -40,7 +40,7 @@ void GetFolderEncryptStatusJob::start()
 	req.setPriority(QNetworkRequest::HighPriority);
 	req.setRawHeader("OCS-APIREQUEST", "true");
     req.setHeader(QNetworkRequest::ContentTypeHeader, QByteArrayLiteral("application/xml"));
-    req.setRawHeader("Depth", "infinity");
+    req.setRawHeader("Depth", "1");
 
 	QByteArray xml = R"(<d:propfind xmlns:d="DAV:"> <d:prop xmlns:nc="http://nextcloud.org/ns"> <nc:is-encrypted/> </d:prop> </d:propfind>)";
 	auto *buf = new QBuffer(this);

--- a/src/libsync/clientsideencryptionjobs.h
+++ b/src/libsync/clientsideencryptionjobs.h
@@ -286,6 +286,8 @@ class OWNCLOUDSYNC_EXPORT GetFolderEncryptStatusJob : public AbstractNetworkJob
 public:
 	explicit GetFolderEncryptStatusJob (const AccountPtr &account, const QString& folder, QObject *parent = nullptr);
 
+    QString folder() const;
+
 public slots:
 	void start() override;
 


### PR DESCRIPTION
OK, so after all I'll go for changing the depth of the incriminated PROPFIND call and do the recursive traversal by hand (which means more roundtrips which is a bit unfortunate). I finally did this for several reasons:
 * we get the fix delivered faster in the hand of users;
 * even if we optimized it on the server to somehow complete, it'd still be potentially expensive;
 * also I found today this depth was used in other code paths than the first call when the sync starts which made things worse (and that was clearly the client at fault there so needed fixing anyway).

Fixes #2347 
Fixes nextcloud/end_to_end_encryption#189