### PR TITLE
Create std::wstrings out of const wchar_t* so a copy is created every time

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -450,7 +450,7 @@ bool deleteSyncRootRegistryKey(const QString &syncRootPath, const QString &provi
     return true;
 }
 
-OCC::Result<void, QString> OCC::CfApiWrapper::registerSyncRoot(const QString path, const QString providerName, const QString providerVersion, const QString folderAlias, const QString displayName, const QString accountDisplayName)
+OCC::Result<void, QString> OCC::CfApiWrapper::registerSyncRoot(const QString &path, const QString &providerName, const QString &providerVersion, const QString &folderAlias, const QString &displayName, const QString &accountDisplayName)
 {
     // even if we fail to register our sync root with shell, we can still proceed with using the VFS
     const auto createRegistryKeyResult = createSyncRootRegistryKeys(providerName, folderAlias, displayName, accountDisplayName, path);
@@ -460,9 +460,11 @@ OCC::Result<void, QString> OCC::CfApiWrapper::registerSyncRoot(const QString pat
         qCWarning(lcCfApiWrapper) << "Failed to create the registry key for path:" << path;
     }
 
-    const auto p = path.toStdWString();
-    const auto name = providerName.toStdWString();
-    const auto version = providerVersion.toStdWString();
+    // API is somehow keeping the pointers for longer than one would expect or freeing them itself
+    // the internal format of QString is likely the right one for wstring on Windows so there's in fact not necessarily a need to copy
+    const auto p = std::wstring(path.toStdWString().data());
+    const auto name = std::wstring(providerName.toStdWString().data());
+    const auto version = std::wstring(providerVersion.toStdWString().data());
 
     CF_SYNC_REGISTRATION info;
     info.ProviderName = name.data();
@@ -489,7 +491,7 @@ OCC::Result<void, QString> OCC::CfApiWrapper::registerSyncRoot(const QString pat
     }
 }
 
-OCC::Result<void, QString> OCC::CfApiWrapper::unregisterSyncRoot(const QString path, const QString providerName, const QString accountDisplayName)
+OCC::Result<void, QString> OCC::CfApiWrapper::unregisterSyncRoot(const QString &path, const QString &providerName, const QString &accountDisplayName)
 {
     const auto deleteRegistryKeyResult = deleteSyncRootRegistryKey(path, providerName, accountDisplayName);
     Q_ASSERT(deleteRegistryKeyResult);

--- a/src/libsync/vfs/cfapi/cfapiwrapper.h
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.h
@@ -71,8 +71,8 @@ private:
     std::unique_ptr<CF_PLACEHOLDER_BASIC_INFO, Deleter> _data;
 };
 
-OWNCLOUDSYNC_EXPORT Result<void, QString> registerSyncRoot(const QString path, const QString providerName, const QString providerVersion, const QString folderAlias, const QString displayName, const QString accountDisplayName);
-OWNCLOUDSYNC_EXPORT Result<void, QString> unregisterSyncRoot(const QString path, const QString providerName, const QString accountDisplayName);
+OWNCLOUDSYNC_EXPORT Result<void, QString> registerSyncRoot(const QString &path, const QString &providerName, const QString &providerVersion, const QString &folderAlias, const QString &displayName, const QString &accountDisplayName);
+OWNCLOUDSYNC_EXPORT Result<void, QString> unregisterSyncRoot(const QString &path, const QString &providerName, const QString &accountDisplayName);
 
 OWNCLOUDSYNC_EXPORT Result<ConnectionKey, QString> connectSyncRoot(const QString &path, VfsCfApi *context);
 OWNCLOUDSYNC_EXPORT Result<void, QString> disconnectSyncRoot(ConnectionKey &&key);


### PR DESCRIPTION
Another way to fix **const QString&** passing by reference, issue.
As an alternative solution. This also works. I haven't really come up with an idea of why this is happening.

FYI, calling **QString::toStdWString().data** directly in the place of usage (filling in the **info** structure with these strings) works too. So, I am wondering, if I should do that instead?