### PR TITLE
Win tests compilation fix.

### DIFF
--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -68,9 +68,9 @@ target_include_directories(
 find_package(SQLite3 3.9.0 REQUIRED)
 if (USE_OUR_OWN_SQLITE3)
     # make sure that the path for the local sqlite3 is before the system one
-    target_include_directories("${csync_NAME}" BEFORE PRIVATE ${SQLITE3_INCLUDE_DIR})
+    target_include_directories("${csync_NAME}" BEFORE PUBLIC ${SQLITE3_INCLUDE_DIR})
 else()
-    target_include_directories("${csync_NAME}" PRIVATE ${SQLITE3_INCLUDE_DIR})
+    target_include_directories("${csync_NAME}" PUBLIC ${SQLITE3_INCLUDE_DIR})
 endif()
 
 


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

Fix for Windows build error of not being able to locate #include <sqlite3.h> in tests.