### PR TITLE
Increase Heading Levels in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,26 +24,24 @@ Guidelines for submitting issues:
 
 <!--- Please keep the note below for others who read your bug report -->
 
-### How to use GitHub
+## How to use GitHub
 
 * Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are affected by the same issue.
 * Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
 * Subscribe to receive notifications on status change and new comments. 
 
-
-### Expected behaviour
+## Expected behaviour
 Tell us what should happen
 
-### Actual behaviour
+## Actual behaviour
 Tell us what happens instead
 
-
-### Steps to reproduce
+## Steps to reproduce
 1.
 2.
 3.
 
-### Client configuration
+## Client configuration
 Client version:
 <!---
 Please try to only report a bug if it happens with the latest version
@@ -60,8 +58,7 @@ Client package (From Nextcloud or distro) (Linux only):
 
 Installation path of client:
 
-
-### Server configuration
+## Server configuration
 <!---
 Optional section. It depends on the issue.
 --->
@@ -69,7 +66,7 @@ Nextcloud version:
 
 Storage backend (external storage):
 
-### Logs
+## Logs
 <!-- desktop client logs are a hard requirement for bug reports because we don't know how to do magic here :) -->
 
 Please use Gist (https://gist.github.com/) or a similar code paster for longer
@@ -83,4 +80,3 @@ On previous releases: Via the command line: `nextcloud --logdebug --logwindow` o
 2. Web server error log:
 
 3. Server logfile: nextcloud log (data/nextcloud.log):
-

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -24,12 +24,11 @@ Guidelines for submitting features:
 
 <!--- Please keep the note below for others who read your bug report -->
 
-### How to use GitHub
+## How to use GitHub
 
 * Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you want to have the same feature implemented.
 * Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
-* Subscribe to receive notifications on status change and new comments. 
+* Subscribe to receive notifications on status change and new comments.
 
-
-### Feature description
+## Feature description
 Tell us how the feature should work


### PR DESCRIPTION
Currently the heading levels in the GitHub Issue templates use `###`, like so:

### Three-Pound-Sign Heading

Three-pound-sign headings are barely distinguishable from regular bolded text. By contrast, two-pound-sign headings (`##`) are significantly larger and feature a horizontal rule, like so:

## Two-Pound-Sign Heading

Using two-pound-sign headings in the Issue templates would help make the different sections of the Issue texts easier to visually scan.

There are no higher-level headings in the GitHub Issue templates, so there is no hierarchy to maintain, and using higher-level headings across the board would not create any conflicts.

There is an even higher-level heading, the one-pound-sign heading (`#`), but it seems a little excessive given the relative length of the document:

# One-Pound-Sign Heading

In this pull request, I changed the headings in the two Issue templates from `###` headings to `##` headings. (I also removed some extra whitespace, which doesn’t render anyway.)

Thoughts? Feedback?