### PR TITLE
update most docker images to use Qt 5.12.10 in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: qt-5.12
 
 steps:
 - name: cmake
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -11,7 +11,7 @@ steps:
     - cd /drone/build
     - cmake -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address ../src
 - name: compile
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -19,7 +19,7 @@ steps:
     - cd /drone/build
     - make -j$(nproc)
 - name: test
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -47,7 +47,7 @@ name: qt-5.12-clang
 
 steps:
 - name: cmake
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -55,7 +55,7 @@ steps:
     - cd /drone/build
     - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address ../src
 - name: compile
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -63,7 +63,7 @@ steps:
     - cd /drone/build
     - ninja
 - name: test
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build
@@ -73,7 +73,7 @@ steps:
     - chown -R test:test .
     - su -c 'ASAN_OPTIONS=detect_leaks=0 ctest --output-on-failure' test
 - name: clang-tidy
-  image: nextcloudci/client-5.12:client-5.12-11
+  image: nextcloudci/client-5.12:client-5.12-12
   volumes:
     - name: build
       path: /drone/build


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
