### PR TITLE
Remove assert that causes crashes

### DIFF
--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -154,8 +154,6 @@ QUrl AbstractNetworkJob::makeAccountUrl(const QString &relativePath) const
 
 QUrl AbstractNetworkJob::makeDavUrl(const QString &relativePath) const
 {
-    // ensure we always used the remote folder
-    ASSERT(relativePath.startsWith(QLatin1Char('/')))
     return Utility::concatUrlPath(_account->davUrl(), relativePath);
 }
 


### PR DESCRIPTION
This assert does not add value. Utility::concatUrlPath() takes care of
appending paths correctly.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
