### PR TITLE
Show/Hide Menubar and Dock Icon on macOS

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -316,6 +316,10 @@ IF( APPLE )
             macOS/progressobserver.m)
     endif()
 
+    list(APPEND client_SRCS foregroundbackground_interface.h)
+    list(APPEND client_SRCS foregroundbackground_mac.mm)
+    list(APPEND client_SRCS foregroundbackground_cocoa.mm)
+
     if(SPARKLE_FOUND AND BUILD_UPDATER)
         # Define this, we need to check in updater.cpp
         add_definitions(-DHAVE_SPARKLE)

--- a/src/gui/foregroundbackground_cocoa.h
+++ b/src/gui/foregroundbackground_cocoa.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) by Elsie Hupp <gpl at elsiehupp dot com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#import <AppKit/NSApplication.h>
+
+/**
+* @brief CocoaProcessType provides methods for moving the application between
+* the background and foreground.
+* @ingroup gui
+*/
+
+#ifndef COCOAPROCESSTYPE_H
+#define COCOAPROCESSTYPE_H
+
+@interface CocoaProcessType : NSApplication
+
+/**
+ * @brief CocoaProcessTypeToForeground() enables the macOS menubar and dock icon, which are necessary for a maximized window to be able to exit full screen.
+ * @ingroup gui
+ */
++ (void)ToForeground;
+
+/**
+ * @brief CocoaProcessTypeToBackground() disables the macOS menubar and dock icon, so that the application will only be present as a menubar icon.
+ * @ingroup gui
+ */
++ (void)ToBackground;
+
+@end
+
+#endif

--- a/src/gui/foregroundbackground_cocoa.mm
+++ b/src/gui/foregroundbackground_cocoa.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) by Elsie Hupp <gpl at elsiehupp dot com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "foregroundbackground_cocoa.h"
+#include "common/utility.h"
+
+@implementation CocoaProcessType
+
++ (void)ToForeground
+{
+        NSApplicationLoad();
+        ProcessSerialNumber processSerialNumber = { 0, kCurrentProcess };
+        TransformProcessType(&processSerialNumber, kProcessTransformToForegroundApplication);
+}
+
++ (void)ToBackground
+{
+        NSApplicationLoad();
+        ProcessSerialNumber processSerialNumber = { 0, kCurrentProcess };
+        TransformProcessType(&processSerialNumber, kProcessTransformToUIElementApplication);
+}
+
+@end

--- a/src/gui/foregroundbackground_interface.h
+++ b/src/gui/foregroundbackground_interface.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) by Elsie Hupp <gpl at elsiehupp dot com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+/**
+* @brief ForegroundBackgroundInterface allows ForegroundBackground to be implemented differently per platform
+* @ingroup gui
+*/
+
+#ifndef FOREGROUNDBACKGROUND_INTERFACE_H
+#define FOREGROUNDBACKGROUND_INTERFACE_H
+
+#include <QObject>
+#include <QEvent>
+
+namespace OCC {
+namespace Ui {
+
+class ForegroundBackground;
+
+}
+}
+
+class ForegroundBackground : public QObject
+{
+    Q_OBJECT
+
+public:
+
+   ForegroundBackground() = default;
+   ~ForegroundBackground() = default;
+
+    /**
+    * @brief EventFilter catches events that should trigger ForegroundBackground
+    * @ingroup gui
+    */
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private:
+    /**
+    * @brief ToForeground() enables the macOS menubar and dock icon, which are necessary for a maximized window to be able to exit full screen.
+    * @ingroup gui
+    */
+    void ToForeground();
+
+    /**
+    * @brief ToBackground() disables the macOS menubar and dock icon, so that the application will only be present as a menubar icon.
+    * @ingroup gui
+    */
+    void ToBackground();
+};
+
+#endif

--- a/src/gui/foregroundbackground_mac.mm
+++ b/src/gui/foregroundbackground_mac.mm
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) by Elsie Hupp <gpl at elsiehupp dot com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "foregroundbackground_interface.h"
+#include "foregroundbackground_cocoa.h"
+
+bool ForegroundBackground::eventFilter(QObject * /*obj*/, QEvent *event)
+{
+    if (event->type() == QEvent::Show) {
+        ToForeground();
+        return true;
+    }
+    if (event->type() == QEvent::Close) {
+        ToBackground();
+        return true;
+    }
+    return false;
+}
+
+void ForegroundBackground::ToForeground()
+{
+    [CocoaProcessType ToForeground];
+}
+
+void ForegroundBackground::ToBackground()
+{
+    [CocoaProcessType ToBackground];
+}

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -64,6 +64,10 @@
 #include <QQuickItem>
 #include <QQmlContext>
 
