### PR TITLE
macOS client is not able to do auto updates

### DIFF
--- a/doc/autoupdate.rst
+++ b/doc/autoupdate.rst
@@ -32,10 +32,9 @@ itself. Should the silent update fail, the client offers a manual download.
 macOS
 ^^^^^
 
-If a new update is available, the Nextcloud client initializes a pop-up dialog
-to alert you of the update and requesting that you update to the latest
-version. Due to their use of the Sparkle frameworks, this is the default
-process for macOS applications.
+There is no automatic updater on macOS. If a new update is available,
+the Nextcloud client initializes a pop-up dialog to alert you of the
+update and requesting that you update to the latest version manually.
 
 Linux
 ^^^^^
@@ -95,14 +94,6 @@ To prevent automatic updates and disallow manual overrides:
 
 .. note:: branded clients have different key names
 
-
-Preventing Automatic Updates in macOS Environments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You can disable the automatic update mechanism, in the macOS operating system,
-by copying the file
-``nextcloud.app/Contents/Resources/deny_autoupdate_com.nextcloud.desktopclient.plist``
-to ``/Library/Preferences/com.nextcloud.desktopclient.plist``.
 
 Preventing Automatic Updates in Linux Environments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
