### PR TITLE
FolderWatcher: fixes and improvements

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1040,6 +1040,7 @@ void Folder::registerFolderWatcher()
     connect(_folderWatcher.data(), &FolderWatcher::becameUnreliable,
         this, &Folder::slotWatcherUnreliable);
     _folderWatcher->init(path());
+    _folderWatcher->startNotificatonTest(path() + QLatin1String(".owncloudsync.log"));
 }
 
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, bool *cancel)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -898,43 +898,6 @@ void Folder::slotItemCompleted(const SyncFileItemPtr &item)
         return;
     }
 
-    // add new directories or remove gone away dirs to the watcher
-    if (_folderWatcher && item->isDirectory()) {
-    switch (item->_instruction) {
-        case CSYNC_INSTRUCTION_NEW:
-                _folderWatcher->addPath(path() + item->_file);
-        break;
-        case CSYNC_INSTRUCTION_REMOVE:
-                _folderWatcher->removePath(path() + item->_file);
-        break;
-        case CSYNC_INSTRUCTION_RENAME:
-                _folderWatcher->removePath(path() + item->_file);
-                _folderWatcher->addPath(path() + item->destination());
-        break;
-        default:
-        break;
-    }
-    }
-
-    // Success and failure of sync items adjust what the next sync is
-    // supposed to do.
-    //
-    // For successes, we want to wipe the file from the list to ensure we don't
-    // rediscover it even if this overall sync fails.
-    //
-    // For failures, we want to add the file to the list so the next sync
-    // will be able to retry it.
-    if (item->_status == SyncFileItem::Success
-        || item->_status == SyncFileItem::FileIgnored
-        || item->_status == SyncFileItem::Restoration
-        || item->_status == SyncFileItem::Conflict) {
-        if (_previousLocalDiscoveryPaths.erase(item->_file.toUtf8()))
-            qCDebug(lcFolder) << "local discovery: wiped" << item->_file;
-    } else {
-        _localDiscoveryPaths.insert(item->_file.toUtf8());
-        qCDebug(lcFolder) << "local discovery: inserted" << item->_file << "due to sync failure";
-    }
-
     _syncResult.processCompletedItem(item);
 
     _fileLog->logItem(*item);

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -86,6 +86,15 @@ void FolderWatcher::appendSubPaths(QDir dir, QStringList& subPaths) {
     }
 }
 
+int FolderWatcher::testLinuxWatchCount() const
+{
+#ifdef Q_OS_LINUX
+    return _d->testWatchCount();
+#else
+    return -1;
+#endif
+}
+
 void FolderWatcher::changeDetected(const QString &path)
 {
     QFileInfo fileInfo(path);
@@ -133,16 +142,5 @@ void FolderWatcher::changeDetected(const QStringList &paths)
         emit pathChanged(path);
     }
 }
-
-void FolderWatcher::addPath(const QString &path)
-{
-    _d->addPath(path);
-}
-
-void FolderWatcher::removePath(const QString &path)
-{
-    _d->removePath(path);
-}
-
 
 } // namespace OCC

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "folder.h"
+#include "filesystem.h"
 
 namespace OCC {
 
@@ -86,6 +87,26 @@ void FolderWatcher::appendSubPaths(QDir dir, QStringList& subPaths) {
     }
 }
 
