### PR TITLE
bring back dynamic load of VFS plugins

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -52,9 +52,6 @@
     <Property Id="INSTALLDIR">
         <RegistrySearch Id="RegistryInstallDir" Type="raw" Root="HKLM" Key="Software\$(var.AppVendor)\$(var.AppName)" Win64="no" />
     </Property>
-	<Property Id="WINDOWSRELEASEID">
-        <RegistrySearch Id="RegistryWindowsReleaseId" Type="raw" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion" Name="ReleaseId"/>
-    </Property>
 
     <!-- Detect legacy NSIS installation -->
     <Property Id="NSIS_UNINSTALLEXE">

--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -214,6 +214,5 @@
             <Condition Level="0">(NO_DESKTOP_SHORTCUT=1)</Condition>
         </Feature>
     </Feature>
-	<Condition Message="This application only runs on Windows 10, version 1709 or higher!">(VersionNT>=603 AND WINDOWSRELEASEID>=1709)</Condition>
     </Product>
 </Wix>

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -11,6 +11,8 @@ set(common_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/remotepermissions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/vfs.cpp
     ${CMAKE_CURRENT_LIST_DIR}/pinstate.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/plugin.cpp
     ${CMAKE_CURRENT_LIST_DIR}/syncfilestatus.cpp
 )
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/vfspluginmetadata.json.in ${CMAKE_CURRENT_BINARY_DIR}/vfspluginmetadata.json)

--- a/src/common/plugin.cpp
+++ b/src/common/plugin.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) by Dominik Schmidt <dschmidt@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "plugin.h"
+
+#include "config.h"
+
+namespace OCC {
+
+PluginFactory::~PluginFactory() = default;
+
+QString pluginFileName(const QString &type, const QString &name)
+{
+    return QStringLiteral("%1sync_%2_%3")
+        .arg(QStringLiteral(APPLICATION_EXECUTABLE), type, name);
+}
+
+}

--- a/src/common/plugin.h
+++ b/src/common/plugin.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) by Dominik Schmidt <dschmidt@owncloud.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include "ocsynclib.h"
+#include <QObject>
+
+namespace OCC {
+
+class OCSYNC_EXPORT PluginFactory
+{
+public:
+    virtual ~PluginFactory();
+    virtual QObject* create(QObject* parent) = 0;
+};
+
+template<class PluginClass>
+class DefaultPluginFactory : public PluginFactory
+{
+public:
+    QObject* create(QObject *parent) override
+    {
+        return new PluginClass(parent);
+    }
+};
+
+/// Return the expected name of a plugin, for use with QPluginLoader
+QString pluginFileName(const QString &type, const QString &name);
+
+}
+
+Q_DECLARE_INTERFACE(OCC::PluginFactory, "org.owncloud.PluginFactory")

--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <QObject>
-#include <QCoreApplication>
 #include <QScopedPointer>
 #include <QSharedPointer>
 
@@ -126,9 +125,6 @@ public:
     using AvailabilityResult = Result<VfsItemAvailability, AvailabilityError>;
 
 public:
-    using Factory = Vfs* (*)();
-    static void registerPlugin(const QString &name, Factory factory);
-
     explicit Vfs(QObject* parent = nullptr);
     virtual ~Vfs();
 

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -58,25 +58,7 @@ set(libsync_SRCS
     creds/abstractcredentials.cpp
     creds/credentialscommon.cpp
     creds/keychainchunk.cpp
-    vfs/suffix/vfs_suffix.cpp
 )
-
-if (WIN32)
-    set(libsync_SRCS ${libsync_SRCS}
-        vfs/cfapi/cfapiwrapper.cpp
-        vfs/cfapi/hydrationjob.cpp
-        vfs/cfapi/vfs_cfapi.cpp
-    )
-    add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
-    list(APPEND OS_SPECIFIC_LINK_LIBRARIES cldapi)
-elseif(LINUX) # elseif(LINUX OR APPLE)
-    set(libsync_SRCS ${libsync_SRCS} vfs/xattr/vfs_xattr.cpp)
-    if (APPLE)
-        set(libsync_SRCS ${libsync_SRCS} vfs/xattr/xattrwrapper_mac.cpp)
-    else()
-        set(libsync_SRCS ${libsync_SRCS} vfs/xattr/xattrwrapper_linux.cpp)
-    endif()
-endif()
 
 if(TOKEN_AUTH_ONLY)
     set (libsync_SRCS ${libsync_SRCS} creds/tokencredentials.cpp)
