### PR TITLE
Handle the warning message when unchecking folders for syncing.

### DIFF
--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -71,8 +71,8 @@ public slots:
     void slotUpdateQuota(qint64 total, qint64 used);
     void slotAccountStateChanged();
     void slotStyleChanged();
-
     AccountState *accountsState() { return _accountState; }
+    void slotHideSelectiveSyncWidget();
 
 protected slots:
     void slotAddFolder();
@@ -102,6 +102,9 @@ protected slots:
     void slotShowMnemonic(const QString &mnemonic);
     void slotNewMnemonicGenerated();
     void slotEncryptFolderFinished(int status);
+
+    void slotSelectiveSyncChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                                  const QVector<int> &roles);
 
 private:
     void showConnectionLabel(const QString &message,

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>581</width>
+    <width>588</width>
     <height>557</height>
    </rect>
   </property>
@@ -39,62 +39,6 @@
           <property name="openExternalLinks">
            <bool>true</bool>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="bigFolderUi" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="selectiveSyncNotification">
-             <property name="styleSheet">
-              <string notr="true">color: red</string>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QPushButton" name="bigFolderSyncAll">
-               <property name="text">
-                <string>Synchronize all</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="bigFolderSyncNone">
-               <property name="text">
-                <string>Synchronize none</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="bigFolderApply">
-               <property name="text">
-                <string>Apply manual changes</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-          </layout>
          </widget>
         </item>
        </layout>
@@ -241,6 +185,9 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="0">
+    <widget class="KMessageWidget" name="encryptionMessage" native="true"/>
+   </item>
    <item row="3" column="0">
     <widget class="OCC::FolderStatusView" name="_folderList">
      <property name="sizePolicy">
@@ -260,8 +207,74 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="KMessageWidget" name="encryptionMessage" native="true"/>
+   <item row="5" column="0">
+    <widget class="QWidget" name="bigFolderUi" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="selectiveSyncNotification">
+        <property name="styleSheet">
+         <string notr="true">color: red</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="bigFolderSyncAll">
+          <property name="text">
+           <string>Synchronize all</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="bigFolderSyncNone">
+          <property name="text">
+           <string>Synchronize none</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="bigFolderApply">
+          <property name="text">
+           <string>Apply manual changes</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Split widgets and slot to handle the refreshing of the view:
- refreshSelectiveSyncStatus is connected to signal dirtyChanged
and will handle big folder warning.
- slotSelectiveSyncChanged  which is connected to dataChanged signal
and will handle the selective sync warning. It fixes #1029 because
it looks for the checkbox state before showing the warning.

![selectivesync](https://user-images.githubusercontent.com/241266/101491761-6c372c00-3964-11eb-8153-a79ba7abae4e.gif)

![bigfolder](https://user-images.githubusercontent.com/241266/101491850-8a049100-3964-11eb-9263-45632a709096.png)

