### PR TITLE
Fix changelog for 2.6.0 documentation

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -18,10 +18,11 @@ Improvements and New Features
 The |version| release of the Nextcloud desktop sync client has many new features and
 improvements.
 
-  * Show server notifications on the client
-  * Improved sync speed
-  * Improved handling of Win32 file locks and network files
-  * Improved user notifications about ignored files and conflicts
-  * Add warnings for old server versions
-  * Update of QtKeyChain to support Windows credential store
-  * Packaging of dolphin overlay icon module for bleeding edge distributions
+* Login flow v2
+* Displays FileIgnored activities with an info icon
+* Add proper CA to client side certificate connection
+* Read .sync_exclude.lst in each subdirectory
+* Full-Scaled new logo in Windows 10 start menu tile
+* Qt5.5 compatiblity patch for login flow V2 + UI improvement (Use newer digest algorithms in TLS error dialog)
+* UI improvement: Message box: Delete / Keep all files
+* More minor fixes, a full list can be found `here <https://github.com/nextcloud/desktop/blob/master/ChangeLog>`_


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/1506

Also when building a new version, make sure it refers to 2.6.0 correctly, currently it is still shown 2.4.0 in the documentation (even though it is the documentation for the 2.6.0 version: https://docs.nextcloud.com/desktop/2.6/introduction.html#improvements-and-new-features):
![grafik](https://user-images.githubusercontent.com/8111200/103168496-f40da900-4833-11eb-8be5-6bce77f78c44.png)
