### PR TITLE
Replace deprecated endl

### DIFF
--- a/shell_integration/windows/NCOverlays/NCOverlay.cpp
+++ b/shell_integration/windows/NCOverlays/NCOverlay.cpp
@@ -154,7 +154,7 @@ IFACEMETHODIMP NCOverlay::GetOverlayInfo(PWSTR pwszIconFile, int cchMax, int *pI
 
     if (GetModuleFileName(instanceHandle, pwszIconFile, cchMax) == 0) {
         HRESULT hResult = HRESULT_FROM_WIN32(GetLastError());
-        wcerr << L"IsOK? " << (hResult == S_OK) << L" with path " << pwszIconFile << L", index " << *pIndex << endl;
+        wcerr << L"IsOK? " << (hResult == S_OK) << L" with path " << pwszIconFile << L", index " << *pIndex; wcerr.flush();
         return hResult;
     }
 

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -170,33 +170,33 @@ void help()
 {
     const char *binaryName = APPLICATION_EXECUTABLE "cmd";
 
-    std::cout << binaryName << " - command line " APPLICATION_NAME " client tool" << std::endl;
-    std::cout << "" << std::endl;
-    std::cout << "Usage: " << binaryName << " [OPTION] <source_dir> <server_url>" << std::endl;
-    std::cout << "" << std::endl;
-    std::cout << "A proxy can either be set manually using --httpproxy." << std::endl;
-    std::cout << "Otherwise, the setting from a configured sync client will be used." << std::endl;
-    std::cout << std::endl;
-    std::cout << "Options:" << std::endl;
-    std::cout << "  --silent, -s           Don't be so verbose" << std::endl;
-    std::cout << "  --httpproxy [proxy]    Specify a http proxy to use." << std::endl;
-    std::cout << "                         Proxy is http://server:port" << std::endl;
-    std::cout << "  --trust                Trust the SSL certification." << std::endl;
-    std::cout << "  --exclude [file]       Exclude list file" << std::endl;
-    std::cout << "  --unsyncedfolders [file]    File containing the list of unsynced remote folders (selective sync)" << std::endl;
-    std::cout << "  --user, -u [name]      Use [name] as the login name" << std::endl;
-    std::cout << "  --password, -p [pass]  Use [pass] as password" << std::endl;
-    std::cout << "  -n                     Use netrc (5) for login" << std::endl;
-    std::cout << "  --non-interactive      Do not block execution with interaction" << std::endl;
-    std::cout << "  --nonshib              Use Non Shibboleth WebDAV authentication" << std::endl;
-    std::cout << "  --davpath [path]       Custom themed dav path, overrides --nonshib" << std::endl;
-    std::cout << "  --max-sync-retries [n] Retries maximum n times (default to 3)" << std::endl;
-    std::cout << "  --uplimit [n]          Limit the upload speed of files to n KB/s" << std::endl;
-    std::cout << "  --downlimit [n]        Limit the download speed of files to n KB/s" << std::endl;
-    std::cout << "  -h                     Sync hidden files, do not ignore them" << std::endl;
-    std::cout << "  --version, -v          Display version and exit" << std::endl;
-    std::cout << "  --logdebug             More verbose logging" << std::endl;
-    std::cout << "" << std::endl;
+    std::cout << binaryName << " - command line " APPLICATION_NAME " client tool"; std::cout.flush();
+    std::cout << ""; std::cout.flush();
+    std::cout << "Usage: " << binaryName << " [OPTION] <source_dir> <server_url>"; std::cout.flush();
+    std::cout << ""; std::cout.flush();
+    std::cout << "A proxy can either be set manually using --httpproxy."; std::cout.flush();
+    std::cout << "Otherwise, the setting from a configured sync client will be used."; std::cout.flush();
+    std::cout << ""; std::cout.flush();
+    std::cout << "Options:"; std::cout.flush();
+    std::cout << "  --silent, -s           Don't be so verbose"; std::cout.flush();
+    std::cout << "  --httpproxy [proxy]    Specify a http proxy to use."; std::cout.flush();
+    std::cout << "                         Proxy is http://server:port"; std::cout.flush();
+    std::cout << "  --trust                Trust the SSL certification."; std::cout.flush();
+    std::cout << "  --exclude [file]       Exclude list file"; std::cout.flush();
+    std::cout << "  --unsyncedfolders [file]    File containing the list of unsynced remote folders (selective sync)"; std::cout.flush();
+    std::cout << "  --user, -u [name]      Use [name] as the login name"; std::cout.flush();
+    std::cout << "  --password, -p [pass]  Use [pass] as password"; std::cout.flush();
+    std::cout << "  -n                     Use netrc (5) for login"; std::cout.flush();
+    std::cout << "  --non-interactive      Do not block execution with interaction"; std::cout.flush();
+    std::cout << "  --nonshib              Use Non Shibboleth WebDAV authentication"; std::cout.flush();
+    std::cout << "  --davpath [path]       Custom themed dav path, overrides --nonshib"; std::cout.flush();
+    std::cout << "  --max-sync-retries [n] Retries maximum n times (default to 3)"; std::cout.flush();
+    std::cout << "  --uplimit [n]          Limit the upload speed of files to n KB/s"; std::cout.flush();
+    std::cout << "  --downlimit [n]        Limit the download speed of files to n KB/s"; std::cout.flush();
+    std::cout << "  -h                     Sync hidden files, do not ignore them"; std::cout.flush();
+    std::cout << "  --version, -v          Display version and exit"; std::cout.flush();
+    std::cout << "  --logdebug             More verbose logging"; std::cout.flush();
+    std::cout << ""; std::cout.flush();
     exit(0);
 }
 
@@ -230,7 +230,7 @@ void parseOptions(const QStringList &app_args, CmdOptions *options)
     }
     QFileInfo fi(options->source_dir);
     if (!fi.exists()) {
-        std::cerr << "Source dir '" << qPrintable(options->source_dir) << "' does not exist." << std::endl;
+        std::cerr << "Source dir '" << qPrintable(options->source_dir) << "' does not exist."; std::cerr.flush();
         exit(1);
     }
     options->source_dir = fi.absoluteFilePath();

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -80,17 +80,17 @@ void setLaunchOnStartup_private(const QString &appName, const QString &guiName, 
 
         QTextStream ts(&iniFile);
         ts.setCodec("UTF-8");
-        ts << QLatin1String("[Desktop Entry]") << endl
-           << QLatin1String("Name=") << guiName << endl
-           << QLatin1String("GenericName=") << QLatin1String("File Synchronizer") << endl
-           << QLatin1String("Exec=\"") << executablePath << "\" --background" << endl
-           << QLatin1String("Terminal=") << "false" << endl
-           << QLatin1String("Icon=") << APPLICATION_ICON_NAME << endl
-           << QLatin1String("Categories=") << QLatin1String("Network") << endl
-           << QLatin1String("Type=") << QLatin1String("Application") << endl
-           << QLatin1String("StartupNotify=") << "false" << endl
-           << QLatin1String("X-GNOME-Autostart-enabled=") << "true" << endl
-           << QLatin1String("X-GNOME-Autostart-Delay=10") << endl;
+        ts << QLatin1String("[Desktop Entry]"); ts.flush();
+        ts << QLatin1String("Name=") << guiName; ts.flush();
+        ts << QLatin1String("GenericName=") << QLatin1String("File Synchronizer"); ts.flush();
+        ts << QLatin1String("Exec=\"") << executablePath << "\" --background"; ts.flush();
+        ts << QLatin1String("Terminal=") << "false"; ts.flush();
+        ts << QLatin1String("Icon=") << APPLICATION_ICON_NAME; ts.flush();
+        ts << QLatin1String("Categories=") << QLatin1String("Network"); ts.flush();
+        ts << QLatin1String("Type=") << QLatin1String("Application"); ts.flush();
+        ts << QLatin1String("StartupNotify=") << "false"; ts.flush();
+        ts << QLatin1String("X-GNOME-Autostart-enabled=") << "true"; ts.flush();
+        ts << QLatin1String("X-GNOME-Autostart-Delay=10"); ts.flush();
     } else {
         if (!QFile::remove(desktopFileLocation)) {
             qCWarning(lcUtility) << "Could not remove autostart desktop file";

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -656,16 +656,13 @@ void Application::showHelp()
     QTextStream stream(&helpText);
     stream << _theme->appName()
            << QLatin1String(" version ")
-           << _theme->version() << endl;
+           << _theme->version(); stream.flush();
 
-    stream << QLatin1String("File synchronisation desktop utility.") << endl
-           << endl
-           << QLatin1String(optionsC);
+    stream << QLatin1String("File synchronisation desktop utility."); stream.flush();
+    stream << QLatin1String(optionsC);
 
     if (_theme->appName() == QLatin1String("ownCloud"))
-        stream << endl
-               << "For more information, see http://www.owncloud.org" << endl
-               << endl;
+        stream << "For more information, see http://www.owncloud.org"; stream.flush();
 
     displayHelpText(helpText);
 }
@@ -678,8 +675,8 @@ void Application::showVersion()
 void Application::showHint(std::string errorHint)
 {
     static QString binName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
-    std::cerr << errorHint << std::endl;
-    std::cerr << "Try '" << binName.toStdString() << " --help' for more information" << std::endl;
+    std::cerr << errorHint; std::cerr.flush();
+    std::cerr << "Try '" << binName.toStdString() << " --help' for more information"; std::cerr.flush();
     std::exit(1);
 }
 

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -80,12 +80,12 @@ void SyncRunFileLog::start(const QString &folderPath)
 
 
     if (!exists) {
-        _out << folderPath << endl;
+        _out << folderPath; _out.flush();
         // We are creating a new file, add the note.
         _out << "# timestamp | duration | file | instruction | dir | modtime | etag | "
                 "size | fileId | status | errorString | http result code | "
-                "other size | other modtime | X-Request-ID"
-             << endl;
+                "other size | other modtime | X-Request-ID";
+        _out.flush();
 
         FileSystem::setFileHidden(filename, true);
     }
@@ -93,7 +93,7 @@ void SyncRunFileLog::start(const QString &folderPath)
 
     _totalDuration.start();
     _lapDuration.start();
-    _out << "#=#=#=# Syncrun started " << dateTimeStr(QDateTime::currentDateTimeUtc()) << endl;
+    _out << "#=#=#=# Syncrun started " << dateTimeStr(QDateTime::currentDateTimeUtc()); _out.flush();
 }
 void SyncRunFileLog::logItem(const SyncFileItem &item)
 {
@@ -131,21 +131,21 @@ void SyncRunFileLog::logItem(const SyncFileItem &item)
     _out << QString::number(item._previousModtime) << L;
     _out << item._requestId << L;
 
-    _out << endl;
+    _out.flush();
 }
 
 void SyncRunFileLog::logLap(const QString &name)
 {
     _out << "#=#=#=#=# " << name << " " << dateTimeStr(QDateTime::currentDateTimeUtc())
          << " (last step: " << _lapDuration.restart() << " msec"
-         << ", total: " << _totalDuration.elapsed() << " msec)" << endl;
+         << ", total: " << _totalDuration.elapsed() << " msec)"; _out.flush();
 }
 
 void SyncRunFileLog::finish()
 {
     _out << "#=#=#=# Syncrun finished " << dateTimeStr(QDateTime::currentDateTimeUtc())
          << " (last step: " << _lapDuration.elapsed() << " msec"
-         << ", total: " << _totalDuration.elapsed() << " msec)" << endl;
+         << ", total: " << _totalDuration.elapsed() << " msec)"; _out.flush();
     _file->close();
 }
 }

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -136,7 +136,7 @@ void Logger::doLog(const QString &msg)
     {
         QMutexLocker lock(&_mutex);
         if (_logstream) {
-            (*_logstream) << msg << endl;
+            (*_logstream) << msg << "\n";
             if (_doFileFlush)
                 _logstream->flush();
         }

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -715,17 +715,17 @@ QString Theme::versionSwitchOutput() const
     QTextStream stream(&helpText);
     stream << appName()
            << QLatin1String(" version ")
-           << version() << endl;
+           << version(); stream.flush();
 #ifdef GIT_SHA1
-    stream << "Git revision " << GIT_SHA1 << endl;
+    stream << "Git revision " << GIT_SHA1; stream.flush();
 #endif
-    stream << "Using Qt " << qVersion() << ", built against Qt " << QT_VERSION_STR << endl;
+    stream << "Using Qt " << qVersion() << ", built against Qt " << QT_VERSION_STR; stream.flush();
 
     if(!QGuiApplication::platformName().isEmpty())
-        stream << "Using Qt platform plugin '" << QGuiApplication::platformName() << "'" << endl;
+        stream << "Using Qt platform plugin '" << QGuiApplication::platformName() << "'"; stream.flush();
 
-    stream << "Using '" << QSslSocket::sslLibraryVersionString() << "'" << endl;
-    stream << "Running on " << Utility::platformName() << ", " << QSysInfo::currentCpuArchitecture() << endl;
+    stream << "Using '" << QSslSocket::sslLibraryVersionString() << "'"; stream.flush();
+    stream << "Running on " << Utility::platformName() << ", " << QSysInfo::currentCpuArchitecture(); stream.flush();
     return helpText;
 }
 


