### PR TITLE
Use title case APPLICATION_EXECUTABLE for macOS

### DIFF
--- a/NEXTCLOUD.cmake
+++ b/NEXTCLOUD.cmake
@@ -1,6 +1,7 @@
 set( APPLICATION_NAME       "Nextcloud" )
 set( APPLICATION_SHORTNAME  "Nextcloud" )
-set( APPLICATION_EXECUTABLE "nextcloud" )
+# APPLICATION_EXECUTABLE is APPLICATION_SHORTNAME,
+# with spaces removed, and (if not macOS) all lowercase
 set( APPLICATION_DOMAIN     "nextcloud.com" )
 set( APPLICATION_VENDOR     "Nextcloud GmbH" )
 set( APPLICATION_UPDATE_URL "https://updates.nextcloud.org/client/" CACHE STRING "URL for updater" )
@@ -11,6 +12,15 @@ set( APPLICATION_SERVER_URL "" CACHE STRING "URL for the server to use. If enter
 set( APPLICATION_SERVER_URL_ENFORCE ON ) # If set and APPLICATION_SERVER_URL is defined, the server can only connect to the pre-defined URL
 set( APPLICATION_REV_DOMAIN "com.nextcloud.desktopclient" )
 set( APPLICATION_VIRTUALFILE_SUFFIX "nextcloud" CACHE STRING "Virtual file suffix (not including the .)")
+
+# The following code is necessary for the macOS .app to have title case
+if (APPLE)
+    string(REPLACE " " "" APPLICATION_EXECUTABLE "${APPLICATION_SHORTNAME}")
+else ()
+    string(REPLACE " " "" temp "${APPLICATION_SHORTNAME}")
+    string(TOLOWER "${temp}" APPLICATION_EXECUTABLE)
+endif()
+# message(STATUS "Debug: APPLICATION_EXECUTABLE is ${APPLICATION_EXECUTABLE}")
 
 set( LINUX_PACKAGE_SHORTNAME "nextcloud" )
 set( LINUX_APPLICATION_ID "${APPLICATION_REV_DOMAIN}.${LINUX_PACKAGE_SHORTNAME}")


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/2898. I tested this change, and it doesn't seem to break anything.

This is a little bit kludgy, but when I tried to change `APPLICATION_EXECUTABLE` after initially setting it, the value only changed in certain places, so I put the initial assignment within a conditional just to make sure.

You could probably remove the code that strips out any spaces (if you prescreen `APPLICATION_SHORTNAME` to be safe as a CMake target), but it's there just in case.

You could also probably move the assignment code to `CMakeLists.txt` if you felt so inclined, but having it in `NEXTCLOUD.cmake` means my commit only changes a single file (since I changed the initial assignment).

Putting the code in `NEXTCLOUD.cmake` means that it won't automatically apply to any OEM themes, so it's up to you if you want to propagate the change.

Also FYI the application icon seems to be broken, but I tried building with `use_cmake_find_inotify_file`, and the application icon is broken there, too, so my code doesn't seem to be to blame.