### PR TITLE
Split content of User::isValueableActivity()

### DIFF
--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -418,14 +418,10 @@ bool User::isActivityOfCurrentAccount(const Folder *folder) const
     return folder->accountState() == _account.data();
 }
 
-bool User::isActivityIgnored(const SyncFileItemPtr &item) const
+bool User::isUnsolvableConflict(const SyncFileItemPtr &item) const
 {
     // We just care about conflict issues that we are able to resolve
-    if (item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file)) {
-        return true;
-    }
-
-    return false;
+    return item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file);
 }
 
 void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
@@ -439,7 +435,7 @@ void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
         return;
     }
 
-    if (isActivityIgnored(item)) {
+    if (isUnsolvableConflict(item)) {
         return;
     }
 

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -413,19 +413,19 @@ void User::slotAddError(const QString &folderAlias, const QString &message, Erro
     }
 }
 
-bool User::isValueableActivity(const Folder *folder, const SyncFileItemPtr &item) const
+bool User::isActivityOfCurrentAccount(const Folder *folder) const
 {
-    // Ignore activity from a different account
-    if (folder->accountState() != _account.data()) {
-        return false;
-    }
+    return folder->accountState() == _account.data();
+}
 
+bool User::isActivityIgnored(const SyncFileItemPtr &item) const
+{
     // We just care about conflict issues that we are able to resolve
     if (item->_status == SyncFileItem::Conflict && !Utility::isConflictFile(item->_file)) {
-        return false;
+        return true;
     }
 
-    return true;
+    return false;
 }
 
 void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
@@ -435,56 +435,62 @@ void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
     if (!folderInstance)
         return;
 
-    if (isValueableActivity(folderInstance, item)) {
-        qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in " << item->_errorString;
+    if (!isActivityOfCurrentAccount(folderInstance)) {
+        return;
+    }
 
-        Activity activity;
-        activity._type = Activity::SyncFileItemType; //client activity
-        activity._status = item->_status;
-        activity._dateTime = QDateTime::currentDateTime();
-        activity._message = item->_originalFile;
-        activity._link = folderInstance->accountState()->account()->url();
-        activity._accName = folderInstance->accountState()->account()->displayName();
-        activity._file = item->_file;
-        activity._folder = folder;
-        activity._fileAction = "";
+    if (isActivityIgnored(item)) {
+        return;
+    }
 
-        if (item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
-            activity._fileAction = "file_deleted";
-        } else if (item->_instruction == CSYNC_INSTRUCTION_NEW) {
-            activity._fileAction = "file_created";
-        } else if (item->_instruction == CSYNC_INSTRUCTION_RENAME) {
-            activity._fileAction = "file_renamed";
+    qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in " << item->_errorString;
+
+    Activity activity;
+    activity._type = Activity::SyncFileItemType; //client activity
+    activity._status = item->_status;
+    activity._dateTime = QDateTime::currentDateTime();
+    activity._message = item->_originalFile;
+    activity._link = folderInstance->accountState()->account()->url();
+    activity._accName = folderInstance->accountState()->account()->displayName();
+    activity._file = item->_file;
+    activity._folder = folder;
+    activity._fileAction = "";
+
+    if (item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
+        activity._fileAction = "file_deleted";
+    } else if (item->_instruction == CSYNC_INSTRUCTION_NEW) {
+        activity._fileAction = "file_created";
+    } else if (item->_instruction == CSYNC_INSTRUCTION_RENAME) {
+        activity._fileAction = "file_renamed";
+    } else {
+        activity._fileAction = "file_changed";
+    }
+
+    if (item->_status == SyncFileItem::NoStatus || item->_status == SyncFileItem::Success) {
+        qCWarning(lcActivity) << "Item " << item->_file << " retrieved successfully.";
+
+        if (item->_direction != SyncFileItem::Up) {
+            activity._message = tr("Synced %1").arg(item->_originalFile);
+        } else if (activity._fileAction == "file_renamed") {
+            activity._message = tr("You renamed %1").arg(item->_originalFile);
+        } else if (activity._fileAction == "file_deleted") {
+            activity._message = tr("You deleted %1").arg(item->_originalFile);
+        } else if (activity._fileAction == "file_created") {
+            activity._message = tr("You created %1").arg(item->_originalFile);
         } else {
-            activity._fileAction = "file_changed";
+            activity._message = tr("You changed %1").arg(item->_originalFile);
         }
 
-        if (item->_status == SyncFileItem::NoStatus || item->_status == SyncFileItem::Success) {
-            qCWarning(lcActivity) << "Item " << item->_file << " retrieved successfully.";
+        _activityModel->addSyncFileItemToActivityList(activity);
+    } else {
+        qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in error " << item->_errorString;
+        activity._subject = item->_errorString;
 
-            if (item->_direction != SyncFileItem::Up) {
-                activity._message = tr("Synced %1").arg(item->_originalFile);
-            } else if (activity._fileAction == "file_renamed") {
-                activity._message = tr("You renamed %1").arg(item->_originalFile);
-            } else if (activity._fileAction == "file_deleted") {
-                activity._message = tr("You deleted %1").arg(item->_originalFile);
-            } else if (activity._fileAction == "file_created") {
-                activity._message = tr("You created %1").arg(item->_originalFile);
-            } else {
-                activity._message = tr("You changed %1").arg(item->_originalFile);
-            }
-
-            _activityModel->addSyncFileItemToActivityList(activity);
+        if (item->_status == SyncFileItem::Status::FileIgnored) {
+            _activityModel->addIgnoredFileToList(activity);
         } else {
-            qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in error " << item->_errorString;
-            activity._subject = item->_errorString;
-
-            if (item->_status == SyncFileItem::Status::FileIgnored) {
-                _activityModel->addIgnoredFileToList(activity);
-            } else {
-                // add 'protocol error' to activity list
-                _activityModel->addErrorToActivityList(activity);
-            }
+            // add 'protocol error' to activity list
+            _activityModel->addErrorToActivityList(activity);
         }
     }
 }

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -81,7 +81,7 @@ private:
     bool checkPushNotificationsAreReady() const;
 
     bool isActivityOfCurrentAccount(const Folder *folder) const;
-    bool isActivityIgnored(const SyncFileItemPtr &item) const;
+    bool isUnsolvableConflict(const SyncFileItemPtr &item) const;
 
 private:
     AccountStatePtr _account;

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -80,7 +80,8 @@ private:
     void connectPushNotifications() const;
     bool checkPushNotificationsAreReady() const;
 
-    bool isValueableActivity(const Folder *folder, const SyncFileItemPtr &item) const;
+    bool isActivityOfCurrentAccount(const Folder *folder) const;
+    bool isActivityIgnored(const SyncFileItemPtr &item) const;
 
 private:
     AccountStatePtr _account;


### PR DESCRIPTION
Refactoring of User::isValueableactivity() because of changes
introduced with merge commit f17c52d.

I like splitting out the checks in separate methods because I find it more readable and the User::slotItemCompleted() is at the moment way to big for my taste.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>