### PR TITLE
Only set dav user after login

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -323,12 +323,29 @@ void OwncloudSetupWizard::slotConnectToOCUrl(const QString &url)
     qCInfo(lcWizard) << "Connect to url: " << url;
     AbstractCredentials *creds = _ocWizard->getCredentials();
     _ocWizard->account()->setCredentials(creds);
-    _ocWizard->setField(QLatin1String("OCUrl"), url);
-    _ocWizard->appendToConfigurationLog(tr("Trying to connect to %1 at %2 …")
-                                            .arg(Theme::instance()->appNameGUI())
-                                            .arg(url));
 
-    testOwnCloudConnect();
+    const auto fetchUserNameJob = new JsonApiJob(_ocWizard->account()->sharedFromThis(), QStringLiteral("/ocs/v1.php/cloud/user"));
+    connect(fetchUserNameJob, &JsonApiJob::jsonReceived, this, [this, url](const QJsonDocument &json, int statusCode) {
+        if (statusCode != 100) {
+            qCWarning(lcWizard) << "Could not fetch username.";
+        }
+
+        sender()->deleteLater();
+
+        const auto objData = json.object().value("ocs").toObject().value("data").toObject();
+        const auto userId = objData.value("id").toString("");
+        const auto displayName = objData.value("display-name").toString("");
+        _ocWizard->account()->setDavUser(userId);
+        _ocWizard->account()->setDavDisplayName(displayName);
+
+        _ocWizard->setField(QLatin1String("OCUrl"), url);
+        _ocWizard->appendToConfigurationLog(tr("Trying to connect to %1 at %2 …")
+                                                .arg(Theme::instance()->appNameGUI())
+                                                .arg(url));
+
+        testOwnCloudConnect();
+    });
+    fetchUserNameJob->start();
 }
 
 void OwncloudSetupWizard::testOwnCloudConnect()

--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -108,27 +108,7 @@ void Flow2AuthWidget::slotAuthResult(Flow2Auth::Result r, const QString &errorSt
     }
     }
 
-    _account->setCredentials(new WebFlowCredentials(user, appPassword));
-    const auto fetchUserNameJob = new JsonApiJob(_account->sharedFromThis(), QStringLiteral("/ocs/v1.php/cloud/user"));
-    connect(fetchUserNameJob, &JsonApiJob::jsonReceived, this, [this, fetchUserNameJob, r, errorString, user, appPassword](const QJsonDocument &json, int statusCode) {
-        fetchUserNameJob->deleteLater();
-        if (statusCode != 100) {
-            qCWarning(lcFlow2AuthWidget) << "Could not fetch username.";
-            _account->setDavUser("");
-            _account->setDavDisplayName(user);
-            emit authResult(r, errorString, user, appPassword);
-            return;
-        }
-
-        const auto objData = json.object().value("ocs").toObject().value("data").toObject();
-        const auto userId = objData.value("id").toString(user);
-        const auto displayName = objData.value("display-name").toString();
-        _account->setDavUser(userId);
-        _account->setDavDisplayName(displayName);
-
-        emit authResult(r, errorString, user, appPassword);
-    });
-    fetchUserNameJob->start();
+    emit authResult(r, errorString, user, appPassword);
 }
 
 void Flow2AuthWidget::setError(const QString &error) {


### PR DESCRIPTION
Setting the credentials of the account inside the auth widget is not a
good idea as that will destroy the previous credentials object which
may wait for a signal to be emitted by the credentials dialog that
was created by the credentials that are going to be deleted. Uff.

It should be enough to set the dav user only after login because the
dav user will never change.

See also the discussion here
https://github.com/nextcloud/desktop/issues/3677#issuecomment-907976839

Fixes #3677

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
