### PR TITLE
Return the login name instead of user id

### DIFF
--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -113,7 +113,8 @@ void Flow2AuthWidget::slotAuthResult(Flow2Auth::Result r, const QString &errorSt
     connect(fetchUserNameJob, &JsonApiJob::jsonReceived, this, [this, fetchUserNameJob, r, errorString, user, appPassword](const QJsonDocument &json, int statusCode) {
         fetchUserNameJob->deleteLater();
         if (statusCode != 100) {
-            qCWarning(lcFlow2AuthWidget) << "Could not fetch username";
+            qCWarning(lcFlow2AuthWidget) << "Could not fetch username.";
+            _account->setDavUser("");
             _account->setDavDisplayName(user);
             emit authResult(r, errorString, user, appPassword);
             return;
@@ -122,9 +123,10 @@ void Flow2AuthWidget::slotAuthResult(Flow2Auth::Result r, const QString &errorSt
         const auto objData = json.object().value("ocs").toObject().value("data").toObject();
         const auto userId = objData.value("id").toString(user);
         const auto displayName = objData.value("display-name").toString();
+        _account->setDavUser(userId);
         _account->setDavDisplayName(displayName);
 
-        emit authResult(r, errorString, userId, appPassword);
+        emit authResult(r, errorString, user, appPassword);
     });
     fetchUserNameJob->start();
 }


### PR DESCRIPTION
App password and login name need to match. If authResult() returns the
user id the user id will be stored in webdav_user

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