+#ifdef Q_OS_MAC
+#include "foregroundbackground_interface.h"
+#endif
+
 #ifdef BUILD_FILE_PROVIDER_MODULE
 #include "macOS/fileprovider.h"
 #include "macOS/fileproviderdomainmanager.h"
@@ -598,6 +602,10 @@ void ownCloudGui::slotShowSettings()
     if (_settingsDialog.isNull()) {
         _settingsDialog = new SettingsDialog(this);
         _settingsDialog->setAttribute(Qt::WA_DeleteOnClose, true);
+#ifdef Q_OS_MAC
+        auto *fgbg = new ForegroundBackground();
+        _settingsDialog->installEventFilter(fgbg);
+#endif
         _settingsDialog->show();
     }
     raiseDialog(_settingsDialog.data());

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -19,6 +19,10 @@
 #include "theme.h"
 #include "owncloudgui.h"
 
+#ifdef Q_OS_MAC
+#include "foregroundbackground_interface.h"
+#endif
+
 #include "wizard/owncloudwizard.h"
 #include "wizard/welcomepage.h"
 #include "wizard/owncloudsetuppage.h"
@@ -56,6 +60,10 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     , _webViewPage(nullptr)
 #endif // WITH_WEBENGINE
 {
+#ifdef Q_OS_MAC
+    auto *fgbg = new ForegroundBackground();
+    this->installEventFilter(fgbg);
+#endif
     setObjectName("owncloudWizard");
 
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);


### PR DESCRIPTION
Branched from #2959.

This pull request adds code to make it so that the onboarding wizard and the settings dialogue both behave like foreground windows on macOS. When either window opens, the application spawns a dock icon and displays a menubar, and when the window is closed, the dock icon despawns, and the menubar is replaced with whatever other application is now in the foreground.

On Linux (or, at least GNOME), this behavior is automatically implemented when the [`Qt::Window` flag](https://doc.qt.io/qt-5/qt.html#WindowType-enum) is used. The behavior is especially important on macOS, because a `Qt::Window` can be maximized, but without a menubar, the application is unable to show the titlebar containing the “stoplight” buttons, so it is very difficult to un-maximize it. (The dock icon and menubar are a package deal in Cocoa, so you can’t have one without the other. While the dock icon isn’t as immediately necessary as the menubar on macOS, implementing a temporary dock icon on macOS has the added benefit of being consistent with the existing behavior on Linux.) The fact that the `Qt::Window` flag does not implement this behavior on macOS by default should probably be rightly considered a bug in Qt, but I digress.

I was unable to get a working copy of Windows installed on my computer, so I was unable to test whether the behavior of `Qt::Window` on Windows is more like Linux or more like macOS. The way the `ForegroundBackground` class I created is structured makes it easy to add a Windows implementation after the fact, and indeed my original intention was to include implementations for multiple different platforms in this pull request.

Ultimately, because the behavior did not require a custom implementation on Linux (or, at least GNOME), and because I was unable to set up a Windows development environment, I decided to make this pull request solely include the macOS implementation. I also haven’t been able to test the behavior on KDE or any other Linux shells aside from GNOME, but there aren’t any other open issues about the existing behavior of the application’s dock icon, so further shell-specific implementations can also safely wait.

It’s worth noting that the onboarding wizard already uses the `Qt::Window` flag, so the changes I’ve made here fix the existing issues of it being difficult to exit fullscreen and [it being difficult to quit the application](https://github.com/nextcloud/desktop/pull/2974) from this wizard. This pull request is a prerequisite for [adding the `Qt::Window` flag to the settings dialogue](https://github.com/nextcloud/desktop/pull/2959), because it would have the same issues that already exist for the onboarding wizard.

There may be other places where it would be desirable for Nextcloud to temporarily spawn a dock icon and a menubar, but like the possible Windows and non-GNOME Linux implementations, I feel like they can be safely deferred to a later pull request.