### PR TITLE
nav pane usability

### DIFF
--- a/src/gui/navigationpanehelper.cpp
+++ b/src/gui/navigationpanehelper.cpp
@@ -98,7 +98,7 @@ void NavigationPaneHelper::updateCloudStorageRegistry()
                 QString title = folder->shortGuiRemotePathOrAppName();
                 // Write the account name in the sidebar only when using more than one account.
                 if (AccountManager::instance()->accounts().size() > 1)
-                    title = title % " - " % folder->accountState()->account()->displayName();
+                    title = title % " - " % folder->accountState()->account()->davDisplayName() % " - " % folder->accountState()->account()->url().host();
                 QString iconPath = QDir::toNativeSeparators(qApp->applicationFilePath());
                 QString targetFolderPath = QDir::toNativeSeparators(folder->cleanPath());
 


### PR DESCRIPTION
Changes the text shown in the Navigation pane when more than one account is configured. Uses an assembled name from human readable variables. This fixes an issue seen when using LDAP backend users, where the users GUID is shown instead of the normal username and url as is seen when not using LDAP backend users. Fixes issue: https://github.com/nextcloud/desktop/issues/3305

Signed-off-by: Benjamin D. <peacepenguin@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
