### PR TITLE
improve logging to better understand why authentication is failing

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -192,7 +192,8 @@ void ConnectionValidator::slotAuthFailed(QNetworkReply *reply)
 
     } else if (reply->error() == QNetworkReply::AuthenticationRequiredError
         || !_account->credentials()->stillValid(reply)) {
-        qCWarning(lcConnectionValidator) << "******** Password is wrong!" << reply->error() << job->errorString();
+        auto authChallenge = reply->rawHeader("WWW-Authenticate").toLower();
+        qCWarning(lcConnectionValidator) << "******** Password is wrong!" << reply->error() << job->errorString() << authChallenge;
         _errors << tr("The provided credentials are not correct");
         stat = CredentialsWrong;
 


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
