### PR TITLE
Ensure we quickly show/hide the systray window on startup

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -206,6 +206,15 @@ void Systray::positionWindow(QQuickWindow *window) const
     window->setPosition(position);
 }
 
+void Systray::forceWindowInit(QQuickWindow *window) const
+{
+    // HACK: At least on Windows, if the systray window is not shown at least once
+    // it can prevent session handling to carry on properly, so we show/hide it here
+    // this shouldn't flicker
+    window->show();
+    window->hide();
+}
+
 QScreen *Systray::currentScreen() const
 {
     const auto screens = QGuiApplication::screens();

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -57,6 +57,7 @@ public:
     Q_INVOKABLE void setOpened();
     Q_INVOKABLE void setClosed();
     Q_INVOKABLE void positionWindow(QQuickWindow *window) const;
+    Q_INVOKABLE void forceWindowInit(QQuickWindow *window) const;
 
 signals:
     void currentUserChanged();

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -24,6 +24,8 @@ Window {
     Accessible.role: Accessible.Application
     Accessible.name: qsTr("Nextcloud desktop main dialog")
 
+    Component.onCompleted: Systray.forceWindowInit(trayWindow)
+
     // Close tray window when focus is lost (e.g. click somewhere else on the screen)
     onActiveChanged: {
         if(!active) {


### PR DESCRIPTION
This is quick enough that no flickering should appear in practice.

We end up doing this because for some reason on Windows (I dug up deep
into the Windows QPA without nailing it down) not showing that systray
window at least once prevents the app object to return from exec() when
the session ends.

It's as if that window would be in some limbo state (neither opened nor
closed) which would prevent quitting. Clearly what we're doing here is a
workaround...

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>