### PR TITLE
use a specific stale label for needs info handling to solve conflict

### DIFF
--- a/.github/workflows/needsinfo.yml
+++ b/.github/workflows/needsinfo.yml
@@ -14,6 +14,7 @@ jobs:
                     days-before-close: 14
                     days-before-pr-close: -1
                     only-labels: 'needs info'
+                    stale-issue-label: 'stale needs info'
                     exempt-issue-labels: 'bug'
                     stale-issue-message: 'This issue has been marked as "needs info" 4 weeks ago.
                                         Please take a look again and try to provide the information requested,


### PR DESCRIPTION
each stale bot needs to have its own stale label such that it does not
remove the label added by the other bot

that can happen due to needs info bot removing stale label on issues
that have both bug and needs info labels

Signed-off-by: Matthieu Gallien <matthieu_gallien@yahoo.fr>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
