### PR TITLE
Bugfix. Crash when printing OpenSSL decryption errors with no e2ee mnemonic,

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -708,8 +708,8 @@ QByteArray decryptStringAsymmetric(EVP_PKEY *privateKey, const QByteArray& data)
     QByteArray out(outlen, '\0');
 
     if (EVP_PKEY_decrypt(ctx, unsignedData(out), &outlen, (unsigned char *)data.constData(), data.size()) <= 0) {
-        qCInfo(lcCseDecryption()) << "Could not decrypt the data.";
-        ERR_print_errors_fp(stdout); // This line is not printing anything.
+        qCCritical(lcCseDecryption()) << "Could not decrypt the data.";
+        qCCritical(lcCseDecryption()) << handleErrors();
         return {};
     } else {
         qCInfo(lcCseDecryption()) << "data decrypted successfully";

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -708,8 +708,8 @@ QByteArray decryptStringAsymmetric(EVP_PKEY *privateKey, const QByteArray& data)
     QByteArray out(outlen, '\0');
 
     if (EVP_PKEY_decrypt(ctx, unsignedData(out), &outlen, (unsigned char *)data.constData(), data.size()) <= 0) {
-        qCCritical(lcCseDecryption()) << "Could not decrypt the data.";
-        qCCritical(lcCseDecryption()) << handleErrors();
+        const auto error = handleErrors();
+        qCCritical(lcCseDecryption()) << "Could not decrypt the data." << error;
         return {};
     } else {
         qCInfo(lcCseDecryption()) << "data decrypted successfully";


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
