### PR TITLE
Add missing override specifier

### DIFF
--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -45,7 +45,7 @@ public:
 
     QString authType() const override;
     QString user() const override;
-    QString password() const;
+    QString password() const override;
     QNetworkAccessManager *createQNAM() const override;
 
     bool ready() const override;


### PR DESCRIPTION
Noticed a warning during compilation. I think I introduced this warning recently.