### PR TITLE
directly send the icon url for activities to the qml component

### DIFF
--- a/src/gui/tray/ActivityData.h
+++ b/src/gui/tray/ActivityData.h
@@ -74,7 +74,6 @@ public:
     qint64 _expireAtMsecs = -1;
     QString _accName;
     QString _icon;
-    QString _iconData;
 
     // Stores information about the error
     int _status;

--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -178,6 +178,10 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             }
         } else {
             // We have an activity
+            if (a._icon.isEmpty()) {
+                return "qrc:///client/theme/black/activity.svg";
+            }
+
             return a._icon;
         }
     }

--- a/src/gui/tray/ActivityListModel.cpp
+++ b/src/gui/tray/ActivityListModel.cpp
@@ -178,11 +178,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             }
         } else {
             // We have an activity
-            if (!a._iconData.isEmpty()) {
-                const QString svgData = "data:image/svg+xml;utf8," + a._iconData;
-                return svgData;
-            }
-            return "qrc:///client/theme/black/activity.svg";
+            return a._icon;
         }
     }
     case ObjectTypeRole:
@@ -299,12 +295,6 @@ void ActivityListModel::slotActivitiesReceived(const QJsonDocument &json, int st
         a._dateTime = QDateTime::fromString(json.value("datetime").toString(), Qt::ISODate);
         a._icon = json.value("icon").toString();
 
-        if (!a._icon.isEmpty()) {
-            auto *iconJob = new IconJob(QUrl(a._icon));
-            iconJob->setProperty("activityId", a._id);
-            connect(iconJob, &IconJob::jobFinished, this, &ActivityListModel::slotIconDownloaded);
-        }
-
         list.append(a);
         _currentItem = list.last()._id;
 
@@ -323,15 +313,6 @@ void ActivityListModel::slotActivitiesReceived(const QJsonDocument &json, int st
     emit activityJobStatusCode(statusCode);
 
     combineActivityLists();
-}
-
-void ActivityListModel::slotIconDownloaded(QByteArray iconData)
-{
-    for (auto i = 0; i < _activityLists.count(); i++) {
-        if (_activityLists[i]._id == sender()->property("activityId").toLongLong()) {
-            _activityLists[i]._iconData = iconData;
-        }
-    }
 }
 
 void ActivityListModel::addErrorToActivityList(Activity activity)

--- a/src/gui/tray/ActivityListModel.h
+++ b/src/gui/tray/ActivityListModel.h
@@ -84,7 +84,6 @@ public slots:
 
 private slots:
     void slotActivitiesReceived(const QJsonDocument &json, int statusCode);
-    void slotIconDownloaded(QByteArray iconData);
 
 signals:
     void activityJobStatusCode(int statusCode);


### PR DESCRIPTION
should allow usage of default cache from Image qml standard component

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
