### PR TITLE
Use More Concise Display Name on Linux?

### DIFF
--- a/mirall.desktop.in
+++ b/mirall.desktop.in
@@ -2,7 +2,7 @@
 Categories=Utility;X-SuSE-SyncUtility;
 Type=Application
 Exec=@APPLICATION_EXECUTABLE@
-Name=@APPLICATION_NAME@ desktop sync client 
+Name=@APPLICATION_NAME@ Desktop
 Comment=@APPLICATION_NAME@ desktop synchronization client
 GenericName=Folder Sync
 Icon=@APPLICATION_ICON_NAME@


### PR DESCRIPTION
The "Name" field in `.desktop` files is the display name shown in the application launcher and sometimes other places. It should ideally be title case and succinct in order to avoid truncation.

Currently it looks like this:
!["Nextcloud desktop sync client" in the top bar](https://user-images.githubusercontent.com/9206310/113004835-e5d86d00-9141-11eb-99d0-38aa8ad36df0.png)
!["Nextcloud desktop sync client" in the GNOME Launcher](https://user-images.githubusercontent.com/9206310/113004957-07395900-9142-11eb-9cdf-8061d9c37680.png)

If I use "Nextcloud Desktop" instead, it looks better in the top bar but still gets truncated in the GNOME Launcher (which is admittedly GNOME's fault):
!["Nextcloud Desktop" in the top bar](https://user-images.githubusercontent.com/9206310/113005155-38b22480-9142-11eb-9d43-c1586389bfbf.png)
!["Nextcloud Desktop" in the GNOME Launcher](https://user-images.githubusercontent.com/9206310/113005178-3e0f6f00-9142-11eb-80cb-40f9416e4600.png)

By contrast, "Nextcloud Sync" is just short enough not to be truncated in the GNOME Launcher:
!["Nextcloud Sync" in the top bar](https://user-images.githubusercontent.com/9206310/113005350-65663c00-9142-11eb-91b8-a4d5268f0831.png)
!["Nextcloud Sync" in the GNOME Launcher](https://user-images.githubusercontent.com/9206310/113005373-68f9c300-9142-11eb-811e-b0ebc924d1f9.png)

I'm on GNOME 3.38, and the Application Launcher still truncates text comedically short on higher DPIs, which [they were ostensibly supposed to fix](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/2173):
![GNOME Launcher with comedically short name truncation; also the dock icon's tooltip](https://user-images.githubusercontent.com/9206310/113007488-449ee600-9144-11eb-9c8d-72ec50942811.png)

Yikes!

I'm most partial to "Nextcloud Desktop" (as contrasted to "Nextcloud Server" and "Nextcloud Mobile"), but "Nextcloud Sync" fits best in terms of not being truncated. I should emphasize that changing the "Name" field in the `.desktop` file only affects a handful of places in the user interface, such as the two places I've shown, and also the tooltip on the dock icon (see the last image), and it's only on Linux. I don't know about how it's used on KDE or any other shell environments, but I imagine its usage is similarly both narrow and highly visible.

I'm also planning on doing a pull request on the Flathub reference, and I'll link the two together once they're both up.

What do you think would be the ideal way of presenting the application in the GUI on Linux? Is it okay that even "Nextcloud Desktop" is likely to be truncated for the foreseeable future on GNOME?


