### PR TITLE
Make sure the settings dialog exist before hiding it

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -658,7 +658,9 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
     }
 
     // For https://github.com/owncloud/client/issues/3783
-    _settingsDialog->hide();
+    if (_settingsDialog) {
+        _settingsDialog->hide();
+    }
 
     const auto accountState = folder->accountState();
 


### PR DESCRIPTION
Because of PR #2580 the settings dialog doesn't always exist. We need to
check for it first before placing calls to it.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>