### PR TITLE
automate removal of needs info labels when the issue is commented

### DIFF
--- a/.github/workflows/needsinfohelper.yaml
+++ b/.github/workflows/needsinfohelper.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
-        if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') }}
+        if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') && ! startsWith(github.event.comment.body, 'This bug report did not receive an update in the last 4 weeks.')}}
         with:
           labels: 'needs info'

--- a/.github/workflows/needsinfohelper.yaml
+++ b/.github/workflows/needsinfohelper.yaml
@@ -6,7 +6,6 @@ jobs:
   remove_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') }}
         with:

--- a/.github/workflows/needsinfohelper.yaml
+++ b/.github/workflows/needsinfohelper.yaml
@@ -1,0 +1,13 @@
+name: Remove Labels
+
+on: [issue_comment]
+
+jobs:
+  remove_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') }}
+        with:
+          labels: 'needs info'


### PR DESCRIPTION
should help handling needs info label in a more efficient way

Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
