### PR TITLE
Tidy Debug Build logic

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -133,6 +133,9 @@ namespace Utility {
     inline bool isLinux(); // use with care
     inline bool isBSD(); // use with care, does not match OS X
 
+    // convenience variable-safe QT_DEBUG passthrough
+    inline bool isDebugBuild();
+
     OCSYNC_EXPORT QString platformName();
     // crash helper for --debug
     OCSYNC_EXPORT void crash();
@@ -312,6 +315,16 @@ inline bool Utility::isLinux()
 inline bool Utility::isBSD()
 {
 #if defined(Q_OS_FREEBSD) || defined(Q_OS_NETBSD) || defined(Q_OS_OPENBSD)
+    return true;
+#else
+    return false;
+#endif
+}
+
+
+inline bool Utility::isDebugBuild()
+{
+#ifdef QT_DEBUG
     return true;
 #else
     return false;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -489,20 +489,15 @@ void Application::slotownCloudWizardDone(int res)
         _checkConnectionTimer.start();
         slotCheckConnection();
 
-        // If one account is configured: enable autostart
-#ifndef QT_DEBUG
-        bool shouldSetAutoStart = (accountMan->accounts().size() == 1);
-#else
-        bool shouldSetAutoStart = false;
-#endif
-#ifdef Q_OS_MAC
-        // Don't auto start when not being 'installed'
-        shouldSetAutoStart = shouldSetAutoStart
-            && QCoreApplication::applicationDirPath().startsWith("/Applications/");
-#endif
-        if (shouldSetAutoStart) {
-            Utility::setLaunchOnStartup(_theme->appName(), _theme->appNameGUI(), true);
-        }
+    // Enable autostart or not
+    Utility::setLaunchOnStartup(_theme->appName(), _theme->appNameGUI(),
+        // Don't autostart debug builds
+        !Utility::isDebugBuild()
+        // Don't autostart if no accounts are configured
+        && accountMan->accounts().size() >= 1
+        // Don't autostart on macOS when not installed to Applications
+        && (!Utility::isMac() || QCoreApplication::applicationDirPath().startsWith("/Applications/"))
+        );
 
         Systray::instance()->showWindow();
     }


### PR DESCRIPTION
This branch creates a convenience function, `Utility::isDebugBuild()`, that can be used in code without requiring inline preprocessor directives, which are less human-readable. The definition of `Utility::isDebugBuild()` is directly adapted from the existing convenience OS-detection methods in `utility.cpp`, so there is a direct precedent for this sort of thing.

The branch additionally incorporates changes I had previously made to the autostart logic on https://github.com/nextcloud/desktop/pull/2965 and should hypothetically make it easier to read (though after a certain point boolean expressions become inherently cumbersome).