### PR TITLE
fix size of the Label with user status

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -362,6 +362,9 @@ Window {
                             spacing: 0
                             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                             Layout.leftMargin: Style.userStatusSpacing
+                            Layout.fillWidth: true
+                            Layout.maximumWidth: parent.width
+
                             Label {
                                 id: currentAccountUser
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
@@ -372,11 +375,14 @@ Window {
                                 font.pixelSize: Style.topLinePixelSize
                                 font.bold: true
                             }
+
                             RowLayout {
                                 id: currentUserStatus
                                 visible: UserModel.currentUser.isConnected &&
                                          UserModel.currentUser.serverHasUserStatus
                                 spacing: Style.accountLabelsSpacing
+                                width: parent.width
+
                                 Label {
                                     id: emoji
                                     visible: UserModel.currentUser.statusEmoji !== ""
@@ -386,6 +392,7 @@ Window {
                                 Label {
                                     id: message
                                     Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
+                                    Layout.fillWidth: true
                                     visible: UserModel.currentUser.statusMessage !== ""
                                     width: Style.currentAccountLabelWidth
                                     text: UserModel.currentUser.statusMessage !== ""


### PR DESCRIPTION
ensure the label width is not higher than the parent to ensure log
string get elided as expected

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
