### PR TITLE
Display invalid filenames as warning

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -115,6 +115,7 @@ set(client_SRCS
     tray/ActivityListModel.cpp
     tray/UserModel.cpp
     tray/NotificationHandler.cpp
+    tray/NotificationCache.cpp
     creds/credentialsfactory.cpp
     creds/httpcredentialsgui.cpp
     creds/oauth.cpp

--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -161,7 +161,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             } else if (a._status == SyncFileItem::SoftError
                 || a._status == SyncFileItem::Conflict
                 || a._status == SyncFileItem::Restoration
-                || a._status == SyncFileItem::FileLocked) {
+                || a._status == SyncFileItem::FileLocked
+                || a._status == SyncFileItem::FileNameInvalid) {
                 return "qrc:///client/theme/black/state-warning.svg";
             } else if (a._status == SyncFileItem::FileIgnored) {
                 return "qrc:///client/theme/black/state-info.svg";

--- a/src/gui/tray/NotificationCache.cpp
+++ b/src/gui/tray/NotificationCache.cpp
@@ -1,0 +1,24 @@
+#include "NotificationCache.h"
+
+namespace OCC {
+
+bool NotificationCache::contains(const Notification &notification) const
+{
+    return _notifications.find(calculateKey(notification)) != _notifications.end();
+}
+
+void NotificationCache::insert(const Notification &notification)
+{
+    _notifications.insert(calculateKey(notification));
+}
+
+void NotificationCache::clear()
+{
+    _notifications.clear();
+}
+
+uint NotificationCache::calculateKey(const Notification &notification) const
+{
+    return qHash(notification.title + notification.message);
+}
+}

--- a/src/gui/tray/NotificationCache.h
+++ b/src/gui/tray/NotificationCache.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QSet>
+
+namespace OCC {
+
+class NotificationCache
+{
+public:
+    struct Notification
+    {
+        QString title;
+        QString message;
+    };
+
+    bool contains(const Notification &notification) const;
+
+    void insert(const Notification &notification);
+
+    void clear();
+
+private:
+    uint calculateKey(const Notification &notification) const;
+
+
+    QSet<uint> _notifications;
+};
+}

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -6,10 +6,12 @@
 #include <QDateTime>
 #include <QStringList>
 #include <QQuickImageProvider>
+#include <QHash>
 
 #include "ActivityListModel.h"
 #include "accountmanager.h"
 #include "folderman.h"
+#include "NotificationCache.h"
 #include <chrono>
 
 namespace OCC {
@@ -25,7 +27,7 @@ class User : public QObject
     Q_PROPERTY(bool serverHasTalk READ serverHasTalk NOTIFY serverHasTalkChanged)
     Q_PROPERTY(QString avatar READ avatarUrl NOTIFY avatarChanged)
 public:
-    User(AccountStatePtr &account, const bool &isCurrent = false, QObject* parent = nullptr);
+    User(AccountStatePtr &account, const bool &isCurrent = false, QObject *parent = nullptr);
 
     AccountPtr account() const;
 
@@ -51,6 +53,7 @@ public:
     UserStatus::Status status() const;
     QString statusMessage() const;
     QUrl statusIcon() const;
+    void processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr &item);
 
 signals:
     void guiLog(const QString &, const QString &);
@@ -91,6 +94,8 @@ private:
     bool isActivityOfCurrentAccount(const Folder *folder) const;
     bool isUnsolvableConflict(const SyncFileItemPtr &item) const;
 
+    void showDesktopNotification(const QString &title, const QString &message);
+
 private:
     AccountStatePtr _account;
     bool _isCurrentUser;
@@ -101,7 +106,7 @@ private:
     QHash<AccountState *, QElapsedTimer> _timeSinceLastCheck;
 
     QElapsedTimer _guiLogTimer;
-    QSet<int> _guiLoggedNotifications;
+    NotificationCache _notificationCache;
 
     // number of currently running notification requests. If non zero,
     // no query for notifications is started.

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -278,6 +278,7 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const QString &loc
                     item->_errorString = tr("The file name is a reserved name on this file system.");
                 }
             }
+            item->_status = SyncFileItem::FileNameInvalid;
             break;
         case CSYNC_FILE_EXCLUDE_TRAILING_SPACE:
             item->_errorString = tr("Filename contains trailing spaces.");

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -66,6 +66,11 @@ public:
         FileLocked, ///< The file is locked
         Restoration, ///< The file was restored because what should have been done was not allowed
 
+        /**
+         * The filename is invalid on this platform and could not created.
+         */
+        FileNameInvalid,
+
         /** For errors that should only appear in the error view.
          *
          * Some errors also produce a summary message. Usually displaying that message is

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ nextcloud_add_test(FolderWatcher)
 nextcloud_add_test(Capabilities)
 nextcloud_add_test(PushNotifications)
 nextcloud_add_test(Theme)
+nextcloud_add_test(NotificationCache)
 
 if( UNIX AND NOT APPLE )
     nextcloud_add_test(InotifyWatcher)

--- a/test/testnotificationcache.cpp
+++ b/test/testnotificationcache.cpp
@@ -1,0 +1,40 @@
+#include <QTest>
+
+#include "tray/NotificationCache.h"
+
+class TestNotificationCache : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testContains_doesNotContainNotification_returnsFalse()
+    {
+        OCC::NotificationCache notificationCache;
+
+        QVERIFY(!notificationCache.contains({ "Title", { "Message" } }));
+    }
+
+    void testContains_doesContainNotification_returnTrue()
+    {
+        OCC::NotificationCache notificationCache;
+        const OCC::NotificationCache::Notification notification { "Title", "message" };
+
+        notificationCache.insert(notification);
+
+        QVERIFY(notificationCache.contains(notification));
+    }
+
+    void testClear_doesContainNotification_clearNotifications()
+    {
+        OCC::NotificationCache notificationCache;
+        const OCC::NotificationCache::Notification notification { "Title", "message" };
+
+        notificationCache.insert(notification);
+        notificationCache.clear();
+
+        QVERIFY(!notificationCache.contains(notification));
+    }
+};
+
+QTEST_GUILESS_MAIN(TestNotificationCache)
+#include "testnotificationcache.moc"


### PR DESCRIPTION
This pr displays a warning in the activity log if a file could not be created because of illegal characters. It looks like this:

![warnings](https://user-images.githubusercontent.com/19961516/111803979-e5351080-88cf-11eb-95e0-f82371128d52.png)

Additionally it shows an operating system notification.

The pr is quick and dirty at the moment. Few things to consider:

- Do we want to group the warnings? Like for ignored files?
- Should an operating system notification only displayed once when the issue first gets detected? 
  (At the moment with each sync run the notification gets displayed again)

Fixes: #3013, #3018, #464