### PR TITLE
User status bug fixing...

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -227,7 +227,7 @@ bool AccountState::isDesktopNotificationsAllowed() const
     return _isDesktopNotificationsAllowed;
 }
 
-void AccountState::setDesktopNotificationsAllowed(const bool isAllowed)
+void AccountState::setDesktopNotificationsAllowed(bool isAllowed)
 {
     _isDesktopNotificationsAllowed = isAllowed;
 }

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -182,7 +182,7 @@ public:
 
     /** Set desktop notifications status retrieved by the notificatons endpoint
     */
-    void setDesktopNotificationsAllowed(const bool isAllowed);
+    void setDesktopNotificationsAllowed(bool isAllowed);
 
     /** Fetch the user status (status, icon, message)
     */

--- a/src/gui/tray/NotificationHandler.cpp
+++ b/src/gui/tray/NotificationHandler.cpp
@@ -64,7 +64,7 @@ void ServerNotificationHandler::slotEtagResponseHeaderReceived(const QByteArray 
     }
 }
 
-void ServerNotificationHandler::slotAllowDesktopNotificationsChanged(const bool isAllowed)
+void ServerNotificationHandler::slotAllowDesktopNotificationsChanged(bool isAllowed)
 {
     auto *account = qvariant_cast<AccountState *>(sender()->property(propertyAccountStateC));
     if (account != nullptr) {

--- a/src/gui/tray/NotificationHandler.h
+++ b/src/gui/tray/NotificationHandler.h
@@ -26,7 +26,7 @@ private slots:
     void slotNotificationsReceived(const QJsonDocument &json, int statusCode);
     void slotEtagResponseHeaderReceived(const QByteArray &value, int statusCode);
     void slotIconDownloaded(QByteArray iconData);
-    void slotAllowDesktopNotificationsChanged(const bool isAllowed);
+    void slotAllowDesktopNotificationsChanged(bool isAllowed);
 
 private:
     QPointer<JsonApiJob> _notificationJob;

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -219,7 +219,8 @@ void User::slotRefreshActivities()
     _activityModel->slotRefreshActivity();
 }
 
-void User::slotRefreshUserStatus() {
+void User::slotRefreshUserStatus() 
+{
     // TODO: check for _account->account()->capabilities().userStatus() 
     if (_account.data() && _account.data()->isConnected()) {
         _account.data()->fetchUserStatus();

--- a/src/gui/tray/UserModel.cpp
+++ b/src/gui/tray/UserModel.cpp
@@ -698,7 +698,7 @@ Q_INVOKABLE bool UserModel::isUserConnected(const int &id)
     return _users[id]->isConnected();
 }
 
-Q_INVOKABLE QUrl UserModel::statusIcon(const int &id)
+Q_INVOKABLE QUrl UserModel::statusIcon(int id)
 {
     if (id < 0 || id >= _users.size()) {
         return {};

--- a/src/gui/tray/UserModel.h
+++ b/src/gui/tray/UserModel.h
@@ -140,7 +140,7 @@ public:
     Q_INVOKABLE bool currentUserHasLocalFolder();
     int currentUserId() const;
     Q_INVOKABLE bool isUserConnected(const int &id);
-    Q_INVOKABLE QUrl statusIcon(const int &id);
+    Q_INVOKABLE QUrl statusIcon(int id);
     Q_INVOKABLE void switchCurrentUser(const int &id);
     Q_INVOKABLE void login(const int &id);
     Q_INVOKABLE void logout(const int &id);

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -452,6 +452,7 @@ Window {
 
                 HeaderButton {
                     id: trayWindowTalkButton
+                    
                     visible: UserModel.currentUser.serverHasTalk
                     icon.source: "qrc:///client/theme/white/talk-app.svg"
                     onClicked: UserModel.openCurrentAccountTalk()
@@ -464,6 +465,7 @@ Window {
                 HeaderButton {
                     id: trayWindowAppsButton
                     icon.source: "qrc:///client/theme/white/more-apps.svg"
+  
                     onClicked: {
                         if(appsMenu.count <= 0) {
                             UserModel.openCurrentAccountServer()

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -403,67 +403,59 @@ Window {
                     }
                 }
 
-                // Filler between account dropdown and header app buttons
-                Item {
-                    id: trayWindowHeaderSpacer
-                    Layout.fillWidth: true
-                }
+                RowLayout {
+                    id: openLocalFolderRowLayout
+                    height: Style.trayWindowHeaderHeight
+                    width: height
+                    anchors.left: accountControlRowLayout.right
+                    anchors.top: accountControlRowLayout.top
+                    spacing: 0
+                    Layout.preferredWidth:  Style.trayWindowHeaderHeight
+                    Layout.preferredHeight: Style.trayWindowHeaderHeight
+                    
+                    HeaderButton {
+                        id: openLocalFolderButton
+                        visible: UserModel.currentUser.hasLocalFolder
+                        icon.source: "qrc:///client/theme/white/folder.svg"
+                        onClicked: UserModel.openCurrentAccountLocalFolder()
+                    }
+                                             
+                    Rectangle {
+                        id: folderStateIndicatorBackground
+                        width: Style.folderStateIndicatorSize
+                        height: width
+                        anchors.top: openLocalFolderButton.verticalCenter
+                        anchors.left: openLocalFolderButton.horizontalCenter
+                        color: Style.ncBlue
+                        radius: width*0.5
+                    }
 
-                HeaderButton {
-                    id: openLocalFolderButton
-
-                    visible: UserModel.currentUser.hasLocalFolder
-                    icon.source: "qrc:///client/theme/white/folder.svg"
-                    onClicked: UserModel.openCurrentAccountLocalFolder()
+                    Image {
+                        id: folderStateIndicator
+                        source: UserModel.isUserConnected(UserModel.currentUserId)
+                                ? Style.stateOnlineImageSource
+                                : Style.stateOfflineImageSource
+                        cache: false
+                        x: folderStateIndicatorBackground.x
+                        y: folderStateIndicatorBackground.y
+                        
+                        sourceSize.width: Style.folderStateIndicatorSize
+                        sourceSize.height: Style.folderStateIndicatorSize
+    
+                        Accessible.role: Accessible.Indicator
+                        Accessible.name: UserModel.isUserConnected(UserModel.currentUserId()) ? qsTr("Connected") : qsTr("Disconnected")
+                    }
 
                     Accessible.role: Accessible.Button
                     Accessible.name: qsTr("Open local folder of current account")
-                    Accessible.onPressAction: openLocalFolderButton.clicked()
-                }
-
-                Rectangle {
-                    id: folderStateIndicatorBackground
-                    width: Style.folderStateIndicatorSize
-                    height: width
-                    anchors.top: openLocalFolderButton.verticalCenter
-                    anchors.left: openLocalFolderButton.horizontalCenter
-                    color: Style.ncBlue
-                    radius: width*0.5
-                }
-
-                Rectangle {
-                    id: folderStateRectangle
-                    width: Style.folderStateIndicatorSize
-                    height: width
-                    anchors.bottom: openLocalFolderButton.bottom
-                    anchors.right: openLocalFolderButton.right
-                    color: openLocalFolderButton.containsMouse ? "white" : "transparent"
-                    opacity: 0.2
-                    radius: width*0.5
-                }
-
-                Image {
-                    id: folderStateIndicator
-                    source: UserModel.isUserConnected(UserModel.currentUserId)
-                            ? Style.stateOnlineImageSource
-                            : Style.stateOfflineImageSource
-                    cache: false
-                    x: folderStateIndicatorBackground.x
-                    y: folderStateIndicatorBackground.y
-                    sourceSize.width: Style.folderStateIndicatorSize
-                    sourceSize.height: Style.folderStateIndicatorSize
-
-                    Accessible.role: Accessible.Indicator
-                    Accessible.name: UserModel.isUserConnected(UserModel.currentUserId()) ? qsTr("Connected") : qsTr("Disconnected")
                 }
 
                 HeaderButton {
                     id: trayWindowTalkButton
-
                     visible: UserModel.currentUser.serverHasTalk
                     icon.source: "qrc:///client/theme/white/talk-app.svg"
                     onClicked: UserModel.openCurrentAccountTalk()
-
+                    
                     Accessible.role: Accessible.Button
                     Accessible.name: qsTr("Open Nextcloud Talk in browser")
                     Accessible.onPressAction: trayWindowTalkButton.clicked()

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -405,10 +405,6 @@ Window {
 
                 RowLayout {
                     id: openLocalFolderRowLayout
-                    height: Style.trayWindowHeaderHeight
-                    width: height
-                    anchors.left: accountControlRowLayout.right
-                    anchors.top: accountControlRowLayout.top
                     spacing: 0
                     Layout.preferredWidth:  Style.trayWindowHeaderHeight
                     Layout.preferredHeight: Style.trayWindowHeaderHeight
@@ -418,26 +414,27 @@ Window {
                         visible: UserModel.currentUser.hasLocalFolder
                         icon.source: "qrc:///client/theme/white/folder.svg"
                         onClicked: UserModel.openCurrentAccountLocalFolder()
-                    }
-                                             
-                    Rectangle {
-                        id: folderStateIndicatorBackground
-                        width: Style.folderStateIndicatorSize
-                        height: width
-                        anchors.top: openLocalFolderButton.verticalCenter
-                        anchors.left: openLocalFolderButton.horizontalCenter
-                        color: Style.ncBlue
-                        radius: width*0.5
-                    }
+                        
+                        Rectangle {
+                            id: folderStateIndicatorBackground
+                            width: Style.folderStateIndicatorSize
+                            height: width
+                            anchors.top: openLocalFolderButton.verticalCenter
+                            anchors.left: openLocalFolderButton.horizontalCenter
+                            color: Style.ncBlue
+                            radius: width*0.5
+                            z: 1
+                        }
+                   }
 
-                    Image {
+                   Image {
                         id: folderStateIndicator
                         source: UserModel.isUserConnected(UserModel.currentUserId)
                                 ? Style.stateOnlineImageSource
                                 : Style.stateOfflineImageSource
                         cache: false
-                        x: folderStateIndicatorBackground.x
-                        y: folderStateIndicatorBackground.y
+                        anchors.top: openLocalFolderButton.verticalCenter
+                        anchors.left: openLocalFolderButton.horizontalCenter
                         
                         sourceSize.width: Style.folderStateIndicatorSize
                         sourceSize.height: Style.folderStateIndicatorSize

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -48,7 +48,7 @@ UserStatus::Status UserStatus::stringToEnum(const QString &status) const
     return preDefinedStatus.value(statusKey, Status::Online);
 }
 
-QString UserStatus::enumToUserString(Status status) const 
+QString UserStatus::enumToString(Status status) const 
 {
     switch (status) {
     case Status::Away:
@@ -93,7 +93,7 @@ void UserStatus::slotFetchUserStatusFinished(const QJsonDocument &json, int stat
     auto statusString = retrievedData.value("status").toString(); 
 
     _status = stringToEnum(statusString);
-    statusString = enumToUserString(_status);
+    statusString = enumToString(_status);
     const auto visibleStatusText = message.isEmpty() ? statusString : message;
 
     _message = QString("%1 %2").arg(emoji, visibleStatusText);

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -53,7 +53,7 @@ void UserStatus::fetchUserStatus(AccountPtr account)
     _job->start();
 }
 
-void UserStatus::slotFetchUserStatusFinished(const QJsonDocument &json, const int statusCode)
+void UserStatus::slotFetchUserStatusFinished(const QJsonDocument &json, int statusCode)
 {
     const QJsonObject defaultValues
     {

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -55,8 +55,7 @@ void UserStatus::fetchUserStatus(AccountPtr account)
 
 void UserStatus::slotFetchUserStatusFinished(const QJsonDocument &json, int statusCode)
 {
-    const QJsonObject defaultValues
-    {
+    const QJsonObject defaultValues {
         {"icon", ""},
         {"message", ""},
         {"status", "online"}

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -107,7 +107,7 @@ UserStatus::Status UserStatus::status() const
 
 QString UserStatus::message() const
 {
-    return _message;
+    return _message.trimmed();
 }
 
 QUrl UserStatus::icon() const

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -90,11 +90,9 @@ void UserStatus::slotFetchUserStatusFinished(const QJsonDocument &json, int stat
     const auto retrievedData = json.object().value("ocs").toObject().value("data").toObject(defaultValues);
     const auto emoji = retrievedData.value("icon").toString();
     const auto message = retrievedData.value("message").toString();
-    auto statusString = retrievedData.value("status").toString(); 
-
-    _status = stringToEnum(statusString);
-    statusString = enumToString(_status);
-    const auto visibleStatusText = message.isEmpty() ? statusString : message;
+    
+    _status = stringToEnum(retrievedData.value("status").toString());
+    const auto visibleStatusText = message.isEmpty() ? enumToString(_status) : message;
 
     _message = QString("%1 %2").arg(emoji, visibleStatusText);
     emit fetchUserStatusFinished();

--- a/src/gui/userstatus.cpp
+++ b/src/gui/userstatus.cpp
@@ -36,27 +36,27 @@ UserStatus::UserStatus(QObject *parent)
 UserStatus::Status UserStatus::stringToEnum(const QString &status) const 
 {
     // it needs to match the Status enum
-    const QHash<QString, Status> preDefinedStatus{{"online", Online},
-                                               {"dnd", DoNotDisturb}, //DoNotDisturb
-                                               {"away", Away},
-                                               {"offline", Offline},
-                                               {"invisible", Invisible}};
+    const QHash<QString, Status> preDefinedStatus{{"online", Status::Online},
+                                               {"dnd", Status::DoNotDisturb}, //DoNotDisturb
+                                               {"away", Status::Away},
+                                               {"offline", Status::Offline},
+                                               {"invisible", Status::Invisible}};
     
     // api should return invisible, dnd,... toLower() it is to make sure 
     // it matches _preDefinedStatus, otherwise the default is online (0)
     const auto statusKey = status.isEmpty() ? QStringLiteral("online") : status.toLower();
-    return preDefinedStatus.value(statusKey, Online);
+    return preDefinedStatus.value(statusKey, Status::Online);
 }
 
 QString UserStatus::enumToUserString(Status status) const 
 {
     switch (status) {
-    case Away:
+    case Status::Away:
         return tr("Away");
-    case DoNotDisturb:
+    case Status::DoNotDisturb:
         return tr("Do not disturb");
-    case Invisible:
-    case Offline:
+    case Status::Invisible:
+    case Status::Offline:
         return tr("Offline");
     default:
         return tr("Online");
@@ -113,12 +113,12 @@ QString UserStatus::message() const
 QUrl UserStatus::icon() const
 {
     switch (_status) {
-    case Away:
+    case Status::Away:
         return Theme::instance()->statusAwayImageSource();
-    case DoNotDisturb:
+    case Status::DoNotDisturb:
         return Theme::instance()->statusDoNotDisturbImageSource();
-    case Invisible:
-    case Offline:
+    case Status::Invisible:
+    case Status::Offline:
         return Theme::instance()->statusInvisibleImageSource();
     default:
         return Theme::instance()->statusOnlineImageSource();

--- a/src/gui/userstatus.h
+++ b/src/gui/userstatus.h
@@ -42,7 +42,7 @@ public:
     QUrl icon() const;
 
 private slots:
-    void slotFetchUserStatusFinished(const QJsonDocument &json, const int statusCode);
+    void slotFetchUserStatusFinished(const QJsonDocument &json, int statusCode);
 
 signals:
     void fetchUserStatusFinished();

--- a/src/gui/userstatus.h
+++ b/src/gui/userstatus.h
@@ -49,7 +49,7 @@ signals:
 
 private:
     Status stringToEnum(const QString &status) const;
-    QString enumToUserString(Status status) const;
+    QString enumToString(Status status) const;
     QPointer<JsonApiJob> _job; // the currently running job
     Status _status = Status::Online;
     QString _message;

--- a/src/gui/userstatus.h
+++ b/src/gui/userstatus.h
@@ -49,16 +49,9 @@ signals:
 
 private:
     Status stringToEnum(const QString &status) const;
-    
-    // it needs to match the Status enum
-    const QHash<QString, int> _preDefinedStatus{{"online", 0},
-                                               {"dnd", 1}, //DoNotDisturb
-                                               {"away", 2},
-                                               {"offline", 3},
-                                               {"invisible", 4}};
-
+    QString enumToUserString(Status status) const;
     QPointer<JsonApiJob> _job; // the currently running job
-    Status _status{Status::Online};
+    Status _status = Status::Online;
     QString _message;
 };
 

--- a/src/gui/userstatus.h
+++ b/src/gui/userstatus.h
@@ -28,7 +28,7 @@ class UserStatus : public QObject
     
 public:
     explicit UserStatus(QObject *parent = nullptr);
-    enum Status {
+    enum class Status {
         Online,
         DoNotDisturb,
         Away,

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -425,7 +425,7 @@ signals:
      * @brief desktopNotificationStatusReceived - signal to report if notifications are allowed
      * @param status - set desktop notifications allowed status 
      */
-    void allowDesktopNotificationsChanged(const bool isAllowed);
+    void allowDesktopNotificationsChanged(bool isAllowed);
 
 private:
     QUrlQuery _additionalParams;


### PR DESCRIPTION
- [x] address Kevin's last comments in the PR #2505 
- [x] if there is no emoji in the status message (and for the default "Online, offline, etc" ones), the text is a bit off to the right, not left-aligned with name and server link
- [x] the menu icon for the other apps is missing on the right next to the Talk icon, and Talk icon moved over? Unrelated to status, but visible in the screenshots and also in the release it seems
![apps](https://user-images.githubusercontent.com/241266/113777285-2d0ac300-972b-11eb-98ed-b5814fcc25cd.png)
