### PR TITLE
Fix VFS crash and false conflict on local new.

### DIFF
--- a/src/common/result.h
+++ b/src/common/result.h
@@ -126,6 +126,8 @@ public:
         ASSERT(_isError);
         return std::move(_error);
     }
+
+    bool isValid() const { return !_isError; }
 };
 
 namespace detail {

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -897,44 +897,54 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         // TODO: We may want to execute the same logic for non-VFS mode, as, moving/renaming the same folder by 2 or more clients at the same time is not possible in Web UI.
         // Keeping it like this (for VFS files and folders only) just to fix a user issue.
         const auto isVfsEnabled = _discoveryData->_syncOptions._vfs && _discoveryData->_syncOptions._vfs->mode() != Vfs::Off;
-        if (localEntry.isVirtualFile || (localEntry.isDirectory && isVfsEnabled)) {
-            // must be a dehydrated placeholder
-            const bool isFilePlaceHolder = !localEntry.isDirectory && _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local);
 
-            // a folder must be online-only (no files should be hydrated)
-            const bool isFolderPlaceholder = localEntry.isDirectory && *_discoveryData->_syncOptions._vfs->availability(path._local) == VfsItemAvailability::OnlineOnly;
+        // must be a dehydrated placeholder
+        const bool isFilePlaceHolder = !localEntry.isDirectory && _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local);
 
-            Q_ASSERT(item->_instruction == CSYNC_INSTRUCTION_NEW);
-            if (item->_instruction != CSYNC_INSTRUCTION_NEW) {
-                qCWarning(lcDisco) << "Wiping virtual file without db entry for" << path._local << ". But, item->_instruction is" << item->_instruction;
+        // either correct availability, or a result with error if the folder is new or otherwise has no availability set yet
+        const auto folderAvailability = localEntry.isDirectory ? _discoveryData->_syncOptions._vfs->availability(path._local) : Vfs::AvailabilityError::NoSuchItem;
+
+        if (!isFilePlaceHolder && !folderAvailability) {
+            // not a file placeholder and not a synced folder placeholder (new local folder)
+            return;
+        }
+
+        // a folder must be online-only (no files should be hydrated)
+        const auto isOnlineOnlyFolder = folderAvailability && *folderAvailability == VfsItemAvailability::OnlineOnly;
+
+        if (!isFilePlaceHolder && !isOnlineOnlyFolder) {
+            // either a VFS file without db entry or a folder with one or more hydrated files
+            if (localEntry.isDirectory && folderAvailability && *folderAvailability != VfsItemAvailability::OnlineOnly) {
+                qCInfo(lcDisco) << "Virtual directory without db entry for" << path._local << "but it contains hydrated file(s), so let's keep it and reupload.";
+                if (_discoveryData) {
+                    emit _discoveryData->addErrorToGui(SyncFileItem::SoftError, tr("Conflict when uploading some files to a folder. Those, conflicted, are going to get cleared!"), path._local);
+                }
+                return;
             }
+            qCWarning(lcDisco) << "Virtual file without db entry for" << path._local
+                               << "but looks odd, keeping";
+            item->_instruction = CSYNC_INSTRUCTION_IGNORE;
 
-            // must be a file placeholder or an online-only folder placeholder
-            if (isFilePlaceHolder || isFolderPlaceholder) {
-                if (isFolderPlaceholder) {
-                    qCInfo(lcDisco) << "Wiping virtual folder without db entry for" << path._local;
-                } else {
-                    qCInfo(lcDisco) << "Wiping virtual file without db entry for" << path._local;
-                }
-                item->_instruction = CSYNC_INSTRUCTION_REMOVE;
-                item->_direction = SyncFileItem::Down;
-                // this flag needs to be unset, otherwise a folder would get marked as new in the processSubJobs
-                _childModified = false;
-                if (isFolderPlaceholder && _discoveryData) {
-                    emit _discoveryData->addErrorToGui(SyncFileItem::SoftError, tr("Conflict when uploading a folder. It's going to get cleared!"), path._local);
-                }
-            } else {
-                if (localEntry.isDirectory && !isFolderPlaceholder) {
-                    qCInfo(lcDisco) << "Virtual directory without db entry for" << path._local << "but it contains hydrated file(s), so let's keep it and reupload.";
-                    if (_discoveryData) {
-                        emit _discoveryData->addErrorToGui(SyncFileItem::SoftError, tr("Conflict when uploading some files to a folder. Those, conflicted, are going to get cleared!"), path._local);
-                    }                    
-                    return;
-                }
-                qCWarning(lcDisco) << "Virtual file without db entry for" << path._local
-                                   << "but looks odd, keeping";
-                item->_instruction = CSYNC_INSTRUCTION_IGNORE;
-            }
+            return;
+        }
+
+        Q_ASSERT(item->_instruction == CSYNC_INSTRUCTION_NEW);
+        if (item->_instruction != CSYNC_INSTRUCTION_NEW) {
+            qCWarning(lcDisco) << "Wiping virtual file without db entry for" << path._local << ". But, item->_instruction is" << item->_instruction;
+            return;
+        }
+
+        if (isOnlineOnlyFolder) {
+            qCInfo(lcDisco) << "Wiping virtual folder without db entry for" << path._local;
+        } else {
+            qCInfo(lcDisco) << "Wiping virtual file without db entry for" << path._local;
+        }
+        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+        item->_direction = SyncFileItem::Down;
+        // this flag needs to be unset, otherwise a folder would get marked as new in the processSubJobs
+        _childModified = false;
+        if (isOnlineOnlyFolder && _discoveryData) {
+            emit _discoveryData->addErrorToGui(SyncFileItem::SoftError, tr("Conflict when uploading a folder. It's going to get cleared!"), path._local);
         }
     };
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -916,24 +916,24 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         const bool isFilePlaceHolder = !localEntry.isDirectory && _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local);
 
         // either correct availability, or a result with error if the folder is new or otherwise has no availability set yet