+void FolderWatcher::startNotificatonTest(const QString &path)
+{
+    Q_ASSERT(_testNotificationPath.isEmpty());
+    _testNotificationPath = path;
+
+    if (QFile::exists(path)) {
+        auto mtime = FileSystem::getModTime(path);
+        FileSystem::setModTime(path, mtime + 1);
+    } else {
+        QFile f(path);
+        f.open(QIODevice::WriteOnly | QIODevice::Append);
+    }
+
+    QTimer::singleShot(5000, this, [&]() {
+        if (!_testNotificationPath.isEmpty())
+            emit becameUnreliable(tr("The watcher did not receive a test notification."));
+        _testNotificationPath.clear();
+    });
+}
+
 int FolderWatcher::testLinuxWatchCount() const
 {
 #ifdef Q_OS_LINUX
@@ -127,6 +148,10 @@ void FolderWatcher::changeDetected(const QStringList &paths)
     // ------- handle ignores:
     for (int i = 0; i < paths.size(); ++i) {
         QString path = paths[i];
+        if (!_testNotificationPath.isEmpty()
+            && Utility::fileNamesEqual(path, _testNotificationPath)) {
+            _testNotificationPath.clear();
+        }
         if (pathIsIgnored(path)) {
             continue;
         }

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -60,7 +60,7 @@ bool FolderWatcher::pathIsIgnored(const QString &path)
         return false;
 
 #ifndef OWNCLOUD_TEST
-    if (_folder->isFileExcludedAbsolute(path)) {
+    if (_folder->isFileExcludedAbsolute(path) && !Utility::isConflictFile(path)) {
         qCDebug(lcFolderWatcher) << "* Ignoring file" << path;
         return true;
     }

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -89,6 +89,14 @@ void FolderWatcher::appendSubPaths(QDir dir, QStringList& subPaths) {
 
 void FolderWatcher::startNotificatonTest(const QString &path)
 {
+#ifdef Q_OS_MAC
+    // Testing the folder watcher on OSX is harder because the watcher
+    // automatically discards changes that were performed by our process.
+    // It would still be useful to test but the OSX implementation
+    // is deferred until later.
+    return;
+#endif
+
     Q_ASSERT(_testNotificationPath.isEmpty());
     _testNotificationPath = path;
 

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -109,6 +109,9 @@ protected slots:
     void changeDetected(const QString &path);
     void changeDetected(const QStringList &paths);
 
+private slots:
+    void startNotificationTestWhenReady();
+
 protected:
     QHash<QString, int> _pendingPathes;
 

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -44,11 +44,6 @@ class Folder;
  * for changes in the local file system. Changes are signalled
  * through the pathChanged() signal.
  *
- * Note that if new folders are created, this folderwatcher class
- * does not automatically add them to the list of monitored
- * dirs. That is the responsibility of the user of this class to
- * call addPath() with the new dir.
- *
  * @ingroup gui
  */
 
@@ -65,14 +60,6 @@ public:
      */
     void init(const QString &root);
 
-    /**
-     * Not all backends are recursive by default.
-     * Those need to be notified when a directory is added or removed while the watcher is disabled.
-     * This is a no-op for backends that are recursive
-     */
-    void addPath(const QString &);
-    void removePath(const QString &);
-
     /* Check if the path is ignored. */
     bool pathIsIgnored(const QString &path);
 
@@ -84,6 +71,9 @@ public:
      * /proc/sys/fs/inotify/max_user_watches is exceeded.
      */
     bool isReliable() const;
+
+    /// For testing linux behavior only
+    int testLinuxWatchCount() const;
 
 signals:
     /** Emitted when one of the watched directories or one

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -22,7 +22,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QHash>
 #include <QScopedPointer>
 #include <QSet>
@@ -117,7 +117,7 @@ protected:
 
 private:
     QScopedPointer<FolderWatcherPrivate> _d;
-    QTime _timer;
+    QElapsedTimer _timer;
     QSet<QString> _lastPaths;
     Folder *_folder;
     bool _isReliable = true;

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -72,6 +72,14 @@ public:
      */
     bool isReliable() const;
 
+    /**
+     * Triggers a change in the path and verifies a notification arrives.
+     *
+     * If no notification is seen, the folderwatcher marks itself as unreliable.
+     * The path must be ignored by the watcher.
+     */
+    void startNotificatonTest(const QString &path);
+
     /// For testing linux behavior only
     int testLinuxWatchCount() const;
 
@@ -112,6 +120,9 @@ private:
     bool _isReliable = true;
 
     void appendSubPaths(QDir dir, QStringList& subPaths);
+
+    /** Path of the expected test notification */
+    QString _testNotificationPath;
 
     friend class FolderWatcherPrivate;
 };

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -31,6 +31,11 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
     , _parent(p)
     , _folder(path)
 {
+    _wipePotentialRenamesSoon = new QTimer(this);
+    _wipePotentialRenamesSoon->setInterval(1000);
+    _wipePotentialRenamesSoon->setSingleShot(true);
+    connect(_wipePotentialRenamesSoon, &QTimer::timeout, this, &FolderWatcherPrivate::wipePotentialRenames);
+
     _fd = inotify_init();
     if (_fd != -1) {
         _socket.reset(new QSocketNotifier(_fd, QSocketNotifier::Read));
@@ -89,6 +94,17 @@ void FolderWatcherPrivate::inotifyRegisterPath(const QString &path)
     }
 }
 
+void FolderWatcherPrivate::applyDirectoryRename(const FolderWatcherPrivate::Rename &rename)
+{
+    QString fromSlash = rename.from + "/";
+    qCInfo(lcFolderWatcher) << "Applying rename from" << rename.from << "to" << rename.to;
+    for (auto &watch : _watches) {
+        if (watch == rename.from || watch.startsWith(fromSlash)) {
+            watch = rename.to + watch.mid(rename.from.size());
+        }
+    }
+}
+
 void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
 {
     int subdirs = 0;
@@ -124,6 +140,11 @@ void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
     }
 }
 
+void FolderWatcherPrivate::wipePotentialRenames()
+{
+    _potentialRenames.clear();
+}
+
 void FolderWatcherPrivate::slotReceivedNotification(int fd)
 {
     int len = 0;
@@ -152,33 +173,44 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
         error = errno;
     }
 
-    // reset counter
-    i = 0;
-    // while there are enough events in the buffer
-    while (i + sizeof(struct inotify_event) < static_cast<unsigned int>(len)) {
+    // iterate events in buffer
+    unsigned int ulen = len;
+    for (i = 0; i + sizeof(inotify_event) < ulen; i += sizeof(inotify_event) + (event ? event->len : 0)) {
         // cast an inotify_event
         event = (struct inotify_event *)&buffer[i];
         if (!event) {
             qCDebug(lcFolderWatcher) << "NULL event";
-            i += sizeof(struct inotify_event);
             continue;
         }
 
         // Fire event for the path that was changed.
-        if (event->len > 0 && event->wd > -1) {
-            QByteArray fileName(event->name);
-            if (fileName.startsWith("._sync_")
-                || fileName.startsWith(".csync_journal.db")
-                || fileName.startsWith(".owncloudsync.log")
-                || fileName.startsWith(".sync_")) {
+        if (event->len == 0 || event->wd <= -1)
+            continue;
+        QByteArray fileName(event->name);
+        if (fileName.startsWith("._sync_")
+            || fileName.startsWith(".csync_journal.db")
+            || fileName.startsWith(".owncloudsync.log")
+            || fileName.startsWith(".sync_")) {
+            continue;
+        }
+        const QString p = _watches[event->wd] + '/' + fileName;
+        _parent->changeDetected(p);
+
+        // Collect events to form complete renames where possible
+        // and apply directory renames to the cached paths.
+        if ((event->mask & (IN_MOVED_TO | IN_MOVED_FROM)) && (event->mask & IN_ISDIR) && event->cookie > 0) {
+            auto &rename = _potentialRenames[event->cookie];
+            if (event->mask & IN_MOVED_TO)
+                rename.to = p;
+            if (event->mask & IN_MOVED_FROM)
+                rename.from = p;
+            if (!rename.from.isEmpty() && !rename.to.isEmpty()) {
+                applyDirectoryRename(rename);
+                _potentialRenames.remove(event->cookie);
             } else {
-                const QString p = _watches[event->wd] + '/' + fileName;
-                _parent->changeDetected(p);
+                _wipePotentialRenamesSoon->start();
             }
         }
-
-        // increment counter
-        i += sizeof(struct inotify_event) + event->len;
     }
 }
 

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -31,11 +31,6 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
     , _parent(p)
     , _folder(path)
 {
-    _wipePotentialRenamesSoon = new QTimer(this);
-    _wipePotentialRenamesSoon->setInterval(1000);
-    _wipePotentialRenamesSoon->setSingleShot(true);
-    connect(_wipePotentialRenamesSoon, &QTimer::timeout, this, &FolderWatcherPrivate::wipePotentialRenames);
-
     _fd = inotify_init();
     if (_fd != -1) {
         _socket.reset(new QSocketNotifier(_fd, QSocketNotifier::Read));
@@ -76,44 +71,36 @@ bool FolderWatcherPrivate::findFoldersBelow(const QDir &dir, QStringList &fullLi
 
 void FolderWatcherPrivate::inotifyRegisterPath(const QString &path)
 {
-    if (!path.isEmpty()) {
-        int wd = inotify_add_watch(_fd, path.toUtf8().constData(),
-            IN_CLOSE_WRITE | IN_ATTRIB | IN_MOVE | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT | IN_ONLYDIR);
-        if (wd > -1) {
-            _watches.insert(wd, path);
-        } else {
-            // If we're running out of memory or inotify watches, become
-            // unreliable.
-            if (_parent->_isReliable && (errno == ENOMEM || errno == ENOSPC)) {
-                _parent->_isReliable = false;
-                emit _parent->becameUnreliable(
-                    tr("This problem usually happens when the inotify watches are exhausted. "
-                       "Check the FAQ for details."));
-            }
-        }
-    }
-}
+    if (path.isEmpty())
+        return;
 
-void FolderWatcherPrivate::applyDirectoryRename(const FolderWatcherPrivate::Rename &rename)
-{
-    QString fromSlash = rename.from + "/";
-    qCInfo(lcFolderWatcher) << "Applying rename from" << rename.from << "to" << rename.to;
-    for (auto &watch : _watches) {
-        if (watch == rename.from || watch.startsWith(fromSlash)) {
-            watch = rename.to + watch.mid(rename.from.size());
+    int wd = inotify_add_watch(_fd, path.toUtf8().constData(),
+        IN_CLOSE_WRITE | IN_ATTRIB | IN_MOVE | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT | IN_ONLYDIR);
+    if (wd > -1) {
+        _watchToPath.insert(wd, path);
+        _pathToWatch.insert(path, wd);
+    } else {
+        // If we're running out of memory or inotify watches, become
+        // unreliable.
+        if (_parent->_isReliable && (errno == ENOMEM || errno == ENOSPC)) {
+            _parent->_isReliable = false;
+            emit _parent->becameUnreliable(
+                tr("This problem usually happens when the inotify watches are exhausted. "
+                   "Check the FAQ for details."));
         }
     }
 }
 
 void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
 {
+    if (_pathToWatch.contains(path))
+        return;
+
     int subdirs = 0;
     qCDebug(lcFolderWatcher) << "(+) Watcher:" << path;
 
     QDir inPath(path);
     inotifyRegisterPath(inPath.absolutePath());
-
-    const QStringList watchedFolders = _watches.values();
 
     QStringList allSubfolders;
     if (!findFoldersBelow(QDir(path), allSubfolders)) {
@@ -123,7 +110,7 @@ void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
     while (subfoldersIt.hasNext()) {
         QString subfolder = subfoldersIt.next();
         QDir folder(subfolder);
-        if (folder.exists() && !watchedFolders.contains(folder.absolutePath())) {
+        if (folder.exists() && !_pathToWatch.contains(folder.absolutePath())) {
             subdirs++;
             if (_parent->pathIsIgnored(subfolder)) {
                 qCDebug(lcFolderWatcher) << "* Not adding" << folder.path();
@@ -138,11 +125,6 @@ void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
     if (subdirs > 0) {
         qCDebug(lcFolderWatcher) << "    `-> and" << subdirs << "subdirectories";
     }
-}
-
-void FolderWatcherPrivate::wipePotentialRenames()
-{
-    _potentialRenames.clear();
 }
 
 void FolderWatcherPrivate::slotReceivedNotification(int fd)
@@ -193,48 +175,44 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
             || fileName.startsWith(".sync_")) {
             continue;
         }
-        const QString p = _watches[event->wd] + '/' + fileName;
+        const QString p = _watchToPath[event->wd] + '/' + fileName;
         _parent->changeDetected(p);
 
-        // Collect events to form complete renames where possible
-        // and apply directory renames to the cached paths.
-        if ((event->mask & (IN_MOVED_TO | IN_MOVED_FROM)) && (event->mask & IN_ISDIR) && event->cookie > 0) {
-            auto &rename = _potentialRenames[event->cookie];
-            if (event->mask & IN_MOVED_TO)
-                rename.to = p;
-            if (event->mask & IN_MOVED_FROM)
-                rename.from = p;
-            if (!rename.from.isEmpty() && !rename.to.isEmpty()) {
-                applyDirectoryRename(rename);
-                _potentialRenames.remove(event->cookie);
-            } else {
-                _wipePotentialRenamesSoon->start();
-            }
+        if ((event->mask & (IN_MOVED_TO | IN_CREATE))
+            && QFileInfo(p).isDir()
+            && !_parent->pathIsIgnored(p)) {
+            slotAddFolderRecursive(p);
+        }
+        if (event->mask & (IN_MOVED_FROM | IN_DELETE)) {
+            removeFoldersBelow(p);
         }
     }
 }
 
-void FolderWatcherPrivate::addPath(const QString &path)
+void FolderWatcherPrivate::removeFoldersBelow(const QString &path)
 {
-    slotAddFolderRecursive(path);
-}
+    auto it = _pathToWatch.find(path);
+    if (it == _pathToWatch.end())
+        return;
 
-void FolderWatcherPrivate::removePath(const QString &path)
-{
-    int wid = -1;
-    // Remove the inotify watch.
-    QHash<int, QString>::const_iterator i = _watches.constBegin();
+    QString pathSlash = path + '/';
 
-    while (i != _watches.constEnd()) {
-        if (i.value() == path) {
-            wid = i.key();
+    // Remove the entry and all subentries
+    while (it != _pathToWatch.end()) {
+        auto itPath = it.key();
+        if (!itPath.startsWith(path))
             break;
+        if (itPath != path && !itPath.startsWith(pathSlash)) {
+            // order is 'foo', 'foo bar', 'foo/bar'
+            ++it;
+            continue;
         }
-        ++i;
-    }
-    if (wid > -1) {
+
+        auto wid = it.value();
         inotify_rm_watch(_fd, wid);
-        _watches.remove(wid);
+        _watchToPath.remove(wid);
+        it = _pathToWatch.erase(it);
+        qCDebug(lcFolderWatcher) << "Removed watch for" << itPath;
     }
 }
 

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -169,9 +169,10 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
         if (event->len == 0 || event->wd <= -1)
             continue;
         QByteArray fileName(event->name);
+        // Filter out journal changes - redundant with filtering in
+        // FolderWatcher::pathIsIgnored.
         if (fileName.startsWith("._sync_")
             || fileName.startsWith(".csync_journal.db")
-            || fileName.startsWith(".owncloudsync.log")
             || fileName.startsWith(".sync_")) {
             continue;
         }

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -41,6 +41,9 @@ public:
 
     int testWatchCount() const { return _pathToWatch.size(); }
 
+    /// On linux the watcher is ready when the ctor finished.
+    bool _ready = true;
+
 protected slots:
     void slotReceivedNotification(int fd);
     void slotAddFolderRecursive(const QString &path);

--- a/src/gui/folderwatcher_mac.h
+++ b/src/gui/folderwatcher_mac.h
@@ -33,9 +33,6 @@ public:
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
     ~FolderWatcherPrivate();
 
-    void addPath(const QString &) {}
-    void removePath(const QString &) {}
-
     void startWatching();
     QStringList addCoalescedPaths(const QStringList &) const;
     void doNotifyParent(const QStringList &);

--- a/src/gui/folderwatcher_mac.h
+++ b/src/gui/folderwatcher_mac.h
@@ -37,6 +37,9 @@ public:
     QStringList addCoalescedPaths(const QStringList &) const;
     void doNotifyParent(const QStringList &);
 
+    /// On OSX the watcher is ready when the ctor finished.
+    bool _ready = true;
+
 private:
     FolderWatcher *_parent;
 

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -84,6 +84,8 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
             break;
         }
 
+        emit ready();
+
         HANDLE handles[] = { _resultEvent, _stopEvent };
         DWORD result = WaitForMultipleObjects(
             2, handles,
@@ -204,6 +206,8 @@ FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path
         _parent, SLOT(changeDetected(const QString &)));
     connect(_thread, SIGNAL(lostChanges()),
         _parent, SIGNAL(lostChanges()));
+    connect(_thread, &WatcherThread::ready,
+        this, [this]() { _ready = 1; });
     _thread->start();
 }
 

--- a/src/gui/folderwatcher_win.h
+++ b/src/gui/folderwatcher_win.h
@@ -74,9 +74,6 @@ public:
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
     ~FolderWatcherPrivate();
 
-    void addPath(const QString &) {}
-    void removePath(const QString &) {}
-
 private:
     FolderWatcher *_parent;
     WatcherThread *_thread;

--- a/src/gui/folderwatcher_win.h
+++ b/src/gui/folderwatcher_win.h
@@ -54,6 +54,7 @@ protected:
 signals:
     void changed(const QString &path);
     void lostChanges();
+    void ready();
 
 private:
     QString _path;
@@ -73,6 +74,9 @@ class FolderWatcherPrivate : public QObject
 public:
     FolderWatcherPrivate(FolderWatcher *p, const QString &path);
     ~FolderWatcherPrivate();
+
+    /// Set to non-zero once the WatcherThread is capturing events.
+    QAtomicInt _ready;
 
 private:
     FolderWatcher *_parent;

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -96,6 +96,12 @@ class TestFolderWatcher : public QObject
         return false;
     }
 
+#ifdef Q_OS_LINUX
+#define CHECK_WATCH_COUNT(n) QCOMPARE(_watcher->testLinuxWatchCount(), (n))
+#else
+#define CHECK_WATCH_COUNT(n) do {} while (false)
+#endif
+
 public:
     TestFolderWatcher() {
         qsrand(QTime::currentTime().msec());
@@ -118,10 +124,24 @@ public:
         _pathChangedSpy.reset(new QSignalSpy(_watcher.data(), SIGNAL(pathChanged(QString))));
     }
 
+    int countFolders(const QString &path)
+    {
+        int n = 0;
+        for (const auto &sub : QDir(path).entryList(QDir::Dirs | QDir::NoDotAndDotDot))
+            n += 1 + countFolders(path + '/' + sub);
+        return n;
+    }
+
 private slots:
     void init()
     {
         _pathChangedSpy->clear();
+        CHECK_WATCH_COUNT(countFolders(_rootPath) + 1);
+    }
+
+    void cleanup()
+    {
+        CHECK_WATCH_COUNT(countFolders(_rootPath) + 1);
     }
 
     void testACreate() { // create a new file
@@ -155,6 +175,11 @@ private slots:
         QString file(_rootPath+"/a1/b1/new_dir");
         mkdir(file);
         QVERIFY(waitForPathChanged(file));
+
+        // Notifications from that new folder arrive too
+        QString file2(_rootPath + "/a1/b1/new_dir/contained");
+        touch(file2);
+        QVERIFY(waitForPathChanged(file2));
     }
 
     void testRemoveADir() {

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -193,6 +193,48 @@ private slots:
         QVERIFY(waitForPathChanged(old_file));
         QVERIFY(waitForPathChanged(new_file));
     }
+
+    void testRenameDirectorySameBase() {
+        QString old_file(_rootPath+"/a1/b1");
+        QString new_file(_rootPath+"/a1/brename");
+        QVERIFY(QFile::exists(old_file));
+        mv(old_file, new_file);
+        QVERIFY(QFile::exists(new_file));
+
+        QVERIFY(waitForPathChanged(old_file));
+        QVERIFY(waitForPathChanged(new_file));
+
+        // Verify that further notifications end up with the correct paths
+
+        QString file(_rootPath+"/a1/brename/c1/random.bin");
+        touch(file);
+        QVERIFY(waitForPathChanged(file));
+
+        QString dir(_rootPath+"/a1/brename/newfolder");
+        mkdir(dir);
+        QVERIFY(waitForPathChanged(dir));
+    }
+
+    void testRenameDirectoryDifferentBase() {
+        QString old_file(_rootPath+"/a1/brename");
+        QString new_file(_rootPath+"/bren");
+        QVERIFY(QFile::exists(old_file));
+        mv(old_file, new_file);
+        QVERIFY(QFile::exists(new_file));
+
+        QVERIFY(waitForPathChanged(old_file));
+        QVERIFY(waitForPathChanged(new_file));
+
+        // Verify that further notifications end up with the correct paths
+
+        QString file(_rootPath+"/bren/c1/random.bin");
+        touch(file);
+        QVERIFY(waitForPathChanged(file));
+
+        QString dir(_rootPath+"/bren/newfolder2");
+        mkdir(dir);
+        QVERIFY(waitForPathChanged(dir));
+    }
 };
 
 #ifdef Q_OS_MAC


### PR DESCRIPTION
Cherry-picked:

- [Folderwatcher: On linux, fix paths after dir renames](https://github.com/owncloud/client/commit/55cf407337a5db93511f1cb061165c53fa6dba6e)
- [FolderWatcher: Always notify about conflict files #7073 ](https://github.com/owncloud/client/commit/6d8b27747b8d0d1ec76a39f6efb2eeffc5397826)
- [FolderWatcher linux: Make automatically recursive #7068 ](https://github.com/owncloud/client/commit/cb5a76729a65f6a474637a2b1578c8aaa7c878c3)
- [FolderWatcher: Become unreliable if test notification fails #7241](https://github.com/owncloud/client/commit/831e718b0c07fbfb2179eeebe25433575fac4d16)
- [FolderWatcher: Wait for ready before testing #7305](https://github.com/owncloud/client/commit/0277b2e478cc3dfa63f69b254566ac911b8f2024)
- [FolderWatcher: Usage of QTime for elapsed time is deprecated](https://github.com/owncloud/client/commit/146d75a2d601509157a0fcd981ef0209926e7d6c)
- [ FolderWatcher: Disable test on OSX #7305 ](https://github.com/owncloud/client/commit/91e0ffe72e3e51112fb96b6b79721a4734320796)