@@ -159,3 +141,6 @@ if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)
 else()
     install(TARGETS ${synclib_NAME} DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/MacOS)
 endif()
+
+
+add_subdirectory(vfs)

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -13,6 +13,7 @@
  */
 #pragma once
 
+#include "owncloudlib.h"
 #include "owncloudpropagator.h"
 #include "networkjobs.h"
 #include "clientsideencryption.h"
@@ -27,7 +28,7 @@ class PropagateDownloadEncrypted;
  * @brief The GETFileJob class
  * @ingroup libsync
  */
-class GETFileJob : public AbstractNetworkJob
+class OWNCLOUDSYNC_EXPORT GETFileJob : public AbstractNetworkJob
 {
     Q_OBJECT
     QIODevice *_device;

--- a/src/libsync/vfs/CMakeLists.txt
+++ b/src/libsync/vfs/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Globbing for plugins has a problem with in-source builds
+# that create directories for the build.
+#file(GLOB VIRTUAL_FILE_SYSTEM_PLUGINS RELATIVE ${CMAKE_CURRENT_LIST_DIR} "*")
+
+list(APPEND VIRTUAL_FILE_SYSTEM_PLUGINS "suffix" "cfapi" "xattr")
+
+message("list of plugins ${VIRTUAL_FILE_SYSTEM_PLUGINS}")
+
+foreach(vfsPlugin ${VIRTUAL_FILE_SYSTEM_PLUGINS})
+    set(vfsPluginPath ${vfsPlugin})
+    get_filename_component(vfsPluginName ${vfsPlugin} NAME)
+    message("discovery ${vfsPlugin}")
+    if (NOT IS_ABSOLUTE ${vfsPlugin})
+        set(vfsPluginPath "${CMAKE_CURRENT_SOURCE_DIR}/${vfsPlugin}")
+        message("${vfsPluginPath}")
+    endif()
+    if(NOT IS_DIRECTORY ${vfsPluginPath})
+        continue()
+    endif()
+
+        message("${vfsPluginPath} ${vfsPluginName}")
+    add_subdirectory(${vfsPluginPath} ${vfsPluginName})
+
+    if(UNIT_TESTING AND IS_DIRECTORY "${vfsPluginPath}/test")
+        add_subdirectory("${vfsPluginPath}/test" "${vfsPluginName}_test")
+        message(STATUS "Added vfsPlugin with tests: ${vfsPluginName}")
+    else()
+        message(STATUS "Added vfsPlugin without tests: ${vfsPluginName}")
+    endif()
+endforeach()

--- a/src/libsync/vfs/cfapi/CMakeLists.txt
+++ b/src/libsync/vfs/cfapi/CMakeLists.txt
@@ -1,0 +1,36 @@
+if (WIN32)
+    add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
+
+    add_library("${synclib_NAME}_vfs_cfapi" SHARED
+        cfapiwrapper.cpp
+        hydrationjob.cpp
+        vfs_cfapi.cpp
+    )
+
+    target_link_libraries("${synclib_NAME}_vfs_cfapi"
+        "${synclib_NAME}"
+        cldapi
+    )
+
+    set_target_properties("${synclib_NAME}_vfs_cfapi" PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+        RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+        PREFIX ""
+        AUTOMOC TRUE
+    )
+
+    target_include_directories("${synclib_NAME}_vfs_cfapi" BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_BINARY_DIR})
+
+    set(vfs_installdir "${PLUGINDIR}")
+
+    GENERATE_EXPORT_HEADER( "${synclib_NAME}_vfs_cfapi"
+        BASE_NAME "${synclib_NAME}_vfs_cfapi"
+        EXPORT_MACRO_NAME NEXTCLOUD_CFAPI_EXPORT
+        EXPORT_FILE_NAME cfapiexport.h
+    )
+
+    INSTALL(TARGETS "${synclib_NAME}_vfs_cfapi"
+      LIBRARY DESTINATION "${vfs_installdir}"
+      RUNTIME DESTINATION "${vfs_installdir}"
+    )
+endif()

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -19,6 +19,8 @@
 #include "hydrationjob.h"
 #include "vfs_cfapi.h"
 
+#include <QCoreApplication>
+#include <QEventLoop>
 #include <QDir>
 #include <QFileInfo>
 #include <QLocalSocket>

