### PR TITLE
Cherry pick updater fixes and improvements

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -163,7 +163,7 @@ IF( APPLE )
     if(SPARKLE_FOUND AND BUILD_UPDATER)
        # Define this, we need to check in updater.cpp
        add_definitions( -DHAVE_SPARKLE )
-       list(APPEND updater_SRCS updater/sparkleupdater_mac.mm)
+       list(APPEND updater_SRCS updater/sparkleupdater_mac.mm updater/sparkleupdater.h)
    endif()
 ENDIF()
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -272,9 +272,25 @@ void GeneralSettings::slotUpdateInfo()
                                       updater->downloadState() != OCUpdater::DownloadComplete);
 
         _ui->autoCheckForUpdatesCheckBox->setChecked(ConfigFile().autoUpdateCheck());
+
+        // Channel selection
+        _ui->updateChannel->setCurrentIndex(ConfigFile().updateChannel() == "beta" ? 1 : 0);
+        connect(_ui->updateChannel, &QComboBox::currentTextChanged,
+            this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
+
     } else {
         // can't have those infos from sparkle currently
         _ui->updatesGroupBox->setVisible(false);
+    }
+}
+
+void GeneralSettings::slotUpdateChannelChanged(const QString &channel)
+{
+    ConfigFile().setUpdateChannel(channel);
+    auto *updater = qobject_cast<OCUpdater *>(Updater::instance());
+    if (updater) {
+        updater->setUpdateUrl(Updater::updateUrl());
+        updater->checkForUpdate();
     }
 }
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -53,6 +53,7 @@ private slots:
     void slotShowLegalNotice();
 #if defined(BUILD_UPDATER)
     void slotUpdateInfo();
+    void slotUpdateChannelChanged(const QString &channel);
     void slotUpdateCheckNow();
     void slotToggleAutoUpdateCheck();
 #endif

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -124,26 +124,46 @@
           </property>
          </widget>
         </item>
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
        </layout>
       </item>
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="updateChannelLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>&amp;Channel</string>
+          </property>
+          <property name="buddy">
+           <cstring>updateChannel</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="updateChannel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>stable</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>beta</string>
+           </property>
+          </item>
+         </widget>
+        </item>
         <item>
          <widget class="QLabel" name="updateStateLabel">
           <property name="text">
@@ -169,22 +189,6 @@
            <string>&amp;Restart &amp;&amp; Update</string>
           </property>
          </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
        </layout>
       </item>

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -202,9 +202,15 @@ void OCUpdater::slotStartInstaller()
         // manually here. We wrap the msiexec and client invocation in a powershell
         // script because owncloud.exe will be shut down for installation.
         // | Out-Null forces powershell to wait for msiexec to finish.
-        QString command = QString("&{msiexec /norestart /passive /i '%1' | Out-Null ; &'%2'}")
-            .arg(QDir::toNativeSeparators(updateFile))
-            .arg(QDir::toNativeSeparators(QCoreApplication::applicationFilePath()));
+        auto preparePathForPowershell = [](QString path) {
+            path.replace("'", "''");
+
+            return QDir::toNativeSeparators(path);
+        };
+
+        QString command = QString("&{msiexec /norestart /passive /i '%1'| Out-Null ; &'%2'}")
+            .arg(preparePathForPowershell(updateFile))
+            .arg(preparePathForPowershell(QCoreApplication::applicationFilePath()));
 
         QProcess::startDetached("powershell.exe", QStringList{"-Command", command});
     }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -298,11 +298,19 @@ void NSISUpdater::slotDownloadFinished()
 
     QUrl url(reply->url());
     _file->close();
