### PR TITLE
Fallback to primary screen if screen under pointer not found

### DIFF
--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -116,7 +116,10 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
 void OwncloudWizard::centerWindow()
 {
     const auto wizardWindow = window();
-    const auto screenGeometry = QGuiApplication::screenAt(wizardWindow->pos())->geometry();
+    const auto screen = QGuiApplication::screenAt(wizardWindow->pos())
+        ? QGuiApplication::screenAt(wizardWindow->pos())
+        : QGuiApplication::primaryScreen();
+    const auto screenGeometry = screen->geometry();
     const auto windowGeometry = wizardWindow->geometry();
     const auto newWindowPosition = screenGeometry.center() - QPoint(windowGeometry.width() / 2, windowGeometry.height() / 2);
     wizardWindow->move(newWindowPosition);


### PR DESCRIPTION
Fixes #3252

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
