### PR TITLE
print the real permissions string instead of its address

### DIFF
--- a/src/common/remotepermissions.h
+++ b/src/common/remotepermissions.h
@@ -99,7 +99,7 @@ public:
 
     friend QDebug operator<<(QDebug &dbg, RemotePermissions p)
     {
-        return dbg << p.toString().constData();
+        return dbg << p.toString();
     }
 };
 


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
