### PR TITLE
Repair E2EE on sync folders which don't point to the root of the server on the remote end

### DIFF
--- a/src/libsync/abstractpropagateremotedeleteencrypted.cpp
+++ b/src/libsync/abstractpropagateremotedeleteencrypted.cpp
@@ -58,7 +58,7 @@ void AbstractPropagateRemoteDeleteEncrypted::storeFirstErrorString(const QString
 void AbstractPropagateRemoteDeleteEncrypted::startLsColJob(const QString &path)
 {
     qCDebug(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED) << "Folder is encrypted, let's get the Id from it.";
-    auto job = new LsColJob(_propagator->account(), path, this);
+    auto job = new LsColJob(_propagator->account(), _propagator->fullRemotePath(path), this);
     job->setProperties({"resourcetype", "http://owncloud.org/ns:fileid"});
     connect(job, &LsColJob::directoryListingSubfolders, this, &AbstractPropagateRemoteDeleteEncrypted::slotFolderEncryptedIdReceived);
     connect(job, &LsColJob::finishedWithError, this, &AbstractPropagateRemoteDeleteEncrypted::taskFailed);


### PR DESCRIPTION
Found a couple of regressions related to the use of E2EE in the context of sync folders configured to not point to / but to some other subfolders on the server. They were introduced during the big changes in the discovery which made the content of the e2eMangledName field change in the database with a different convention to what almost all the jobs were expecting. The only exception was one place in the newer changes done by @allexzander around deletion.