### PR TITLE
Repair chunked uploads

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -318,7 +318,7 @@ void PropagateUploadFileNG::startNextChunk()
 
     const QString fileName = _fileToUpload._path;
     auto device = std::make_unique<UploadDevice>(
-            fileName, _currentChunk, _currentChunkSize, &propagator()->_bandwidthManager);
+            fileName, _sent, _currentChunkSize, &propagator()->_bandwidthManager);
     if (!device->open(QIODevice::ReadOnly)) {
         qCWarning(lcPropagateUploadNG) << "Could not prepare upload device: " << device->errorString();
 


### PR DESCRIPTION
There's been a confusion between the chunk number and the chunk
offset leading to corruptions... Let's pass the proper offset to
the UploadDevice again.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>

Fix #2822 