### PR TITLE
Delete apptoken after account removal.

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -380,6 +380,8 @@ void AccountManager::deleteAccount(AccountState *account)
     // Forget E2E keys
     account->account()->e2e()->forgetSensitiveData(account->account());
 
+    account->account()->deleteAppToken();
+
     emit accountSyncConnectionRemoved(account);
     emit accountRemoved(account);
 }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -245,6 +245,8 @@ public:
     void writeAppPasswordOnce(QString appPassword);
     void deleteAppPassword();
 
+    void deleteAppToken();
+
     /// Direct Editing
     // Check for the directEditing capability
     void fetchDirectEditors(const QUrl &directEditingURL, const QString &directEditingETag);


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This will fix #3597 