### PR TITLE
fix errors when calling CfRegisterSyncRoot by setting more fields

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -23,6 +23,7 @@
 #include <QFileInfo>
 #include <QLocalSocket>
 #include <QLoggingCategory>
+#include <QUuid>
 
 #include <sddl.h>
 #include <cfapi.h>
@@ -467,14 +468,17 @@ OCC::Result<void, QString> OCC::CfApiWrapper::registerSyncRoot(const QString &pa
     const auto version = std::wstring(providerVersion.toStdWString().data());
 
     CF_SYNC_REGISTRATION info;
+    info.StructSize = sizeof(info) + (name.length() + version.length()) * sizeof(wchar_t);
     info.ProviderName = name.data();
     info.ProviderVersion = version.data();
     info.SyncRootIdentity = nullptr;
     info.SyncRootIdentityLength = 0;
     info.FileIdentity = nullptr;
     info.FileIdentityLength = 0;
+    info.ProviderId = QUuid::createUuid();
 
     CF_SYNC_POLICIES policies;
+    policies.StructSize = sizeof(policies);
     policies.Hydration.Primary = CF_HYDRATION_POLICY_FULL;
     policies.Hydration.Modifier = CF_HYDRATION_POLICY_MODIFIER_NONE;
     policies.Population.Primary = CF_POPULATION_POLICY_ALWAYS_FULL;


### PR DESCRIPTION
sets a reasonable size of the StructSize members in the struct passed to
CfRegisterSyncRoot function

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
