### PR TITLE
Enforce fetching of user id

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -317,7 +317,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     qCInfo(lcAccountManager) << "Account for" << acc->url() << "using auth type" << authType;
 
     acc->_serverVersion = settings.value(QLatin1String(serverVersionC)).toString();
-    acc->_davUser = settings.value(QLatin1String(davUserC)).toString();
+    acc->_davUser = settings.value(QLatin1String(davUserC), "").toString();
 
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -488,7 +488,27 @@ void Account::slotHandleSslErrors(QNetworkReply *reply, QList<QSslError> errors)
 
 void Account::slotCredentialsFetched()
 {
-    emit credentialsFetched(_credentials.data());
+    if (_davUser.isEmpty()) {
+        qCDebug(lcAccount) << "User id not set. Fetch it.";
+        const auto fetchUserNameJob = new JsonApiJob(sharedFromThis(), QStringLiteral("/ocs/v1.php/cloud/user"));
+        connect(fetchUserNameJob, &JsonApiJob::jsonReceived, this, [this, fetchUserNameJob](const QJsonDocument &json, int statusCode) {
+            fetchUserNameJob->deleteLater();
+            if (statusCode != 100) {
+                qCWarning(lcAccount) << "Could not fetch user id. Login will probably not work.";
+                emit credentialsFetched(_credentials.data());
+                return;
+            }
+
+            const auto objData = json.object().value("ocs").toObject().value("data").toObject();
+            const auto userId = objData.value("id").toString("");
+            setDavUser(userId);
+            emit credentialsFetched(_credentials.data());
+        });
+        fetchUserNameJob->start();
+    } else {
+        qCDebug(lcAccount) << "User id already fetched.";
+        emit credentialsFetched(_credentials.data());
+    }
 }
 
 void Account::slotCredentialsAsked()


### PR DESCRIPTION
With the change of commit 3e61bdc4318827d486221e56fbca3804b639fdd7
users that had their email address stored as dav_user in nextcloud.cfg
would not be able to login anymore because only the user id can be
used for login. With this commit the dav_user entry in the
nextcloud.cfg file gets replaced with dav_user_id to enforce ONE TIME
fetching of the user id for every user. As the user id can not change
it should be enough to fetch it one time.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
