### PR TITLE
Cfapi: Make sure no data is transfered after cancellation

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -351,11 +351,13 @@ void GETFileJob::slotReadyRead()
 
 void GETFileJob::cancel()
 {
-    if (reply()->isRunning()) {
-        reply()->abort();
+    const auto networkReply = reply();
+    if (networkReply && networkReply->isRunning()) {
+        networkReply->abort();
     }
-
-    emit canceled();
+    if (_device && _device->isOpen()) {
+        _device->close();
+    }
 }
 
 void GETFileJob::onTimedOut()

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -110,7 +110,6 @@ public:
     void setExpectedContentLength(qint64 size) { _expectedContentLength = size; }
 
 signals:
-    void canceled();
     void finishedSignal();
     void downloadProgress(qint64, qint64);
 private slots:

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -146,6 +146,22 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
         return;
     }
 
+    QLocalSocket signalSocket;
+    const QString signalSocketName = requestId + ":cancellation";
+    signalSocket.connectToServer(signalSocketName);
+    const auto cancellationSocketConnectResult = signalSocket.waitForConnected();
+    if (!cancellationSocketConnectResult) {
+        qCWarning(lcCfApiWrapper) << "Couldn't connect the socket" << signalSocketName
+                                  << signalSocket.error() << signalSocket.errorString();
+        sendTransferError();
+        return;
+    }
+
+    auto hydrationRequestCancelled = false;
+    QObject::connect(&signalSocket, &QLocalSocket::readyRead, &loop, [&] {
+        hydrationRequestCancelled = true;
+    });
+
     // CFAPI expects sent blocks to be of a multiple of a block size.
     // Only the last sent block is allowed to be of a different size than
     // a multiple of a block size
@@ -169,6 +185,11 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
     };
 
     QObject::connect(&socket, &QLocalSocket::readyRead, &loop, [&] {
+        if (hydrationRequestCancelled) {
+            qCDebug(lcCfApiWrapper) << "Don't transfer data because request" << requestId << "was cancelled";
+            return;
+        }
+
         const auto receivedData = socket.readAll();
         if (receivedData.isEmpty()) {
             qCWarning(lcCfApiWrapper) << "Unexpected empty data received" << requestId;
@@ -180,24 +201,34 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
         alignAndSendData(receivedData);
     });
 
-    QObject::connect(vfs, &OCC::VfsCfApi::hydrationRequestFinished, &loop, [&](const QString &id, int s) {
+    QObject::connect(vfs, &OCC::VfsCfApi::hydrationRequestFinished, &loop, [&](const QString &id) {
         qDebug(lcCfApiWrapper) << "Hydration finished for request" << id;
         if (requestId == id) {
-            const auto status = static_cast<OCC::HydrationJob::Status>(s);
-            qCInfo(lcCfApiWrapper) << "Hydration done for" << path << requestId << status;
-            if (status != OCC::HydrationJob::Success) {
-                sendTransferError();
-            }
+            socket.close();
+            signalSocket.close();
             loop.quit();
         }
     });
 
     loop.exec();
 
-    if (!protrudingData.isEmpty()) {
+    if (!hydrationRequestCancelled && !protrudingData.isEmpty()) {
         qDebug(lcCfApiWrapper) << "Send remaining protruding data. Size:" << protrudingData.size();
         sendTransferInfo(protrudingData, dataOffset);
     }
+
+    int hydrationJobResult = OCC::HydrationJob::Status::Error;
+    const auto invokeFinalizeResult = QMetaObject::invokeMethod(
+        vfs, [=] { vfs->finalizeHydrationJob(requestId); }, Qt::BlockingQueuedConnection,
+        &hydrationJobResult);
+    if (!invokeFinalizeResult) {
+        qCritical(lcCfApiWrapper) << "Failed to finalize hydration job for" << path << requestId;
+    }
+
+    if (static_cast<OCC::HydrationJob::Status>(hydrationJobResult) == OCC::HydrationJob::Success) {
+        sendTransferError();
+    }
+}
 }
 
 void CALLBACK cfApiCancelFetchData(const CF_CALLBACK_INFO *callbackInfo, const CF_CALLBACK_PARAMETERS * /*callbackParameters*/)
@@ -216,7 +247,6 @@ void CALLBACK cfApiCancelFetchData(const CF_CALLBACK_INFO *callbackInfo, const C
         qCritical(lcCfApiWrapper) << "Failed to cancel hydration for" << path << requestId;
     }
 }
-
 
 CF_CALLBACK_REGISTRATION cfApiCallbacks[] = {
     { CF_CALLBACK_TYPE_FETCH_DATA, cfApiFetchDataCallback },
@@ -290,8 +320,6 @@ CF_SET_PIN_FLAGS pinRecurseModeToCfSetPinFlags(OCC::CfApiWrapper::SetPinRecurseM
         Q_UNREACHABLE();
         return CF_SET_PIN_FLAG_NONE;
     }
-}
-
 }
 
 OCC::CfApiWrapper::ConnectionKey::ConnectionKey()

