### PR TITLE
Make monochrome icons the default on Linux and Mac OS.

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -896,10 +896,10 @@ void ConfigFile::setPromptDeleteFiles(bool promptDeleteFiles)
 bool ConfigFile::monoIcons() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    bool monoDefault = false; // On Mac we want bw by default
-#ifdef Q_OS_MAC
-    // OEM themes are not obliged to ship mono icons
-    monoDefault = (0 == (strcmp("ownCloud", APPLICATION_NAME)));
+    // On Mac and Linux we want bw by default
+    bool monoDefault = QByteArrayLiteral("Nextcloud") == QByteArrayLiteral(APPLICATION_NAME);
+#ifdef Q_OS_WIN
+    monoDefault = false;
 #endif
     return settings.value(QLatin1String(monoIconsC), monoDefault).toBool();
 }


### PR DESCRIPTION
Unless it is branded with other icons.

See 1st item in #2721 