### PR TITLE
Move journaldb files back to sync folders

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -499,7 +499,7 @@ restart_sync:
     }
 
     Cmd cmd;
-    QString dbPath = options.source_dir + SyncJournalDb::makeDbName(credentialFreeUrl, folder, user);
+    QString dbPath = options.source_dir + SyncJournalDb::makeDbName(options.source_dir, credentialFreeUrl, folder, user);
     SyncJournalDb db(dbPath);
 
     if (!selectiveSyncList.empty()) {

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -499,7 +499,7 @@ restart_sync:
     }
 
     Cmd cmd;
-    QString dbPath = SyncJournalDb::makeDbName(credentialFreeUrl, folder, user);
+    QString dbPath = options.source_dir + SyncJournalDb::makeDbName(credentialFreeUrl, folder, user);
     SyncJournalDb db(dbPath);
 
     if (!selectiveSyncList.empty()) {

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -46,7 +46,8 @@ public:
     virtual ~SyncJournalDb();
 
     /// Create a journal path for a specific configuration
-    static QString makeDbName(const QUrl &remoteUrl,
+    static QString makeDbName(const QString &localPath,
+        const QUrl &remoteUrl,
         const QString &remotePath,
         const QString &user);
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1204,7 +1204,7 @@ QString FolderDefinition::absoluteJournalPath() const
 
 QString FolderDefinition::defaultJournalPath(AccountPtr account)
 {
-    return SyncJournalDb::makeDbName(account->url(), targetPath, account->credentials()->user());
+    return SyncJournalDb::makeDbName(localPath, account->url(), targetPath, account->credentials()->user());
 }
 
 } // namespace OCC

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -51,7 +51,7 @@ public:
     QString alias;
     /// path on local machine
     QString localPath;
-    /// path to the journal, usually in QStandardPaths::AppDataLocation
+    /// path to the journal, usually relative to localPath
     QString journalPath;
     /// path on remote
     QString targetPath;


### PR DESCRIPTION
So after wondering which path to follow regarding this topic I finally went for moving them back to the sync folder... This was the easiest route code wise as well.

Incidentally while updating the migration code I found a couple of concatenations which looked fishy, thus I'm wondering if they were not the cause of the remaining "it lost my selective sync settings" issues which got reported.

It works in my own testing but I definitely welcome more testing with potentially exotic setups since I likely didn't think of everything. Like the previous time it is somewhat a risky move so we'd better be extra careful.