### PR TITLE
Display the content of the login dialog correct

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -156,8 +156,8 @@ void WebFlowCredentials::askFromUser() {
             _askDialog->setUrl(url);
         }
 
-        QString msg = tr("You have been logged out of %1 as user %2. Please login again")
-                .arg(_account->displayName(), _user);
+        QString msg = tr("You have been logged out of %1 as user %2. Please login again.")
+                          .arg(_account->displayName(), _user);
         _askDialog->setInfo(msg);
 
         _askDialog->show();

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -27,19 +27,12 @@ WebFlowCredentialsDialog::WebFlowCredentialsDialog(Account *account, bool useFlo
     _layout->setSpacing(0);
     _layout->setMargin(0);
 
-    if(_useFlow2) {
-        _headerBanner = new HeaderBanner(this);
-        _layout->addWidget(_headerBanner);
-        Theme *theme = Theme::instance();
-        _headerBanner->setup(tr("Log in"), theme->wizardHeaderLogo(), theme->wizardHeaderBanner(),
-                             Qt::AutoText, QString::fromLatin1("color:#fff;"));
-    }
-
     _containerLayout = new QVBoxLayout(this);
     _containerLayout->setSpacing(spacing);
     _containerLayout->setMargin(margin);
 
     _infoLabel = new QLabel();
+    _infoLabel->setAlignment(Qt::AlignCenter);
     _containerLayout->addWidget(_infoLabel);
 
     if (_useFlow2) {

--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -45,6 +45,8 @@ Flow2AuthWidget::Flow2AuthWidget(QWidget *parent)
 
     _ui.progressLayout->addWidget(_progressIndi);
     stopSpinner(false);
+
+    customizeStyle();
 }
 
 void Flow2AuthWidget::setLogo()


### PR DESCRIPTION
This adjustment is necessary because of the changes of the new account
wizard that were introduced with:
e0b7ef15b207f59d73884f8e1c12a206803c5c40

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

This is how the dialog looks with the fix:
https://cloud.nextcloud.com/s/9WEr7ZcxYrFPWAi

@jancborchardt Your input on this is would be valuable:) Is the dialog ok?

General note:
Maybe we should start to refactor the wizard a bit and remove these `void customizeStyle()` methods. They are not used at the moment and problems like the one this pr fixes right now would not exist.