### PR TITLE
Allow creation of new folders from the Settings Dialog.

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ endif()
 set(client_UI_SRCS
     accountsettings.ui
     conflictdialog.ui
+    foldercreationdialog.ui
     folderwizardsourcepage.ui
     folderwizardtargetpage.ui
     generalsettings.ui
@@ -60,6 +61,7 @@ set(client_SRCS
     conflictsolver.cpp
     connectionvalidator.cpp
     folder.cpp
+    foldercreationdialog.cpp
     folderman.cpp
     folderstatusmodel.cpp
     folderstatusdelegate.cpp

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -85,6 +85,7 @@ protected slots:
     void slotOpenCurrentFolder(); // sync folder
     void slotOpenCurrentLocalSubFolder(); // selected subfolder in sync folder
     void slotEditCurrentIgnoredFiles();
+    void slotOpenMakeFolderDialog();
     void slotEditCurrentLocalIgnoredFiles();
     void slotEnableVfsCurrentFolder();
     void slotDisableVfsCurrentFolder();

--- a/src/gui/foldercreationdialog.cpp
+++ b/src/gui/foldercreationdialog.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) by Oleksandr Zolotov <alex@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "foldercreationdialog.h"
+#include "ui_foldercreationdialog.h"
+
+#include <limits>
+
+#include <QDir>
+#include <QMessageBox>
+
+FolderCreationDialog::FolderCreationDialog(const QString &destination, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::FolderCreationDialog)
+    , _destination(destination)
+{
+    ui->setupUi(this);
+
+    ui->labelErrorMessage->setVisible(false);
+
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    connect(ui->newFolderNameEdit, &QLineEdit::textChanged, this, &FolderCreationDialog::slotNewFolderNameEditTextEdited);
+
+    const QString suggestedFolderNamePrefix = QObject::tr("New folder");
+
+    const auto newFolderFullPath = _destination + "/" + suggestedFolderNamePrefix;
+    if (!QDir(newFolderFullPath).exists()) {
+        ui->newFolderNameEdit->setText(suggestedFolderNamePrefix);
+    } else {
+        for (unsigned int i = 2; i < std::numeric_limits<unsigned int>::max(); ++i) {
+            const QString suggestedPostfix = QString(" (%1)").arg(i);
+
+            if (!QDir(newFolderFullPath + suggestedPostfix).exists()) {
+                ui->newFolderNameEdit->setText(suggestedFolderNamePrefix + suggestedPostfix);
+                break;
+            }
+        }
+    }
+
+    ui->newFolderNameEdit->setFocus();
+    ui->newFolderNameEdit->selectAll();
+}
+
+FolderCreationDialog::~FolderCreationDialog()
+{
+    delete ui;
+}
+
+void FolderCreationDialog::accept()
+{
+    Q_ASSERT(!_destination.endsWith('/'));
+
+    if (QDir(_destination + "/" + ui->newFolderNameEdit->text()).exists()) {
+        ui->labelErrorMessage->setVisible(true);
+        return;
+    }
+
+    if (!QDir(_destination).mkdir(ui->newFolderNameEdit->text())) {
+        QMessageBox::critical(this, tr("Error"), tr("Could not create a folder! Check your write permissions."));
+    }
+
+    QDialog::accept();
+}
+
+void FolderCreationDialog::slotNewFolderNameEditTextEdited()
+{
+    if (!ui->newFolderNameEdit->text().isEmpty() && QDir(_destination + "/" + ui->newFolderNameEdit->text()).exists()) {
+        ui->labelErrorMessage->setVisible(true);
+    } else {
+        ui->labelErrorMessage->setVisible(false);
+    }
+}

--- a/src/gui/foldercreationdialog.h
+++ b/src/gui/foldercreationdialog.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) by Oleksandr Zolotov <alex@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef FOLDERCREATIONDIALOG_H
+#define FOLDERCREATIONDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class FolderCreationDialog;
+}
+
+class FolderCreationDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FolderCreationDialog(const QString &destination, QWidget *parent = nullptr);
+    ~FolderCreationDialog();
+
+private slots:
+    void accept() override;
+
+    void slotNewFolderNameEditTextEdited();
+
+private:
+    Ui::FolderCreationDialog *ui;
+
+    QString _destination;
+};
+
+#endif // FOLDERCREATIONDIALOG_H

--- a/src/gui/foldercreationdialog.ui
+++ b/src/gui/foldercreationdialog.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FolderCreationDialog</class>
+ <widget class="QDialog" name="FolderCreationDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>355</width>
+    <height>138</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Create new folder</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>90</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="newFolderNameEdit">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>30</y>
+     <width>321</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="placeholderText">
+    <string>Enter folder name</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="labelErrorMessage">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>60</y>
+     <width>321</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">color: rgb(255, 0, 0)</string>
+   </property>
+   <property name="text">
+    <string>Folder already exists</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FolderCreationDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FolderCreationDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -60,8 +60,9 @@ public:
     struct SubFolderInfo
     {
         Folder *_folder = nullptr;
-        QString _name;
-        QString _path;
+        QString _name; // Folder name to be displayed in the UI
+        QString _path; // Sub-folder path that should always point to a local filesystem's folder
+        QString _e2eMangledName; // Mangled name that needs to be used when making fetch requests and should not be used for displaying in the UI
         QVector<int> _pathIdx;
         QVector<SubFolderInfo> _subs;
         qint64 _size = 0;


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

Also fixed incorrect path for SubFolderInfo that was resulting in an inability to open encrypted subfolder and create a new folder inside it via the Settings Dialog's context menu.