### PR TITLE
prevent crash in Accont::davPath without credentials

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -99,7 +99,7 @@ AccountPtr Account::sharedFromThis()
 
 QString Account::davUser() const
 {
-    return _davUser.isEmpty() ? _credentials->user() : _davUser;
+    return _davUser.isEmpty() && _credentials ? _credentials->user() : _davUser;
 }
 
 void Account::setDavUser(const QString &newDavUser)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 
 nextcloud_add_benchmark(LargeSync)
 
+nextcloud_add_test(Account)
 nextcloud_add_test(FolderMan)
 nextcloud_add_test(RemoteWipe)
 

--- a/test/testaccount.cpp
+++ b/test/testaccount.cpp
@@ -23,7 +23,7 @@ class TestAccount: public QObject
     Q_OBJECT
 
 private slots:
-    void testDavPathCrash()
+    void testAccountDavPath_unitialized_noCrash()
     {
         AccountPtr account = Account::create();
         account->davPath();

--- a/test/testaccount.cpp
+++ b/test/testaccount.cpp
@@ -1,0 +1,34 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <qglobal.h>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "common/utility.h"
+#include "folderman.h"
+#include "account.h"
+#include "accountstate.h"
+#include "configfile.h"
+#include "testhelper.h"
+
+using namespace OCC;
+
+class TestAccount: public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testDavPathCrash()
+    {
+        AccountPtr account = Account::create();
+        account->davPath();
+    }
+};
+
+QTEST_APPLESS_MAIN(TestAccount)
+#include "testaccount.moc"


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
