### PR TITLE
Ensure a sync happens after a conflict resolution

### DIFF
--- a/src/gui/socketapi.cpp
+++ b/src/gui/socketapi.cpp
@@ -711,7 +711,9 @@ void SocketApi::command_RESOLVE_CONFLICT(const QString &localFile, SocketListene
     dialog.setBaseFilename(baseName);
     dialog.setLocalVersionFilename(conflictedPath);
     dialog.setRemoteVersionFilename(basePath);
-    dialog.exec();
+    if (dialog.exec() == ConflictDialog::Accepted) {
+        fileData.folder->scheduleThisFolderSoon();
+    }
 #endif
 }
 

--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -448,7 +448,9 @@ void ActivityListModel::triggerDefaultAction(int activityIndex) const
         dialog.setBaseFilename(baseName);
         dialog.setLocalVersionFilename(conflictedPath);
         dialog.setRemoteVersionFilename(basePath);
-        dialog.exec();
+        if (dialog.exec() == ConflictDialog::Accepted) {
+            folder->scheduleThisFolderSoon();
+        }
         return;
     }
 


### PR DESCRIPTION
You'd expect that after a conflict resolution the file watcher would
pick up the change and trigger a sync. For some reason it doesn't seem
to happen on at least some Ubuntu systems. In such cases the user would
then still have a stale conflict entry in the activity list and wouldn't
be able to do anything with it.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>