### PR TITLE
Allow Quit from Initial Setup

### DIFF
--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -121,6 +121,8 @@ void OwncloudHttpCredsPage::cleanupPage()
 {
     _ui.leUsername->clear();
     _ui.lePassword->clear();
+    // Cancel button is shown again if you go back to the first page
+    _ocWizard->setOption(QWizard::CancelButtonOnLeft);
 }
 
 bool OwncloudHttpCredsPage::validatePage()

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -263,6 +263,8 @@ bool OwncloudSetupPage::validatePage()
         stopSpinner();
         _checking = false;
         emit completeChanged();
+        // Cancel button is only shown on the first page
+        _ocWizard->setOption(QWizard::NoCancelButton);
         return true;
     }
 }

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -115,6 +115,7 @@ protected:
 
 private:
     void customizeStyle();
+    void reject() override;
     void adjustWizardSize();
     int calculateLongestSideOfWizardPages(const QList<QSize> &pageSizes) const;
     QList<QSize> calculateWizardPageSizes() const;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/2969.

I've tested this on macOS but not on Linux or Windows.

I'm thinking of adding my code from https://github.com/nextcloud/desktop/pull/2959 that shows and hides the dock icon, as well. (I'll put it in a separate commit so it's easier to test.)