### PR TITLE
Enable high dpi scaling on all platforms

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -64,10 +64,7 @@ int main(int argc, char **argv)
     // OpenSSL 1.1.0: No explicit initialisation or de-initialisation is necessary.
 
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
-#ifdef Q_OS_WIN
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
-#endif // !Q_OS_WIN
-
 #ifdef Q_OS_MAC
     Mac::CocoaInitializer cocoaInit; // RIIA
 #endif


### PR DESCRIPTION
Fixes #2295, #1079, #914

I'm unsure why this has been enabled only on Windows in the past? @er-vin @camilasan  you know more about that?

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>