### PR TITLE
Remove html tags from strings that may appear in notifications

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -149,11 +149,11 @@ QString OCUpdater::statusString() const
     case DownloadComplete:
         return tr("%1 available. Restart application to start the update.").arg(updateVersion);
     case DownloadFailed:
-        return tr("Could not download update. Please click <a href='%1'>here</a> to download the update manually.").arg(_updateInfo.web());
+        return tr("Could not download update. Please open %1 to download the update manually.").arg(_updateInfo.web());
     case DownloadTimedOut:
         return tr("Could not check for new updates.");
     case UpdateOnlyAvailableThroughSystem:
-        return tr("New %1 is available. Please click <a href='%2'>here</a> to download the update.").arg(updateVersion, _updateInfo.web());
+        return tr("New %1 is available. Please open %2 to download the update.").arg(updateVersion, _updateInfo.web());
     case CheckingServer:
         return tr("Checking update server …");
     case Unknown:


### PR DESCRIPTION
The content of notifications on MacOS are not allowed to contain HTML
tags in it. Linux (Free Desktop) notifications may contain HTML tags
in their content. However, it is optional that the notification daemon
interprets the tags. The GNOME notification daemon does not interpret
HTML tags and even does not strip them off. KDE's daemon interprets
the tags. For now I think it's the best solution to remove the HTML
tags. In the future we should fire a action if the user clicks on the
notification and react on it and open the link then. This should work
on all platforms. But as this change involves working with the native
MacOS api and I don't have hardware for that at the moment for that I
will postpone it.

Fixes #2200

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>