### PR TITLE
Fix incorrect type when reading the 'logExpire' property from config.

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -971,7 +971,7 @@ void ConfigFile::setLogDebug(bool enabled)
 int ConfigFile::logExpire() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(logExpireC), 24).toBool();
+    return settings.value(QLatin1String(logExpireC), 24).toInt();
 }
 
 void ConfigFile::setLogExpire(int hours)


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>