### PR TITLE
Remove unused function declaration

### DIFF
--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -982,7 +982,7 @@ void FakeFolder::fromDisk(QDir &dir, FileInfo &templateFi)
     }
 }
 
-FileInfo &findOrCreateDirs(FileInfo &base, PathComponents components)
+static FileInfo &findOrCreateDirs(FileInfo &base, PathComponents components)
 {
     if (components.isEmpty())
         return base;

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -486,9 +486,6 @@ private:
     static void fromDisk(QDir &dir, FileInfo &templateFi);
 };
 
-static FileInfo &findOrCreateDirs(FileInfo &base, PathComponents components);
-
-
 /* Return the FileInfo for a conflict file for the specified relative filename */
 inline const FileInfo *findConflict(FileInfo &dir, const QString &filename)
 {


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
