### PR TITLE
Add separate GitHub templates for features and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,10 @@
+---
+name: Bugs
+about: Crashes and other bugs
+labels: 'bug'
+
+---
+
 <!--
 Thanks for reporting issues back to Nextcloud!
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and Questions
+    url: "https://help.nextcloud.com/"
+    about: "If you have trouble with setting up Nextcloud, please use the forum instead of opening an issue here."

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,35 @@
+---
+name: Features
+about: New functionality
+labels: 'enhancement'
+
+---
+
+<!--
+Thanks for requesting a feature for Nextcloud!
+
+This is the **issue tracker of Nextcloud**, please do NOT use this to get answers to your questions or get help for fixing your installation. You can find help debugging your system on our home user forums: https://help.nextcloud.com or, if you use Nextcloud in a large organization, ask our engineers on https://portal.nextcloud.com. See also  https://nextcloud.com/support for support options.
+
+Guidelines for submitting features:
+
+* Please search the existing features first, it's likely that your feature was already requested or even implemented.
+    - Go to https://github.com/nextcloud and type any word in the top search/command bar. You probably see something like "We couldn’t find any repositories matching ..." then click "Issues" in the left navigation.
+    - You can also filter by appending e. g. "state:open" to the search string.
+    - More info on search syntax within github: https://help.github.com/articles/searching-issues
+    
+* Please fill in as much of the template below as possible.
+
+* Also note that we have a https://nextcloud.com/contribute/code-of-conduct/ that applies on Github. To summarize it: be kind. We try our best to be nice, too. If you can't be bothered to be polite, please just don't bother to report issues as we won't feel motivated to help you. 
+-->
+
+<!--- Please keep the note below for others who read your bug report -->
+
+### How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you want to have the same feature implemented.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments. 
+
+
+### Feature description
+Tell us how the feature should work


### PR DESCRIPTION
Additionally, this commit adds functionality to label automatically
feature and bug reports.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
