### PR TITLE
Don't constrain size of hover background

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -11,10 +11,8 @@ MouseArea {
     hoverEnabled: true
     
     Rectangle {
-        anchors.left: activityMouseArea.left
+        anchors.fill: parent
         anchors.margins: 2
-        width: Style.trayWindowMouseAreaWidth
-        height: Style.trayWindowHeaderHeight
         color: (parent.containsMouse ? Style.lightHover : "transparent")
     }
         

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -19,7 +19,6 @@ QtObject {
 
     // Dimensions and sizes
     property int trayWindowWidth: 400
-    property int trayWindowMouseAreaWidth: 396
     property int trayWindowHeight: 510
     property int trayWindowRadius: 10
     property int trayWindowBorderWidth: 1


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

If the main dialog is a regular window the size of the background when hovering over the activity list items should not be constrained. Otherwise, the hover effect will just be visible on the half of the activity list item. 