### PR TITLE
Delay initialization of SettingsDialog

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -59,7 +59,7 @@ const char propertyAccountC[] = "oc_account";
 ownCloudGui::ownCloudGui(Application *parent)
     : QObject(parent)
     , _tray(nullptr)
-    , _settingsDialog(new SettingsDialog(this))
+    , _settingsDialog(nullptr)
     , _logBrowser(nullptr)
 #ifdef WITH_LIBCLOUDPROVIDERS
     , _bus(QDBusConnection::sessionBus())

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -62,7 +62,6 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
 {
     ConfigFile cfg;
 
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     _ui->setupUi(this);
     _toolBar = new QToolBar;
     _toolBar->setIconSize(QSize(32, 32));
@@ -130,6 +129,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
 
     customizeStyle();
 
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     cfg.restoreGeometry(this);
 }
 


### PR DESCRIPTION
As discussed with @er-vin in #2197's review.

- `ownCloudGui::slotShowSettings` already got what it takes to create it only when we try to show it for the first time:

  https://github.com/nextcloud/desktop/blob/2b16ab2565ae7c7a8bfdb86f58daa1d26d342e6e/src/gui/owncloudgui.cpp#L556-L564

  This however has some implications:

  Pros:
  - Only created when needed, while testing saved ca. 20 MB of RAM and got freed again after closing the dialog.
  - Since we defaulted to the new Tray UI from 3.0, this is an added bonus for users don't opening the settings.

  Cons:
  - Resources like the avatar image have to be refetched everytime the dialog is recreated.
    This may be desired as well, because it ensures displaying no outdated info (e.g. on connection issues).

- Fix crash in `SettingsDialog` with delayed initialization 
  `setWindowFlags` triggered `changeEvent`, thus causing a crash in `customizeStyle`.

  This fix should be kept even if we decide against delayed init in the future.