### PR TITLE
Issue a warning for Debian pipeline failures but don't fail the CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,7 +122,7 @@ steps:
 - name: build
   image: nextcloudci/client-debian-ci:client-debian-ci-2
   commands:
-    - /bin/bash -c "./admin/linux/debian/drone-build.sh"
+    - /bin/bash -c "./admin/linux/debian/drone-build.sh" || echo "[WARNING] Debian build failed but this is a non-blocking CI event"
   environment:
     DEBIAN_SECRET_KEY:
       from_secret: DEBIAN_SECRET_KEY


### PR DESCRIPTION
Since this fails every time we bump the version number and takes time to
catch up while failing every following PRs, let's prevent this pipeline
from failing the CI.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>