### PR TITLE
Give the user a more descriptive error message when syncing is aborted.

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1013,9 +1013,8 @@ void SyncEngine::abort()
         // Delete the discovery and all child jobs after ensuring
         // it can't finish and start the propagator
         disconnect(_discoveryPhase.data(), nullptr, this, nullptr);
-        _discoveryPhase.take()->deleteLater();
 
-        syncError(tr("Aborted"));
+        syncError(tr("Syncing got interrupted by another request. You may try to restart it manually."));
         finalize(false);
     }
 }


### PR DESCRIPTION
There are no screenshots because I couldn't trigger it again but I got the "Aborted" message a few times while working in #2723.

I just think "Aborted" is terrible :shrug: 