### PR TITLE
in wizard always use the correct way to get dav path

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -445,11 +445,6 @@ int main(int argc, char **argv)
     account->setUrl(url);
     account->setSslErrorHandler(sslErrorHandler);
 
-    // Do not do it if '--nonshib' was passed. This mean we should only connect to the 'nonshib'
-    // dav endpoint. Since we do not get the capabilities, in that case, this has the additional
-    // side effect that chunking-ng will be disabled. (because otherwise it would use the new
-    // 'dav' endpoint instead of the nonshib one (which still use the old chunking)
-
     QEventLoop loop;
     auto *job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/capabilities"));
     QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -75,7 +75,6 @@ struct CmdOptions
     bool useNetrc;
     bool interactive;
     bool ignoreHiddenFiles;
-    bool nonShib;
     QString exclude;
     QString unsyncedfolders;
     QString davPath;
@@ -188,8 +187,6 @@ void help()
     std::cout << "  --password, -p [pass]  Use [pass] as password" << std::endl;
     std::cout << "  -n                     Use netrc (5) for login" << std::endl;
     std::cout << "  --non-interactive      Do not block execution with interaction" << std::endl;
-    std::cout << "  --nonshib              Use Non Shibboleth WebDAV authentication" << std::endl;
-    std::cout << "  --davpath [path]       Custom themed dav path, overrides --nonshib" << std::endl;
     std::cout << "  --max-sync-retries [n] Retries maximum n times (default to 3)" << std::endl;
     std::cout << "  --uplimit [n]          Limit the upload speed of files to n KB/s" << std::endl;
     std::cout << "  --downlimit [n]        Limit the download speed of files to n KB/s" << std::endl;
@@ -263,10 +260,6 @@ void parseOptions(const QStringList &app_args, CmdOptions *options)
             options->exclude = it.next();
         } else if (option == "--unsyncedfolders" && !it.peekNext().startsWith("-")) {
             options->unsyncedfolders = it.next();
-        } else if (option == "--nonshib") {
-            options->nonShib = true;
-        } else if (option == "--davpath" && !it.peekNext().startsWith("-")) {
-            options->davPath = it.next();
         } else if (option == "--max-sync-retries" && !it.peekNext().startsWith("-")) {
             options->restartTimes = it.next().toInt();
         } else if (option == "--uplimit" && !it.peekNext().startsWith("-")) {
@@ -328,7 +321,6 @@ int main(int argc, char **argv)
     options.useNetrc = false;
     options.interactive = true;
     options.ignoreHiddenFiles = false; // Default is to sync hidden files
-    options.nonShib = false;
     options.restartTimes = 3;
     options.uplimit = 0;
     options.downlimit = 0;
@@ -350,14 +342,6 @@ int main(int argc, char **argv)
     // check if the webDAV path was added to the url and append if not.
     if (!options.target_url.endsWith("/")) {
         options.target_url.append("/");
-    }
-
-    if (options.nonShib) {
-        account->setNonShib(true);
-    }
-
-    if (!options.davPath.isEmpty()) {
-        account->setDavPath(options.davPath);
     }
 
     if (!options.target_url.contains(account->davPath())) {
@@ -461,40 +445,37 @@ int main(int argc, char **argv)
     account->setUrl(url);
     account->setSslErrorHandler(sslErrorHandler);
 
-    // Perform a call to get the capabilities.
-    if (!options.nonShib) {
-        // Do not do it if '--nonshib' was passed. This mean we should only connect to the 'nonshib'
-        // dav endpoint. Since we do not get the capabilities, in that case, this has the additional
-        // side effect that chunking-ng will be disabled. (because otherwise it would use the new
-        // 'dav' endpoint instead of the nonshib one (which still use the old chunking)
+    // Do not do it if '--nonshib' was passed. This mean we should only connect to the 'nonshib'
+    // dav endpoint. Since we do not get the capabilities, in that case, this has the additional
+    // side effect that chunking-ng will be disabled. (because otherwise it would use the new
+    // 'dav' endpoint instead of the nonshib one (which still use the old chunking)
 
-        QEventLoop loop;
-        auto *job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/capabilities"));
-        QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {
-            auto caps = json.object().value("ocs").toObject().value("data").toObject().value("capabilities").toObject();
-            qDebug() << "Server capabilities" << caps;
-            account->setCapabilities(caps.toVariantMap());
-            account->setServerVersion(caps["core"].toObject()["status"].toObject()["version"].toString());
-            loop.quit();
-        });
-        job->start();
-        loop.exec();
+    QEventLoop loop;
+    auto *job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/capabilities"));
+    QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {
+        auto caps = json.object().value("ocs").toObject().value("data").toObject().value("capabilities").toObject();
+        qDebug() << "Server capabilities" << caps;
+        account->setCapabilities(caps.toVariantMap());
+        account->setServerVersion(caps["core"].toObject()["status"].toObject()["version"].toString());
+        loop.quit();
+    });
+    job->start();
+    loop.exec();
 
-        if (job->reply()->error() != QNetworkReply::NoError){
-            std::cout<<"Error connecting to server\n";
-            return EXIT_FAILURE;
-        }
-
-        job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"));
-        QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {
-            const QJsonObject data = json.object().value("ocs").toObject().value("data").toObject();
-            account->setDavUser(data.value("id").toString());
-            account->setDavDisplayName(data.value("display-name").toString());
-            loop.quit();
-        });
-        job->start();
-        loop.exec();
+    if (job->reply()->error() != QNetworkReply::NoError){
+        std::cout<<"Error connecting to server\n";
+        return EXIT_FAILURE;
     }
