### PR TITLE
put VFS plugins into the correct path

### DIFF
--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -49,6 +49,9 @@ make DESTDIR=/app install
 cd /app
 
 mv ./usr/lib/x86_64-linux-gnu/* ./usr/lib/
+mkdir ./usr/plugins
+mv ./usr/lib/nextcloudsync_vfs_suffix.so ./usr/plugins
+mv ./usr/lib/nextcloudsync_vfs_xattr.so ./usr/plugins
 rm -rf ./usr/lib/cmake
 rm -rf ./usr/include
 rm -rf ./usr/mkspecs


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
