### PR TITLE
clang's variadic macro warnings: only for clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,10 +30,12 @@ if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2")
   endif()
 
-  # Calling Qt's qCWarning(category, ...) with no params for "..." is a GNU
-  # extension (C++11 §16.3/4 forbids them). Silence clang's warnings.
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+  if (CMAKE_CXX_COMPILER MATCHES "Clang")
+    # Calling Qt's qCWarning(category, ...) with no params for "..." is a GNU
+    # extension (C++11 §16.3/4 forbids them). Silence clang's warnings.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+  endif()
 endif()
 
 if(WIN32)


### PR DESCRIPTION
following settings of cmake/modules/Warnings.cmake

once applied, no more zillon of warning on building as below:
```
cc1plus: note: unrecognized command-line option '-Wno-gnu-zero-variadic-macro-arguments' may have been intended to silence earlier diagnostics
```
Edit: appeared on 3.1.3 or 3.2 release
