### PR TITLE
Fix CfAPI wrapper build in Win32 mode

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -346,13 +346,13 @@ OCC::CfApiWrapper::FileHandle OCC::CfApiWrapper::handleForPath(const QString &pa
         HANDLE handle = nullptr;
         const qint64 openResult = CfOpenFileWithOplock(path.toStdWString().data(), CF_OPEN_FILE_FLAG_NONE, &handle);
         if (openResult == S_OK) {
-            return {handle, CfCloseHandle};
+            return FileHandle(handle, CfCloseHandle);
         }
     } else {
         const auto handle = CreateFile(path.toStdWString().data(), 0, 0, nullptr,
                                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
         if (handle != INVALID_HANDLE_VALUE) {
-            return {handle, [](HANDLE h) { CloseHandle(h); }};
+            return FileHandle(handle, [](HANDLE h) { CloseHandle(h); });
         }
     }
 


### PR DESCRIPTION
For some reason MSVC manages to deduce the right constructor in Win64
mode but not in Win32 mode. So let's be more explicit about what we
return.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>