--- a/src/libsync/vfs/cfapi/hydrationjob.h
+++ b/src/libsync/vfs/cfapi/hydrationjob.h
@@ -23,6 +23,7 @@ class QLocalSocket;
 namespace OCC {
 class GETFileJob;
 class SyncJournalDb;
+class VfsCfApi;
 
 class OWNCLOUDSYNC_EXPORT HydrationJob : public QObject
 {
@@ -31,6 +32,7 @@ public:
     enum Status {
         Success = 0,
         Error,
+        Cancelled,
     };
     Q_ENUM(Status)
 
@@ -58,29 +60,31 @@ public:
 
     void start();
     void cancel();
+    void finalize(OCC::VfsCfApi *vfs);
 
 signals:
     void finished(HydrationJob *job);
-    void canceled(HydrationJob *job);
 
 private:
     void emitFinished(Status status);
-    void emitCanceled();
 
     void onNewConnection();
+    void onCancellationServerNewConnection();
     void onGetFinished();
-    void onGetCanceled();
 
     AccountPtr _account;
     QString _remotePath;
     QString _localPath;
     SyncJournalDb *_journal = nullptr;
+    bool _isCancelled = false;
 
     QString _requestId;
     QString _folderPath;
 
-    QLocalServer *_server = nullptr;
-    QLocalSocket *_socket = nullptr;
+    QLocalServer *_transferDataServer = nullptr;
+    QLocalServer *_signalServer = nullptr;
+    QLocalSocket *_transferDataSocket = nullptr;
+    QLocalSocket *_signalSocket = nullptr;
     GETFileJob *_job = nullptr;
     Status _status = Success;
 };

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -269,16 +269,28 @@ Vfs::AvailabilityResult VfsCfApi::availability(const QString &folderPath)
     return AvailabilityError::NoSuchItem;
 }
 
-void VfsCfApi::cancelHydration(const QString &requestId, const QString & /*path*/)
+HydrationJob *VfsCfApi::findHydrationJob(const QString &requestId) const
 {
     // Find matching hydration job for request id
     const auto hydrationJobsIter = std::find_if(d->hydrationJobs.cbegin(), d->hydrationJobs.cend(), [&](const HydrationJob *job) {
         return job->requestId() == requestId;
     });
 
-    // If found, cancel it
     if (hydrationJobsIter != d->hydrationJobs.cend()) {
-        (*hydrationJobsIter)->cancel();
+        return *hydrationJobsIter;
+    }
+
+    return nullptr;
+}
+
+void VfsCfApi::cancelHydration(const QString &requestId, const QString & /*path*/)
+{
+    // Find matching hydration job for request id
+    const auto hydrationJob = findHydrationJob(requestId);
+    // If found, cancel it
+    if (hydrationJob) {
+        qCInfo(lcCfApi) << "Cancel hydration";
+        hydrationJob->cancel();
     }
 }
 
