### PR TITLE
Load the theme resource explictly

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -52,6 +52,7 @@ void warnSystray()
 int main(int argc, char **argv)
 {
     Q_INIT_RESOURCE(resources);
+    Q_INIT_RESOURCE(theme);
 
     // Work around a bug in KDE's qqc2-desktop-style which breaks
     // buttons with icons not based on a name, by forcing a style name


### PR DESCRIPTION
Otherwise they won't be loaded automatically at startup leading to lots
of missing icons. Since they're now in a static library they need that
explicit loading.

This fix a regression introduced by #2834 