-        const auto folderAvailability = localEntry.isDirectory ? _discoveryData->_syncOptions._vfs->availability(path._local) : Vfs::AvailabilityResult(Vfs::AvailabilityError::NoSuchItem);
+        const auto folderPlaceHolderAvailability = localEntry.isDirectory ? _discoveryData->_syncOptions._vfs->availability(path._local) : Vfs::AvailabilityResult(Vfs::AvailabilityError::NoSuchItem);
 
         const auto folderPinState = localEntry.isDirectory ? _discoveryData->_syncOptions._vfs->pinState(path._local) : Optional<PinStateEnums::PinState>(PinState::Unspecified);
 
-        if (!isFilePlaceHolder && !folderAvailability.isValid() && !folderPinState.isValid()) {
+        if (!isFilePlaceHolder && !folderPlaceHolderAvailability.isValid() && !folderPinState.isValid()) {
             // not a file placeholder and not a synced folder placeholder (new local folder)
             return;
         }
 
         const auto isFolderPinStateOnlineOnly = (folderPinState.isValid() && *folderPinState == PinState::OnlineOnly);
 
-        const auto isFolderAvailabilityOnlineOnly = (folderAvailability.isValid() && *folderAvailability == VfsItemAvailability::OnlineOnly);
+        const auto isfolderPlaceHolderAvailabilityOnlineOnly = (folderPlaceHolderAvailability.isValid() && *folderPlaceHolderAvailability == VfsItemAvailability::OnlineOnly);
 
         // a folder is considered online-only if: no files are hydrated, or, if it's an empty folder
-        const auto isOnlineOnlyFolder = isFolderAvailabilityOnlineOnly || !folderAvailability && isFolderPinStateOnlineOnly;
+        const auto isOnlineOnlyFolder = isfolderPlaceHolderAvailabilityOnlineOnly || !folderPlaceHolderAvailability && isFolderPinStateOnlineOnly;
 
         if (!isFilePlaceHolder && !isOnlineOnlyFolder) {
-            if (localEntry.isDirectory && folderAvailability.isValid() && !isOnlineOnlyFolder) {
+            if (localEntry.isDirectory && folderPlaceHolderAvailability.isValid() && !isOnlineOnlyFolder) {
                 // a VFS folder but is not online0only (has some files hydrated)
                 qCInfo(lcDisco) << "Virtual directory without db entry for" << path._local << "but it contains hydrated file(s), so let's keep it and reupload.";
                 emit _discoveryData->addErrorToGui(SyncFileItem::SoftError, tr("Conflict when uploading some files to a folder. Those, conflicted, are going to get cleared!"), path._local);


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This should do it. Just need to test a couple of times more and maybe come up with some additional scenarios...
Having said that, it works well now when creating new folder and still works as expected when renaming on 2 clients.