### PR TITLE
Systray add force sync

### DIFF
--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -84,6 +84,7 @@ public slots:
     void slotNewUserSelected();
 
 private slots:
+    void slotForceSyncAllFolders();
     void slotUnpauseAllFolders();
     void slotPauseAllFolders();
 


### PR DESCRIPTION
This is basically a copy-pasta from Systray::setPauseOnAllFoldersHelper() and AccountSettings::slotForceSyncCurrentFolder()

I am not sure whether 

```
        selectedFolder->slotWipeErrorBlacklist(); // issue #6757

        // Insert the selected folder at the front of the queue
        folderMan->scheduleFolderNext(selectedFolder);
```

is sensible/required for a function like this. Can an experienced dev advise?