### PR TITLE
Move FolderCreationDialog into the OCC namespace

### DIFF
--- a/src/gui/foldercreationdialog.cpp
+++ b/src/gui/foldercreationdialog.cpp
@@ -20,6 +20,8 @@
 #include <QDir>
 #include <QMessageBox>
 
+namespace OCC {
+
 FolderCreationDialog::FolderCreationDialog(const QString &destination, QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::FolderCreationDialog)
@@ -81,4 +83,6 @@ void FolderCreationDialog::slotNewFolderNameEditTextEdited()
     } else {
         ui->labelErrorMessage->setVisible(false);
     }
+}
+
 }

--- a/src/gui/foldercreationdialog.h
+++ b/src/gui/foldercreationdialog.h
@@ -17,6 +17,8 @@
 
 #include <QDialog>
 
+namespace OCC {
+
 namespace Ui {
 class FolderCreationDialog;
 }
@@ -39,5 +41,7 @@ private:
 
     QString _destination;
 };
+
+}
 
 #endif // FOLDERCREATIONDIALOG_H

--- a/src/gui/foldercreationdialog.ui
+++ b/src/gui/foldercreationdialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>FolderCreationDialog</class>
- <widget class="QDialog" name="FolderCreationDialog">
+ <class>OCC::FolderCreationDialog</class>
+ <widget class="QDialog" name="OCC::FolderCreationDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -67,7 +67,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>FolderCreationDialog</receiver>
+   <receiver>OCC::FolderCreationDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -83,7 +83,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>FolderCreationDialog</receiver>
+   <receiver>OCC::FolderCreationDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
Compilation has started to fail recently with the following:

```In file included from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/moc_foldercreationdialog.cpp:10,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/mocs_compilation.cpp:24:
/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/../../../../../src/gui/foldercreationdialog.h:38:5: error: reference to ‘Ui’ is ambiguous
   38 |     Ui::FolderCreationDialog *ui;
      |     ^~
In file included from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/moc_accountsettings.cpp:10,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/mocs_compilation.cpp:7:
/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/../../../../../src/gui/accountsettings.h:37:11: note: candidates are: ‘namespace OCC::Ui { }’
   37 | namespace Ui {
      |           ^~
In file included from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/moc_foldercreationdialog.cpp:10,
                 from /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/mocs_compilation.cpp:24:
/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/gui/nextcloudCore_autogen/EWIEGA46WW/../../../../../src/gui/foldercreationdialog.h:20:11: note:                 ‘namespace Ui { }’
   20 | namespace Ui {
      |           ^~
```
This patch attempts to fix it by moving FolderCreationDialog into the OCC namespace.