### PR TITLE
add missing call to tr to get a translated string

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -466,8 +466,8 @@ QString Theme::about() const
               .arg(QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION)) + QString(" (%1)").arg(osName))
               .arg(helpUrl());
 
-    devString += QString("<p><small>Using virtual files plugin: %1</small></p>")
-        .arg(Vfs::modeToString(bestAvailableVfsMode()));
+    devString += tr("<p><small>Using virtual files plugin: %1</small></p>")
+                     .arg(Vfs::modeToString(bestAvailableVfsMode()));
 
     return devString;
 }


### PR DESCRIPTION
Fix #3250

Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
