### PR TITLE
Add install.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ admin/win/nsi/l10n/pofiles/*.po
 *~$
 build*
 cscope.*
+install.sh
 tags
 t1.cfg
 


### PR DESCRIPTION
When I was working on [the build instructions](https://github.com/nextcloud/desktop/pull/2931) one thing that came up was the possibility of the user being able to construct a shell script. While I’m not exactly ready to submit instructions for said shell script, adding `install.sh` to `.gitignore` would help prepare for allowing the user to have a shell script that lives inside the cloned repository. Because of platform differences, this shell script would be created during the initial setup process and would not itself be stored on git.

Yes? No?