### PR TITLE
Update utility.cpp

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -111,7 +111,7 @@ void Utility::setupFavLink(const QString &folder)
 
 QString Utility::octetsToString(qint64 octets)
 {
-#define THE_FACTOR 1024
+#define THE_FACTOR 1000
     static const qint64 kb = THE_FACTOR;
     static const qint64 mb = THE_FACTOR * kb;
     static const qint64 gb = THE_FACTOR * mb;


### PR DESCRIPTION
Change THE_FACTOR to be 1000 instead of 1024 to correctly represent the SI units that are used in `octetsToString`.

This was changed in 995b42d0fc31bee5882b2f6a704400f4f221c192 from 1000 to 1024 without proper explanation of reasons. 

Note: I have not build and tested this change, so I'm submitting this purely because of the theoretical correctness of it.

Signed-off-by: Sascha Knott <knottsascha@gmail.com>