### PR TITLE
Ensure that the users id is used for accessing webdav

### DIFF
--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -16,11 +16,17 @@
 
 #include "common/utility.h"
 #include "account.h"
+#include "creds/webflowcredentials.h"
+#include "networkjobs.h"
 #include "wizard/owncloudwizardcommon.h"
 #include "theme.h"
 #include "linklabel.h"
 
 #include "QProgressIndicator.h"
+
+#include <QJsonDocument>
+#include <QStringLiteral>
+#include <QJsonObject>
 
 namespace OCC {
 
@@ -102,7 +108,25 @@ void Flow2AuthWidget::slotAuthResult(Flow2Auth::Result r, const QString &errorSt
     }
     }
 
-    emit authResult(r, errorString, user, appPassword);
+    _account->setCredentials(new WebFlowCredentials(user, appPassword));
+    const auto fetchUserNameJob = new JsonApiJob(_account->sharedFromThis(), QStringLiteral("/ocs/v1.php/cloud/user"));
+    connect(fetchUserNameJob, &JsonApiJob::jsonReceived, this, [this, fetchUserNameJob, r, errorString, user, appPassword](const QJsonDocument &json, int statusCode) {
+        fetchUserNameJob->deleteLater();
+        if (statusCode != 100) {
+            qCWarning(lcFlow2AuthWidget) << "Could not fetch username";
+            _account->setDavDisplayName(user);
+            emit authResult(r, errorString, user, appPassword);
+            return;
+        }
+
+        const auto objData = json.object().value("ocs").toObject().value("data").toObject();
+        const auto userId = objData.value("id").toString(user);
+        const auto displayName = objData.value("display-name").toString();
+        _account->setDavDisplayName(displayName);
+
+        emit authResult(r, errorString, userId, appPassword);
+    });
+    fetchUserNameJob->start();
 }
 
 void Flow2AuthWidget::setError(const QString &error) {

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -168,7 +168,7 @@ void OwncloudAdvancedSetupPage::initializePage()
     _ui.confCheckBoxExternal->setChecked(cfgFile.confirmExternalStorage());
 
     fetchUserAvatar();
-    fetchUserData();
+    setUserInformation();
 
     customizeStyle();
 
@@ -201,20 +201,9 @@ void OwncloudAdvancedSetupPage::fetchUserAvatar()
     avatarJob->start();
 }
 
-void OwncloudAdvancedSetupPage::fetchUserData()
+void OwncloudAdvancedSetupPage::setUserInformation()
 {
     const auto account = _ocWizard->account();
-
-    // Fetch user data
-    const auto userJob = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"), this);
-    userJob->setTimeout(20 * 1000);
-    connect(userJob, &JsonApiJob::jsonReceived, this, [this](const QJsonDocument &json) {
-        const auto objData = json.object().value("ocs").toObject().value("data").toObject();
-        const auto displayName = objData.value("display-name").toString();
-        _ui.userNameLabel->setText(displayName);
-    });
-    userJob->start();
-
     const auto serverUrl = account->url().toString();
     setServerAddressLabelUrl(serverUrl);
     const auto userName = account->davDisplayName();

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -82,7 +82,7 @@ private:
     void setResolutionGuiVisible(bool value);
     void setupResoultionWidget();
     void fetchUserAvatar();
-    void fetchUserData();
+    void setUserInformation();
 
     // TODO: remove when UX decision is made
     void refreshVirtualFilesAvailibility(const QString &path);


### PR DESCRIPTION
https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html#obtaining-the-login-credentials
states that the email address can be used for login but it's not
allowed to use the email address to access webdav.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

Fixes #3628

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
