### PR TITLE
Set default maxChunkSize to 1000MB

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -41,7 +41,7 @@ Some interesting values that can be set on the configuration file are:
 | ``chunkSize``                    | ``10000000`` (10 MB)   | Specifies the chunk size of uploaded files in bytes.                                                   |
 |                                  |                        | The client will dynamically adjust this size within the maximum and minimum bounds (see below).        |
 +----------------------------------+------------------------+--------------------------------------------------------------------------------------------------------+
-| ``maxChunkSize``                 | ``100000000`` (100 MB) | Specifies the maximum chunk size of uploaded files in bytes.                                           |
+| ``maxChunkSize``                 | ``1000000000`` (1000 MB) | Specifies the maximum chunk size of uploaded files in bytes.                                           |
 +----------------------------------+------------------------+--------------------------------------------------------------------------------------------------------+
 | ``minChunkSize``                 | ``1000000`` (1 MB)     | Specifies the minimum chunk size of uploaded files in bytes.                                           |
 +----------------------------------+------------------------+--------------------------------------------------------------------------------------------------------+

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -228,7 +228,7 @@ qint64 ConfigFile::chunkSize() const
 qint64 ConfigFile::maxChunkSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(maxChunkSizeC), 100 * 1000 * 1000).toLongLong(); // default to 100 MB
+    return settings.value(QLatin1String(maxChunkSizeC), 1000 * 1000 * 1000).toLongLong(); // default to 1000 MB
 }
 
 qint64 ConfigFile::minChunkSize() const

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -57,7 +57,7 @@ struct OWNCLOUDSYNC_EXPORT SyncOptions
     qint64 _minChunkSize = 1 * 1000 * 1000; // 1MB
 
     /** The maximum chunk size in bytes for chunked uploads */
-    qint64 _maxChunkSize = 100 * 1000 * 1000; // 100MB
+    qint64 _maxChunkSize = 1000 * 1000 * 1000; // 1000MB
 
     /** The target duration of chunk uploads for dynamic chunk sizing.
      *


### PR DESCRIPTION
fix #3313

Superseds https://github.com/nextcloud/desktop/pull/3314
Signed-off-by: szaimen <szaimen@e.mail.de>