### PR TITLE
Remove request to config for userVisibleURL.

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -227,17 +227,6 @@ void ConnectionValidator::checkServerCapabilities()
     job->setTimeout(timeoutToUseMsec);
     QObject::connect(job, &JsonApiJob::jsonReceived, this, &ConnectionValidator::slotCapabilitiesRecieved);
     job->start();
-
-    // And we'll retrieve the ocs config in parallel
-    // note that 'this' might be destroyed before the job finishes, so intentionally not parented
-    auto configJob = new JsonApiJob(_account, QLatin1String("ocs/v1.php/config"));
-    configJob->setTimeout(timeoutToUseMsec);
-    auto account = _account; // capturing account by value will make it live long enough
-    QObject::connect(configJob, &JsonApiJob::jsonReceived, _account.data(),
-        [=](const QJsonDocument &json) {
-            ocsConfigReceived(json, account);
-        });
-    configJob->start();
 }
 
 void ConnectionValidator::slotCapabilitiesRecieved(const QJsonDocument &json)
@@ -258,17 +247,6 @@ void ConnectionValidator::slotCapabilitiesRecieved(const QJsonDocument &json)
     _account->fetchDirectEditors(directEditingURL, directEditingETag);
 
     fetchUser();
-}
-
-void ConnectionValidator::ocsConfigReceived(const QJsonDocument &json, AccountPtr account)
-{
-    QString host = json.object().value("ocs").toObject().value("data").toObject().value("host").toString();
-    if (host.isEmpty()) {
-        qCWarning(lcConnectionValidator) << "Could not extract 'host' from ocs config reply";
-        return;
-    }
-    qCInfo(lcConnectionValidator) << "Determined user-visible host to be" << host;
-    account->setUserVisibleHost(host);
 }
 
 void ConnectionValidator::fetchUser()

--- a/src/gui/connectionvalidator.h
+++ b/src/gui/connectionvalidator.h
@@ -60,8 +60,7 @@ namespace OCC {
   +---------------------------+
   |
   +-> checkServerCapabilities --------------v (in parallel)
-        JsonApiJob (cloud/capabilities)     JsonApiJob (ocs/v1.php/config)
-        |                                   +-> ocsConfigReceived
+        JsonApiJob (cloud/capabilities)
         +-> slotCapabilitiesRecieved -+
                                       |
     +---------------------------------+
@@ -131,7 +130,6 @@ private:
     void reportResult(Status status);
     void checkServerCapabilities();
     void fetchUser();
-    static void ocsConfigReceived(const QJsonDocument &json, AccountPtr account);
 
     /** Sets the account's server version
      *


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
To fix https://github.com/nextcloud/server/issues/15688

`_userVisibleUrl` is always initialized in the `void Account::setUrl(const QUrl &url)`