### PR TITLE
Use default sharing permissions from server

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -631,19 +631,7 @@ void ownCloudGui::slotShowShareDialog(const QString &sharePath, const QString &l
         }
     }
 
-    // As a first approximation, set the set of permissions that can be granted
-    // either to everything (resharing allowed) or nothing (no resharing).
-    //
-    // The correct value will be found with a propfind from ShareDialog.
-    // (we want to show the dialog directly, not wait for the propfind first)
-    SharePermissions maxSharingPermissions =
-        SharePermissionRead
-        | SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete
-        | SharePermissionShare;
-    if (!resharingAllowed) {
-        maxSharingPermissions = {};
-    }
-
+    auto maxSharingPermissions = resharingAllowed? SharePermissions(accountState->account()->capabilities().shareDefaultPermissions()) : SharePermissions({});
 
     ShareDialog *w = nullptr;
     if (_shareDialogs.contains(localPath) && _shareDialogs[localPath]) {

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -402,11 +402,8 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex &index)
             }
         }
 
-        // Default permissions on creation
-        int permissions = SharePermissionCreate | SharePermissionUpdate
-                | SharePermissionDelete | SharePermissionShare;
         _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
-            sharee->shareWith(), SharePermission(permissions), password);
+            sharee->shareWith(), _maxSharingPermissions, password);
     }
 
     _ui->shareeLineEdit->setEnabled(false);

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -371,40 +371,30 @@ void ShareUserGroupWidget::slotCompleterActivated(const QModelIndex &index)
      */
 
     _lastCreatedShareId = QString();
-
-    if (sharee->type() == Sharee::Federated
-        && _account->serverVersionInt() < Account::makeServerVersion(9, 1, 0)) {
-        int permissions = SharePermissionRead | SharePermissionUpdate;
-        if (!_isFile) {
-            permissions |= SharePermissionCreate | SharePermissionDelete;
+    
+    QString password;
+    if (sharee->type() == Sharee::Email && _account->capabilities().shareEmailPasswordEnforced()) {
+        _ui->shareeLineEdit->clear();
+        // always show a dialog for password-enforced email shares
+        bool ok = false;
+        
+        do {
+            password = QInputDialog::getText(
+                this,
+                tr("Password for share required"),
+                tr("Please enter a password for your email share:"),
+                QLineEdit::Password,
+                QString(),
+                &ok);
+        } while (password.isEmpty() && ok);
+        
+        if (!ok) {
+            return;
         }
-        _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
-            sharee->shareWith(), SharePermission(permissions));
-    } else {
-        QString password;
-        if (sharee->type() == Sharee::Email && _account->capabilities().shareEmailPasswordEnforced()) {
-            _ui->shareeLineEdit->clear();
-            // always show a dialog for password-enforced email shares
-            bool ok = false;
-
-            do {
-                password = QInputDialog::getText(
-                            this,
-                            tr("Password for share required"),
-                            tr("Please enter a password for your email share:"),
-                            QLineEdit::Password,
-                            QString(),
-                            &ok);
-            } while (password.isEmpty() && ok);
-
-            if (!ok) {
-                return;
-            }
-        }
-
-        _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
-            sharee->shareWith(), _maxSharingPermissions, password);
     }
+    
+    _manager->createShare(_sharePath, Share::ShareType(sharee->type()),
+        sharee->shareWith(), _maxSharingPermissions, password);
 
     _ui->shareeLineEdit->setEnabled(false);
     _ui->shareeLineEdit->clear();

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -100,6 +100,15 @@ bool Capabilities::shareResharing() const
     return _capabilities["files_sharing"].toMap()["resharing"].toBool();
 }
 
+int Capabilities::shareDefaultPermissions() const
+{
+    if(_capabilities["files_sharing"].toMap().contains("default_permissions")) {
+        return _capabilities["files_sharing"].toMap()["default_permissions"].toInt();
+    }
+    
+    return {};
+}
+
 bool Capabilities::clientSideEncryptionAvailable() const
 {
     auto it = _capabilities.constFind(QStringLiteral("end-to-end-encryption"));

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -57,6 +57,7 @@ public:
     int sharePublicLinkExpireDateDays() const;
     bool sharePublicLinkMultiple() const;
     bool shareResharing() const;
+    int shareDefaultPermissions() const;
     bool chunkingNg() const;
     bool userStatusNotification() const;
     bool userStatus() const;

--- a/test/testcapabilities.cpp
+++ b/test/testcapabilities.cpp
@@ -214,6 +214,35 @@ private slots:
 
         QVERIFY(!capabilities.userStatusSupportsEmoji());
     }
+    
+    void testShareDefaultPermissions_defaultSharePermissionsNotInCapabilities_returnZero()
+    {
+        QVariantMap filesSharingMap;
+        filesSharingMap["api_enabled"] = false;
+        
+        QVariantMap capabilitiesMap;
+        capabilitiesMap["files_sharing"] = filesSharingMap;
+        
+        const OCC::Capabilities capabilities(capabilitiesMap);
+        const auto defaultSharePermissionsNotInCapabilities = capabilities.shareDefaultPermissions();
+
+        QCOMPARE(defaultSharePermissionsNotInCapabilities, {});
+    }
+    
+    void testShareDefaultPermissions_defaultSharePermissionsAvailable_returnPermissions()
+    {
+        QVariantMap filesSharingMap;
+        filesSharingMap["api_enabled"] = true;
+        filesSharingMap["default_permissions"] = 31;
+        
+        QVariantMap capabilitiesMap;
+        capabilitiesMap["files_sharing"] = filesSharingMap;
+        
+        const OCC::Capabilities capabilities(capabilitiesMap);
+        const auto defaultSharePermissionsAvailable = capabilities.shareDefaultPermissions();
+
+        QCOMPARE(defaultSharePermissionsAvailable, 31);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestCapabilities)


### PR DESCRIPTION
It should solve #3107.
Not really a feature, most of the logic was in place but we were not using the permissions set in the server settings.

- [x] modify tests for the new capability check