### PR TITLE
Add missing error handling for downloads of client side encryption

### DIFF
--- a/src/libsync/propagatedownloadencrypted.cpp
+++ b/src/libsync/propagatedownloadencrypted.cpp
@@ -56,8 +56,16 @@ void PropagateDownloadEncrypted::checkFolderId(const QStringList &list)
   auto metadataJob = new GetMetadataApiJob(_propagator->account(), folderInfo.fileId);
   connect(metadataJob, &GetMetadataApiJob::jsonReceived,
           this, &PropagateDownloadEncrypted::checkFolderEncryptedMetadata);
+  connect(metadataJob, &GetMetadataApiJob::error,
+          this, &PropagateDownloadEncrypted::folderEncryptedMetadataError);
 
   metadataJob->start();
+}
+
+void PropagateDownloadEncrypted::folderEncryptedMetadataError(const QByteArray & /*fileId*/, int /*httpReturnCode*/)
+{
+    qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << _info.fileName();
+    emit failed();
 }
 
 void PropagateDownloadEncrypted::checkFolderEncryptedMetadata(const QJsonDocument &json)

--- a/src/libsync/propagatedownloadencrypted.h
+++ b/src/libsync/propagatedownloadencrypted.h
@@ -24,6 +24,7 @@ public slots:
   void checkFolderId(const QStringList &list);
   void checkFolderEncryptedMetadata(const QJsonDocument &json);
   void folderIdError();
+  void folderEncryptedMetadataError(const QByteArray &fileId, int httpReturnCode);
 
 signals:
   void fileMetadataFound();


### PR DESCRIPTION
The missing error handlers can cause the sync to hang forever

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>