### PR TITLE
also update ownCloud years interval in copyright notice

### DIFF
--- a/src/gui/legalnotice.cpp
+++ b/src/gui/legalnotice.cpp
@@ -53,7 +53,7 @@ void LegalNotice::changeEvent(QEvent *e)
 void LegalNotice::customizeStyle()
 {
     QString notice = tr("<p>Copyright 2017-2021 Nextcloud GmbH<br />"
-                        "Copyright 2012-2018 ownCloud GmbH</p>");
+                        "Copyright 2012-2021 ownCloud GmbH</p>");
 
     notice += tr("<p>Licensed under the GNU General Public License (GPL) Version 2.0 or any later version.</p>");
 


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
