### PR TITLE
Add debug log to check which folders are being skipped during syncing.

### DIFF
--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -141,6 +141,8 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
 
             if (!skip) {
                 emit changed(longfile);
+            } else {
+                qCDebug(lcFolderWatcher) << "Skipping syncing of" << longfile;
             }
 
             if (curEntry->NextEntryOffset == 0) {


### PR DESCRIPTION
Signed-off-by: Camila <hello@camila.codes>