### PR TITLE
fix needs info label remover action by providing github token

### DIFF
--- a/.github/workflows/needsinfohelper.yaml
+++ b/.github/workflows/needsinfohelper.yaml
@@ -10,3 +10,5 @@ jobs:
         if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') && ! startsWith(github.event.comment.body, 'This bug report did not receive an update in the last 4 weeks.')}}
         with:
           labels: 'needs info'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
