### PR TITLE
use folders in CMake

### DIFF
--- a/cmake/modules/DefineCMakeDefaults.cmake
+++ b/cmake/modules/DefineCMakeDefaults.cmake
@@ -25,3 +25,5 @@ set(GENERIC_LIB_SOVERSION "0")
 # set -Werror
 set(CMAKE_ENABLE_WERROR ON)
 
+# enables folders for targets to be visible in an IDE
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(testutils
 
 target_link_libraries(testutils PUBLIC ${APPLICATION_EXECUTABLE}sync Qt5::Test)
 target_include_directories(testutils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(testutils PROPERTIES FOLDER Tests)
 
 nextcloud_add_test(NextcloudPropagator)
 

--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -29,11 +29,12 @@ macro(nextcloud_add_test test_class)
         COMMAND ${OWNCLOUD_TEST_CLASS}Test
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-      target_include_directories(${OWNCLOUD_TEST_CLASS}Test
+    target_include_directories(${OWNCLOUD_TEST_CLASS}Test
         PRIVATE
         "${CMAKE_SOURCE_DIR}/test/"
         ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer
         )
+    set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES FOLDER Tests)
 endmacro()
 
 macro(nextcloud_add_benchmark test_class)
@@ -63,4 +64,5 @@ macro(nextcloud_add_benchmark test_class)
 
     add_definitions(-DOWNCLOUD_TEST)
     add_definitions(-DOWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
+    set_target_properties(${OWNCLOUD_TEST_CLASS}Bench PROPERTIES FOLDER Tests/Benchmarks)
 endmacro()


### PR DESCRIPTION
This sets folders for targets to be visible in an IDE.

Before in VS (if tests ore on):
![NC_3 2](https://user-images.githubusercontent.com/1271541/117448121-02d53c80-af47-11eb-8598-c713d12372d7.png)

Now in VS:
![NC_3 2_folders](https://user-images.githubusercontent.com/1271541/117448136-0799f080-af47-11eb-8b7b-bae2d3cb90c4.png)
