### PR TITLE
Add name suffix option for avoiding conflicts

### DIFF
--- a/NEXTCLOUD.cmake
+++ b/NEXTCLOUD.cmake
@@ -15,6 +15,32 @@ set( APPLICATION_VIRTUALFILE_SUFFIX "nextcloud" CACHE STRING "Virtual file suffi
 set( LINUX_PACKAGE_SHORTNAME "nextcloud" )
 set( LINUX_APPLICATION_ID "${APPLICATION_REV_DOMAIN}.${LINUX_PACKAGE_SHORTNAME}")
 
+if (NOT AD_HOC_NAME_SUFFIX)
+    if (QT_DEBUG)
+        set(AD_HOC_NAME_SUFFIX " Debug")
+        message(STATUS "QT_DEBUG is set to ${QT_DEBUG}, with no AD_HOC_NAME_SUFFIX, so AD_HOC_NAME_SUFFIX has been set to \"${AD_HOC_NAME_SUFFIX}\" by default. Set AD_HOC_NAME_SUFFIX to NO_SUFFIX to override.")
+    else()
+        set(AD_HOC_NAME_SUFFIX "NO_SUFFIX"
+            CACHE STRING
+            "Choose a suffix with which to append the application name, configuration directory, etc., in order to allow multiple builds to be tested separately and concurrently.
+            Characters other than a-z, A-Z, 0-9, \"_\", \".\", \"+\" and \"-\" will be stripped out where required by CMake.
+            Set to the empty string (\"\") or NO_SUFFIX to disable."
+            FORCE)
+    endif()
+endif ()
+
+if (NOT AD_HOC_NAME_SUFFIX STREQUAL "NO_SUFFIX")
+    message(STATUS "AD_HOC_NAME_SUFFIX is set to a value other than \"\". Name variables will be appended with safe variations of AD_HOC_NAME_SUFFIX value \"${AD_HOC_NAME_SUFFIX}\" to prevent conflicts.")
+    string(REGEX REPLACE [^a-zA-Z0-9\._+-] "" SUFFIX_STRIPPED "${AD_HOC_NAME_SUFFIX}")
+    string(TOLOWER ${SUFFIX_STRIPPED} SUFFIX_LOWER)
+    string(APPEND APPLICATION_NAME "${AD_HOC_NAME_SUFFIX}")
+    string(APPEND APPLICATION_SHORTNAME "${SUFFIX_STRIPPED}")
+    string(APPEND APPLICATION_EXECUTABLE "${SUFFIX_LOWER}")
+    string(APPEND APPLICATION_REV_DOMAIN "${SUFFIX_LOWER}")
+    string(APPEND LINUX_PACKAGE_SHORTNAME "${SUFFIX_LOWER}")
+    string(APPEND LINUX_APPLICATION_ID "${SUFFIX_LOWER}")
+endif()
+
 set( THEME_CLASS            "NextcloudTheme" )
 set( WIN_SETUP_BITMAP_PATH  "${CMAKE_SOURCE_DIR}/admin/win/nsi" )
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -116,7 +116,7 @@ QString Theme::statusHeaderText(SyncResult::Status status) const
 
 bool Theme::isBranded() const
 {
-    return appNameGUI() != QStringLiteral("Nextcloud");
+    return !appNameGUI().contains("Nextcloud");
 }
 
 QString Theme::appNameGUI() const


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/2941.

Yes, the code setting `CMAKE_BUILD_TYPE` to `RelWithDebInfo` was broken. (I discovered this because it needed to work in order to implement the `-dev` suffix.) The reason it wasn't working is that `set()` needs the keyword `FORCE` in order to override a user input, even if that user input is `null`.

For the `-dev` suffix itself, I put the code in `NEXTCLOUD.cmake` (as with https://github.com/nextcloud/desktop/pull/2945) because, again, `NEXTCLOUD.cmake` is for some reason imported/run twice, and I didn't want the suffix to appear in some places and not in others (or even doubled up). You can clearly see the code running twice from the `message()` output in the terminal.

The fact that the `-dev` suffix isn't run by OEM builds is less of an issue than in https://github.com/nextcloud/desktop/pull/2945 due to the fact that test builds are much more likely to be non-OEM builds in the first place.

This should go without saying, but the `message()` output can be commented out if desired, though much of it only runs when `CMAKE_BUILD_TYPE` is already set to something other than `Release`. In any case, the `message()` output with `CMAKE_BUILD_TYPE` itself should probably go in `DefineCMakeDefaults.cmake`, though it's worth noting that `NEXTCLOUD.cmake` imports `DefineCMakeDefaults.cmake`, so the message would print at least three times (rather than only twice at present). It wasn't entirely clear to me why, but IIRC the value of `CMAKE_BUILD_TYPE` as assigned in `DefineCMakeDefaults.cmake` wasn't available to `NEXTCLOUD.cmake` without `DefineCMakeDefaults.cmake` being directly imported.

I've tested this pull request on macOS, and it worked as intended, but I have not tested it on Windows or Linux.