### PR TITLE
Change default install directory for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ if(NOT WITH_CRASHREPORTER)
 endif()
 
 include(GNUInstallDirs)
+if(APPLE AND CMAKE_INSTALL_PREFIX MATCHES "/usr/local")
+    # set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/Builds")
+    set(CMAKE_INSTALL_PREFIX "../..")
+endif()
 include(DefineInstallationPaths)
 include(GenerateExportHeader)
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/2970.

I initially thought to use `~/Builds` (actually `$ENV{HOME}/Builds` because [CMake doesn't like `~`](https://stackoverflow.com/questions/48647992/cmake-error-file-install-destination-is-not-a-directory#comment84294262_48647992)), but then I realized that it would be more value-neutral to have the build end up in the parent directory of the cloned repository, i.e. `../..`. I was slightly concerned that `../..` might have a similar problem to the one with `~`, but the build succeed, and the application was functional.

One thing to note is I initially tried putting the logic in place of [`GNUInstallDirs.cmake:316`](https://github.com/nextcloud/desktop/blob/f17c52dccd0f7e0cce6c6062cf11a5ad03ac2b8d/src/gui/CMakeLists.txt#L316), but doing so required using the `PARENT_SCOPE` variable and then adding `set(CMAKE_INSTALL_DIRECTORY ${CMAKE_INSTALL_DIRECTORY} PARENT_SCOPE)` at the bottom of [`src/CMakeLists.txt`](https://github.com/nextcloud/desktop/blob/7e91166d7a714d494788318e0d5fdd4f9a671d0b/src/CMakeLists.txt).

Putting the logic in the root `CMakeLists.txt` made it so that I only had to change a single file (albeit leaving the vestigial `GNUInstallDirs.cmake:316`), and checking for `CMAKE_INSTALL_PREFIX MATCHES "/usr/local"` in the `if()` conditional meant that the logic would only execute when the user hasn't specified `CMAKE_INSTALL_DIRECTORY`. It wasn't possible to use `NOT DEFINED` because `CMAKE_INSTALL_PREFIX` carries a default value (of `/usr/local`).

I'm perfectly fine with putting the logic in `GNUInstallDirs.cmake` if the maintainers think it's more advisable, but my opinion is that depending on a chain of `PARENT_SCOPE` keywords seems more brittle than leaving the logic at the top level. (I would ask that any "perfect is better than done" responses dramatically increasing the scope only be paired with a commitment to do the "perfect" version oneself.)

Thoughts?