### PR TITLE
Temporary solution for file restoration issue due to failing the data…

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -795,8 +795,55 @@ void SyncEngine::slotPropagationFinished(bool success)
         _anotherSyncNeeded = ImmediateFollowUp;
     }
 
+    // TODO: Remove this when the file restoration problem is fixed for a user
+    bool shouldStartSyncAgain = false;
+    const auto checkAndOverrideSetDataFingerprint = [this, &shouldStartSyncAgain] {
+        const int dataFingerprintOverrideThreshold = 9;
+        const QString dataFingerprintOverrideHostHash = QStringLiteral("63debc9ef6d217649ea70632ca573a1db7a237ba61c48cdd2bf797f7060233db");
+        const auto accountHost = account()->url().host();
+        const auto accountDisplayName = account()->displayName();
+
+        if (_dataFingerprintSetFailCount >= 0) {
+            qCWarning(lcEngine) << "setDataFingerprint has failed for account" << accountDisplayName << "on host" << accountHost << "due to sync errors. Checking the possibility for override...";
+
+            if (_dataFingerprintSetFailCount > 0) {
+                if (_dataFingerprintSetFailCount >= dataFingerprintOverrideThreshold) {
+                    qCWarning(lcEngine) << "All sync attempts failed for account" << accountDisplayName << "on host" << accountHost << "setting the dataFingerprint anyway.";
+                    _journal->setDataFingerprint(_discoveryPhase->_dataFingerprint);
+                    // this mechanism should only run once per app launch
+                    _dataFingerprintSetFailCount = -1;
+                } else {
+                    ++_dataFingerprintSetFailCount;
+                    // request to start sync again as it won't happen by itself unless the file has changed on the server or in the local folder
+                    shouldStartSyncAgain = true;
+                }
+            } else {
+                // only compare hash once
+                // if it matches - we don't need to calculate it again while _dataFingerprintSetFailCount is greater than 0
+                const auto accountHostHash = QString::fromUtf8(QCryptographicHash::hash(accountHost.toUtf8(), QCryptographicHash::Sha256).toHex());
+
+                if (accountHostHash == dataFingerprintOverrideHostHash) {
+                    qCInfo(lcEngine) << "accountHostHash" << accountHostHash << "equals to dataFingerprintOverrideHostHash" << dataFingerprintOverrideHostHash << "_dataFingerprintSetFailCount" << _dataFingerprintSetFailCount;
+                    ++_dataFingerprintSetFailCount;
+                    // request to start sync again as it won't happen by itself unless the file has changed on the server or in the local folder
+                    shouldStartSyncAgain = true;
+                } else {
+                    qCInfo(lcEngine) << "accountHostHash" << accountHostHash << "differs from dataFingerprintOverrideHostHash" << dataFingerprintOverrideHostHash;
+                    // give up on calculating the has next time, as it's not the host we are looking for
+                    _dataFingerprintSetFailCount = -1;
+                }
+            }
+        } else {
+            qCWarning(lcEngine) << "setDataFingerprint was overridden already for account" << accountDisplayName << "on host" << accountHost << "but is failing again! Or, it's not the host that we are looking for.";
+        }
+    };
+    //
+
     if (success && _discoveryPhase) {
         _journal->setDataFingerprint(_discoveryPhase->_dataFingerprint);
+    } else if (_discoveryPhase) {
+        // TODO: Remove this when the file restoration problem is fixed for a user
+        checkAndOverrideSetDataFingerprint();
     }
 
     conflictRecordMaintenance();
@@ -812,6 +859,12 @@ void SyncEngine::slotPropagationFinished(bool success)
     emit transmissionProgress(*_progressInfo);
 
     finalize(success);
+
+    if (shouldStartSyncAgain) {
+        // TODO: Remove this when the file restoration problem is fixed for a user
+        qCWarning(lcEngine) << "Starting sync again for account" << account()->displayName() << "on host" << account()->url().host() << "due to setDataFingerprint override is running.";
+        startSync();
+    }
 }
 
 void SyncEngine::finalize(bool success)

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -289,6 +289,9 @@ private:
     LocalDiscoveryStyle _lastLocalDiscoveryStyle = LocalDiscoveryStyle::FilesystemOnly;
     LocalDiscoveryStyle _localDiscoveryStyle = LocalDiscoveryStyle::FilesystemOnly;
     std::set<QString> _localDiscoveryPaths;
+
+    // TODO: Remove this when the file restoration problem is fixed for a user
+    int _dataFingerprintSetFailCount = 0;
 };
 }
 


### PR DESCRIPTION
After discussing it internally with server-side engineers, I have prepared this temporary solution that will fix the "stuck" `dataFingerprint` automatically after 10 failed attempts to synchronize the data. This logic will only work if the hostname (cloud.<whatever>.com) SH2 hash matches the hard-coded pre-calculated hash for the hostname that the users with a `Constant Old Files` restoration problem connect to.

The main discussion has been held here https://github.com/nextcloud/desktop/pull/2927. Also, a few details were discussed internally.

Signed-off-by: allexzander <blackslayer4@gmail.com>