### PR TITLE
remove a tr call where translator cannot do anything meaningful

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -468,7 +468,7 @@ QString Theme::about() const
 
     devString += tr("<p><small>Using virtual files plugin: %1</small></p>")
                      .arg(Vfs::modeToString(bestAvailableVfsMode()));
-    devString += tr("<br>%1")
+    devString += QStringLiteral("<br>%1")
               .arg(QSysInfo::productType() % QLatin1Char('-') % QSysInfo::kernelVersion());
 
     return devString;


### PR DESCRIPTION
close #3708

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
