### PR TITLE
takes ECMCoverageOption from ECM to enable code coverage analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ endif()
 
 set( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules )
 
+include(ECMCoverageOption)
+
 if(NOT CRASHREPORTER_EXECUTABLE)
     set(CRASHREPORTER_EXECUTABLE "${APPLICATION_EXECUTABLE}_crash_reporter")
 endif()

--- a/cmake/modules/ECMCoverageOption.cmake
+++ b/cmake/modules/ECMCoverageOption.cmake
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2014 Aleix Pol Gonzalez <aleixpol@kde.org>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+ECMCoverageOption
+--------------------
+
+Allow users to easily enable GCov code coverage support.
+
+Code coverage allows you to check how much of your codebase is covered by
+your tests. This module makes it easy to build with support for
+`GCov <https://gcc.gnu.org/onlinedocs/gcc/Gcov.html>`_.
+
+When this module is included, a ``BUILD_COVERAGE`` option is added (default
+OFF). Turning this option on enables GCC's coverage instrumentation, and
+links against ``libgcov``.
+
+Note that this will probably break the build if you are not using GCC.
+
+Since 1.3.0.
+#]=======================================================================]
+
+option(BUILD_COVERAGE "Build the project with gcov support" OFF)
+
+if(BUILD_COVERAGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
+endif()


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
