### PR TITLE
Removed translation for "etag" and changed spelling

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -409,7 +409,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(
         if (serverEntry.remotePerm.isNull())
             missingData.append(tr("permissions"));
         if (serverEntry.etag.isEmpty())
-            missingData.append(tr("etag"));
+            missingData.append("ETag");
         if (serverEntry.fileId.isEmpty())
             missingData.append(tr("file id"));
         if (!missingData.isEmpty()) {

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -167,7 +167,7 @@ private slots:
         QCOMPARE(completeSpy.findItem("nofileid")->_instruction, CSYNC_INSTRUCTION_ERROR);
         QCOMPARE(completeSpy.findItem("nopermissions")->_instruction, CSYNC_INSTRUCTION_NEW);
         QCOMPARE(completeSpy.findItem("nopermissions/A")->_instruction, CSYNC_INSTRUCTION_ERROR);
-        QVERIFY(completeSpy.findItem("noetag")->_errorString.contains("etag"));
+        QVERIFY(completeSpy.findItem("noetag")->_errorString.contains("ETag"));
         QVERIFY(completeSpy.findItem("nofileid")->_errorString.contains("file id"));
         QVERIFY(completeSpy.findItem("nopermissions/A")->_errorString.contains("permissions"));
     }


### PR DESCRIPTION
Shouldn't be translated.

Just checked https://en.wikipedia.org/wiki/HTTP_ETag and all available localized pages.

Signed-off-by: rakekniven <mark.ziegler@rakekniven.de>