### PR TITLE
Prevent crash in dialog that warns user about vfs and e2ee

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -82,24 +82,24 @@ static const char progressBarStyleC[] =
 
 void showEnableE2eeWithVirtualFilesWarningDialog(std::function<void(void)> onAccept)
 {
-    const auto e2eeWithVirtualFilesWarningMsgBox = new QMessageBox;
-    e2eeWithVirtualFilesWarningMsgBox->setAttribute(Qt::WA_DeleteOnClose);
-    e2eeWithVirtualFilesWarningMsgBox->setText(AccountSettings::tr("End-to-End Encryption with Virtual Files"));
-    e2eeWithVirtualFilesWarningMsgBox->setInformativeText(AccountSettings::tr("You seem to have the Virtual Files feature enabled on this folder. At "
-                                                                              " the moment, it is not possible to implicitly download virtual files that are "
-                                                                              "End-to-End encrypted. To get the best experience with Virtual Files and"
-                                                                              " End-to-End Encryption, make sure the encrypted folder is marked with"
-                                                                              " \"Make always available locally\"."));
-    e2eeWithVirtualFilesWarningMsgBox->setIcon(QMessageBox::Warning);
-    const auto dontEncryptButton = e2eeWithVirtualFilesWarningMsgBox->addButton(QMessageBox::StandardButton::Cancel);
+    const auto messageBox = new QMessageBox;
+    messageBox->setAttribute(Qt::WA_DeleteOnClose);
+    messageBox->setText(AccountSettings::tr("End-to-End Encryption with Virtual Files"));
+    messageBox->setInformativeText(AccountSettings::tr("You seem to have the Virtual Files feature enabled on this folder. At "
+                                                       " the moment, it is not possible to implicitly download virtual files that are "
+                                                       "End-to-End encrypted. To get the best experience with Virtual Files and"
+                                                       " End-to-End Encryption, make sure the encrypted folder is marked with"
+                                                       " \"Make always available locally\"."));
+    messageBox->setIcon(QMessageBox::Warning);
+    const auto dontEncryptButton = messageBox->addButton(QMessageBox::StandardButton::Cancel);
     Q_ASSERT(dontEncryptButton);
     dontEncryptButton->setText(AccountSettings::tr("Don't encrypt folder"));
-    const auto encryptButton = e2eeWithVirtualFilesWarningMsgBox->addButton(QMessageBox::StandardButton::Ok);
+    const auto encryptButton = messageBox->addButton(QMessageBox::StandardButton::Ok);
     Q_ASSERT(encryptButton);
     encryptButton->setText(AccountSettings::tr("Encrypt folder"));
-    QObject::connect(e2eeWithVirtualFilesWarningMsgBox, &QMessageBox::accepted, onAccept);
+    QObject::connect(messageBox, &QMessageBox::accepted, onAccept);
 
-    e2eeWithVirtualFilesWarningMsgBox->open();
+    messageBox->open();
 }
 
 /**
@@ -270,8 +270,8 @@ void AccountSettings::slotEncryptFolderFinished(int status)
     }
 
     const auto folder = job->property(propertyFolder).value<Folder *>();
-    const auto path = job->property(propertyPath).value<QString>();
     Q_ASSERT(folder);
+    const auto path = job->property(propertyPath).value<QString>();
     const auto index = _model->indexForPath(folder, path);
     Q_ASSERT(index.isValid());
     _model->resetAndFetch(index.parent());
@@ -353,6 +353,7 @@ void AccountSettings::slotMarkSubfolderEncrypted(FolderStatusModel::SubFolderInf
         // Does the file still exist?
         SyncJournalFileRecord record;
         if (!folder->journalDb()->getFileRecord(choppedPath, &record) || !record.isValid()) {
+            qCWarning(lcAccountSettings) << "Could not encrypt folder because" << path << "does not exist anymore";
             return;
         }
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -14,6 +14,7 @@
 
 
 #include "accountsettings.h"
+#include "common/syncjournalfilerecord.h"
 #include "ui_accountsettings.h"
 
 #include "theme.h"
@@ -59,7 +60,8 @@
 #include "account.h"
 
 namespace {
-constexpr auto propertyFolderInfo = "folderInfo";
+constexpr auto propertyFolder = "folder";
+constexpr auto propertyPath = "path";
 }
 
 namespace OCC {
@@ -78,26 +80,26 @@ static const char progressBarStyleC[] =
     "background-color: %1; width: 1px;"
     "}";
 
-bool showEnableE2eeWithVirtualFilesWarningDialog()
+void showEnableE2eeWithVirtualFilesWarningDialog(std::function<void(void)> onAccept)
 {
-    QMessageBox e2eeWithVirtualFilesWarningMsgBox;
-    e2eeWithVirtualFilesWarningMsgBox.setText(AccountSettings::tr("End-to-End Encryption with Virtual Files"));
-    e2eeWithVirtualFilesWarningMsgBox.setInformativeText(AccountSettings::tr("You seem to have the Virtual Files feature enabled on this folder. At "
-                                                                             " the moment, it is not possible to implicitly download virtual files that are "
-                                                                             "end-to-end encrypted. To get the best experience with Virtual Files and"
-                                                                             " End-to-End Encryption, make sure the encrypted folder is marked with"
-                                                                             " \"Make always available locally\"."));
-    e2eeWithVirtualFilesWarningMsgBox.setIcon(QMessageBox::Warning);
-    const auto dontEncryptButton = e2eeWithVirtualFilesWarningMsgBox.addButton(QMessageBox::StandardButton::Ok);
+    const auto e2eeWithVirtualFilesWarningMsgBox = new QMessageBox;
+    e2eeWithVirtualFilesWarningMsgBox->setAttribute(Qt::WA_DeleteOnClose);
+    e2eeWithVirtualFilesWarningMsgBox->setText(AccountSettings::tr("End-to-End Encryption with Virtual Files"));
+    e2eeWithVirtualFilesWarningMsgBox->setInformativeText(AccountSettings::tr("You seem to have the Virtual Files feature enabled on this folder. At "
+                                                                              " the moment, it is not possible to implicitly download virtual files that are "
+                                                                              "End-to-End encrypted. To get the best experience with Virtual Files and"
+                                                                              " End-to-End Encryption, make sure the encrypted folder is marked with"
+                                                                              " \"Make always available locally\"."));
+    e2eeWithVirtualFilesWarningMsgBox->setIcon(QMessageBox::Warning);
+    const auto dontEncryptButton = e2eeWithVirtualFilesWarningMsgBox->addButton(QMessageBox::StandardButton::Cancel);
     Q_ASSERT(dontEncryptButton);
     dontEncryptButton->setText(AccountSettings::tr("Don't encrypt folder"));
-    const auto encryptButton = e2eeWithVirtualFilesWarningMsgBox.addButton(QMessageBox::StandardButton::Cancel);
+    const auto encryptButton = e2eeWithVirtualFilesWarningMsgBox->addButton(QMessageBox::StandardButton::Ok);
     Q_ASSERT(encryptButton);
     encryptButton->setText(AccountSettings::tr("Encrypt folder"));
-    e2eeWithVirtualFilesWarningMsgBox.exec();
+    QObject::connect(e2eeWithVirtualFilesWarningMsgBox, &QMessageBox::accepted, onAccept);
 
-
-    return e2eeWithVirtualFilesWarningMsgBox.clickedButton() != dontEncryptButton;
+    e2eeWithVirtualFilesWarningMsgBox->open();
 }
 
 /**
@@ -267,9 +269,10 @@ void AccountSettings::slotEncryptFolderFinished(int status)
         QMessageBox::warning(nullptr, tr("Warning"), job->errorString());
     }
 
-    const auto folderInfo = job->property(propertyFolderInfo).value<FolderStatusModel::SubFolderInfo*>();
-    Q_ASSERT(folderInfo);
-    const auto index = _model->indexForPath(folderInfo->_folder, folderInfo->_path);
+    const auto folder = job->property(propertyFolder).value<Folder *>();
+    const auto path = job->property(propertyPath).value<QString>();
+    Q_ASSERT(folder);
+    const auto index = _model->indexForPath(folder, path);
     Q_ASSERT(index.isValid());
     _model->resetAndFetch(index.parent());
 
@@ -339,21 +342,33 @@ void AccountSettings::slotMarkSubfolderEncrypted(FolderStatusModel::SubFolderInf
 
     const auto folder = folderInfo->_folder;
     Q_ASSERT(folder);
+    const auto path = folderInfo->_path;
+    const auto fileId = folderInfo->_fileId;
+    const auto encryptFolder = [this, fileId, folder, path] {
+        // Folder info have directory paths in Foo/Bar/ convention...
+        Q_ASSERT(!path.startsWith('/') && path.endsWith('/'));
+        // But EncryptFolderJob expects directory path Foo/Bar convention
+        const auto choppedPath = path.chopped(1);
+
+        // Does the file still exist?
+        SyncJournalFileRecord record;
+        if (!folder->journalDb()->getFileRecord(choppedPath, &record) || !record.isValid()) {
+            return;
+        }
+
+        auto job = new OCC::EncryptFolderJob(accountsState()->account(), folder->journalDb(), choppedPath, fileId, this);
+        job->setProperty(propertyFolder, QVariant::fromValue(folder));
+        job->setProperty(propertyPath, QVariant::fromValue(path));
+        connect(job, &OCC::EncryptFolderJob::finished, this, &AccountSettings::slotEncryptFolderFinished);
+        job->start();
+    };
+
     if (folder->virtualFilesEnabled()
-        && folder->vfs().mode() == Vfs::WindowsCfApi
-        && !showEnableE2eeWithVirtualFilesWarningDialog()) {
+        && folder->vfs().mode() == Vfs::WindowsCfApi) {
+        showEnableE2eeWithVirtualFilesWarningDialog(encryptFolder);
         return;
     }
-
-    // Folder info have directory paths in Foo/Bar/ convention...
-    Q_ASSERT(!folderInfo->_path.startsWith('/') && folderInfo->_path.endsWith('/'));
-    // But EncryptFolderJob expects directory path Foo/Bar convention
-    const auto path = folderInfo->_path.chopped(1);
-
-    auto job = new OCC::EncryptFolderJob(accountsState()->account(), folderInfo->_folder->journalDb(), path, folderInfo->_fileId, this);
-    job->setProperty(propertyFolderInfo, QVariant::fromValue(folderInfo));
-    connect(job, &OCC::EncryptFolderJob::finished, this, &AccountSettings::slotEncryptFolderFinished);
-    job->start();
+    encryptFolder();
 }
 
 void AccountSettings::slotEditCurrentIgnoredFiles()


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

I know the root cause of the problem lies in the fact that we use a pointer from a model too long, but I wanted to make this fix as non-invasive as possible.
