### PR TITLE
VFS. Display local file name clash error when syncing in VFS mode.

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -434,6 +434,11 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
         _item->_type = ItemTypeFile;
     }
     if (_item->_type == ItemTypeVirtualFile) {
+        if (propagator()->localFileNameClash(_item->_file)) {
+            done(SyncFileItem::NormalError, tr("File %1 cannot be downloaded because of a local file name clash!").arg(QDir::toNativeSeparators(_item->_file)));
+            return;
+        }
+
         qCDebug(lcPropagateDownload) << "creating virtual file" << _item->_file;
         auto r = vfs->createPlaceholder(*_item);
         if (!r) {


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

This fixes https://github.com/nextcloud/desktop/issues/3198