### PR DESCRIPTION
I also replaced `std::endl` with `&Qt::endl` for good measure.

This compiles correctly on macOS (#3124 aside).

Resolves the following compiler warnings:
```
//src/libsync/logger.cpp:139:37: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
            (*_logstream) << msg << endl;
                                    ^
//src/libsync/theme.cpp:698:28: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
           << version() << endl;
                           ^
//src/libsync/theme.cpp:700:46: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
    stream << "Git revision " << GIT_SHA1 << endl;
                                             ^
//src/libsync/theme.cpp:702:87: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...Qt " << qVersion() << ", built against Qt " << QT_VERSION_STR << endl;
                                                                      ^
//src/libsync/theme.cpp:705:93: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...Qt platform plugin '" << QGuiApplication::platformName() << "'" << endl;
                                                                        ^
//src/libsync/theme.cpp:707:76: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
    stream << "Using '" << QSslSocket::sslLibraryVersionString() << "'" << endl;
                                                                           ^
//src/libsync/theme.cpp:708:105: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...<< ", " << QSysInfo::currentCpuArchitecture() << endl;
                                                      ^
//src/libsync/theme.cpp:702:87: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...Qt " << qVersion() << ", built against Qt " << QT_VERSION_STR << endl;
                                                                      ^
//src/libsync/theme.cpp:705:93: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...Qt platform plugin '" << QGuiApplication::platformName() << "'" << endl;
                                                                        ^
//src/libsync/theme.cpp:707:76: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
    stream << "Using '" << QSslSocket::sslLibraryVersionString() << "'" << endl;
                                                                           ^
//src/libsync/theme.cpp:708:105: warning: 
      'endl' is deprecated: Use Qt::endl [-Wdeprecated-declarations]
  ...<< ", " << QSysInfo::currentCpuArchitecture() << endl;
                                                      ^
```