### PR TITLE
Use dynamic path for account online/offline state icon. Refresh GUI on connection state change.

### DIFF
--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -81,7 +81,9 @@ MenuItem {
                         }
                         Image {
                             id: accountStateIndicator
-                            source: isConnected ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+                            source: model.isConnected
+                                    ? Style.stateOnlineImageSource
+                                    : Style.stateOfflineImageSource
                             cache: false
                             x: accountStateIndicatorBackground.x + 1
                             y: accountStateIndicatorBackground.y + 1
@@ -89,7 +91,7 @@ MenuItem {
                             sourceSize.height: Style.accountAvatarStateIndicatorSize
 
                             Accessible.role: Accessible.Indicator
-                            Accessible.name: isConnected ? qsTr("Account connected") : qsTr("Account not connected")
+                            Accessible.name: model.isConnected ? qsTr("Account connected") : qsTr("Account not connected")
                         }
                     }
 
@@ -163,11 +165,11 @@ MenuItem {
                     }
 
                     MenuItem {
-                        text: isConnected ? qsTr("Log out") : qsTr("Log in")
+                        text: model.isConnected ? qsTr("Log out") : qsTr("Log in")
                         font.pixelSize: Style.topLinePixelSize
                         hoverEnabled: true
                         onClicked: {
-                            isConnected ? UserModel.logout(index) : UserModel.login(index)
+                            model.isConnected ? UserModel.logout(index) : UserModel.login(index)
                             accountMenu.close()
                         }
 
@@ -182,10 +184,10 @@ MenuItem {
                         }
 
                         Accessible.role: Accessible.Button
-                        Accessible.name: isConnected ? qsTr("Log out") : qsTr("Log in")
+                        Accessible.name: model.isConnected ? qsTr("Log out") : qsTr("Log in")
 
                         onPressed: {
-                            if (isConnected) {
+                            if (model.isConnected) {
                                 UserModel.logout(index)
                             } else {
                                 UserModel.login(index)
@@ -219,6 +221,15 @@ MenuItem {
                         Accessible.onPressAction: removeAccountButton.clicked()
                     }
                 }
+            }
+        }
+
+        Connections {
+            target: UserModel
+            onRefreshCurrentUserGui: {
+                accountStateIndicator.source = model.isConnected
+                        ? Style.stateOnlineImageSource
+                        : Style.stateOfflineImageSource
             }
         }
 }   // MenuItem userLine

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -52,6 +52,7 @@ signals:
     void hasLocalFolderChanged();
     void serverHasTalkChanged();
     void avatarChanged();
+    void accountStateChanged(int state);
 
 public slots:
     void slotItemCompleted(const QString &folder, const SyncFileItemPtr &item);

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -36,7 +36,9 @@ Window {
 
     onVisibleChanged: {
         currentAccountStateIndicator.source = ""
-        currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+        currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId)
+                ? Style.stateOnlineImageSource
+                : Style.stateOfflineImageSource
 
         // HACK: reload account Instantiator immediately by restting it - could be done better I guess
         // see also id:accountMenu below
@@ -48,7 +50,9 @@ Window {
         target: UserModel
         onRefreshCurrentUserGui: {
             currentAccountStateIndicator.source = ""
-            currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+            currentAccountStateIndicator.source = UserModel.isUserConnected(UserModel.currentUserId)
+                    ? Style.stateOnlineImageSource
+                    : Style.stateOfflineImageSource
         }
         onNewUserSelected: {
             accountMenu.close();
@@ -357,7 +361,9 @@ Window {
 
                             Image {
                                 id: currentAccountStateIndicator
-                                source: UserModel.isUserConnected(UserModel.currentUserId) ? "qrc:///client/theme/colored/state-ok.svg" : "qrc:///client/theme/colored/state-offline.svg"
+                                source: UserModel.isUserConnected(UserModel.currentUserId)
+                                        ? Style.stateOnlineImageSource
+                                        : Style.stateOfflineImageSource
                                 cache: false
                                 x: currentAccountStateIndicatorBackground.x + 1
                                 y: currentAccountStateIndicatorBackground.y + 1

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -40,6 +40,8 @@ class OWNCLOUDSYNC_EXPORT Theme : public QObject
     Q_PROPERTY(bool branded READ isBranded CONSTANT)
     Q_PROPERTY(QString appNameGUI READ appNameGUI CONSTANT)
     Q_PROPERTY(QString appName READ appName CONSTANT)
+    Q_PROPERTY(QUrl stateOnlineImageSource READ stateOnlineImageSource CONSTANT)
+    Q_PROPERTY(QUrl stateOfflineImageSource READ stateOfflineImageSource CONSTANT)
 #ifndef TOKEN_AUTH_ONLY
     Q_PROPERTY(QIcon folderDisabledIcon READ folderDisabledIcon CONSTANT)
     Q_PROPERTY(QIcon folderOfflineIcon READ folderOfflineIcon CONSTANT)
@@ -108,6 +110,18 @@ public:
      * @return QString with app name.
      */
     virtual QString appName() const;
+
+    /**
+     * @brief Returns full path to an online state icon
+     * @return QUrl full path to an icon
+     */
+    QUrl stateOnlineImageSource() const;
+
+    /**
+     * @brief Returns full path to an offline state icon
+     * @return QUrl full path to an icon
+     */
+    QUrl stateOfflineImageSource() const;
 
     /**
      * @brief configFileName
@@ -491,6 +505,14 @@ protected:
 #ifndef TOKEN_AUTH_ONLY
     QIcon themeIcon(const QString &name, bool sysTray = false) const;
 #endif
+    /**
+     * @brief Generates image path in the resources
+     * @param name Name of the image file
+     * @param size Size in the power of two (16, 32, 64, etc.)
+     * @param sysTray Whether the image requested is for Systray or not
+     * @return QString image path in the resources
+     **/
+    QString themeImagePath(const QString &name, int size = -1, bool sysTray = false) const;
     Theme();
 
 signals:

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -28,6 +28,9 @@ QtObject {
     property int currentAccountButtonRadius: 2
     property int currentAccountLabelWidth: 128
 
+    property url stateOnlineImageSource: Theme.stateOnlineImageSource
+    property url stateOfflineImageSource: Theme.stateOfflineImageSource
+
     property int accountAvatarSize: (trayWindowHeaderHeight - 16)
     property int accountAvatarStateIndicatorSize: 16
     property int accountLabelWidth: 128


### PR DESCRIPTION
Use a method from Theme to generate a path for online/offline account state icon.

Also, added a signal/slot connection from connection state change to GUI so the online/offline icon will get refreshed without reopening the window.

Signed-off-by: allexzander blackslayer4@gmail.com