### PR TITLE
Git ignore convert.exe and .dir-locals.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ CPackOptions.cmake
 CPackSourceConfig.cmake
 
 compile_commands.json
+convert.exe
+.dir-locals.el


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

These two bothered me for some time now. I know I could add them to the global ignore list, but I want `.dir-locals.el` committed in some projects.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