+
+    job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"));
+    QObject::connect(job, &JsonApiJob::jsonReceived, [&](const QJsonDocument &json) {
+        const QJsonObject data = json.object().value("ocs").toObject().value("data").toObject();
+        account->setDavUser(data.value("id").toString());
+        account->setDavDisplayName(data.value("display-name").toString());
+        loop.quit();
+    });
+    job->start();
+    loop.exec();
 
     // much lower age than the default since this utility is usually made to be run right after a change in the tests
     SyncEngine::minimumFileAgeForUpload = std::chrono::milliseconds(0);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -85,18 +85,7 @@ Account::~Account() = default;
 
 QString Account::davPath() const
 {
-    if (capabilities().chunkingNg()) {
-        // The chunking-ng means the server prefer to use the new webdav URL
-        return QLatin1String("/remote.php/dav/files/") + davUser() + QLatin1Char('/');
-    }
-
-    // make sure to have a trailing slash
-    if (!_davPath.endsWith('/')) {
-        QString dp(_davPath);
-        dp.append('/');
-        return dp;
-    }
-    return _davPath;
+    return QLatin1String("/remote.php/dav/files/") + davUser() + QLatin1Char('/');
 }
 
 void Account::setSharedThis(AccountPtr sharedThis)

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -59,7 +59,6 @@ const char app_password[] = "_app-password";
 Account::Account(QObject *parent)
     : QObject(parent)
     , _capabilities(QVariantMap())
-    , _davPath(Theme::instance()->webDavPath())
 {
     qRegisterMetaType<AccountPtr>("AccountPtr");
     qRegisterMetaType<Account *>("Account*");
@@ -558,15 +557,6 @@ void Account::setServerVersion(const QString &version)
     auto oldServerVersion = _serverVersion;
     _serverVersion = version;
     emit serverVersionChanged(this, oldServerVersion, version);
-}
-
-void Account::setNonShib(bool nonShib)
-{
-    if (nonShib) {
-        _davPath = Theme::instance()->webDavPathNonShib();
-    } else {
-        _davPath = Theme::instance()->webDavPath();
-    }
 }
 
 void Account::writeAppPasswordOnce(QString appPassword){

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -124,8 +124,6 @@ public:
      * @returns the (themeable) dav path for the account.
      */
     QString davPath() const;
-    void setDavPath(const QString &s) { _davPath = s; }
-    void setNonShib(bool nonShib);
 
     /** Returns webdav entry URL, based on url() */
     QUrl davUrl() const;
@@ -329,7 +327,6 @@ private:
 
     static QString _configFileName;
 
-    QString _davPath; // defaults to value from theme, might be overwritten in brandings
     ClientSideEncryption _e2e;
 
     /// Used in RemoteWipe

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -643,16 +643,6 @@ bool Theme::wizardSelectiveSyncDefaultNothing() const
     return false;
 }
 
-QString Theme::webDavPath() const
-{
-    return QLatin1String("remote.php/dav/");
-}
-
-QString Theme::webDavPathNonShib() const
-{
-    return QLatin1String("remote.php/nonshib-webdav/");
-}
-
 bool Theme::linkSharing() const
 {
     return true;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -338,15 +338,6 @@ public:
     virtual bool wizardHideExternalStorageConfirmationCheckbox() const;
 
     /**
-     * Alternative path on the server that provides access to the webdav capabilities
-     *
-     * Attention: Make sure that this string does NOT have a leading slash and that
-     * it has a trailing slash, for example "remote.php/dav/".
-     */
-    virtual QString webDavPath() const;
-    virtual QString webDavPathNonShib() const;
-
-    /**
      * @brief Sharing options
      *
      * Allow link sharing and or user/group sharing

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -214,10 +214,11 @@ private slots:
             if (verb == "PROPFIND") {
                 auto data = stream->readAll();
                 if (data.contains("data-fingerprint")) {
-                    if (request.url().path().endsWith("dav/"))
+                    if (request.url().path().endsWith("dav/files/admin/")) {
                         ++fingerprintRequests;
-                    else
+                    } else {
                         fingerprintRequests = -10000; // fingerprint queried on incorrect path
+                    }
                 }
             }
             return nullptr;

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -91,7 +91,7 @@ private slots:
         auto oldLocalState = fakeFolder.currentLocalState();
         auto oldRemoteState = fakeFolder.currentRemoteState();
 
-        QString errorFolder = "dav/B";
+        QString errorFolder = "dav/files/admin/B";
         QString fatalErrorPrefix = "Server replied with an error while reading directory 'B' : ";
         fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *)
                 -> QNetworkReply *{
@@ -133,7 +133,7 @@ private slots:
         //
         // Check the same discovery error on the sync root
         //
-        errorFolder = "dav/";
+        errorFolder = "dav/files/admin/";
         fatalErrorPrefix = "Server replied with an error while reading directory '' : ";
         errorSpy.clear();
         QVERIFY(!fakeFolder.syncOnce());


### PR DESCRIPTION
fixes listing being incorrect when using dav endpoint

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
