### PR TITLE
Call finish() if going to remove all files

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1240,8 +1240,11 @@ bool Folder::virtualFilesEnabled() const
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, std::function<void(bool)> callback)
 {
     ConfigFile cfgFile;
-    if (!cfgFile.promptDeleteFiles())
+    if (!cfgFile.promptDeleteFiles()) {
+        callback(false);
         return;
+    }
+
     const QString msg = dir == SyncFileItem::Down ? tr("All files in the sync folder '%1' folder were deleted on the server.\n"
                                                  "These deletes will be synchronized to your local sync folder, making such files "
                                                  "unavailable unless you have a right to restore. \n"


### PR DESCRIPTION
While investigating #3172, I discovered that the sync will hang forever
if the user has deleted all files on the server. Calling the callback
resolves the problem.

Fixes #3172

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
