### PR TITLE
only compile xattr virtual files backend for linux platform (not unices)

### DIFF
--- a/src/libsync/vfs/xattr/CMakeLists.txt
+++ b/src/libsync/vfs/xattr/CMakeLists.txt
@@ -1,10 +1,8 @@
 if (LINUX)
-    set(vfs_xattr_SRCS vfs_xattr.cpp)
-    if (APPLE)
-        set(vfs_xattr_SRCS ${vfs_xattr_SRCS} xattrwrapper_mac.cpp)
-    else()
-        set(vfs_xattr_SRCS ${vfs_xattr_SRCS} xattrwrapper_linux.cpp)
-    endif()
+    set(vfs_xattr_SRCS
+        vfs_xattr.cpp
+        xattrwrapper_linux.cpp
+    )
 
     add_library("${synclib_NAME}_vfs_xattr" SHARED
         ${vfs_xattr_SRCS}

--- a/src/libsync/vfs/xattr/CMakeLists.txt
+++ b/src/libsync/vfs/xattr/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (UNIX)
+if (LINUX)
     set(vfs_xattr_SRCS vfs_xattr.cpp)
     if (APPLE)
         set(vfs_xattr_SRCS ${vfs_xattr_SRCS} xattrwrapper_mac.cpp)


### PR DESCRIPTION
for a reason a mac os platform specific file is missing and before xattr
plugin was compiled only for linux

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
