### PR TITLE
sync-exclude.lst: Add desktop.ini, accidentally removed by a480a31.

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -10,6 +10,7 @@
 ].ds_store
 ._*
 ]Thumbs.db
+desktop.ini
 ]photothumb.db
 System Volume Information
 


### PR DESCRIPTION
Signed-off-by: jtagcat <git-514635f7@jtag.cat>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Closes https://github.com/nextcloud/desktop/issues/3155

Assuming it as a mistake, not re-adding the uppercase version, as it's already hard-coded ignored.