+
+    ConfigFile cfg;
+    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+
+    // remove previously downloaded but not used installer
+    QFile oldTargetFile(settings.value(updateAvailableC).toString());
+    if (oldTargetFile.exists()) {
+        oldTargetFile.remove();
+    }
+
     QFile::copy(_file->fileName(), _targetFile);
     setDownloadState(DownloadComplete);
     qCInfo(lcUpdater) << "Downloaded" << url.toString() << "to" << _targetFile;
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
     settings.setValue(updateTargetVersionC, updateInfo().version());
     settings.setValue(updateAvailableC, _targetFile);
 }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -325,7 +325,7 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
             showDialog(info);
         }
         if (!url.isEmpty()) {
-            _targetFile = cfg.configPath() + url.mid(url.lastIndexOf('/'));
+            _targetFile = cfg.configPath() + url.mid(url.lastIndexOf('/')+1);
             if (QFile(_targetFile).exists()) {
                 setDownloadState(DownloadComplete);
             } else {

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -92,6 +92,11 @@ OCUpdater::OCUpdater(const QUrl &url)
 {
 }
 
+void OCUpdater::setUpdateUrl(const QUrl &url)
+{
+    _updateUrl = url;
+}
+
 bool OCUpdater::performUpdate()
 {
     ConfigFile cfg;

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -208,9 +208,11 @@ void OCUpdater::slotStartInstaller()
             return QDir::toNativeSeparators(path);
         };
 
-        QString command = QString("&{msiexec /norestart /passive /i '%1'| Out-Null ; &'%2'}")
-            .arg(preparePathForPowershell(updateFile))
-            .arg(preparePathForPowershell(QCoreApplication::applicationFilePath()));
+        auto msiLogFile = cfg.configPath() + "msi.log";
+        QString command = QString("&{msiexec /norestart /passive /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
+             .arg(preparePathForPowershell(updateFile))
+             .arg(preparePathForPowershell(msiLogFile))
+             .arg(preparePathForPowershell(QCoreApplication::applicationFilePath()));
 
         QProcess::startDetached("powershell.exe", QStringList{"-Command", command});
     }

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -208,7 +208,7 @@ void OCUpdater::slotStartInstaller()
             return QDir::toNativeSeparators(path);
         };
 
-        auto msiLogFile = cfg.configPath() + "msi.log";
+        QString msiLogFile = cfg.configPath() + "msi.log";
         QString command = QString("&{msiexec /norestart /passive /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
              .arg(preparePathForPowershell(updateFile))
              .arg(preparePathForPowershell(msiLogFile))

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -192,8 +192,13 @@ void OCUpdater::slotStartInstaller()
     settings.setValue(autoUpdateAttemptedC, true);
     settings.sync();
     qCInfo(lcUpdater) << "Running updater" << updateFile;
-    QProcess::startDetached(updateFile, QStringList() << "/S"
-                                                      << "/launch");
+
+    if(updateFile.endsWith(".exe")) {
+        QProcess::startDetached(updateFile, QStringList() << "/S"
+                                                        << "/launch");
+    } else {
+        QDesktopServices::openUrl(QUrl("file:///" + updateFile, QUrl::TolerantMode));
+    }
 }
 
 void OCUpdater::checkForUpdate()

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -335,10 +335,16 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
     qint64 infoVersion = Helper::stringVersionToInt(info.version());
     qint64 seenVersion = Helper::stringVersionToInt(settings.value(seenVersionC).toString());
     qint64 currVersion = Helper::currentVersionToInt();
-    if (info.version().isEmpty()
-        || infoVersion <= currVersion
-        || infoVersion <= seenVersion) {
+    if (info.version().isEmpty())
+    {
+        qCInfo(lcUpdater) << "No version information available at the moment";
+        setDownloadState(UpToDate);
+    } else if (infoVersion <= currVersion
+               || infoVersion <= seenVersion) {
         qCInfo(lcUpdater) << "Client is on latest version!";
+        qCInfo(lcUpdater) << "Your version:" << currVersion;
+        qCInfo(lcUpdater) << "Skipped version:" << seenVersion;
+        qCInfo(lcUpdater) << "Available version:" << infoVersion;
         setDownloadState(UpToDate);
     } else {
         QString url = info.downloadUrl();

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -141,19 +141,19 @@ void OCUpdater::backgroundCheckForUpdate()
 
 QString OCUpdater::statusString() const
 {
-    QString updateVersion = _updateInfo.version();
+    QString updateVersion = _updateInfo.versionString();
 
     switch (downloadState()) {
     case Downloading:
-        return tr("Downloading version %1. Please wait …").arg(updateVersion);
+        return tr("Downloading %1. Please wait …").arg(updateVersion);
     case DownloadComplete:
-        return tr("%1 version %2 available. Restart application to start the update.").arg(Theme::instance()->appNameGUI(), updateVersion);
+        return tr("%1 available. Restart application to start the update.").arg(Theme::instance()->appNameGUI(), updateVersion);
     case DownloadFailed:
         return tr("Could not download update. Please click <a href='%1'>here</a> to download the update manually.").arg(_updateInfo.web());
     case DownloadTimedOut:
         return tr("Could not check for new updates.");
     case UpdateOnlyAvailableThroughSystem:
-        return tr("New %1 version %2 is available. Please click <a href='%3'>here</a> to download the update.").arg(Theme::instance()->appNameGUI(), updateVersion, _updateInfo.web());
+        return tr("New %1 is available. Please click <a href='%2'>here</a> to download the update.").arg(updateVersion, _updateInfo.web());
     case CheckingServer:
         return tr("Checking update server …");
     case Unknown:

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -32,7 +32,6 @@ namespace OCC {
 static const char updateAvailableC[] = "Updater/updateAvailable";
 static const char updateTargetVersionC[] = "Updater/updateTargetVersion";
 static const char seenVersionC[] = "Updater/seenVersion";
-static const char autoUpdateFailedVersionC[] = "Updater/autoUpdateFailedVersion";
 static const char autoUpdateAttemptedC[] = "Updater/autoUpdateAttempted";
 
 
@@ -275,7 +274,6 @@ void OCUpdater::slotTimedOut()
 
 NSISUpdater::NSISUpdater(const QUrl &url)
     : OCUpdater(url)
-    , _showFallbackMessage(false)
 {
 }
 
@@ -285,6 +283,18 @@ void NSISUpdater::slotWriteFile()
     if (_file->isOpen()) {
         _file->write(reply->readAll());
     }
+}
+
+void NSISUpdater::wipeUpdateData()
+{
+    ConfigFile cfg;
+    QSettings settings(cfg.configFile(), QSettings::IniFormat);
+    QString updateFileName = settings.value(updateAvailableC).toString();
+    if (!updateFileName.isEmpty())
+        QFile::remove(updateFileName);
+    settings.remove(updateAvailableC);
+    settings.remove(updateTargetVersionC);
+    settings.remove(autoUpdateAttemptedC);
 }
 
 void NSISUpdater::slotDownloadFinished()
@@ -329,12 +339,9 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
         setDownloadState(UpToDate);
     } else {
         QString url = info.downloadUrl();
-        qint64 autoUpdateFailedVersion =
-            Helper::stringVersionToInt(settings.value(autoUpdateFailedVersionC).toString());
-        if (url.isEmpty() || _showFallbackMessage || infoVersion == autoUpdateFailedVersion) {
-            showDialog(info);
-        }
-        if (!url.isEmpty()) {
+        if (url.isEmpty()) {
+            showNoUrlDialog(info);
+        } else {
             _targetFile = cfg.configPath() + url.mid(url.lastIndexOf('/')+1);
             if (QFile(_targetFile).exists()) {
                 setDownloadState(DownloadComplete);
@@ -353,14 +360,15 @@ void NSISUpdater::versionInfoArrived(const UpdateInfo &info)
     }
 }
 
-void NSISUpdater::showDialog(const UpdateInfo &info)
+void NSISUpdater::showNoUrlDialog(const UpdateInfo &info)
 {
     // if the version tag is set, there is a newer version.
     auto *msgBox = new QDialog;
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
+    msgBox->setWindowFlags(msgBox->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    QIcon infoIcon = msgBox->style()->standardIcon(QStyle::SP_MessageBoxInformation, nullptr, nullptr);
-    int iconSize = msgBox->style()->pixelMetric(QStyle::PM_MessageBoxIconSize, nullptr, nullptr);
+    QIcon infoIcon = msgBox->style()->standardIcon(QStyle::SP_MessageBoxInformation);
+    int iconSize = msgBox->style()->pixelMetric(QStyle::PM_MessageBoxIconSize);
 
     msgBox->setWindowIcon(infoIcon);
 
@@ -387,7 +395,6 @@ void NSISUpdater::showDialog(const UpdateInfo &info)
     hlayout->addWidget(lbl);
 
     auto *bb = new QDialogButtonBox;
-    bb->setWindowFlags(bb->windowFlags() & ~Qt::WindowContextHelpButtonHint);
     QPushButton *skip = bb->addButton(tr("Skip this version"), QDialogButtonBox::ResetRole);
     QPushButton *reject = bb->addButton(tr("Skip this time"), QDialogButtonBox::AcceptRole);
     QPushButton *getupdate = bb->addButton(tr("Get update"), QDialogButtonBox::AcceptRole);
@@ -397,14 +404,78 @@ void NSISUpdater::showDialog(const UpdateInfo &info)
     connect(getupdate, &QAbstractButton::clicked, msgBox, &QDialog::accept);
 
     connect(skip, &QAbstractButton::clicked, this, &NSISUpdater::slotSetSeenVersion);
-    connect(getupdate, SIGNAL(clicked()), SLOT(slotOpenUpdateUrl()));
+    connect(getupdate, &QAbstractButton::clicked, this, &NSISUpdater::slotOpenUpdateUrl);
 
     layout->addWidget(bb);
 
     msgBox->open();
 }
 
-NSISUpdater::UpdateState NSISUpdater::updateStateOnStart()
+void NSISUpdater::showUpdateErrorDialog()
+{
+    QDialog *msgBox = new QDialog;
+    msgBox->setAttribute(Qt::WA_DeleteOnClose);
+    msgBox->setWindowFlags(msgBox->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    QIcon infoIcon = msgBox->style()->standardIcon(QStyle::SP_MessageBoxInformation);
+    int iconSize = msgBox->style()->pixelMetric(QStyle::PM_MessageBoxIconSize);
+
+    msgBox->setWindowIcon(infoIcon);
+
+    QVBoxLayout *layout = new QVBoxLayout(msgBox);
+    QHBoxLayout *hlayout = new QHBoxLayout;
+    layout->addLayout(hlayout);
+
+    msgBox->setWindowTitle(tr("Update Failed"));
+
+    QLabel *ico = new QLabel;
+    ico->setFixedSize(iconSize, iconSize);
+    ico->setPixmap(infoIcon.pixmap(iconSize));
+    QLabel *lbl = new QLabel;
+    QString txt = tr("<p>A new version of the %1 Client is available but the updating process failed.</p>"
+                     "<p><b>%2</b> has been downloaded. The installed version is %3.</p>")
+                      .arg(Utility::escape(Theme::instance()->appNameGUI()),
+                          Utility::escape(updateInfo().versionString()), Utility::escape(clientVersion()));
+
+    lbl->setText(txt);
+    lbl->setTextFormat(Qt::RichText);
+    lbl->setWordWrap(true);
+
+    hlayout->addWidget(ico);
+    hlayout->addWidget(lbl);
+
+    QDialogButtonBox *bb = new QDialogButtonBox;
+    QPushButton *skip = bb->addButton(tr("Skip this version"), QDialogButtonBox::ResetRole);
+    QPushButton *askagain = bb->addButton(tr("Ask again later"), QDialogButtonBox::ResetRole);
+    QPushButton *retry = bb->addButton(tr("Restart and update"), QDialogButtonBox::AcceptRole);
+    QPushButton *getupdate = bb->addButton(tr("Update manually"), QDialogButtonBox::AcceptRole);
+
+    connect(skip, &QAbstractButton::clicked, msgBox, &QDialog::reject);
+    connect(askagain, &QAbstractButton::clicked, msgBox, &QDialog::reject);
+    connect(retry, &QAbstractButton::clicked, msgBox, &QDialog::accept);
+    connect(getupdate, &QAbstractButton::clicked, msgBox, &QDialog::accept);
+
+    connect(skip, &QAbstractButton::clicked, this, [this]() {
+        wipeUpdateData();
+        slotSetSeenVersion();
+    });
+    // askagain: do nothing
+    connect(retry, &QAbstractButton::clicked, this, [this]() {
+        slotStartInstaller();
+        qApp->quit();
+    });
+    connect(getupdate, &QAbstractButton::clicked, this, [this]() {
+        wipeUpdateData();
+        slotSetSeenVersion();
+        slotOpenUpdateUrl();
+    });
+
+    layout->addWidget(bb);
+
+    msgBox->open();
+}
+
+bool NSISUpdater::handleStartup()
 {
     ConfigFile cfg;
     QSettings settings(cfg.configFile(), QSettings::IniFormat);
@@ -413,44 +484,20 @@ NSISUpdater::UpdateState NSISUpdater::updateStateOnStart()
     if (!updateFileName.isEmpty() && QFile(updateFileName).exists()) {
         // did it try to execute the update?
         if (settings.value(autoUpdateAttemptedC, false).toBool()) {
-            // clean up
-            settings.remove(autoUpdateAttemptedC);
-            settings.remove(updateAvailableC);
-            QFile::remove(updateFileName);
             if (updateSucceeded()) {
-                // success: clean up even more
-                settings.remove(updateTargetVersionC);
-                settings.remove(autoUpdateFailedVersionC);
-                return NoUpdate;
+                // success: clean up
+                wipeUpdateData();
+                return false;
             } else {
-                // auto update failed. Set autoUpdateFailedVersion as a hint
-                // for visual fallback notification
-                QString targetVersion = settings.value(updateTargetVersionC).toString();
-                settings.setValue(autoUpdateFailedVersionC, targetVersion);
-                settings.remove(updateTargetVersionC);
-                return UpdateFailed;
+                // auto update failed. Ask user what to do
+                showUpdateErrorDialog();
+                return false;
             }
         } else {
-            if (!settings.contains(autoUpdateFailedVersionC)) {
-                return UpdateAvailable;
-            }
+            return performUpdate();
         }
     }
-    return NoUpdate;
-}
-
-bool NSISUpdater::handleStartup()
-{
-    switch (updateStateOnStart()) {
-    case NSISUpdater::UpdateAvailable:
-        return performUpdate();
-    case NSISUpdater::UpdateFailed:
-        _showFallbackMessage = true;
-        return false;
-    case NSISUpdater::NoUpdate:
-    default:
-        return false;
-    }
+    return false;
 }
 
 void NSISUpdater::slotSetSeenVersion()

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -427,7 +427,7 @@ void NSISUpdater::showNoUrlDialog(const UpdateInfo &info)
 
 void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 {
-    QDialog *msgBox = new QDialog;
+    auto msgBox = new QDialog;
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
     msgBox->setWindowFlags(msgBox->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
@@ -436,16 +436,16 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 
     msgBox->setWindowIcon(infoIcon);
 
-    QVBoxLayout *layout = new QVBoxLayout(msgBox);
-    QHBoxLayout *hlayout = new QHBoxLayout;
+    auto layout = new QVBoxLayout(msgBox);
+    auto hlayout = new QHBoxLayout;
     layout->addLayout(hlayout);
 
     msgBox->setWindowTitle(tr("Update Failed"));
 
-    QLabel *ico = new QLabel;
+    auto ico = new QLabel;
     ico->setFixedSize(iconSize, iconSize);
     ico->setPixmap(infoIcon.pixmap(iconSize));
-    QLabel *lbl = new QLabel;
+    auto lbl = new QLabel;
     QString txt = tr("<p>A new version of the %1 Client is available but the updating process failed.</p>"
                      "<p><b>%2</b> has been downloaded. The installed version is %3.</p>")
                       .arg(Utility::escape(Theme::instance()->appNameGUI()),
@@ -458,11 +458,11 @@ void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
     hlayout->addWidget(ico);
     hlayout->addWidget(lbl);
 
-    QDialogButtonBox *bb = new QDialogButtonBox;
-    QPushButton *skip = bb->addButton(tr("Skip this version"), QDialogButtonBox::ResetRole);
-    QPushButton *askagain = bb->addButton(tr("Ask again later"), QDialogButtonBox::ResetRole);
-    QPushButton *retry = bb->addButton(tr("Restart and update"), QDialogButtonBox::AcceptRole);
-    QPushButton *getupdate = bb->addButton(tr("Update manually"), QDialogButtonBox::AcceptRole);
+    auto bb = new QDialogButtonBox;
+    auto skip = bb->addButton(tr("Skip this version"), QDialogButtonBox::ResetRole);
+    auto askagain = bb->addButton(tr("Ask again later"), QDialogButtonBox::ResetRole);
+    auto retry = bb->addButton(tr("Restart and update"), QDialogButtonBox::AcceptRole);
+    auto getupdate = bb->addButton(tr("Update manually"), QDialogButtonBox::AcceptRole);
 
     connect(skip, &QAbstractButton::clicked, msgBox, &QDialog::reject);
     connect(askagain, &QAbstractButton::clicked, msgBox, &QDialog::reject);

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -147,7 +147,7 @@ QString OCUpdater::statusString() const
     case Downloading:
         return tr("Downloading %1. Please wait …").arg(updateVersion);
     case DownloadComplete:
-        return tr("%1 available. Restart application to start the update.").arg(Theme::instance()->appNameGUI(), updateVersion);
+        return tr("%1 available. Restart application to start the update.").arg(updateVersion);
     case DownloadFailed:
         return tr("Could not download update. Please click <a href='%1'>here</a> to download the update manually.").arg(_updateInfo.web());
     case DownloadTimedOut:

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -465,8 +465,6 @@ void NSISUpdater::showUpdateErrorDialog()
         qApp->quit();
     });
     connect(getupdate, &QAbstractButton::clicked, this, [this]() {
-        wipeUpdateData();
-        slotSetSeenVersion();
         slotOpenUpdateUrl();
     });
 

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -31,6 +31,7 @@ namespace OCC {
 
 static const char updateAvailableC[] = "Updater/updateAvailable";
 static const char updateTargetVersionC[] = "Updater/updateTargetVersion";
+static const char updateTargetVersionStringC[] = "Updater/updateTargetVersionString";
 static const char seenVersionC[] = "Updater/seenVersion";
 static const char autoUpdateAttemptedC[] = "Updater/autoUpdateAttempted";
 
@@ -294,6 +295,7 @@ void NSISUpdater::wipeUpdateData()
         QFile::remove(updateFileName);
     settings.remove(updateAvailableC);
     settings.remove(updateTargetVersionC);
+    settings.remove(updateTargetVersionStringC);
     settings.remove(autoUpdateAttemptedC);
 }
 
@@ -322,6 +324,7 @@ void NSISUpdater::slotDownloadFinished()
     setDownloadState(DownloadComplete);
     qCInfo(lcUpdater) << "Downloaded" << url.toString() << "to" << _targetFile;
     settings.setValue(updateTargetVersionC, updateInfo().version());
+    settings.setValue(updateTargetVersionStringC, updateInfo().versionString());
     settings.setValue(updateAvailableC, _targetFile);
 }
 
@@ -411,7 +414,7 @@ void NSISUpdater::showNoUrlDialog(const UpdateInfo &info)
     msgBox->open();
 }
 
-void NSISUpdater::showUpdateErrorDialog()
+void NSISUpdater::showUpdateErrorDialog(const QString &targetVersion)
 {
     QDialog *msgBox = new QDialog;
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
@@ -435,7 +438,7 @@ void NSISUpdater::showUpdateErrorDialog()
     QString txt = tr("<p>A new version of the %1 Client is available but the updating process failed.</p>"
                      "<p><b>%2</b> has been downloaded. The installed version is %3.</p>")
                       .arg(Utility::escape(Theme::instance()->appNameGUI()),
-                          Utility::escape(updateInfo().versionString()), Utility::escape(clientVersion()));
+                          Utility::escape(targetVersion), Utility::escape(clientVersion()));
 
     lbl->setText(txt);
     lbl->setTextFormat(Qt::RichText);
@@ -488,7 +491,7 @@ bool NSISUpdater::handleStartup()
                 return false;
             } else {
                 // auto update failed. Ask user what to do
-                showUpdateErrorDialog();
+                showUpdateErrorDialog(settings.value(updateTargetVersionStringC).toString());
                 return false;
             }
         } else {

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -115,6 +115,7 @@ signals:
     void requestRestart();
 
 public slots:
+    // FIXME Maybe this should be in the NSISUpdater which should have been called WindowsUpdater
     void slotStartInstaller();
 
 protected slots:

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -158,7 +158,7 @@ private slots:
 private:
     void wipeUpdateData();
     void showNoUrlDialog(const UpdateInfo &info);
-    void showUpdateErrorDialog();
+    void showUpdateErrorDialog(const QString &targetVersion);
     void versionInfoArrived(const UpdateInfo &info) override;
     QScopedPointer<QTemporaryFile> _file;
     QString _targetFile;

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -120,9 +120,9 @@ public slots:
 
 protected slots:
     void backgroundCheckForUpdate() override;
+    void slotOpenUpdateUrl();
 
 private slots:
-    void slotOpenUpdateUrl();
     void slotVersionInfoArrived();
     void slotTimedOut();
 
@@ -148,9 +148,6 @@ class NSISUpdater : public OCUpdater
 {
     Q_OBJECT
 public:
-    enum UpdateState { NoUpdate = 0,
-        UpdateAvailable,
-        UpdateFailed };
     explicit NSISUpdater(const QUrl &url);
     bool handleStartup() override;
 private slots:
@@ -159,12 +156,12 @@ private slots:
     void slotWriteFile();
 
 private:
-    NSISUpdater::UpdateState updateStateOnStart();
-    void showDialog(const UpdateInfo &info);
+    void wipeUpdateData();
+    void showNoUrlDialog(const UpdateInfo &info);
+    void showUpdateErrorDialog();
     void versionInfoArrived(const UpdateInfo &info) override;
     QScopedPointer<QTemporaryFile> _file;
     QString _targetFile;
-    bool _showFallbackMessage;
 };
 
 /**

--- a/src/gui/updater/ocupdater.h
+++ b/src/gui/updater/ocupdater.h
@@ -99,6 +99,8 @@ public:
         UpdateOnlyAvailableThroughSystem };
     explicit OCUpdater(const QUrl &url);
 
+    void setUpdateUrl(const QUrl &url);
+
     bool performUpdate();
 
     void checkForUpdate() override;

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -23,6 +23,7 @@ namespace OCC {
 
 class SparkleUpdater : public Updater
 {
+    Q_OBJECT
 public:
     SparkleUpdater(const QString &appCastUrl);
     ~SparkleUpdater();
@@ -31,6 +32,8 @@ public:
     void checkForUpdate() override;
     void backgroundCheckForUpdate() override;
     bool handleStartup() override { return false; }
+
+    QString statusString();
 
 private:
     class Private;

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -25,8 +25,10 @@ class SparkleUpdater : public Updater
 {
     Q_OBJECT
 public:
-    SparkleUpdater(const QString &appCastUrl);
+    SparkleUpdater(const QUrl &appCastUrl);
     ~SparkleUpdater();
+
+    void setUpdateUrl(const QUrl &url);
 
     // unused in this updater
     void checkForUpdate() override;

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -83,7 +83,7 @@ class SparkleUpdater::Private
 };
 
 // Delete ~/Library//Preferences/com.owncloud.desktopclient.plist to re-test
-SparkleUpdater::SparkleUpdater(const QString& appCastUrl)
+SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     : Updater()
 {
     d = new Private;
@@ -99,9 +99,7 @@ SparkleUpdater::SparkleUpdater(const QString& appCastUrl)
     [d->updater resetUpdateCycle];
     [d->updater retain];
 
-    NSURL* url = [NSURL URLWithString:
-            [NSString stringWithUTF8String: appCastUrl.toUtf8().data()]];
-    [d->updater setFeedURL: url];
+    setUpdateUrl(appCastUrl);
 
     // Sparkle 1.8 required
     NSString *userAgent = [NSString stringWithUTF8String: Utility::userAgentString().data()];
@@ -112,6 +110,13 @@ SparkleUpdater::~SparkleUpdater()
 {
     [d->updater release];
     delete d;
+}
+
+void SparkleUpdater::setUpdateUrl(const QUrl &url)
+{
+    NSURL* nsurl = [NSURL URLWithString:
+            [NSString stringWithUTF8String: url.toString().toUtf8().data()]];
+    [d->updater setFeedURL: nsurl];
 }
 
 // FIXME: Should be changed to not instanicate the SparkleUpdater at all in this case

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -21,13 +21,11 @@
 #include "common/utility.h"
 #include "updater/sparkleupdater.h"
 
-// Does not work yet
 @interface DelegateObject : NSObject <SUUpdaterDelegate>
 - (BOOL)updaterMayCheckForUpdates:(SUUpdater *)bundle;
 @end
 @implementation DelegateObject //(SUUpdaterDelegateInformalProtocol)
 
-// Only possible in later versions, we're not up to date here.
 - (BOOL)updaterMayCheckForUpdates:(SUUpdater *)bundle
 {
     Q_UNUSED(bundle)
@@ -40,13 +38,14 @@
 {
     Q_UNUSED(updater)
     Q_UNUSED(update)
+    qCDebug(OCC::lcUpdater) << "";
 }
 
 // Sent when a valid update is not found.
-// Does not seem to get called ever.
 - (void)updaterDidNotFindUpdate:(SUUpdater *)update
 {
     Q_UNUSED(update)
+    qCDebug(OCC::lcUpdater) << "";
 }
 
 // Sent immediately before installing the specified update.
@@ -54,16 +53,21 @@
 {
     Q_UNUSED(updater)
     Q_UNUSED(update)
+    qCDebug(OCC::lcUpdater) << "";
 }
 
-// Tried implementing those methods, but they never ever seem to get called
-//- (void) updater:(SUUpdater *)updater didAbortWithError:(NSError *)error
-//{
-//}
+- (void) updater:(SUUpdater *)updater didAbortWithError:(NSError *)error
+{
+    Q_UNUSED(updater)
+    qCDebug(OCC::lcUpdater) << error.description;
+}
 
-//- (void)updater:(SUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast
-//{
-//}
+- (void)updater:(SUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast
+{
+    Q_UNUSED(updater)
+    Q_UNUSED(appcast)
+    qCDebug(OCC::lcUpdater) << "";
+}
 
 
 @end

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -114,7 +114,7 @@ SparkleUpdater::~SparkleUpdater()
     delete d;
 }
 
-
+// FIXME: Should be changed to not instanicate the SparkleUpdater at all in this case
 bool autoUpdaterAllowed()
 {
     // See https://github.com/owncloud/client/issues/2931
@@ -141,6 +141,12 @@ void SparkleUpdater::backgroundCheckForUpdate()
     if (autoUpdaterAllowed()) {
         [d->updater checkForUpdatesInBackground];
     }
+}
+
+QString SparkleUpdater::statusString()
+{
+    // FIXME Show the real state depending on the callbacks
+    return QString();
 }
 
 } // namespace OCC

--- a/src/gui/updater/updateinfo.cpp
+++ b/src/gui/updater/updateinfo.cpp
@@ -89,6 +89,9 @@ UpdateInfo UpdateInfo::parseString(const QString &xml, bool *ok)
     QDomDocument doc;
     if (!doc.setContent(xml, false, &errorMsg, &errorLine, &errorCol)) {
         qCCritical(lcUpdater) << errorMsg << " at " << errorLine << "," << errorCol;
+        qCCritical(lcUpdater()) << "->" << xml.splitRef("\n")[errorLine] << "<-\n"
+                                << QStringLiteral(" ").repeated(2 + errorCol - 1) << "^\n"
+                                << "->" << xml << "<-";
         if (ok)
             *ok = false;
         return UpdateInfo();

--- a/src/gui/updater/updateinfo.cpp
+++ b/src/gui/updater/updateinfo.cpp
@@ -88,9 +88,9 @@ UpdateInfo UpdateInfo::parseString(const QString &xml, bool *ok)
     int errorLine = 0, errorCol = 0;
     QDomDocument doc;
     if (!doc.setContent(xml, false, &errorMsg, &errorLine, &errorCol)) {
-        qCCritical(lcUpdater) << errorMsg << " at " << errorLine << "," << errorCol;
-        qCCritical(lcUpdater()) << "->" << xml.splitRef("\n")[errorLine] << "<-\n"
-                                << QStringLiteral(" ").repeated(2 + errorCol - 1) << "^\n"
+        qCCritical(lcUpdater).noquote().nospace() << errorMsg << " at " << errorLine << "," << errorCol
+                                << "\n" <<  xml.splitRef("\n").value(errorLine-1) << "\n"
+                                << QString(" ").repeated(errorCol - 1) << "^\n"
                                 << "->" << xml << "<-";
         if (ok)
             *ok = false;

--- a/src/gui/updater/updateinfo.cpp
+++ b/src/gui/updater/updateinfo.cpp
@@ -88,7 +88,7 @@ UpdateInfo UpdateInfo::parseString(const QString &xml, bool *ok)
     int errorLine = 0, errorCol = 0;
     QDomDocument doc;
     if (!doc.setContent(xml, false, &errorMsg, &errorLine, &errorCol)) {
-        qCCritical(lcUpdater).noquote().nospace() << errorMsg << " at " << errorLine << "," << errorCol
+        qCWarning(lcUpdater).noquote().nospace() << errorMsg << " at " << errorLine << "," << errorCol
                                 << "\n" <<  xml.splitRef("\n").value(errorLine-1) << "\n"
                                 << QString(" ").repeated(errorCol - 1) << "^\n"
                                 << "->" << xml << "<-";

--- a/src/gui/updater/updateinfo.cpp
+++ b/src/gui/updater/updateinfo.cpp
@@ -82,34 +82,6 @@ UpdateInfo UpdateInfo::parseElement(const QDomElement &element, bool *ok)
     return result;
 }
 
-UpdateInfo UpdateInfo::parseFile(const QString &filename, bool *ok)
-{
-    QFile file(filename);
-    if (!file.open(QIODevice::ReadOnly)) {
-        qCCritical(lcUpdater) << "Unable to open file '" << filename << "'";
-        if (ok)
-            *ok = false;
-        return UpdateInfo();
-    }
-
-    QString errorMsg;
-    int errorLine = 0, errorCol = 0;
-    QDomDocument doc;
-    if (!doc.setContent(&file, false, &errorMsg, &errorLine, &errorCol)) {
-        qCCritical(lcUpdater) << errorMsg << " at " << errorLine << "," << errorCol;
-        if (ok)
-            *ok = false;
-        return UpdateInfo();
-    }
-
-    bool documentOk = false;
-    UpdateInfo c = parseElement(doc.documentElement(), &documentOk);
-    if (ok) {
-        *ok = documentOk;
-    }
-    return c;
-}
-
 UpdateInfo UpdateInfo::parseString(const QString &xml, bool *ok)
 {
     QString errorMsg;

--- a/src/gui/updater/updateinfo.h
+++ b/src/gui/updater/updateinfo.h
@@ -23,7 +23,6 @@ public:
       Parse XML object from DOM element.
      */
     static UpdateInfo parseElement(const QDomElement &element, bool *ok);
-    static UpdateInfo parseFile(const QString &filename, bool *ok);
     static UpdateInfo parseString(const QString &xml, bool *ok);
 
 private:

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -89,6 +89,8 @@ QUrlQuery Updater::getQueryParams()
     query.addQueryItem(QStringLiteral("version"), clientVersion());
     query.addQueryItem(QStringLiteral("platform"), platform);
     query.addQueryItem(QStringLiteral("oem"), theme->appName());
+    query.addQueryItem(QStringLiteral("buildArch"), QSysInfo::buildCpuArchitecture());
+    query.addQueryItem(QStringLiteral("currentArch"), QSysInfo::currentCpuArchitecture());
 
     QString suffix = QStringLiteral(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
     query.addQueryItem(QStringLiteral("versionsuffix"), suffix);

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -130,7 +130,7 @@ Updater *Updater::create()
     }
 
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    return new SparkleUpdater(url.toString());
+    return new SparkleUpdater(url);
 #elif defined(Q_OS_WIN32)
     // the best we can do is notify about updates
     return new NSISUpdater(url);

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -128,6 +128,7 @@ QString Updater::getSystemInfo()
 Updater *Updater::create()
 {
     auto url = updateUrl();
+    qCDebug(lcUpdater) << url;
     if (url.isEmpty()) {
         qCWarning(lcUpdater) << "Not a valid updater URL, will not do update check";
         return nullptr;

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -58,6 +58,10 @@ QUrl Updater::updateUrl()
     urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
 #endif
 
+#if defined(Q_OS_WIN)
+    urlQuery.addQueryItem(QLatin1String("msi"), QLatin1String("true"));
+#endif
+
     updateBaseUrl.setQuery(urlQuery);
 
     return updateBaseUrl;

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -71,31 +71,31 @@ QUrlQuery Updater::getQueryParams()
 {
     QUrlQuery query;
     Theme *theme = Theme::instance();
-    QString platform = QLatin1String("stranger");
+    QString platform = QStringLiteral("stranger");
     if (Utility::isLinux()) {
-        platform = QLatin1String("linux");
+        platform = QStringLiteral("linux");
     } else if (Utility::isBSD()) {
-        platform = QLatin1String("bsd");
+        platform = QStringLiteral("bsd");
     } else if (Utility::isWindows()) {
-        platform = QLatin1String("win32");
+        platform = QStringLiteral("win32");
     } else if (Utility::isMac()) {
-        platform = QLatin1String("macos");
+        platform = QStringLiteral("macos");
     }
 
     QString sysInfo = getSystemInfo();
     if (!sysInfo.isEmpty()) {
-        query.addQueryItem(QLatin1String("client"), sysInfo);
+        query.addQueryItem(QStringLiteral("client"), sysInfo);
     }
-    query.addQueryItem(QLatin1String("version"), clientVersion());
-    query.addQueryItem(QLatin1String("platform"), platform);
-    query.addQueryItem(QLatin1String("oem"), theme->appName());
+    query.addQueryItem(QStringLiteral("version"), clientVersion());
+    query.addQueryItem(QStringLiteral("platform"), platform);
+    query.addQueryItem(QStringLiteral("oem"), theme->appName());
 
-    QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
-    query.addQueryItem(QLatin1String("versionsuffix"), suffix);
+    QString suffix = QStringLiteral(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
+    query.addQueryItem(QStringLiteral("versionsuffix"), suffix);
 
     auto channel = ConfigFile().updateChannel();
-    if (channel != "stable") {
-        query.addQueryItem(QLatin1String("channel"), channel);
+    if (channel != QLatin1String("stable")) {
+        query.addQueryItem(QStringLiteral("channel"), channel);
     }
 
     // updateSegment (see configfile.h)

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -132,9 +132,10 @@ Updater *Updater::create()
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
     return new SparkleUpdater(url);
 #elif defined(Q_OS_WIN32)
-    // the best we can do is notify about updates
+    // Also for MSI
     return new NSISUpdater(url);
 #else
+    // the best we can do is notify about updates
     return new PassiveUpdateNotifier(url);
 #endif
 }

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -23,6 +23,7 @@
 #include "theme.h"
 #include "common/utility.h"
 #include "version.h"
+#include "configfile.h"
 
 #include "config.h"
 #include "configfile.h"
@@ -39,6 +40,27 @@ Updater *Updater::instance()
         _instance = create();
     }
     return _instance;
+}
+
+QUrl Updater::updateUrl()
+{
+    QUrl updateBaseUrl(QString::fromLocal8Bit(qgetenv("OCC_UPDATE_URL")));
+    if (updateBaseUrl.isEmpty()) {
+        updateBaseUrl = QUrl(QLatin1String(APPLICATION_UPDATE_URL));
+    }
+    if (!updateBaseUrl.isValid() || updateBaseUrl.host() == ".") {
+        return QUrl();
+    }
+
+    auto urlQuery = getQueryParams();
+
+#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
+    urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
+#endif
+
+    updateBaseUrl.setQuery(urlQuery);
+
+    return updateBaseUrl;
 }
 
 QUrlQuery Updater::getQueryParams()
@@ -66,14 +88,10 @@ QUrlQuery Updater::getQueryParams()
 
     QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
     query.addQueryItem(QLatin1String("versionsuffix"), suffix);
-    if (suffix.startsWith("daily")
-            || suffix.startsWith("nightly")
-            || suffix.startsWith("alpha")
-            || suffix.startsWith("rc")
-            || suffix.startsWith("beta")) {
-        query.addQueryItem(QLatin1String("channel"), "beta");
-        // FIXME: Provide a checkbox in UI to enable regular versions to switch
-        // to beta channel
+
+    auto channel = ConfigFile().updateChannel();
+    if (channel != "stable") {
+        query.addQueryItem(QLatin1String("channel"), channel);
     }
 
     // updateSegment (see configfile.h)
@@ -105,30 +123,19 @@ QString Updater::getSystemInfo()
 // To test, cmake with -DAPPLICATION_UPDATE_URL="http://127.0.0.1:8080/test.rss"
 Updater *Updater::create()
 {
-    QUrl updateBaseUrl(QString::fromLocal8Bit(qgetenv("OCC_UPDATE_URL")));
-    if (updateBaseUrl.isEmpty()) {
-        updateBaseUrl = QUrl(QLatin1String(APPLICATION_UPDATE_URL));
-    }
-    if (!updateBaseUrl.isValid() || updateBaseUrl.host() == ".") {
+    auto url = updateUrl();
+    if (url.isEmpty()) {
         qCWarning(lcUpdater) << "Not a valid updater URL, will not do update check";
         return nullptr;
     }
 
-    auto urlQuery = getQueryParams();
-
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
-#endif
-
-    updateBaseUrl.setQuery(urlQuery);
-
-#if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    return new SparkleUpdater(updateBaseUrl.toString());
+    return new SparkleUpdater(url.toString());
 #elif defined(Q_OS_WIN32)
     // the best we can do is notify about updates
-    return new NSISUpdater(updateBaseUrl);
+    return new NSISUpdater(url);
 #else
-    return new PassiveUpdateNotifier(QUrl(updateBaseUrl));
+    return new PassiveUpdateNotifier(url);
 #endif
 }
 

--- a/src/gui/updater/updater.h
+++ b/src/gui/updater/updater.h
@@ -37,6 +37,7 @@ public:
     };
 
     static Updater *instance();
+    static QUrl updateUrl();
 
     virtual void checkForUpdate() = 0;
     virtual void backgroundCheckForUpdate() = 0;

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -18,6 +18,7 @@
 #include "theme.h"
 #include "common/utility.h"
 #include "common/asserts.h"
+#include "version.h"
 
 #include "creds/abstractcredentials.h"
 #include "creds/keychainchunk.h"
@@ -67,6 +68,7 @@ static const char skipUpdateCheckC[] = "skipUpdateCheck";
 static const char autoUpdateCheckC[] = "autoUpdateCheck";
 static const char updateCheckIntervalC[] = "updateCheckInterval";
 static const char updateSegmentC[] = "updateSegment";
+static const char updateChannelC[] = "updateChannel";
 static const char geometryC[] = "geometry";
 static const char timeoutC[] = "timeout";
 static const char chunkSizeC[] = "chunkSize";
@@ -622,6 +624,28 @@ int ConfigFile::updateSegment() const
     }
 
     return segment;
+}
+
+QString ConfigFile::updateChannel() const
+{
+    QString defaultUpdateChannel = QStringLiteral("stable");
+    QString suffix = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION_SUFFIX));
+    if (suffix.startsWith("daily")
+        || suffix.startsWith("nightly")
+        || suffix.startsWith("alpha")
+        || suffix.startsWith("rc")
+        || suffix.startsWith("beta")) {
+        defaultUpdateChannel = QStringLiteral("beta");
+    }
+
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(QLatin1String(updateChannelC), defaultUpdateChannel).toString();
+}
+
+void ConfigFile::setUpdateChannel(const QString &channel)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(QLatin1String(updateChannelC), channel);
 }
 
 int ConfigFile::maxLogLines() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -171,6 +171,9 @@ public:
         See: https://github.com/nextcloud/client_updater_server/pull/36 */
     int updateSegment() const;
 
+    QString updateChannel() const;
+    void setUpdateChannel(const QString &channel);
+
     void saveGeometryHeader(QHeaderView *header);
     void restoreGeometryHeader(QHeaderView *header);
 


### PR DESCRIPTION
This opens the door to the support for msi based updates (although the server side doesn't provide them yet). This should also get the sparkle based updates on Mac to work (this would need to be tested further though). 

Also contains nice improvements regarding the logging of the updater and error handling.