### PR TITLE
Fix crash when opening conflict dialog

### DIFF
--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -413,6 +413,22 @@ void User::slotAddError(const QString &folderAlias, const QString &message, Erro
     }
 }
 
+bool User::isValueableActivity(const Folder *folder, const SyncFileItemPtr &item) const
+{
+    // Check if we are adding it to the right account and if it is useful information (protocol errors)
+    const auto isDifferentAccount = folder->accountState() != _account.data();
+    const auto isConflictFromOriginalFile = item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file);
+
+    if (isDifferentAccount) {
+        return false;
+    }
+    if (isConflictFromOriginalFile) {
+        return false;
+    }
+
+    return true;
+}
+
 void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
 {
     auto folderInstance = FolderMan::instance()->folder(folder);
@@ -420,8 +436,7 @@ void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
     if (!folderInstance)
         return;
 
-    // check if we are adding it to the right account and if it is useful information (protocol errors)
-    if (folderInstance->accountState() == _account.data()) {
+    if (isValueableActivity(folderInstance, item)) {
         qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in " << item->_errorString;
 
         Activity activity;

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -415,14 +415,13 @@ void User::slotAddError(const QString &folderAlias, const QString &message, Erro
 
 bool User::isValueableActivity(const Folder *folder, const SyncFileItemPtr &item) const
 {
-    // Check if we are adding it to the right account and if it is useful information (protocol errors)
-    const auto isDifferentAccount = folder->accountState() != _account.data();
-    const auto isConflictFromOriginalFile = item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file);
-
-    if (isDifferentAccount) {
+    // Ignore activity from a different account
+    if (folder->accountState() != _account.data()) {
         return false;
     }
-    if (isConflictFromOriginalFile) {
+
+    // We just care about conflict issues that we are able to resolve
+    if (item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file)) {
         return false;
     }
 

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -80,6 +80,8 @@ private:
     void connectPushNotifications() const;
     bool checkPushNotificationsAreReady() const;
 
+    bool isValueableActivity(const Folder *folder, const SyncFileItemPtr &item) const;
+
 private:
     AccountStatePtr _account;
     bool _isCurrentUser;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -742,12 +742,11 @@ bool OwncloudPropagator::createConflict(const SyncFileItemPtr &item,
             conflictItem->_size = item->_previousSize;
             emit newItem(conflictItem);
             composite->appendTask(conflictItem);
-        } else {
-            // Directories we can't process in one go. The next sync run
-            // will take care of uploading the conflict dir contents.
-            _anotherSyncNeeded = true;
         }
     }
+
+    // Need a new sync to detect the created copy of the conflicting file
+    _anotherSyncNeeded = true;
 
     return true;
 }


### PR DESCRIPTION
Note: This PR is a draft. It fixes the problem but probably needs some polishing. I first wanted to hear your thoughts about this problem, my findings and my proposed solution before I investigate further.

Now to the actual problem:

When the client runs and a conflict gets detected, the sync engine runs
two times.

On the first run, the sync engine  detects the conflict, marks the
file as a conflict and propagates that to the GUI. This leads to an
error notification with the original filename in the main dialog.

The sync engine runs then a second time. On this second run, the file
that originally caused the conflict is not anymore a conflict
file. Instead, the sync engine detects the conflicted copy and
propagates that file as a conflict to the GUI.

When opening the conflict dialog with the original file name (not the
conflicted copy) a crash happens. Usually, the two sync runs are really
fast, so the user does not notice the first notification. However, a
problem can occur if a conflict gets created while the client is not
running. Since then, the client does not do two sync runs. It does only
run once.

Steps to reproduce the original Issue on master:

- Stop the client
- Modify a synced file on the server
- Modify the same file on the local machine
- Start the client
- Wait that the conflict gets detected
- Press on the conflict notification
- Observe the crash

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>