### PR TITLE
Misc fixes for Windows 7

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -227,6 +227,7 @@ namespace Utility {
     OCSYNC_EXPORT QByteArray conflictFileBaseNameFromPattern(const QByteArray &conflictName);
 
 #ifdef Q_OS_WIN
+    OCSYNC_EXPORT bool registryKeyExists(HKEY hRootKey, const QString &subKey);
     OCSYNC_EXPORT QVariant registryGetKeyValue(HKEY hRootKey, const QString &subKey, const QString &valueName);
     OCSYNC_EXPORT bool registrySetKeyValue(HKEY hRootKey, const QString &subKey, const QString &valueName, DWORD type, const QVariant &value);
     OCSYNC_EXPORT bool registryDeleteKeyTree(HKEY hRootKey, const QString &subKey);

--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -114,6 +114,17 @@ QRect Utility::getTaskbarDimensions()
     return QRect(barRect.left, barRect.top, (barRect.right - barRect.left), (barRect.bottom - barRect.top));
 }
 
+bool Utility::registryKeyExists(HKEY hRootKey, const QString &subKey)
+{
+    HKEY hKey;
+
+    REGSAM sam = KEY_READ | KEY_WOW64_64KEY;
+    LONG result = RegOpenKeyEx(hRootKey, reinterpret_cast<LPCWSTR>(subKey.utf16()), 0, sam, &hKey);
+
+    RegCloseKey(hKey);
+    return result != ERROR_FILE_NOT_FOUND;
+}
+
 QVariant Utility::registryGetKeyValue(HKEY hRootKey, const QString &subKey, const QString &valueName)
 {
     QVariant value;

--- a/src/gui/navigationpanehelper.cpp
+++ b/src/gui/navigationpanehelper.cpp
@@ -66,17 +66,18 @@ void NavigationPaneHelper::updateCloudStorageRegistry()
     // that matches ours when we saved.
     QVector<QUuid> entriesToRemove;
 #ifdef Q_OS_WIN
-    Utility::registryWalkSubKeys(
-        HKEY_CURRENT_USER,
-        QStringLiteral(R"(Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace)"),
-        [&entriesToRemove](HKEY key, const QString &subKey) {
-            QVariant appName = Utility::registryGetKeyValue(key, subKey, QStringLiteral("ApplicationName"));
-            if (appName.toString() == QLatin1String(APPLICATION_NAME)) {
-                QUuid clsid{ subKey };
-                Q_ASSERT(!clsid.isNull());
-                entriesToRemove.append(clsid);
-            }
-        });
+    QString nameSpaceKey = QStringLiteral(R"(Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace)");
+    if (Utility::registryKeyExists(HKEY_CURRENT_USER, nameSpaceKey)) {
+        Utility::registryWalkSubKeys(HKEY_CURRENT_USER, nameSpaceKey,
+            [&entriesToRemove](HKEY key, const QString &subKey) {
+                QVariant appName = Utility::registryGetKeyValue(key, subKey, QStringLiteral("ApplicationName"));
+                if (appName.toString() == QLatin1String(APPLICATION_NAME)) {
+                    QUuid clsid{ subKey };
+                    Q_ASSERT(!clsid.isNull());
+                    entriesToRemove.append(clsid);
+                }
+            });
+    }
 #endif
 
     // Only save folder entries if the option is enabled.

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -238,9 +238,15 @@ Systray::TaskBarPosition Systray::taskbarOrientation() const
     return TaskBarPosition::Top;
 // Windows: Check registry for actual taskbar orientation
 #elif defined(Q_OS_WIN)
-    auto taskbarPosition = Utility::registryGetKeyValue(HKEY_CURRENT_USER,
-        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StuckRects3",
-        "Settings");
+    auto taskbarPositionSubkey = QStringLiteral("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StuckRects3");
+    if (!Utility::registryKeyExists(HKEY_CURRENT_USER, taskbarPositionSubkey)) {
+        // Windows 7
+        taskbarPositionSubkey = QStringLiteral("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StuckRects2");
+    }
+    if (!Utility::registryKeyExists(HKEY_CURRENT_USER, taskbarPositionSubkey)) {
+        return TaskBarPosition::Bottom;
+    }
+    auto taskbarPosition = Utility::registryGetKeyValue(HKEY_CURRENT_USER, taskbarPositionSubkey, "Settings");
     switch (taskbarPosition.toInt()) {
     // Mapping windows binary value (0 = left, 1 = top, 2 = right, 3 = bottom) to qml logic (0 = bottom, 1 = left...)
     case 0:
@@ -393,7 +399,7 @@ QPoint Systray::computeWindowPosition(int width, int height) const
     qCDebug(lcSystray) << "taskbarScreenEdge:" << taskbarScreenEdge;
     qCDebug(lcSystray) << "screenRect:" << screenRect;
     qCDebug(lcSystray) << "windowRect (reference)" << QRect(topLeft, bottomRight);
-    qCDebug(lcSystray) << "windowRect (adjusted )" << windowRect;
+    qCDebug(lcSystray) << "windowRect (adjusted)" << windowRect;
 
     return windowRect.topLeft();
 }


### PR DESCRIPTION
This fixes the following issues with the desktop app on Windows 7:

1. Registry key `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace` does not exist

2. Task bar position is not calculated properly because `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StuckRects3` does not exist, but `StuckRects2` can be used instead