### PR TITLE
Run legacy uninstall exe in a secure way

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -58,9 +58,9 @@
 
     <!-- Detect legacy NSIS installation -->
     <Property Id="NSIS_UNINSTALLEXE">
-        <DirectorySearch Id="LegacyUninstallVersion" Path="[INSTALLDIR]">
-            <FileSearch Name="Uninstall.exe" />
-        </DirectorySearch>
+        <RegistrySearch Id="RegistryLegacyUninstallString" Type="file" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\$(var.AppName)" Name="UninstallString" Win64="no">
+		    <FileSearch Id="LegacyUninstallFileName" Name="Uninstall.exe"/>
+	    </RegistrySearch>
     </Property>
 
     <!-- Property to disable update checks -->


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

`UninstallString` Registry property is created by NSIS installer. We must query it and then run the `Uninstall.exe` file that is contained within this property, or, do nothing if it is empty.