### PR TITLE
[WIP] Use reverse domain for directory names (at least on macOS)

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -129,6 +129,14 @@ bool AccountManager::restoreFromLegacySettings()
     // try to open the correctly themed settings
     auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
 
+    if (settings->childKeys().isEmpty()) {
+        qCInfo(lcAccountManager) << "Migrate: restoreFromLegacySettings, checking settings group"
+                                << Theme::instance()->appRevDomain();
+
+        // try to open the correctly themed settings
+        settings = ConfigFile::settingsWithGroup(Theme::instance()->appRevDomain());
+    }
+
     // if the settings file could not be opened, the childKeys list is empty
     // then try to load settings from a very old place
     if (settings->childKeys().isEmpty()) {

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -18,6 +18,8 @@
 #include "common/utility.h"
 #include "filesystem.h"
 #include <qfileinfo.h>
+#include <theme.h>
+#include <QStandardPaths>
 
 namespace OCC {
 
@@ -31,8 +33,18 @@ QString SyncRunFileLog::dateTimeStr(const QDateTime &dt)
 void SyncRunFileLog::start(const QString &folderPath)
 {
     const qint64 logfileMaxSize = 10 * 1024 * 1024; // 10MiB
+    QString temppath;
 
-    const QString logpath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if (Utility::isMac()) {
+        // "~/Library/Logs/<appRevDomain>"
+        temppath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/../Logs/" + Theme::instance()->appRevDomain();
+    } else {
+        // "~/.local/share/<appRevDomain>", "/usr/local/share/<appRevDomain>", or "/usr/share/<appRevDomain>"
+        temppath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/" + Theme::instance()->appRevDomain();
+    }
+
+    const QString logpath = temppath;
+
     if(!QDir(logpath).exists()) {
         QDir().mkdir(logpath);
     }

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -287,7 +287,7 @@ void Account::lendCookieJarTo(QNetworkAccessManager *guest)
 
 QString Account::cookieJarPath()
 {
-    return QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/cookies" + id() + ".db";
+    return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/" + Theme::instance()->appRevDomain() + "/cookies" + id() + ".db";
 }
 
 void Account::resetNetworkAccessManager()

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -713,7 +713,7 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
     QVariant systemSetting;
     if (Utility::isMac()) {
         // QSettings systemSettings(QString("/Library/Preferences/" Theme::instance()->appRevDomain() ".plist"), QSettings::NativeFormat);
-        QSettings systemSettings(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/" + Theme::instance()->appRevDomain() + "/" + Theme::instance()->appName() ".plist", QSettings::NativeFormat);
+        QSettings systemSettings(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/" + Theme::instance()->appRevDomain() + "/" + Theme::instance()->appName() + ".plist", QSettings::NativeFormat);
         if (!group.isEmpty()) {
             systemSettings.beginGroup(group);
         }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -318,8 +318,8 @@ QString ConfigFile::configPath() const
 {
     if (_confDir.isEmpty()) {
         if (!Utility::isWindows()) {
-            // On Unix, use the AppConfigLocation for the settings, that's configurable with the XDG_CONFIG_HOME env variable.
-            _confDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+            // On Unix, use the ConfigLocation for the settings, that's configurable with the XDG_CONFIG_HOME env variable.
+            _confDir = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/" + Theme::instance()->appRevDomain();
         } else {
             // On Windows, use AppDataLocation, that's where the roaming data is and where we should store the config file
              auto newLocation = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
@@ -712,13 +712,14 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
 {
     QVariant systemSetting;
     if (Utility::isMac()) {
-        QSettings systemSettings(QLatin1String("/Library/Preferences/" APPLICATION_REV_DOMAIN ".plist"), QSettings::NativeFormat);
+        // QSettings systemSettings(QString("/Library/Preferences/" Theme::instance()->appRevDomain() ".plist"), QSettings::NativeFormat);
+        QSettings systemSettings(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/" + Theme::instance()->appRevDomain() + "/" + Theme::instance()->appName() ".plist", QSettings::NativeFormat);
         if (!group.isEmpty()) {
             systemSettings.beginGroup(group);
         }
         systemSetting = systemSettings.value(param, defaultValue);
     } else if (Utility::isUnix()) {
-        QSettings systemSettings(QString(SYSCONFDIR "/%1/%1.conf").arg(Theme::instance()->appName()), QSettings::NativeFormat);
+        QSettings systemSettings(QString(SYSCONFDIR "/%1/%1.conf").arg(Theme::instance()->appRevDomain()), QSettings::NativeFormat);
         if (!group.isEmpty()) {
             systemSettings.beginGroup(group);
         }

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -15,12 +15,14 @@
 #include "logger.h"
 
 #include "config.h"
+#include <theme.h>
 
 #include <QDir>
 #include <QStringList>
 #include <QtGlobal>
 #include <QTextCodec>
 #include <qmetaobject.h>
+#include <QStandardPaths>
 
 #include <iostream>
 
@@ -230,8 +232,12 @@ void Logger::setLogDebug(bool debug)
 
 QString Logger::temporaryFolderLogDirPath() const
 {
-    QString dirName = APPLICATION_SHORTNAME + QString("-logdir");
-    return QDir::temp().filePath(dirName);
+    if (Utility::isMac()) {
+        return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/../Logs/" + Theme::instance()->appRevDomain();
+    } else {
+        QString dirName = APPLICATION_SHORTNAME + QString("-logdir");
+        return QDir::temp().filePath(dirName);
+    }
 }
 
 void Logger::setupTemporaryFolderLogDir()

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -129,6 +129,11 @@ QString Theme::appName() const
     return APPLICATION_SHORTNAME;
 }
 
+QString Theme::appRevDomain() const
+{
+    return APPLICATION_REV_DOMAIN;
+}
+
 QUrl Theme::stateOnlineImageSource() const
 {
     return imagePathToUrl(themeImagePath("state-ok"));

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -40,6 +40,7 @@ class OWNCLOUDSYNC_EXPORT Theme : public QObject
     Q_PROPERTY(bool branded READ isBranded CONSTANT)
     Q_PROPERTY(QString appNameGUI READ appNameGUI CONSTANT)
     Q_PROPERTY(QString appName READ appName CONSTANT)
+    Q_PROPERTY(QString appRevDomain READ appRevDomain CONSTANT)
     Q_PROPERTY(QUrl stateOnlineImageSource READ stateOnlineImageSource CONSTANT)
     Q_PROPERTY(QUrl stateOfflineImageSource READ stateOfflineImageSource CONSTANT)
     Q_PROPERTY(QUrl stateOnlineImageSource READ stateOnlineImageSource CONSTANT)
@@ -115,6 +116,20 @@ public:
      * @return QString with app name.
      */
     virtual QString appName() const;
+
+    /**
+     * @brief appRevDomain - Application Reverse Domain
+     *
+     * Use and redefine this as an application's XDG-compliant unique name.
+     * It is used for the cache, config, and log file directories.
+     *
+     * By default, the name is derived from the APPLICATION_REV_DOMAIN
+     * cmake variable, and should be the same. This method is only
+     * reimplementable for legacy reasons.
+     *
+     * @return QString with app name.
+     */
+    virtual QString appRevDomain() const;
 
     /**
      * @brief Returns full path to an online state icon


### PR DESCRIPTION
## Expected Behavior
On macOS:
* Preferences should be stored in `~/Library/Preferences/${APPLICATION_REV_DOMAIN}`
* Logs should be stored in `~/Library/Logs/${APPLICATION_REV_DOMAIN}`
* Caches should be stored in `~/Library/Caches/${APPLICATION_REV_DOMAIN}`
* Etc., etc.

## Actual Behavior
Basically everything is stored in `~/Library/Preferences/${APPLICATION_SHORTNAME}`. (This is partially Qt’s fault for using `<APPNAME>` in [`QStandardPaths`](https://doc.qt.io/qt-5/qstandardpaths.html).)

## Rationale
Using standard directory locations is important for non-“Container” apps on macOS for several reasons:
* While Apple doesn’t provide this functionality up-front for non-“Container” applications, third-party uninstall utilities look for application data in certain standard locations, so it’s easier to achieve a clean uninstall if you follow convention. (This isn’t that much of an issue with Nextcloud Desktop, but Linux ports that save application data in `~/.config` on macOS are particularly egregious.)
* Saving logs in `~/Library/Logs` (regardless of subfolder) allows the logs to automatically appear in [Console.app](https://www.howtogeek.com/356942/how-to-view-the-system-log-on-a-mac/). Files ending in `.log` will open in Console.app regardless, but using the standard log directory prevents the user from having to navigate to the hidden Library folder in their home directory, and having logs automatically appear in Console.app is just a user-friendly convenience.

## Commentary
I started this several months ago, and only just now rebased it on master (by moving it from my fork to a fresh branch on the main repository).

This is very much a work in progress (considering I haven’t really done anything with it in like two months). Among other things, I don’t remember what changes actually achieve their intended effects, and I don’t know what behaviors are the norm on Linux. IIRC for the most part I limited my changes to macOS.

## Requests for Feedback (e.g. Questions)
* What are the norms for the directories reflected in `QStandardPaths` on Windows and Linux?
* Should there be special considerations for unusual packaging situations such as Flatpak (where everything is in a reverse-domain top-level directory to begin with)?
* Any other thoughts?