### PR TITLE
Remove unnecessary cfapi logging statements

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -92,7 +92,6 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
     };
 
     const auto sendTransferInfo = [=](QByteArray &data, qint64 offset) {
-        qDebug(lcCfApiWrapper) << "Send transfer info. Offset:" << offset;
         cfApiSendTransferInfo(callbackInfo->ConnectionKey,
                               callbackInfo->TransferKey,
                               STATUS_SUCCESS,
@@ -165,7 +164,6 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
         protrudingData = data.right(protudingSize);
         data.chop(protudingSize);
 
-        qDebug(lcCfApiWrapper) << "Send data block. Size:" << data.size();
         sendTransferInfo(data, dataOffset);
         dataOffset += data.size();
     };


### PR DESCRIPTION
For big files that can add a lot lines to the log files.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

This helps with https://github.com/nextcloud/desktop/issues/3287

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
