### PR TITLE
use QFileInfo to check if path is absolute to avoid assert on windows

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -385,8 +385,7 @@ void AccountSettings::slotEditCurrentLocalIgnoredFiles()
 
 void AccountSettings::openIgnoredFilesDialog(const QString & absFolderPath)
 {
-    Q_ASSERT(absFolderPath.startsWith('/'));
-    Q_ASSERT(absFolderPath.endsWith('/'));
+    Q_ASSERT(QFileInfo(absFolderPath).isAbsolute());
 
     const QString ignoreFile = absFolderPath + ".sync-exclude.lst";
     auto layout = new QVBoxLayout();


### PR DESCRIPTION
on windos absolute path does not have to start with / . Remove failing assert
when editing ignored files list.

Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>