### PR TITLE
VFS. Allow dehydartion of readonly files. Preserve 'readonly' flag when creating a placeholder.

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -430,7 +430,7 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
 
         if (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) {
             // make sure ReadOnly flag is preserved for placeholder, similarly to regular files
-            FileSystem::setFileReadOnlyWeak(propagator()->fullLocalPath(_item->_file), true);
+            FileSystem::setFileReadOnly(propagator()->fullLocalPath(_item->_file), true);
         }
 
         return;
@@ -455,7 +455,7 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
 
         if (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) {
             // make sure ReadOnly flag is preserved for placeholder, similarly to regular files
-            FileSystem::setFileReadOnlyWeak(propagator()->fullLocalPath(_item->_file), true);
+            FileSystem::setFileReadOnly(propagator()->fullLocalPath(_item->_file), true);
         }
 
         return;

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -427,6 +427,12 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
         }
         propagator()->_journal->deleteFileRecord(_item->_originalFile);
         updateMetadata(false);
+
+        if (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) {
+            // make sure ReadOnly flag is preserved for placeholder, similarly to regular files
+            FileSystem::setFileReadOnlyWeak(propagator()->fullLocalPath(_item->_file), true);
+        }
+
         return;
     }
     if (vfs->mode() == Vfs::Off && _item->_type == ItemTypeVirtualFile) {
@@ -446,6 +452,12 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
             return;
         }
         updateMetadata(false);
+
+        if (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) {
+            // make sure ReadOnly flag is preserved for placeholder, similarly to regular files
+            FileSystem::setFileReadOnlyWeak(propagator()->fullLocalPath(_item->_file), true);
+        }
+
         return;
     }
 

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -129,7 +129,7 @@ Result<void, QString> VfsCfApi::dehydratePlaceholder(const SyncFileItem &item)
 {
     const auto previousPin = pinState(item._file);
 
-    if (!QFile::remove(_setupParams.filesystemPath + item._file)) {
+    if (!FileSystem::remove(_setupParams.filesystemPath + item._file)) {
         return QStringLiteral("Couldn't remove %1 to fulfill dehydration").arg(item._file);
     }
 


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

This fixes https://github.com/nextcloud/desktop/issues/3156