### PR TITLE
Fixed the autostart for AppImages. See #2504.

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <QStandardPaths>
+#include <QtGlobal>
 
 namespace OCC {
 
@@ -71,12 +72,18 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
             qCWarning(lcUtility) << "Could not write auto start entry" << desktopFileLocation;
             return;
         }
+        // When running inside an AppImage, we need to set the path to the
+        // AppImage instead of the path to the executable
+        const QString appImagePath = qEnvironmentVariable("APPIMAGE");
+        const bool runningInsideAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
+        const QString executablePath = runningInsideAppImage ? appImagePath : QCoreApplication::applicationFilePath();
+
         QTextStream ts(&iniFile);
         ts.setCodec("UTF-8");
         ts << QLatin1String("[Desktop Entry]") << endl
            << QLatin1String("Name=") << guiName << endl
            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
-           << QLatin1String("Exec=") << QCoreApplication::applicationFilePath() << " --background" << endl
+           << QLatin1String("Exec=\"") << executablePath << "\" --background" << endl
            << QLatin1String("Terminal=") << "false" << endl
            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
            << QLatin1String("Categories=") << QLatin1String("Network") << endl


### PR DESCRIPTION
For details please see the discussion in #2504. This fix sets the application path to the enviornment variable APPIMAGE, if the variable exists and points to an existing file. According to the discussion, this should fix #2504.

I cannot, however, check whether this fixes the bug, since I cannot build the AppImage, because the `build-appimage.sh` is aparently expecting to be run on a certain version of a certain Linux distribution under some CI/CD system. (And I do not know which one.)

Would be great, if someone could build the AppImage and test it.