### PR TITLE
Temporary! Windows. VFS. Block Virtual Files for partition root sync folders.

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -676,6 +676,26 @@ QByteArray Utility::conflictFileBaseNameFromPattern(const QByteArray &conflictNa
     return conflictName.left(tagStart) + conflictName.mid(tagEnd);
 }
 
+bool Utility::isPathWindowsDrivePartitionRoot(const QString &path)
+{
+    Q_UNUSED(path)
+#ifdef Q_OS_WIN
+    // should be 2 or 3 characters length
+    if (!(path.size() >= 2 && path.size() <= 3)) {
+        return false;
+    }
+
+    // must mutch a pattern "[A-Za-z]:"
+    if (!(path.at(1) == QLatin1Char(':') && path.at(0).isLetter())) {
+        return false;
+    }
+
+    // final check - last character should be either slash/backslash, or, it should be missing
+    return path.size() < 3 || path.at(2) == QLatin1Char('/') || path.at(2) == QLatin1Char('\\');
+#endif
+    return false;
+}
+
 QString Utility::sanitizeForFileName(const QString &name)
 {
     const auto invalid = QStringLiteral(R"(/?<>\:*|")");

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -235,6 +235,11 @@ namespace Utility {
      */
     OCSYNC_EXPORT QByteArray conflictFileBaseNameFromPattern(const QByteArray &conflictName);
 
+    /**
+     * @brief Check whether the path is a root of a Windows drive partition ([c:/, d:/, e:/, etc.)
+     */
+    OCSYNC_EXPORT bool isPathWindowsDrivePartitionRoot(const QString &path);
+
 #ifdef Q_OS_WIN
     OCSYNC_EXPORT bool registryKeyExists(HKEY hRootKey, const QString &subKey);
     OCSYNC_EXPORT QVariant registryGetKeyValue(HKEY hRootKey, const QString &subKey, const QString &valueName);

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -571,6 +571,9 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
         const auto mode = bestAvailableVfsMode();
         if (mode == Vfs::WindowsCfApi || ConfigFile().showExperimentalOptions()) {
             ac = menu->addAction(tr("Enable virtual file support %1 …").arg(mode == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
+            // TODO: remove when UX decision is made
+            ac->setEnabled(!Utility::isPathWindowsDrivePartitionRoot(folder->path()));
+            //
             connect(ac, &QAction::triggered, this, &AccountSettings::slotEnableVfsCurrentFolder);
         }
     }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -536,6 +536,21 @@ void FolderWizardSelectiveSync::initializePage()
         initialBlacklist = QStringList("/");
     }
     _selectiveSync->setFolderInfo(targetPath, alias, initialBlacklist);
+
+    if (_virtualFilesCheckBox) {
+        // TODO: remove when UX decision is made
+        if (Utility::isPathWindowsDrivePartitionRoot(wizard()->field(QStringLiteral("sourceFolder")).toString())) {
+            _virtualFilesCheckBox->setChecked(false);
+            _virtualFilesCheckBox->setEnabled(false);
+            _virtualFilesCheckBox->setText(tr("Virtual files are not supported for Windows partition roots as local folder. Please choose a valid subfolder under drive letter."));
+        } else {
+            _virtualFilesCheckBox->setChecked(bestAvailableVfsMode() == Vfs::WindowsCfApi);
+            _virtualFilesCheckBox->setEnabled(true);
+            _virtualFilesCheckBox->setText(tr("Use virtual files instead of downloading content immediately %1").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
+        }
+        //
+    }
+
     QWizardPage::initializePage();
 }
 

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -221,6 +221,24 @@ void OwncloudAdvancedSetupPage::fetchUserData()
     _ui.userNameLabel->setText(userName);
 }
 
+void OwncloudAdvancedSetupPage::refreshVirtualFilesAvailibility(const QString &path)
+{
+    // TODO: remove when UX decision is made
+    if (!_ui.rVirtualFileSync->isVisible()) {
+        return;
+    }
+
+    if (Utility::isPathWindowsDrivePartitionRoot(path)) {
+        _ui.rVirtualFileSync->setText(tr("Virtual files are not supported for Windows partition roots as local folder. Please choose a valid subfolder under drive letter."));
+        setRadioChecked(_ui.rSyncEverything);
+        _ui.rVirtualFileSync->setEnabled(false);
+    } else {
+        _ui.rVirtualFileSync->setText(tr("Use &virtual files instead of downloading content immediately %1").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
+        _ui.rVirtualFileSync->setEnabled(true);
+    }
+    //
+}
+
 void OwncloudAdvancedSetupPage::setServerAddressLabelUrl(const QUrl &url)
 {
     if (!url.isValid()) {
@@ -411,6 +429,9 @@ void OwncloudAdvancedSetupPage::slotSelectFolder()
 {
     QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Local Sync Folder"), QDir::homePath());
     if (!dir.isEmpty()) {
+        // TODO: remove when UX decision is made
+        refreshVirtualFilesAvailibility(dir);
+
         setLocalFolderPushButtonPath(dir);
         wizard()->setProperty("localFolder", dir);
         updateStatus();

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -84,6 +84,9 @@ private:
     void fetchUserAvatar();
     void fetchUserData();
 
+    // TODO: remove when UX decision is made
+    void refreshVirtualFilesAvailibility(const QString &path);
+
     Ui_OwncloudAdvancedSetupPage _ui;
     bool _checking = false;
     bool _created = false;


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This fixes https://github.com/nextcloud/desktop/issues/3158.

A temporary solution that we can implement quickly until the UX design is ready for this.

CfAPI doesn't work for root partitions on Windows (drive letters like c:/, d:/, e:/, etc.).

This is to be included in 3.2.2 as a quick solution.