### PR TITLE
Repair basic auth support

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -86,17 +86,6 @@ bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
         return false;
     }
 
-    if (wiz->_ocWizard->currentId() == WizardCommon::Page_ShibbolethCreds) {
-        // Try to find if there is a browser open and raise that instead (Issue #6105)
-        const auto allWindow = qApp->topLevelWidgets();
-        auto it = std::find_if(allWindow.cbegin(), allWindow.cend(), [](QWidget *w)
-            { return QLatin1String(w->metaObject()->className()) == QLatin1String("OCC::ShibbolethWebView"); });
-        if (it != allWindow.cend()) {
-            ownCloudGui::raiseDialog(*it);
-            return true;
-        }
-    }
-
     ownCloudGui::raiseDialog(wiz->_ocWizard);
     return true;
 }
@@ -413,7 +402,7 @@ void OwncloudSetupWizard::slotAuthError()
 
     // bring wizard to top
     _ocWizard->bringToTop();
-    if (_ocWizard->currentId() == WizardCommon::Page_ShibbolethCreds || _ocWizard->currentId() == WizardCommon::Page_OAuthCreds || _ocWizard->currentId() == WizardCommon::Page_Flow2AuthCreds) {
+    if (_ocWizard->currentId() == WizardCommon::Page_OAuthCreds || _ocWizard->currentId() == WizardCommon::Page_Flow2AuthCreds) {
         _ocWizard->back();
     }
     _ocWizard->displayError(errorMsg, _ocWizard->currentId() == WizardCommon::Page_ServerSetup && checkDowngradeAdvised(reply));

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -228,8 +228,6 @@ int OwncloudSetupPage::nextId() const
         return WizardCommon::Page_OAuthCreds;
     case DetermineAuthTypeJob::LoginFlowV2:
         return WizardCommon::Page_Flow2AuthCreds;
-    case DetermineAuthTypeJob::Shibboleth:
-        return WizardCommon::Page_ShibbolethCreds;
     case DetermineAuthTypeJob::WebViewFlow:
         return WizardCommon::Page_WebView;
     }

--- a/src/gui/wizard/owncloudwizardcommon.h
+++ b/src/gui/wizard/owncloudwizardcommon.h
@@ -44,7 +44,6 @@ namespace WizardCommon {
         Page_Welcome,
         Page_ServerSetup,
         Page_HttpCreds,
-        Page_ShibbolethCreds,
         Page_OAuthCreds,
         Page_Flow2AuthCreds,
         Page_WebView,

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -919,11 +919,6 @@ void DetermineAuthTypeJob::start()
     propfind->setIgnoreCredentialFailure(true);
     oldFlowRequired->setIgnoreCredentialFailure(true);
 
-    connect(get, &AbstractNetworkJob::redirected, this, [this, get](QNetworkReply *, const QUrl &target, int) {
-        Q_UNUSED(this)
-        Q_UNUSED(get)
-        Q_UNUSED(target)
-    });
     connect(get, &SimpleNetworkJob::finishedSignal, this, [this]() {
         _getDone = true;
         checkAllDone();
@@ -968,16 +963,13 @@ void DetermineAuthTypeJob::checkAllDone()
     }
 
     auto result = _resultPropfind;
-    // OAuth > Shib > Basic
-    if (_resultGet == Shibboleth && result != OAuth)
-        result = Shibboleth;
 
-    // WebViewFlow > OAuth > Shib > Basic
+    // WebViewFlow > OAuth > Basic
     if (_account->serverVersionInt() >= Account::makeServerVersion(12, 0, 0)) {
         result = WebViewFlow;
     }
 
-    // LoginFlowV2 > WebViewFlow > OAuth > Shib > Basic
+    // LoginFlowV2 > WebViewFlow > OAuth > Basic
     if (_account->serverVersionInt() >= Account::makeServerVersion(16, 0, 0)) {
         result = LoginFlowV2;
     }

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -437,6 +437,7 @@ class OWNCLOUDSYNC_EXPORT DetermineAuthTypeJob : public QObject
     Q_OBJECT
 public:
     enum AuthType {
+        NoAuthType, // used only before we got a chance to probe the server
         Basic, // also the catch-all fallback for backwards compatibility reasons
         OAuth,
         WebViewFlow,
@@ -453,9 +454,9 @@ private:
     void checkAllDone();
 
     AccountPtr _account;
-    AuthType _resultGet = Basic;
-    AuthType _resultPropfind = Basic;
-    AuthType _resultOldFlow = Basic;
+    AuthType _resultGet = NoAuthType;
+    AuthType _resultPropfind = NoAuthType;
+    AuthType _resultOldFlow = NoAuthType;
     bool _getDone = false;
     bool _propfindDone = false;
     bool _oldFlowDone = false;

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -439,7 +439,6 @@ public:
     enum AuthType {
         Basic, // also the catch-all fallback for backwards compatibility reasons
         OAuth,
-        Shibboleth,
         WebViewFlow,
         LoginFlowV2
     };


### PR DESCRIPTION
This PR cleans up the remnant of the shibboleth code in a first commit. Then it proceeds with repairing the support for basic auth which apparently got broken around the time the shibboleth code was first disabled. Changed a bit the logic we still apply the same priority order for the auth modes but if we get a basic auth error on the account URL we can safely assume basic auth is enabled on the server.

Since I'm now using daily a server with basic auth enabled this was easy to debug and figure out what was wrong. ;-)

Fix #2046 