### PR TITLE
Autostart also when Debug build has multiple accounts

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -491,7 +491,7 @@ void Application::slotownCloudWizardDone(int res)
 
         // If one account is configured: enable autostart
 #ifndef QT_DEBUG
-        bool shouldSetAutoStart = (accountMan->accounts().size() == 1);
+        bool shouldSetAutoStart = (accountMan->accounts().size() >= 1);
 #else
         bool shouldSetAutoStart = false;
 #endif


### PR DESCRIPTION
Right now Line 494 of `application.cpp` reads as follows:
https://github.com/nextcloud/desktop/blob/6c194be02de4b76907c251941e3d75849f950f37/src/gui/application.cpp#L494

If I understand this correctly, it means that debug builds should autostart if they have one account set up. It seems like it would be better for this code to allow for more than one account set up, hence `>=` rather than `==`.