### PR TITLE
Configuration Options for Windows Registry

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -850,8 +850,9 @@ void ConfigFile::setDownloadLimit(int kbytes)
 QPair<bool, qint64> ConfigFile::newBigFolderSizeLimit() const
 {
     auto defaultValue = Theme::instance()->newBigFolderSizeLimit();
-    qint64 value = getValue(newBigFolderSizeLimitC, QString(), defaultValue).toLongLong();
-    bool use = value >= 0 && getValue(useNewBigFolderSizeLimitC, QString(), true).toBool();
+    const auto fallback = getValue(newBigFolderSizeLimitC, QString(), defaultValue).toLongLong();
+    const auto value = getPolicySetting(QLatin1String(newBigFolderSizeLimitC), fallback).toLongLong();
+    const bool use = value >= 0 && useNewBigFolderSizeLimit();
     return qMakePair(use, qMax<qint64>(0, value));
 }
 
@@ -863,7 +864,14 @@ void ConfigFile::setNewBigFolderSizeLimit(bool isChecked, qint64 mbytes)
 
 bool ConfigFile::confirmExternalStorage() const
 {
-    return getValue(confirmExternalStorageC, QString(), true).toBool();
+    const auto fallback = getValue(confirmExternalStorageC, QString(), true);
+    return getPolicySetting(QLatin1String(confirmExternalStorageC), fallback).toBool();
+}
+
+bool ConfigFile::useNewBigFolderSizeLimit() const
+{
+    const auto fallback = getValue(useNewBigFolderSizeLimitC, QString(), true);
+    return getPolicySetting(QLatin1String(useNewBigFolderSizeLimitC), fallback).toBool();
 }
 
 void ConfigFile::setConfirmExternalStorage(bool isChecked)
@@ -913,7 +921,8 @@ void ConfigFile::setMonoIcons(bool useMonoIcons)
 bool ConfigFile::crashReporter() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(crashReporterC), true).toBool();
+    const auto fallback = settings.value(QLatin1String(crashReporterC), true);
+    return getPolicySetting(QLatin1String(crashReporterC), fallback).toBool();
 }
 
 void ConfigFile::setCrashReporter(bool enabled)

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -137,6 +137,7 @@ public:
     /** [checked, size in MB] **/
     QPair<bool, qint64> newBigFolderSizeLimit() const;
     void setNewBigFolderSizeLimit(bool isChecked, qint64 mbytes);
+    bool useNewBigFolderSizeLimit() const;
     bool confirmExternalStorage() const;
     void setConfirmExternalStorage(bool);
 


### PR DESCRIPTION
Hi,
I created this issue https://github.com/nextcloud/desktop/issues/2890 and tried to implement it.
I have added these configuration  options

-  confirmExternalStorage
-  crashReporter
-  newBigFolderSizeLimit
-   useNewBigFolderSizeLimit

to the Windows registry.
They should behave the same as when you change it in the GUI.
I used a REG File wih these Settings to test:
```
Windows Registry Editor Version 5.00

[HKEY_CURRENT_USER\Software\Policies\Nextcloud GmbH\Nextcloud]
"newBigFolderSizeLimit"=dword:00005000
"skipUpdateCheck"=dword:00000001
"confirmExternalStorage"=dword:00000000
"useNewBigFolderSizeLimit"=dword:00000000
```
This is what the Client UI looks like:
![grafik](https://user-images.githubusercontent.com/10107699/107241607-6ffe3200-6a2b-11eb-8968-819f0ae59523.png)
