### PR TITLE
VFS CfAPI implementation shouldn't get stuck

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -52,7 +52,6 @@ void cfApiSendTransferInfo(const CF_CONNECTION_KEY &connectionKey, const CF_TRAN
     opParams.TransferData.Length.QuadPart = length;
 
     const qint64 result = CfExecute(&opInfo, &opParams);
-    Q_ASSERT(result == S_OK);
     if (result != S_OK) {
         qCCritical(lcCfApiWrapper) << "Couldn't send transfer info" << QString::number(transferKey.QuadPart, 16) << ":" << _com_error(result).ErrorMessage();
     }


### PR DESCRIPTION
In some fringe cases the client would crash while we could in fact somewhat gracefully handle them. So let's be a little less assert heavy since Windows likes to poke the client several times until it gets what it wants...