### PR TITLE
Remove last left over of the "remote" wording

### DIFF
--- a/src/gui/conflictdialog.cpp
+++ b/src/gui/conflictdialog.cpp
@@ -153,7 +153,7 @@ void ConflictDialog::updateWidgets()
     const auto remoteVersion = _solver->remoteVersionFilename();
     updateGroup(remoteVersion,
                 _ui->remoteVersionLink,
-                tr("Open remote version"),
+                tr("Open server version"),
                 _ui->remoteVersionMtime,
                 _ui->remoteVersionSize,
                 _ui->remoteVersionButton);


### PR DESCRIPTION
I switched from "remote" to "server" but apparently left one behind by
mistake...

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>

Fix #2588