### PR TITLE
Do not include glib.h with extern C (2)

### DIFF
--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -13,12 +13,10 @@
  * for more details.
  */
 
-extern "C" {
-    #include <glib.h>
-    #include <gio.h>
-    #include <cloudprovidersaccountexporter.h>
-    #include <cloudprovidersproviderexporter.h>
-}
+#include <glib.h>
+#include <gio.h>
+#include <cloudprovidersaccountexporter.h>
+#include <cloudprovidersproviderexporter.h>
 
 #include "cloudproviderwrapper.h"
 #include <account.h>


### PR DESCRIPTION
The same as #2972, but for another file. 

There seem to be no more inclusions of glib.h in the code. :)