### PR TITLE
Fix Dialog display issues

### DIFF
--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -65,6 +65,10 @@ WebFlowCredentialsDialog::WebFlowCredentialsDialog(Account *account, bool useFlo
     auto app = static_cast<Application *>(qApp);
     connect(app, &Application::isShowingSettingsDialog, this, &WebFlowCredentialsDialog::slotShowSettingsDialog);
 
+    // Delay between calls to ownCloudGui::raiseDialog, to not annoy the users while they're switching to the Settings dialog
+    _raiseDelayTimer.setInterval(1000);
+    _raiseDelayTimer.setSingleShot(true);
+
     _errorLabel = new QLabel();
     _errorLabel->hide();
     _containerLayout->addWidget(_errorLabel);
@@ -151,6 +155,11 @@ void WebFlowCredentialsDialog::customizeStyle()
 
 void WebFlowCredentialsDialog::slotShowSettingsDialog()
 {
+    if (_raiseDelayTimer.isActive())
+        return;
+
+    _raiseDelayTimer.start();
+
     // bring window to top but slightly delay, to avoid being hidden behind the SettingsDialog
     QTimer::singleShot(100, this, [this] {
         ownCloudGui::raiseDialog(this);

--- a/src/gui/creds/webflowcredentialsdialog.h
+++ b/src/gui/creds/webflowcredentialsdialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include <QUrl>
+#include <QTimer>
 
 #include "accountfwd.h"
 #include "creds/flow2auth.h"
@@ -57,6 +58,8 @@ private:
     QVBoxLayout *_layout;
     QVBoxLayout *_containerLayout;
     HeaderBanner *_headerBanner;
+
+    QTimer _raiseDelayTimer;
 };
 
 } // namespace OCC

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -654,9 +654,6 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         return;
     }
 
-    // For https://github.com/owncloud/client/issues/3783
-    _settingsDialog->hide();
-
     const auto accountState = folder->accountState();
 
     const QString file = localPath.mid(folder->cleanPath().length() + 1);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -163,9 +163,7 @@ void ownCloudGui::slotOpenSettingsDialog()
 
 void ownCloudGui::slotOpenMainDialog()
 {
-    if (!_tray->isOpen()) {
-        _tray->showWindow();
-    }
+    slotTrayClicked(QSystemTrayIcon::Trigger);
 }
 
 void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
@@ -187,7 +185,6 @@ void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
             } else {
                 _tray->showWindow();
             }
-
         }
     }
     // FIXME: Also make sure that any auto updater dialogue https://github.com/owncloud/client/issues/5613


### PR DESCRIPTION
- Fix display issue with raising Share dialogs while Settings are open
- Modify `ownCloudGui::slotOpenMainDialog` to show the appropriate window(s):
  The previous implementation only considered showing the Tray window, which may lead to undesired behaviour:
  - If there are no accounts configured, the wizard should be shown instead
  - Other open windows would not be shown on second app invocation (Settings, ShareDialog)
- `WebFlowCredentialsDialog`:
  - Add a timer to delay between calls to `ownCloudGui::raiseDialog`, to not annoy the users while they're switching to the Settings dialog

This originally was part of #2197 but is independent.