### PR TITLE
Enable clazy in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,7 +53,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address ../src
+    - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clazy -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address ../src
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.12-18
   volumes:
@@ -61,7 +61,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - ninja
+    - ninja 2>1 | /drone/src/admin/linux/count_compiler_warnings.py /drone/src
 - name: test
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.12-18
   volumes:

--- a/admin/linux/count_compiler_warnings.py
+++ b/admin/linux/count_compiler_warnings.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Small script that counts the warnings which the compiler emits
+# and takes care that not more warnings are added.
+
+import sys
+import re
+import requests
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} REPOSITORY_PATH")
+    sys.exit(1)
+
+repository_path = sys.argv[1]
+warning_regex = re.compile(r'warning:', re.M)
+max_allowed_warnings_count_response = requests.get(
+    "https://nextclouddesktopwarningscount.felixweilbach.de")
+
+if max_allowed_warnings_count_response.status_code != 200:
+    print('Can not get maximum number of allowed warnings')
+    sys.exit(1)
+
+max_allowed_warnings_count = int(max_allowed_warnings_count_response.content)
+
+print("Max number of allowed warnings:", max_allowed_warnings_count)
+
+warnings_count = 0
+
+for line in sys.stdin:
+    if warning_regex.findall(line):
+        warnings_count += 1
+
+    print(line, end="")
+
+    if warnings_count > max_allowed_warnings_count:
+        print("Error: Too many warnings! You probably introduced a new warning!")
+        sys.exit(1)
+
+print("Total number of warnings:", warnings_count)


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

Additionally to that I can setup a cron job on the server which then builds master every few hours and updates the number of warnings.

It might be possible to setup drone in a way that a pipeline which updates the number of warnings gets only executed when something is merged to master, but I haven't found out how to do this yet, and we said that we want to keep it quick and dirty;) Adding some conditional logic to the `count_compiler_warnings.py` script which updates the number of warnings based on the active branch might be dangerous as we then would need to expose secrets to public pull requests.

Of course we can use an different server for this.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
