### PR TITLE
remove broken assert that is not needed and break account setup

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -149,8 +149,6 @@ void AbstractNetworkJob::adoptRequest(QNetworkReply *reply)
 
 QUrl AbstractNetworkJob::makeAccountUrl(const QString &relativePath) const
 {
-    // ensure we always used the remote folder
-    ASSERT(relativePath.startsWith(QLatin1Char('/')))
     return Utility::concatUrlPath(_account->url(), relativePath);
 }
 


### PR DESCRIPTION
it has been also removed from the original branch so no problem removing
it

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
