### PR TITLE
Handle the case when the release version differs from that in VERSION.cmake

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -76,7 +76,7 @@ for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
 
     git merge ${DRONE_COMMIT}
 
-    admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution} ${revdate}
+    admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog ${distribution} ${revdate} ${basever}
     cat /tmp/tmpchangelog debian/changelog > debian/changelog.new
     mv debian/changelog.new debian/changelog
 

--- a/admin/linux/debian/scripts/git2changelog.py
+++ b/admin/linux/debian/scripts/git2changelog.py
@@ -31,7 +31,7 @@ def getCommitVersion(commit):
     try:
         for line in subprocess.check_output(["git", "show",
                                              commit + ":VERSION.cmake"]).splitlines():
-            m = re.match("set\( MIRALL_VERSION_([A-Z]+) +([0-9])+ *\)", line)
+            m = re.match("set\( MIRALL_VERSION_([A-Z]+) +([0-9]+) *\)", line)
             if m is not None:
                 kind=m.group(1)
                 version=m.group(2)
@@ -48,7 +48,7 @@ def getCommitVersion(commit):
     except:
         return None
 
-def collectEntries(baseCommit, baseVersion, kind, finalRevDate, config):
+def collectEntries(baseCommit, baseVersion, kind, finalBaseVersion, finalRevDate, config):
 
     newVersionCommit = None
     newVersionTag = None
@@ -89,7 +89,6 @@ def collectEntries(baseCommit, baseVersion, kind, finalRevDate, config):
                 newVersionOrigTag = lastVersionTag
                 (baseVersion, _kind) = result
 
-
         version=getCommitVersion(commit)
         if version and version!=lastCMAKEVersion:
             tag = "v" + version
@@ -119,6 +118,8 @@ def collectEntries(baseCommit, baseVersion, kind, finalRevDate, config):
             revdate = datetime.datetime.now().strftime("%Y%m%d.%H%M%S")+ "." + commit
         else:
             revdate = finalRevDate
+        if finalBaseVersion is not None:
+            baseVersion = finalBaseVersion
         entries[-1] = (commit, name, email, date, revdate, subject, baseVersion, kind)
 
     entries.reverse()
@@ -167,8 +168,10 @@ if __name__ == "__main__":
 
     distribution = sys.argv[2]
     finalRevDate = sys.argv[3] if len(sys.argv)>3 else None
+    finalBaseVersion = sys.argv[4] if len(sys.argv)>4 else None
 
-    entries = collectEntries(baseCommit, baseVersion, "alpha", finalRevDate, config)
+    entries = collectEntries(baseCommit, baseVersion, "alpha",
+                             finalBaseVersion, finalRevDate, config)
 
     with open(sys.argv[1], "wt") as f:
         (baseVersion, revdate, kind) = genChangeLogEntries(f, entries, distribution)


### PR DESCRIPTION
The Debian build determines the version by scanning the Git log and examining the contents of VERSION.cmake as well as any tags that may point to a commit. The tags have precedence over the contents of VERSION.cmake, so in case of v3.1.0-rc1 the version was correctly detected to be 3.1.0.

Based on this information an "orig" archive is created the name of which contains the version.

Then each target distribution is taken and the corresponding Debian branch is fetched and checked out and the commit to release (i.e. v3.1.0-rc1 in this case) is merged into the branch locally to create a mix of the code to release and the Debian additions. Then a changelog is generated based on the contents of the Git log where the version for a changelog entry is generated as described above. However, in this case tags are lost due to the merging, so only the contents of VERSION.cmake remains. Thus the version in the first changelog entry will have a version 3.0.81 and the package building tool expects an "orig" archive with a name containing that version number, which is thus not found and the building fails.

This patch fixes the issue by using the correctly determined version for the version in the first changelog entry.