### PR TITLE
Do no include glib.h with extern C

### DIFF
--- a/src/gui/cloudproviders/cloudprovidermanager.cpp
+++ b/src/gui/cloudproviders/cloudprovidermanager.cpp
@@ -12,11 +12,10 @@
  * for more details.
  */
 
-extern "C" {
-    #include <glib.h>
-    #include <gio.h>
-    #include <cloudprovidersproviderexporter.h>
-}
+#include <glib.h>
+#include <gio.h>
+#include <cloudprovidersproviderexporter.h>
+
 #include "cloudproviderwrapper.h"
 #include "cloudprovidermanager.h"
 #include "account.h"


### PR DESCRIPTION
Compilation fails on Hirsute with errors like:

```
In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from /<<PKGBUILDDIR>>/src/gui/cloudproviders/cloudprovidermanager.cpp:16:
/usr/include/c++/10/type_traits:56:3: error: template with C linkage
   56 |   template<typename _Tp, _Tp __v>
      |   ^~~~~~~~
/<<PKGBUILDDIR>>/src/gui/cloudproviders/cloudprovidermanager.cpp:15:1: note: ‘extern "C"’ linkage started here
   15 | extern "C" {
      | ^~~~~~~~~~
```
This is due to `glib/gatomic.h` now including `<type_traits>` when being compiled with C++. I think `glib.h` and similar headers can be safely included into C++ code without extern "C" nowadays. Hence this patch removes it from `cloudprovidermanager.cpp`.
