### PR TITLE
Fix build against Qt 5.15.3

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -588,7 +588,7 @@ QString ExcludedFiles::convertToRegexpSyntax(QString exclude, bool wildcardsMatc
             // Translate [! to [^
             QString bracketExpr = exclude.mid(i, j - i + 1);
             if (bracketExpr.startsWith(QLatin1String("[!")))
-                bracketExpr[1] = '^';
+                bracketExpr[1] = QLatin1Char('^');
             regex.append(bracketExpr);
             i = j;
             break;


### PR DESCRIPTION
Use QLatin1Char to prevent build error due to stricter QT_NO_CAST_FROM_ASCII