### PR TITLE
Use only one crt

### DIFF
--- a/admin/win/tools/CMakeLists.txt
+++ b/admin/win/tools/CMakeLists.txt
@@ -47,11 +47,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINKER_FLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LINKER_FLAGS}")
 
-# Use static runtime for all subdirectories
-foreach(buildType "" "_DEBUG" "_MINSIZEREL" "_RELEASE" "_RELWITHDEBINFO")
-    string(REPLACE "/MD" "/MT" "CMAKE_CXX_FLAGS${buildType}" "${CMAKE_CXX_FLAGS${buildType}}")
-endforeach()
-
 add_subdirectory(NCToolsShared)
 
 if(BUILD_WIN_MSI)

--- a/shell_integration/windows/CMakeLists.txt
+++ b/shell_integration/windows/CMakeLists.txt
@@ -1,8 +1,3 @@
-# Use static runtime for all subdirectories
-foreach(buildType "" "_DEBUG" "_MINSIZEREL" "_RELEASE" "_RELWITHDEBINFO")
-    string(REPLACE "/MD" "/MT" "CMAKE_CXX_FLAGS${buildType}" "${CMAKE_CXX_FLAGS${buildType}}")
-endforeach()
-
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
Using multiple crts can cause issues when passing objects across dll
boundaries.

See also:
- https://docs.microsoft.com/en-us/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries?view=msvc-160
- https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>