### PR TITLE
Have the new account wizard open again

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -214,9 +214,6 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
         _ui->encryptionMessage->hide();
     }
 
-    connect(UserModel::instance(), &UserModel::addAccount,
-         this, &AccountSettings::slotOpenAccountWizard);
-
     customizeStyle();
 }
 
@@ -249,17 +246,6 @@ QString AccountSettings::selectedFolderAlias() const
     if (!selected.isValid())
         return "";
     return _model->data(selected, FolderStatusDelegate::FolderAliasRole).toString();
-}
-
-void AccountSettings::slotOpenAccountWizard()
-{
-    // We can't call isSystemTrayAvailable with appmenu-qt5 because it breaks the systemtray
-    // (issue #4693, #4944)
-    if (qgetenv("QT_QPA_PLATFORMTHEME") == "appmenu-qt5" || QSystemTrayIcon::isSystemTrayAvailable()) {
-        topLevelWidget()->close();
-    }
-
-    OwncloudSetupWizard::runWizard(qApp, SLOT(slotownCloudWizardDone(int)), nullptr);
 }
 
 void AccountSettings::slotToggleSignInState()

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -89,7 +89,6 @@ protected slots:
     void slotFolderWizardRejected();
     void slotDeleteAccount();
     void slotToggleSignInState();
-    void slotOpenAccountWizard();
     void refreshSelectiveSyncStatus();
     void slotMarkSubfolderEncrypted(const FolderStatusModel::SubFolderInfo* folderInfo);
     void slotSubfolderContextMenuRequested(const QModelIndex& idx, const QPoint& point);

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -119,6 +119,8 @@ Systray::Systray()
 
     connect(UserModel::instance(), &UserModel::newUserSelected,
         this, &Systray::slotNewUserSelected);
+    connect(UserModel::instance(), &UserModel::addAccount,
+            this, &Systray::openAccountWizard);
 
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, &Systray::showWindow);


### PR DESCRIPTION
UserModel can't be connected to AccountSettings if the settings dialog
doesn't exist. This is the case now since we delay the creation of that
dialog and free it after use.

Instead it should be properly channeled through the Systray object all
the way up to OwncloudGui which knows how to handle this properly.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>

Fix #2706