### PR TITLE
Set button on QMessageBox before changing the text

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -88,10 +88,14 @@ bool showEnableE2eeWithVirtualFilesWarningDialog()
                                                                              " End-to-End Encryption, make sure the encrypted folder is marked with"
                                                                              " \"Make always available locally\"."));
     e2eeWithVirtualFilesWarningMsgBox.setIcon(QMessageBox::Warning);
-    const auto dontEncryptButton = e2eeWithVirtualFilesWarningMsgBox.button(QMessageBox::StandardButton::Ok);
-    const auto encryptButton = e2eeWithVirtualFilesWarningMsgBox.button(QMessageBox::StandardButton::Cancel);
+    const auto dontEncryptButton = e2eeWithVirtualFilesWarningMsgBox.addButton(QMessageBox::StandardButton::Ok);
+    Q_ASSERT(dontEncryptButton);
     dontEncryptButton->setText(AccountSettings::tr("Don't encrypt folder"));
+    const auto encryptButton = e2eeWithVirtualFilesWarningMsgBox.addButton(QMessageBox::StandardButton::Cancel);
+    Q_ASSERT(encryptButton);
     encryptButton->setText(AccountSettings::tr("Encrypt folder"));
+    e2eeWithVirtualFilesWarningMsgBox.exec();
+
 
     return e2eeWithVirtualFilesWarningMsgBox.clickedButton() != dontEncryptButton;
 }


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
