### PR TITLE
Improve error message

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -780,7 +780,7 @@ void PropagateDownloadFile::slotGetFinished()
     if (_tmpFile.size() == 0 && _item->_size > 0) {
         FileSystem::remove(_tmpFile.fileName());
         done(SyncFileItem::NormalError,
-            tr("The downloaded file is empty despite that the server announced it should have been %1.")
+            tr("The downloaded file is empty, but the server said it should have been %1.")
                 .arg(Utility::octetsToString(_item->_size)));
         return;
     }


### PR DESCRIPTION
This one is more user-friendly and grammatically correct.