### PR TITLE
no longer produce installers that would be stored by appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,6 @@ install:
 build_script:
 - ps: |
     craft --src-dir $env:APPVEYOR_BUILD_FOLDER nextcloud-client
-    craft --package --src-dir $env:APPVEYOR_BUILD_FOLDER nextcloud-client
-    cp C:\CraftMaster\windows-msvc2019_64-cl\tmp\*.7z $env:APPVEYOR_BUILD_FOLDER
-    cp C:\CraftMaster\windows-msvc2019_64-cl\tmp\*.exe $env:APPVEYOR_BUILD_FOLDER
 
 test_script:
 - ps: |
@@ -43,7 +40,3 @@ test_script:
 environment:
     matrix:
     - TARGET: windows-msvc2019_64-cl
-
-artifacts:
-  - path: '*.7z'
-  - path: '*.exe'


### PR DESCRIPTION
appveyor storage is limited and we ran into trouble with that

plan is to directly use github to do that and have links directly in PRs

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
