### PR TITLE
Don't treat new folders in unpinned folders as files to dehydrate

### DIFF
--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -187,8 +187,10 @@ bool VfsCfApi::statTypeVirtualFile(csync_file_stat_t *stat, void *statData)
     // It's a dir with a reparse point due to the placeholder info (hence the cloud tag)
     // if we don't remove the reparse point flag the discovery will end up thinking
     // it is a file... let's prevent it
-    if (isDirectory && hasReparsePoint && hasCloudTag) {
-        ffd->dwFileAttributes &= ~FILE_ATTRIBUTE_REPARSE_POINT;
+    if (isDirectory) {
+        if (hasReparsePoint && hasCloudTag) {
+            ffd->dwFileAttributes &= ~FILE_ATTRIBUTE_REPARSE_POINT;
+        }
         return false;
     } else if (isSparseFile && isPinned) {
         stat->type = ItemTypeVirtualFileDownload;

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -1067,6 +1067,33 @@ private slots:
         QCOMPARE(*vfs->pinState("onlinerenamed2/file1rename"), PinState::OnlineOnly);
     }
 
+    void testEmptyFolderInOnlineOnlyRoot()
+    {
+        FakeFolder fakeFolder{ FileInfo() };
+        setupVfs(fakeFolder);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        ItemCompletedSpy completeSpy(fakeFolder);
+
+        auto cleanup = [&]() {
+            completeSpy.clear();
+        };
+        cleanup();
+
+        // OnlineOnly forced on the root
+        setPinState(fakeFolder.localPath(), PinState::OnlineOnly, cfapi::NoRecurse);
+
+        // No effect sync
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        cleanup();
+
+        // Add an empty folder which should propagate
+        fakeFolder.localModifier().mkdir("A");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        cleanup();
+    }
+
     void testIncompatiblePins()
     {
         FakeFolder fakeFolder{ FileInfo() };


### PR DESCRIPTION
This would only happen if the parent of the newly created folder would
be explicitly set to online only, hence why it went under the radar
previously.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>