--- a/src/libsync/vfs/cfapi/cfapiwrapper.h
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.h
@@ -15,7 +15,7 @@
 
 #include <memory>
 
-#include "owncloudlib.h"
+#include "cfapiexport.h"
 #include "common/pinstate.h"
 #include "common/result.h"
 #include "common/vfs.h"
@@ -29,7 +29,7 @@ class VfsCfApi;
 namespace CfApiWrapper
 {
 
-class OWNCLOUDSYNC_EXPORT ConnectionKey
+class NEXTCLOUD_CFAPI_EXPORT ConnectionKey
 {
 public:
     ConnectionKey();
@@ -39,7 +39,7 @@ private:
     std::unique_ptr<void, void(*)(void *)> _data;
 };
 
-class OWNCLOUDSYNC_EXPORT FileHandle
+class NEXTCLOUD_CFAPI_EXPORT FileHandle
 {
 public:
     using Deleter = void (*)(void *);
@@ -54,7 +54,7 @@ private:
     std::unique_ptr<void, void(*)(void *)> _data;
 };
 
-class OWNCLOUDSYNC_EXPORT PlaceHolderInfo
+class NEXTCLOUD_CFAPI_EXPORT PlaceHolderInfo
 {
 public:
     using Deleter = void (*)(CF_PLACEHOLDER_BASIC_INFO *);
@@ -72,17 +72,17 @@ private:
     std::unique_ptr<CF_PLACEHOLDER_BASIC_INFO, Deleter> _data;
 };
 
-OWNCLOUDSYNC_EXPORT Result<void, QString> registerSyncRoot(const QString &path, const QString &providerName, const QString &providerVersion, const QString &folderAlias, const QString &displayName, const QString &accountDisplayName);
-OWNCLOUDSYNC_EXPORT Result<void, QString> unregisterSyncRoot(const QString &path, const QString &providerName, const QString &accountDisplayName);
+NEXTCLOUD_CFAPI_EXPORT Result<void, QString> registerSyncRoot(const QString &path, const QString &providerName, const QString &providerVersion, const QString &folderAlias, const QString &displayName, const QString &accountDisplayName);
+NEXTCLOUD_CFAPI_EXPORT Result<void, QString> unregisterSyncRoot(const QString &path, const QString &providerName, const QString &accountDisplayName);
 
-OWNCLOUDSYNC_EXPORT Result<ConnectionKey, QString> connectSyncRoot(const QString &path, VfsCfApi *context);
-OWNCLOUDSYNC_EXPORT Result<void, QString> disconnectSyncRoot(ConnectionKey &&key);
+NEXTCLOUD_CFAPI_EXPORT Result<ConnectionKey, QString> connectSyncRoot(const QString &path, VfsCfApi *context);
+NEXTCLOUD_CFAPI_EXPORT Result<void, QString> disconnectSyncRoot(ConnectionKey &&key);
 
-OWNCLOUDSYNC_EXPORT bool isSparseFile(const QString &path);
+NEXTCLOUD_CFAPI_EXPORT bool isSparseFile(const QString &path);
 
-OWNCLOUDSYNC_EXPORT FileHandle handleForPath(const QString &path);
+NEXTCLOUD_CFAPI_EXPORT FileHandle handleForPath(const QString &path);
 
-OWNCLOUDSYNC_EXPORT PlaceHolderInfo findPlaceholderInfo(const FileHandle &handle);
+PlaceHolderInfo findPlaceholderInfo(const FileHandle &handle);
 
 enum SetPinRecurseMode {
     NoRecurse = 0,
@@ -90,10 +90,10 @@ enum SetPinRecurseMode {
     ChildrenOnly
 };
 
-OWNCLOUDSYNC_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> setPinState(const FileHandle &handle, PinState state, SetPinRecurseMode mode);
-OWNCLOUDSYNC_EXPORT Result<void, QString> createPlaceholderInfo(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId);
-OWNCLOUDSYNC_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> updatePlaceholderInfo(const FileHandle &handle, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath = QString());
-OWNCLOUDSYNC_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> convertToPlaceholder(const FileHandle &handle, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath);
+NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> setPinState(const FileHandle &handle, PinState state, SetPinRecurseMode mode);
+NEXTCLOUD_CFAPI_EXPORT Result<void, QString> createPlaceholderInfo(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId);
+NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> updatePlaceholderInfo(const FileHandle &handle, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath = QString());
+NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> convertToPlaceholder(const FileHandle &handle, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath);
 
 }
 

--- a/src/libsync/vfs/cfapi/hydrationjob.h
+++ b/src/libsync/vfs/cfapi/hydrationjob.h
@@ -25,7 +25,7 @@ class GETFileJob;
 class SyncJournalDb;
 class VfsCfApi;
 
-class OWNCLOUDSYNC_EXPORT HydrationJob : public QObject
+class HydrationJob : public QObject
 {
     Q_OBJECT
 public:

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -119,7 +119,7 @@ Result<void, QString> VfsCfApi::updateMetadata(const QString &filePath, time_t m
         }
     } else {
         qCWarning(lcCfApi) << "Couldn't update metadata for non existing file" << localPath;
-        return QStringLiteral("Couldn't update metadata");
+        return {QStringLiteral("Couldn't update metadata")};
     }
 }
 
