### PR TITLE
Fix QML debugging by removing incorrect dependency

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -30,7 +30,6 @@
 #include <QMap>
 #include <QUrl>
 #include <QUrlQuery>
-#include <QtQuick/QQuickImageProvider>
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
Removed QML dependency from nextcloudcmd target.
Signed-off-by: allexzander <blackslayer4@gmail.com>