### PR TITLE
Use smooth scrolling in folder status list

### DIFF
--- a/src/gui/folderstatusview.cpp
+++ b/src/gui/folderstatusview.cpp
@@ -15,10 +15,14 @@
 #include "folderstatusview.h"
 #include "folderstatusdelegate.h"
 
+#include <QScrollBar>
+
 namespace OCC {
 
 FolderStatusView::FolderStatusView(QWidget *parent) : QTreeView(parent)
 {
+    this->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    this->verticalScrollBar()->setSingleStep(5);
 }
 
 QModelIndex FolderStatusView::indexAt(const QPoint &point) const


### PR DESCRIPTION
Currently the folder status list uses scroll increments based on the `QTreeView` list. This can be a problem on smaller screens because the full height of each top-level item (which is three or more lines of text) counts as a single scroll increment.

The code I added makes it use `5px` increments instead, which approximates smooth scrolling. Using `ScrollPerPixel` without specifying pixel increments leaves a much larger default scroll increment, and using `1px` makes scrolling unusually slow. Hypothetically the scroll increment could be based on a variable from elsewhere, but `5px` seems to work reasonably well.

I’ve tested this on Debian GNOME, and I wish the operating system specified a sensible default scroll increment, but it doesn’t. I haven’t tested this on Windows or macOS. macOS does use smooth scrolling by default, but if this interferes with the default smooth scrolling, I might have to wrap this in a `!isMac()` conditional.