### PR TITLE
Also output the event flags in the debug logs

### DIFF
--- a/src/gui/folderwatcher_mac.cpp
+++ b/src/gui/folderwatcher_mac.cpp
@@ -72,7 +72,7 @@ static void callback(
         QString fn = qstring.normalized(QString::NormalizationForm_C);
 
         if (!(eventFlags[i] & c_interestingFlags)) {
-            qCDebug(lcFolderWatcher) << "Ignoring non-content changes for" << fn;
+            qCDebug(lcFolderWatcher) << "Ignoring non-content changes for" << fn << eventFlags[i];
             continue;
         }
 


### PR DESCRIPTION
When we skip a watcher event on mac, we log the file path but not the
event flags which came with it. Let's add it, it should help figure out
what's going on with #2578.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>