### PR TITLE
Windows MSI. Do not allow installing Nextcloud client on < Windows 10 or < 1709

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -52,6 +52,9 @@
     <Property Id="INSTALLDIR">
         <RegistrySearch Id="RegistryInstallDir" Type="raw" Root="HKLM" Key="Software\$(var.AppVendor)\$(var.AppName)" Win64="no" />
     </Property>
+	<Property Id="WINDOWSRELEASEID">
+        <RegistrySearch Id="RegistryWindowsReleaseId" Type="raw" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion" Name="ReleaseId"/>
+    </Property>
 
     <!-- Detect legacy NSIS installation -->
     <Property Id="NSIS_UNINSTALLEXE">
@@ -214,6 +217,6 @@
             <Condition Level="0">(NO_DESKTOP_SHORTCUT=1)</Condition>
         </Feature>
     </Feature>
-
+	<Condition Message="This application only runs on Windows 10, version 1709 or higher!">(VersionNT>=603 AND WINDOWSRELEASEID>=1709)</Condition>
     </Product>
 </Wix>


### PR DESCRIPTION
From version 3.2.1 and onwards, a minimum of Windows 10 version 1709 is supported. According to this https://docs.microsoft.com/en-us/windows/win32/cfapi/cloud-files-api-portal

This will fix https://github.com/nextcloud/desktop/issues/3083