@@ -360,7 +372,6 @@ void VfsCfApi::scheduleHydrationJob(const QString &requestId, const QString &fol
     job->setRequestId(requestId);
     job->setFolderPath(folderPath);
     connect(job, &HydrationJob::finished, this, &VfsCfApi::onHydrationJobFinished);
-    connect(job, &HydrationJob::canceled, this, &VfsCfApi::onHydrationJobCanceled);
     d->hydrationJobs << job;
     job->start();
     emit hydrationRequestReady(requestId);
@@ -370,30 +381,27 @@ void VfsCfApi::onHydrationJobFinished(HydrationJob *job)
 {
     Q_ASSERT(d->hydrationJobs.contains(job));
     qCInfo(lcCfApi) << "Hydration job finished" << job->requestId() << job->folderPath() << job->status();
-    emit hydrationRequestFinished(job->requestId(), job->status());
-    d->hydrationJobs.removeAll(job);
-    if (d->hydrationJobs.isEmpty()) {
-        emit doneHydrating();
-    }
+    emit hydrationRequestFinished(job->requestId());
 }
 
-void VfsCfApi::onHydrationJobCanceled(HydrationJob *job)
+int VfsCfApi::finalizeHydrationJob(const QString &requestId)
 {
-    const auto folderRelativePath = job->folderPath();
-    SyncJournalFileRecord record;
-    if (!params().journal->getFileRecord(folderRelativePath, &record)) {
-        qCWarning(lcCfApi) << "Could not read file record from journal for canceled hydration request.";
-        return;
+    qCDebug(lcCfApi) << "Finalize hydration job" << requestId;
+    // Find matching hydration job for request id
+    const auto hydrationJob = findHydrationJob(requestId);
+
+    // If found, finalize it
+    if (hydrationJob) {
+        hydrationJob->finalize(this);
+        d->hydrationJobs.removeAll(hydrationJob);
+        hydrationJob->deleteLater();
+        if (d->hydrationJobs.isEmpty()) {
+            emit doneHydrating();
+        }
+        return hydrationJob->status();
     }
 
-    // Remove placeholder file because there might be already pumped
-    // some data into it
-    const auto folderPath = job->localPath();
-    QFile::remove(folderPath + folderRelativePath);
-
-    // Create a new placeholder file
-    const auto item = SyncFileItem::fromSyncJournalFileRecord(record);
-    createPlaceholder(*item);
+    return HydrationJob::Status::Error;
 }
 
 VfsCfApi::HydratationAndPinStates VfsCfApi::computeRecursiveHydrationAndPinStates(const QString &folderPath, const Optional<PinState> &basePinState)

--- a/src/libsync/vfs/cfapi/vfs_cfapi.h
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.h
@@ -55,6 +55,8 @@ public:
 
     void cancelHydration(const QString &requestId, const QString &path);
 
+    int finalizeHydrationJob(const QString &requestId);
+
 public slots:
     void requestHydration(const QString &requestId, const QString &path);
     void fileStatusChanged(const QString &systemFileName, SyncFileStatus fileStatus) override;
@@ -62,7 +64,7 @@ public slots:
 signals:
     void hydrationRequestReady(const QString &requestId);
     void hydrationRequestFailed(const QString &requestId);
-    void hydrationRequestFinished(const QString &requestId, int status);
+    void hydrationRequestFinished(const QString &requestId);
 
 protected:
     void startImpl(const VfsSetupParams &params) override;
@@ -70,7 +72,7 @@ protected:
 private:
     void scheduleHydrationJob(const QString &requestId, const QString &folderPath);
     void onHydrationJobFinished(HydrationJob *job);
-    void onHydrationJobCanceled(HydrationJob *job);
+    HydrationJob *findHydrationJob(const QString &requestId) const;
 
     struct HasHydratedDehydrated {
         bool hasHydrated = false;


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

This a different version of https://github.com/nextcloud/desktop/pull/3289 that works without global variables.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