@@ -460,5 +460,3 @@ VfsCfApi::HydratationAndPinStates VfsCfApi::computeRecursiveHydrationAndPinState
 }
 
 } // namespace OCC
-
-OCC_DEFINE_VFS_FACTORY("win", OCC::VfsCfApi)

--- a/src/libsync/vfs/cfapi/vfs_cfapi.h
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.h
@@ -17,6 +17,7 @@
 #include <QScopedPointer>
 
 #include "common/vfs.h"
+#include "common/plugin.h"
 
 namespace OCC {
 class HydrationJob;
@@ -85,6 +86,13 @@ private:
     HydratationAndPinStates computeRecursiveHydrationAndPinStates(const QString &path, const Optional<PinState> &basePinState);
 
     QScopedPointer<VfsCfApiPrivate> d;
+};
+
+class CfApiVfsPluginFactory : public QObject, public DefaultPluginFactory<VfsCfApi>
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.owncloud.PluginFactory" FILE "vfspluginmetadata.json")
+    Q_INTERFACES(OCC::PluginFactory)
 };
 
 } // namespace OCC

--- a/src/libsync/vfs/suffix/CMakeLists.txt
+++ b/src/libsync/vfs/suffix/CMakeLists.txt
@@ -1,0 +1,34 @@
+add_library("${synclib_NAME}_vfs_suffix" SHARED
+    vfs_suffix.cpp
+)
+
+target_link_libraries("${synclib_NAME}_vfs_suffix"
+    "${synclib_NAME}"
+)
+
+set_target_properties("${synclib_NAME}_vfs_suffix" PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+    RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+    PREFIX ""
+    AUTOMOC TRUE
+)
+
+if(APPLE)
+    # for being loadable when client run from build dir
+    set(vfs_buildoutputdir "${BIN_OUTPUT_DIRECTORY}/${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns/")
+    set_target_properties("${synclib_NAME}_vfs_suffix"
+        PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
+        RUNTIME_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
+    )
+    # For being loadable when client run from install dir (after make macdeployqt)
+    set(vfs_installdir "${LIB_INSTALL_DIR}/../PlugIns")
+else()
+    set(vfs_installdir "${PLUGINDIR}")
+endif()
+
+INSTALL(TARGETS "${synclib_NAME}_vfs_suffix"
+  LIBRARY DESTINATION "${vfs_installdir}"
+  RUNTIME DESTINATION "${vfs_installdir}"
+)
+

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -151,5 +151,3 @@ Vfs::AvailabilityResult VfsSuffix::availability(const QString &folderPath)
 }
 
 } // namespace OCC
-
-OCC_DEFINE_VFS_FACTORY("suffix", OCC::VfsSuffix)

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -17,6 +17,7 @@
 #include <QScopedPointer>
 
 #include "common/vfs.h"
+#include "common/plugin.h"
 
 namespace OCC {
 
@@ -58,6 +59,13 @@ public slots:
 
 protected:
     void startImpl(const VfsSetupParams &params) override;
+};
+
+class SuffixVfsPluginFactory : public QObject, public DefaultPluginFactory<VfsSuffix>
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.owncloud.PluginFactory" FILE "vfspluginmetadata.json")
+    Q_INTERFACES(OCC::PluginFactory)
 };
 
 } // namespace OCC

