### PR TITLE
[WIP] Replace deprecated qrand with QRandomGenerator

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <iostream>
-#include <random>
+// #include <QRandomGenerator>
 #include <qcoreapplication.h>
 #include <QStringList>
 #include <QUrl>
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
     qputenv("OPENSSL_CONF", opensslConf.toLocal8Bit());
 #endif
 
-    qsrand(std::random_device()());
+    // QRandomGenerator randGen = QRandomGenerator(std::random_device()());
 
     CmdOptions options;
     options.silent = false;

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -36,6 +36,7 @@
 #include <QStandardPaths>
 #include <QCollator>
 #include <QSysInfo>
+#include <QRandomGenerator>
 
 
 #ifdef Q_OS_UNIX
@@ -63,14 +64,14 @@ Q_LOGGING_CATEGORY(lcUtility, "nextcloud.sync.utility", QtInfoMsg)
 bool Utility::writeRandomFile(const QString &fname, int size)
 {
     int maxSize = 10 * 10 * 1024;
-    qsrand(QDateTime::currentMSecsSinceEpoch());
+    QRandomGenerator randGen = QRandomGenerator(QDateTime::currentMSecsSinceEpoch());
 
     if (size == -1)
-        size = qrand() % maxSize;
+        size = (int) randGen.generate() % maxSize;
 
     QString randString;
     for (int i = 0; i < size; i++) {
-        int r = qrand() % 128;
+        int r = (int) randGen.generate() % 128;
         randString.append(QChar(r));
     }
 

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -36,7 +36,6 @@
 #include <QStandardPaths>
 #include <QCollator>
 #include <QSysInfo>
-#include <QRandomGenerator>
 
 
 #ifdef Q_OS_UNIX
@@ -64,14 +63,13 @@ Q_LOGGING_CATEGORY(lcUtility, "nextcloud.sync.utility", QtInfoMsg)
 bool Utility::writeRandomFile(const QString &fname, int size)
 {
     int maxSize = 10 * 10 * 1024;
-    QRandomGenerator randGen = QRandomGenerator(QDateTime::currentMSecsSinceEpoch());
 
     if (size == -1)
-        size = (int) randGen.generate() % maxSize;
+        size = (int) seededRandom.generate() % maxSize;
 
     QString randString;
     for (int i = 0; i < size; i++) {
-        int r = (int) randGen.generate() % 128;
+        int r = (int) seededRandom.generate() % 128;
         randString.append(QChar(r));
     }
 

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -28,6 +28,7 @@
 #include <QElapsedTimer>
 #include <QLoggingCategory>
 #include <QMap>
+#include <QRandomGenerator>
 #include <QUrl>
 #include <QUrlQuery>
 #include <functional>
@@ -71,6 +72,8 @@ namespace Utility {
     OCSYNC_EXPORT void setLaunchOnStartup(const QString &appName, const QString &guiName, bool launch);
     OCSYNC_EXPORT uint convertSizeToUint(size_t &convertVar);
     OCSYNC_EXPORT int convertSizeToInt(size_t &convertVar);
+
+    OCSYNC_EXPORT QRandomGenerator seededRandom = QRandomGenerator(QDateTime::currentMSecsSinceEpoch());
 
 #ifdef Q_OS_WIN
     OCSYNC_EXPORT DWORD convertSizeToDWORD(size_t &convertVar);

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -31,6 +31,7 @@
 #include <QJsonArray>
 #include <QNetworkRequest>
 #include <QBuffer>
+#include <QRandomGenerator>
 
 namespace OCC {
 
@@ -42,7 +43,7 @@ AccountState::AccountState(AccountPtr account)
     , _state(AccountState::Disconnected)
     , _connectionStatus(ConnectionValidator::Undefined)
     , _waitingForNewCredentials(false)
-    , _maintenanceToConnectedDelay(60000 + (qrand() % (4 * 60000))) // 1-5min delay
+    , _maintenanceToConnectedDelay(60000 + ((int) QRandomGenerator::global()->generate() % (4 * 60000))) // 1-5min delay
     , _remoteWipe(new RemoteWipe(_account))
     , _userStatus(new UserStatus(this))
     , _isDesktopNotificationsAllowed(true)

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -17,7 +17,7 @@
 #include "application.h"
 
 #include <iostream>
-#include <random>
+// #include <QRandomGenerator>
 
 #include "config.h"
 #include "account.h"
@@ -185,7 +185,7 @@ Application::Application(int &argc, char **argv)
 {
     _startedAt.start();
 
-    qsrand(std::random_device()());
+    // QRandomGenerator randGen = QRandomGenerator(std::random_device()());
 
 #ifdef Q_OS_WIN
     // Ensure OpenSSL config file is only loaded from app directory

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -38,6 +38,7 @@
 #include <QLoggingCategory>
 #include <QSettings>
 #include <QNetworkProxy>
+#include <QRandomGenerator>
 #include <QStandardPaths>
 
 #define QTLEGACY (QT_VERSION < QT_VERSION_CHECK(5,9,0))
@@ -643,7 +644,7 @@ int ConfigFile::updateSegment() const
     // Invalid? (Unset at the very first launch)
     if(segment < 0 || segment > 99) {
         // Save valid segment value, normally has to be done only once.
-        segment = qrand() % 99;
+        segment = (int) QRandomGenerator::global()->generate() % 99;
         settings.setValue(QLatin1String(updateSegmentC), segment);
     }
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -62,9 +62,9 @@ QString OWNCLOUDSYNC_EXPORT createDownloadTmpFileName(const QString &previous)
     int overhead = 1 + 1 + 2 + 8; // slash dot dot-tilde ffffffff"
     int spaceForFileName = qMin(254, tmpFileName.length() + overhead) - overhead;
     if (tmpPath.length() > 0) {
-        return tmpPath + '/' + '.' + tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint(qrand() % 0xFFFFFFFF), 16));
+        return tmpPath + '/' + '.' + tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint((int) Utility::seededRandom.generate() % 0xFFFFFFFF), 16));
     } else {
-        return '.' + tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint(qrand() % 0xFFFFFFFF), 16));
+        return '.' + tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint((int) Utility::seededRandom.generate() % 0xFFFFFFFF), 16));
     }
 }
 

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -229,7 +229,7 @@ void PropagateUploadFileNG::slotDeleteJobFinished()
 void PropagateUploadFileNG::startNewUpload()
 {
     ASSERT(propagator()->_activeJobList.count(this) == 1);
-    _transferId = uint(qrand() ^ uint(_item->_modtime) ^ (uint(_fileToUpload._size) << 16) ^ qHash(_fileToUpload._file));
+    _transferId = uint((int) Utility::seededRandom.generate() ^ uint(_item->_modtime) ^ (uint(_fileToUpload._size) << 16) ^ qHash(_fileToUpload._file));
     _sent = 0;
     _currentChunk = 0;
 

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -39,7 +39,7 @@ void PropagateUploadFileV1::doStartUpload()
 {
     _chunkCount = int(std::ceil(_fileToUpload._size / double(chunkSize())));
     _startChunk = 0;
-    _transferId = uint(qrand()) ^ uint(_item->_modtime) ^ (uint(_fileToUpload._size) << 16);
+    _transferId = uint((int) Utility::seededRandom.generate()) ^ uint(_item->_modtime) ^ (uint(_fileToUpload._size) << 16);
 
     const SyncJournalDb::UploadInfo progressInfo = propagator()->_journal->getUploadInfo(_item->_file);
 

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -50,10 +50,10 @@ inline QString getFilePathFromUrl(const QUrl &url) {
 
 
 inline QByteArray generateEtag() {
-    return QByteArray::number(QDateTime::currentDateTimeUtc().toMSecsSinceEpoch(), 16) + QByteArray::number(qrand(), 16);
+    return QByteArray::number(QDateTime::currentDateTimeUtc().toMSecsSinceEpoch(), 16) + QByteArray::number((int) QRandomGenerator::global()->generate(), 16);
 }
 inline QByteArray generateFileId() {
-    return QByteArray::number(qrand(), 16);
+    return QByteArray::number((int) QRandomGenerator::global()->generate(), 16);
 }
 
 class PathComponents : public QStringList {


### PR DESCRIPTION
This compiles correctly on macOS (#3124 aside).

Resolves the following compiler warnings:
```cmake
//src/common/utility.cpp:66:5: warning: 
      'qsrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
    qsrand(QDateTime::currentMSecsSinceEpoch());
    ^
//src/common/utility.cpp:69:16: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
        size = qrand() % maxSize;
               ^
//src/common/utility.cpp:73:17: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
        int r = qrand() % 128;
                ^
//src/libsync/configfile.cpp:646:19: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
        segment = qrand() % 99;
                  ^
//src/libsync/propagatedownload.cpp:65:104: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
  ...tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint(qrand(...
                                                                       ^
//src/libsync/propagatedownload.cpp:67:88: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
  ...tmpFileName.left(spaceForFileName) + ".~" + (QString::number(uint(qrand(...
                                                                       ^
//src/libsync/propagateuploadv1.cpp:42:24: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
    _transferId = uint(qrand()) ^ uint(_item->_modtime) ^ (uint(_fileToU...
                       ^
//src/libsync/propagateuploadng.cpp:232:24: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
    _transferId = uint(qrand() ^ uint(_item->_modtime) ^ (uint(_fileToUp...
                       ^
//src/cmd/cmd.cpp:323:5: warning: 
      'qsrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
    qsrand(std::random_device()());
    ^
//test/syncenginetestutils.h:53:109: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
  ...16) + QByteArray::number(qrand(), 16);
                              ^
//test/syncenginetestutils.h:56:31: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
    return QByteArray::number(qrand(), 16);
                              ^
//test/testfolderwatcher.cpp:107:9: warning: 
      'qsrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
        qsrand(QTime::currentTime().msec());
        ^
//test/testutility.cpp:62:43: warning: 
      'qrand' is deprecated: use QRandomGenerator instead
      [-Wdeprecated-declarations]
        QString postfix = QString::number(qrand());
                                          ^
```