### PR TITLE
Don't use variables for CMake target identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,6 @@ if(NOT CRASHREPORTER_EXECUTABLE)
     set(CRASHREPORTER_EXECUTABLE "${APPLICATION_EXECUTABLE}_crash_reporter")
 endif()
 
-set(synclib_NAME "${APPLICATION_EXECUTABLE}sync")
-set(csync_NAME "${APPLICATION_EXECUTABLE}_csync")
-
 include(Warnings)
 
 include(${CMAKE_SOURCE_DIR}/VERSION.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ endif()
 
 include(ECMEnableSanitizers)
 
-set(synclib_NAME ${APPLICATION_EXECUTABLE}sync)
-
 find_package(Qt5 5.12 COMPONENTS Core Network Xml Concurrent REQUIRED)
 find_package(Qt5 5.12 COMPONENTS WebEngineWidgets WebEngine)
 

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -1,14 +1,11 @@
 project(cmd)
 set(CMAKE_AUTOMOC TRUE)
 
-set(cmd_NAME ${APPLICATION_EXECUTABLE}cmd)
-
 add_library(cmdCore STATIC simplesslerrorhandler.cpp netrcparser.cpp)
 
 target_link_libraries(cmdCore
   PUBLIC
-  "${csync_NAME}"
-  "${synclib_NAME}"
+  nextcloudsync
   Qt5::Core
   Qt5::Network
   )
@@ -27,20 +24,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
 endif()
 
 if(NOT BUILD_LIBRARIES_ONLY)
-  add_executable(${cmd_NAME} cmd.cpp)
+  add_executable(nextcloudcmd cmd.cpp)
+  set_target_properties(nextcloudcmd PROPERTIES
+    RUNTIME_OUTPUT_NAME "${APPLICATION_EXECUTABLE}cmd")
+
+  target_link_libraries(nextcloudcmd cmdCore)
 
   if(BUILD_OWNCLOUD_OSX_BUNDLE)
-    set_target_properties(${cmd_NAME} PROPERTIES
+    set_target_properties(nextcloudcmd PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${BIN_OUTPUT_DIRECTORY}/${OWNCLOUD_OSX_BUNDLE}/Contents/MacOS")
   else()
-    set_target_properties(${cmd_NAME} PROPERTIES
+    set_target_properties(nextcloudcmd PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY})
 
-    install(TARGETS ${cmd_NAME}
+    install(TARGETS nextcloudcmd
 	  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()
-
-  target_link_libraries(${cmd_NAME} cmdCore)
 endif()

--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -58,10 +58,10 @@ endif()
 
 configure_file(csync_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/csync_version.h)
 
-add_library("${csync_NAME}" SHARED ${common_SOURCES} ${csync_SRCS})
+add_library(nextcloud_csync SHARED ${common_SOURCES} ${csync_SRCS})
 
 target_include_directories(
-  "${csync_NAME}"
+  nextcloud_csync
   PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/std
 )
 
@@ -69,26 +69,26 @@ if(USE_OUR_OWN_SQLITE3)
   message(STATUS "Using own sqlite3 version")
   add_library(sqlite3 STATIC "${CMAKE_SOURCE_DIR}/src/3rdparty/sqlite3/sqlite3.c")
   target_include_directories(sqlite3 PUBLIC "${CMAKE_SOURCE_DIR}/src/3rdparty/sqlite3")
-  target_link_libraries("${csync_NAME}" PUBLIC sqlite3)
+  target_link_libraries(nextcloud_csync PUBLIC sqlite3)
 else()
-  target_include_directories("${csync_NAME}" PUBLIC ${SQLITE3_INCLUDE_DIR})
-  target_link_libraries("${csync_NAME}" PUBLIC ${SQLITE3_LIBRARIES})
+  target_include_directories(nextcloud_csync PUBLIC ${SQLITE3_INCLUDE_DIR})
+  target_link_libraries(nextcloud_csync PUBLIC ${SQLITE3_LIBRARIES})
 endif()
 
 
-generate_export_header("${csync_NAME}"
+generate_export_header(nextcloud_csync
   EXPORT_MACRO_NAME OCSYNC_EXPORT
   EXPORT_FILE_NAME ocsynclib.h
 )
 
-target_link_libraries("${csync_NAME}"
+target_link_libraries(nextcloud_csync
   PUBLIC
   ${CSYNC_REQUIRED_LIBRARIES}
   Qt5::Core Qt5::Concurrent
 )
 
 if(ZLIB_FOUND)
-  target_link_libraries("${csync_NAME}" PUBLIC ZLIB::ZLIB)
+  target_link_libraries(nextcloud_csync PUBLIC ZLIB::ZLIB)
 endif(ZLIB_FOUND)
 
 
@@ -96,11 +96,11 @@ endif(ZLIB_FOUND)
 if (APPLE)
     find_library(FOUNDATION_LIBRARY NAMES Foundation)
     find_library(CORESERVICES_LIBRARY NAMES CoreServices)
-    target_link_libraries("${csync_NAME}" PUBLIC ${FOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
+    target_link_libraries(nextcloud_csync PUBLIC ${FOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
 endif()
 
 set_target_properties(
-  "${csync_NAME}"
+  nextcloud_csync
     PROPERTIES
       VERSION
         ${LIBRARY_VERSION}
@@ -108,11 +108,13 @@ set_target_properties(
         ${LIBRARY_SOVERSION}
       RUNTIME_OUTPUT_DIRECTORY
         ${BIN_OUTPUT_DIRECTORY}
+      LIBRARY_OUTPUT_NAME
+        "${APPLICATION_EXECUTABLE}_csync"
 )
 if(BUILD_OWNCLOUD_OSX_BUNDLE)
   INSTALL(
     TARGETS
-    "${csync_NAME}"
+    nextcloud_csync
     LIBRARY DESTINATION
 	${LIB_INSTALL_DIR}
     ARCHIVE DESTINATION
@@ -123,7 +125,7 @@ if(BUILD_OWNCLOUD_OSX_BUNDLE)
 else()
   INSTALL(
   TARGETS
-  "${csync_NAME}"
+  nextcloud_csync
   LIBRARY DESTINATION
     ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -327,6 +327,7 @@ add_library(nextcloudCore STATIC ${final_src})
 
 target_link_libraries(nextcloudCore
   PUBLIC
+  nextcloudsync
   Qt5::Widgets
   Qt5::GuiPrivate
   Qt5::Svg
@@ -335,7 +336,6 @@ target_link_libraries(nextcloudCore
   Qt5::Qml
   Qt5::Quick
   Qt5::QuickControls2
-  ${synclib_NAME}
   )
 
 if(Qt5WebEngine_FOUND AND Qt5WebEngineWidgets_FOUND)
@@ -376,17 +376,23 @@ if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)
     endif()
 
     # we may not add MACOSX_BUNDLE here, if not building one
-    add_executable(${APPLICATION_EXECUTABLE} WIN32 main.cpp ${client_version} ${client_manifest} ${APP_ICON})
+    add_executable(nextcloud WIN32 main.cpp ${client_version} ${client_manifest} ${APP_ICON})
+    set_target_properties(nextcloud PROPERTIES
+      OUTPUT_NAME "${APPLICATION_EXECUTABLE}"
+    )
 else()
     # set(CMAKE_INSTALL_PREFIX ".") # Examples use /Applications. hurmpf.
     set(MACOSX_BUNDLE_ICON_FILE "${APPLICATION_ICON_NAME}.icns")
 
     # we must add MACOSX_BUNDLE only if building a bundle
-    add_executable(${APPLICATION_EXECUTABLE} WIN32 MACOSX_BUNDLE main.cpp ${APP_ICON})
+    add_executable(nextcloud WIN32 MACOSX_BUNDLE main.cpp ${APP_ICON})
 
     if (BUILD_OWNCLOUD_OSX_BUNDLE)
-      set_target_properties(${APPLICATION_EXECUTABLE} PROPERTIES
+      set_target_properties(nextcloud PROPERTIES
         OUTPUT_NAME "${APPLICATION_NAME}")
+    else()
+      set_target_properties(nextcloud PROPERTIES
+        OUTPUT_NAME "${APPLICATION_EXECUTABLE}")
     endif()
 
     set (QM_DIR ${OWNCLOUD_OSX_BUNDLE}/Contents/Resources/Translations)
@@ -406,20 +412,17 @@ endif()
 
 IF(BUILD_UPDATER)
     add_library(updater STATIC ${updater_SRCS})
-    target_link_libraries(updater ${synclib_NAME} ${updater_DEPS} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml)
+    target_link_libraries(updater nextcloudsync ${updater_DEPS} Qt5::Widgets Qt5::Svg Qt5::Network Qt5::Xml)
     target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
     set_target_properties(updater PROPERTIES AUTOMOC ON)
+    target_link_libraries(nextcloudCore PUBLIC updater)
 endif()
 
-set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY  ${BIN_OUTPUT_DIRECTORY}
+set_target_properties(nextcloud PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
 )
 
-target_link_libraries(${APPLICATION_EXECUTABLE} nextcloudCore)
-
-IF(BUILD_UPDATER)
-  target_link_libraries(nextcloudCore PUBLIC updater)
-endif()
+target_link_libraries(nextcloud PRIVATE nextcloudCore)
 
 target_link_libraries(nextcloudCore PUBLIC ${OS_SPECIFIC_LINK_LIBRARIES})
 
@@ -471,7 +474,7 @@ endif()
 target_compile_definitions(nextcloudCore PRIVATE "QT_DISABLE_DEPRECATED_BEFORE=0")
 
 
-install(TARGETS ${APPLICATION_EXECUTABLE}
+install(TARGETS nextcloud
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -85,19 +85,20 @@ set(creds_HEADERS
 IF (NOT APPLE)
     INSTALL(
         FILES ${owncloudsync_HEADERS}
-	DESTINATION ${INCLUDE_INSTALL_DIR}/${synclib_NAME}/mirall
+	DESTINATION ${INCLUDE_INSTALL_DIR}/nextcloudsync/mirall
     )
     INSTALL(
         FILES ${creds_HEADERS}
-	DESTINATION ${INCLUDE_INSTALL_DIR}/${synclib_NAME}/creds
+	DESTINATION ${INCLUDE_INSTALL_DIR}/nextcloudsync/creds
     )
 ENDIF(NOT APPLE)
 
 find_package(Qt5 REQUIRED COMPONENTS WebSockets)
-add_library(${synclib_NAME} SHARED ${libsync_SRCS})
-target_link_libraries(${synclib_NAME}
+add_library(nextcloudsync SHARED ${libsync_SRCS})
+set_target_properties(nextcloudsync PROPERTIES LIBRARY_OUTPUT_NAME ${APPLICATION_EXECUTABLE}sync)
+target_link_libraries(nextcloudsync
   PUBLIC
-  "${csync_NAME}"
+  nextcloud_csync
   OpenSSL::Crypto
   OpenSSL::SSL
   ${OS_SPECIFIC_LINK_LIBRARIES}
@@ -108,38 +109,38 @@ target_link_libraries(${synclib_NAME}
 
 if (NOT TOKEN_AUTH_ONLY)
     find_package(Qt5 REQUIRED COMPONENTS Widgets Svg)
-    target_link_libraries(${synclib_NAME} PUBLIC Qt5::Widgets Qt5::Svg qt5keychain)
+    target_link_libraries(nextcloudsync PUBLIC Qt5::Widgets Qt5::Svg qt5keychain)
 endif()
 
 if(Inotify_FOUND)
-    target_include_directories(${synclib_NAME} PRIVATE ${Inotify_INCLUDE_DIRS})
-    target_link_libraries(${synclib_NAME} PUBLIC ${Inotify_LIBRARIES})
+    target_include_directories(nextcloudsync PRIVATE ${Inotify_INCLUDE_DIRS})
+    target_link_libraries(nextcloudsync PUBLIC ${Inotify_LIBRARIES})
 endif()
 
-GENERATE_EXPORT_HEADER( ${synclib_NAME}
-	BASE_NAME ${synclib_NAME}
+GENERATE_EXPORT_HEADER( nextcloudsync
+	BASE_NAME nextcloudsync
 	EXPORT_MACRO_NAME OWNCLOUDSYNC_EXPORT
         EXPORT_FILE_NAME owncloudlib.h
 	STATIC_DEFINE OWNCLOUD_BUILT_AS_STATIC
 )
 
-target_include_directories(${synclib_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(nextcloudsync PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 
-set_target_properties( ${synclib_NAME}  PROPERTIES
+set_target_properties( nextcloudsync  PROPERTIES
 	VERSION ${MIRALL_VERSION}
 	SOVERSION ${MIRALL_SOVERSION}
 	RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
 )
 
 if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)
-    install(TARGETS ${synclib_NAME}
+    install(TARGETS nextcloudsync
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 else()
-    install(TARGETS ${synclib_NAME} DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/MacOS)
+    install(TARGETS nextcloudsync DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/MacOS)
 endif()
 
 

--- a/src/libsync/vfs/cfapi/CMakeLists.txt
+++ b/src/libsync/vfs/cfapi/CMakeLists.txt
@@ -6,6 +6,10 @@ if (WIN32)
         hydrationjob.cpp
         vfs_cfapi.cpp
     )
+    set_target_properties(nextcloudsync_vfs_cfapi
+        PROPERTIES
+        LIBRARY_OUTPUT_NAME ${APPLICATION_EXECUTABLE}sync_vfs_cfapi
+    )
 
     target_link_libraries(nextcloudsync_vfs_cfapi PRIVATE
         nextcloudsync

--- a/src/libsync/vfs/cfapi/CMakeLists.txt
+++ b/src/libsync/vfs/cfapi/CMakeLists.txt
@@ -1,35 +1,35 @@
 if (WIN32)
     add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
 
-    add_library("${synclib_NAME}_vfs_cfapi" SHARED
+    add_library(nextcloudsync_vfs_cfapi SHARED
         cfapiwrapper.cpp
         hydrationjob.cpp
         vfs_cfapi.cpp
     )
 
-    target_link_libraries("${synclib_NAME}_vfs_cfapi"
-        "${synclib_NAME}"
+    target_link_libraries(nextcloudsync_vfs_cfapi PRIVATE
+        nextcloudsync
         cldapi
     )
 
-    set_target_properties("${synclib_NAME}_vfs_cfapi" PROPERTIES
+    set_target_properties("nextcloudsync_vfs_cfapi" PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
         RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
         PREFIX ""
         AUTOMOC TRUE
     )
 
-    target_include_directories("${synclib_NAME}_vfs_cfapi" BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_BINARY_DIR})
+    target_include_directories("nextcloudsync_vfs_cfapi" BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_BINARY_DIR})
 
     set(vfs_installdir "${PLUGINDIR}")
 
-    GENERATE_EXPORT_HEADER( "${synclib_NAME}_vfs_cfapi"
-        BASE_NAME "${synclib_NAME}_vfs_cfapi"
+    generate_export_header(nextcloudsync_vfs_cfapi
+        BASE_NAME nextcloudsync_vfs_cfapi
         EXPORT_MACRO_NAME NEXTCLOUD_CFAPI_EXPORT
         EXPORT_FILE_NAME cfapiexport.h
     )
 
-    INSTALL(TARGETS "${synclib_NAME}_vfs_cfapi"
+    install(TARGETS nextcloudsync_vfs_cfapi
       LIBRARY DESTINATION "${vfs_installdir}"
       RUNTIME DESTINATION "${vfs_installdir}"
     )

--- a/src/libsync/vfs/suffix/CMakeLists.txt
+++ b/src/libsync/vfs/suffix/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_library(nextcloudsync_vfs_suffix SHARED
     vfs_suffix.cpp
 )
+set_target_properties(nextcloudsync_vfs_suffix
+    PROPERTIES
+    LIBRARY_OUTPUT_NAME ${APPLICATION_EXECUTABLE}sync_vfs_suffix
+)
 
 target_link_libraries(nextcloudsync_vfs_suffix PRIVATE nextcloudsync)
 

--- a/src/libsync/vfs/suffix/CMakeLists.txt
+++ b/src/libsync/vfs/suffix/CMakeLists.txt
@@ -1,12 +1,10 @@
-add_library("${synclib_NAME}_vfs_suffix" SHARED
+add_library(nextcloudsync_vfs_suffix SHARED
     vfs_suffix.cpp
 )
 
-target_link_libraries("${synclib_NAME}_vfs_suffix"
-    "${synclib_NAME}"
-)
+target_link_libraries(nextcloudsync_vfs_suffix PRIVATE nextcloudsync)
 
-set_target_properties("${synclib_NAME}_vfs_suffix" PROPERTIES
+set_target_properties(nextcloudsync_vfs_suffix PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
     RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
     PREFIX ""
@@ -16,7 +14,7 @@ set_target_properties("${synclib_NAME}_vfs_suffix" PROPERTIES
 if(APPLE)
     # for being loadable when client run from build dir
     set(vfs_buildoutputdir "${BIN_OUTPUT_DIRECTORY}/${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns/")
-    set_target_properties("${synclib_NAME}_vfs_suffix"
+    set_target_properties(nextcloudsync_vfs_suffix
         PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
         RUNTIME_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
@@ -27,7 +25,7 @@ else()
     set(vfs_installdir "${PLUGINDIR}")
 endif()
 
-INSTALL(TARGETS "${synclib_NAME}_vfs_suffix"
+install(TARGETS nextcloudsync_vfs_suffix
   LIBRARY DESTINATION "${vfs_installdir}"
   RUNTIME DESTINATION "${vfs_installdir}"
 )

--- a/src/libsync/vfs/xattr/CMakeLists.txt
+++ b/src/libsync/vfs/xattr/CMakeLists.txt
@@ -7,6 +7,10 @@ if (LINUX)
     add_library(nextcloudsync_vfs_xattr SHARED
         ${vfs_xattr_SRCS}
     )
+    set_target_properties(nextcloudsync_vfs_xattr
+        PROPERTIES
+        LIBRARY_OUTPUT_NAME ${APPLICATION_EXECUTABLE}sync_vfs_xattr
+    )
 
     target_link_libraries(nextcloudsync_vfs_xattr PRIVATE nextcloudsync)
 

--- a/src/libsync/vfs/xattr/CMakeLists.txt
+++ b/src/libsync/vfs/xattr/CMakeLists.txt
@@ -4,27 +4,25 @@ if (LINUX)
         xattrwrapper_linux.cpp
     )
 
-    add_library("${synclib_NAME}_vfs_xattr" SHARED
+    add_library(nextcloudsync_vfs_xattr SHARED
         ${vfs_xattr_SRCS}
     )
 
-    target_link_libraries("${synclib_NAME}_vfs_xattr"
-        "${synclib_NAME}"
-    )
+    target_link_libraries(nextcloudsync_vfs_xattr PRIVATE nextcloudsync)
 
-    set_target_properties("${synclib_NAME}_vfs_xattr" PROPERTIES
+    set_target_properties(nextcloudsync_vfs_xattr PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
         RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
         PREFIX ""
         AUTOMOC TRUE
     )
 
-    target_include_directories("${synclib_NAME}_vfs_xattr" BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+    target_include_directories(nextcloudsync_vfs_xattr BEFORE PUBLIC ${CMAKE_CURRENT_BINARY_DIR} INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
     if(APPLE)
         # for being loadable when client run from build dir
         set(vfs_buildoutputdir "${BIN_OUTPUT_DIRECTORY}/${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns/")
-        set_target_properties("${synclib_NAME}_vfs_xattr"
+        set_target_properties(nextcloudsync_vfs_xattr
             PROPERTIES
             LIBRARY_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
             RUNTIME_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
@@ -35,13 +33,13 @@ if (LINUX)
         set(vfs_installdir "${PLUGINDIR}")
     endif()
 
-    GENERATE_EXPORT_HEADER( "${synclib_NAME}_vfs_xattr"
-        BASE_NAME "${synclib_NAME}_vfs_xattr"
+    generate_export_header(nextcloudsync_vfs_xattr
+        BASE_NAME nextcloudsync_vfs_xattr
         EXPORT_MACRO_NAME NEXTCLOUD_XATTR_EXPORT
         EXPORT_FILE_NAME xattrexport.h
     )
 
-    INSTALL(TARGETS "${synclib_NAME}_vfs_xattr"
+    install(TARGETS nextcloudsync_vfs_xattr
       LIBRARY DESTINATION "${vfs_installdir}"
       RUNTIME DESTINATION "${vfs_installdir}"
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(testutils
   testhelper.cpp
 )
 
-target_link_libraries(testutils PUBLIC ${APPLICATION_EXECUTABLE}sync Qt5::Test)
+target_link_libraries(testutils PUBLIC nextcloudsync Qt5::Test)
 target_include_directories(testutils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(testutils PROPERTIES FOLDER Tests)
 

--- a/test/csync/CMakeLists.txt
+++ b/test/csync/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
 add_library(${TORTURE_LIBRARY} STATIC torture.c cmdline.c)
 target_link_libraries(${TORTURE_LIBRARY} ${CMOCKA_LIBRARIES})
 
-set(TEST_TARGET_LIBRARIES ${TORTURE_LIBRARY} Qt5::Core "${csync_NAME}")
+set(TEST_TARGET_LIBRARIES ${TORTURE_LIBRARY} Qt5::Core nextcloud_csync)
 
 # create tests
 

--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -8,8 +8,8 @@ macro(nextcloud_add_test test_class)
     add_executable(${OWNCLOUD_TEST_CLASS}Test test${OWNCLOUD_TEST_CLASS_LOWERCASE}.cpp)
     set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY})
 
-    target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
-      ${APPLICATION_EXECUTABLE}sync
+    target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
+      nextcloudsync
       testutils
       nextcloudCore
       cmdCore
@@ -18,19 +18,19 @@ macro(nextcloud_add_test test_class)
     )
 
     if (WIN32)
-        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
-            "${synclib_NAME}_vfs_cfapi"
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
+            nextcloudsync_vfs_cfapi
         )
     endif()
 
     if (UNIX)
-        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
-            "${synclib_NAME}_vfs_xattr"
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
+            nextcloudsync_vfs_xattr
         )
     endif()
 
     IF(BUILD_UPDATER)
-        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
             updater
         )
     endif()
@@ -58,7 +58,7 @@ macro(nextcloud_add_benchmark test_class)
     set_target_properties(${OWNCLOUD_TEST_CLASS}Bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY})
 
     target_link_libraries(${OWNCLOUD_TEST_CLASS}Bench
-      ${APPLICATION_EXECUTABLE}sync
+      nextcloudsync
       testutils
       nextcloudCore
       cmdCore


### PR DESCRIPTION
This makes the code a bit nicer to read and maybe a bit more robust.

Set the relevant OUTPUT_NAME target properties to keep the ability to
customize the names of the installed binaries.

Signed-off-by: Nicolas Fella <nicolas.fella@gmx.de>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