--- a/src/libsync/vfs/xattr/CMakeLists.txt
+++ b/src/libsync/vfs/xattr/CMakeLists.txt
@@ -1,0 +1,50 @@
+if (UNIX)
+    set(vfs_xattr_SRCS vfs_xattr.cpp)
+    if (APPLE)
+        set(vfs_xattr_SRCS ${vfs_xattr_SRCS} xattrwrapper_mac.cpp)
+    else()
+        set(vfs_xattr_SRCS ${vfs_xattr_SRCS} xattrwrapper_linux.cpp)
+    endif()
+
+    add_library("${synclib_NAME}_vfs_xattr" SHARED
+        ${vfs_xattr_SRCS}
+    )
+
+    target_link_libraries("${synclib_NAME}_vfs_xattr"
+        "${synclib_NAME}"
+    )
+
+    set_target_properties("${synclib_NAME}_vfs_xattr" PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+        RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+        PREFIX ""
+        AUTOMOC TRUE
+    )
+
+    target_include_directories("${synclib_NAME}_vfs_xattr" BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+
+    if(APPLE)
+        # for being loadable when client run from build dir
+        set(vfs_buildoutputdir "${BIN_OUTPUT_DIRECTORY}/${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns/")
+        set_target_properties("${synclib_NAME}_vfs_xattr"
+            PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
+            RUNTIME_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
+        )
+        # For being loadable when client run from install dir (after make macdeployqt)
+        set(vfs_installdir "${LIB_INSTALL_DIR}/../PlugIns")
+    else()
+        set(vfs_installdir "${PLUGINDIR}")
+    endif()
+
+    GENERATE_EXPORT_HEADER( "${synclib_NAME}_vfs_xattr"
+        BASE_NAME "${synclib_NAME}_vfs_xattr"
+        EXPORT_MACRO_NAME NEXTCLOUD_XATTR_EXPORT
+        EXPORT_FILE_NAME xattrexport.h
+    )
+
+    INSTALL(TARGETS "${synclib_NAME}_vfs_xattr"
+      LIBRARY DESTINATION "${vfs_installdir}"
+      RUNTIME DESTINATION "${vfs_installdir}"
+    )
+endif()

--- a/src/libsync/vfs/xattr/vfs_xattr.cpp
+++ b/src/libsync/vfs/xattr/vfs_xattr.cpp
@@ -182,5 +182,3 @@ void VfsXAttr::fileStatusChanged(const QString &, SyncFileStatus)
 }
 
 } // namespace OCC
-
-OCC_DEFINE_VFS_FACTORY("xattr", OCC::VfsXAttr)

--- a/src/libsync/vfs/xattr/vfs_xattr.h
+++ b/src/libsync/vfs/xattr/vfs_xattr.h
@@ -17,6 +17,7 @@
 #include <QScopedPointer>
 
 #include "common/vfs.h"
+#include "common/plugin.h"
 
 namespace OCC {
 
@@ -56,6 +57,13 @@ public slots:
 
 protected:
     void startImpl(const VfsSetupParams &params) override;
+};
+
+class XattrVfsPluginFactory : public QObject, public DefaultPluginFactory<VfsXAttr>
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.owncloud.PluginFactory" FILE "vfspluginmetadata.json")
+    Q_INTERFACES(OCC::PluginFactory)
 };
 
 } // namespace OCC

--- a/src/libsync/vfs/xattr/xattrwrapper.h
+++ b/src/libsync/vfs/xattr/xattrwrapper.h
@@ -18,6 +18,8 @@
 #include "owncloudlib.h"
 #include "common/result.h"
 
+#include "xattrexport.h"
+
 namespace OCC {
 
 namespace XAttrWrapper

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,10 @@ if( UNIX AND NOT APPLE )
 endif(UNIX AND NOT APPLE)
 
 if (WIN32)
+    include_directories(
+        ${CMAKE_BINARY_DIR}/src/libsync/vfs/cfapi
+    )
+
     nextcloud_add_test(LongWinPath)
     nextcloud_add_test(SyncCfApi)
 elseif(LINUX) # elseif(LINUX OR APPLE)

--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -17,6 +17,18 @@ macro(nextcloud_add_test test_class)
       Qt5::Quick
     )
 
+    if (WIN32)
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
+            "${synclib_NAME}_vfs_cfapi"
+        )
+    endif()
+
+    if (UNIX)
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
+            "${synclib_NAME}_vfs_xattr"
+        )
+    endif()
+
     IF(BUILD_UPDATER)
         target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
             updater


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
