### PR TITLE
Fix codecForLocale() being incorrectly detected

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -59,6 +59,7 @@
 #include <QMessageBox>
 #include <QDesktopServices>
 #include <QGuiApplication>
+#include <QQuickStyle>
 
 class QSocket;
 
@@ -183,6 +184,13 @@ Application::Application(int &argc, char **argv)
     , _debugMode(false)
     , _backgroundMode(false)
 {
+    // Work around a bug in KDE's qqc2-desktop-style which breaks
+    // buttons with icons not based on a name, by forcing a style name
+    // the platformtheme plugin won't try to force qqc2-desktops-style
+    // anymore.
+    // Can be removed once the bug in qqc2-desktop-style is gone.
+    QQuickStyle::setStyle("Default");
+
     _startedAt.start();
 
     qsrand(std::random_device()());

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -34,7 +34,6 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QDebug>
-#include <QQuickStyle>
 #include <QQuickWindow>
 
 using namespace OCC;
@@ -53,13 +52,6 @@ int main(int argc, char **argv)
 {
     Q_INIT_RESOURCE(resources);
     Q_INIT_RESOURCE(theme);
-
-    // Work around a bug in KDE's qqc2-desktop-style which breaks
-    // buttons with icons not based on a name, by forcing a style name
-    // the platformtheme plugin won't try to force qqc2-desktops-style
-    // anymore.
-    // Can be removed once the bug in qqc2-desktop-style is gone.
-    QQuickStyle::setStyle("Default");
 
     // OpenSSL 1.1.0: No explicit initialisation or de-initialisation is necessary.
 


### PR DESCRIPTION
QQuickStyle::setStyle() will call QTextCodec::codecForLocale(), and
that calls ucnv_getDefaultName() on Qt configured with ICU.
ucnv_getDefaultName() is intended to be called only after a setlocale()
call; if it were called before such, it would *cache* a wrong result.

In Qt applications, the setlocale() call is made in the constructor of
QCoreApplication, and that makes QTextCodec::codecForLocale() gives the
wrong codec.

This commit fixes the wrong behaviour by moving the setStyle() call
to after the QCoreApplication constructor has been called.

Xref: https://bugs.kde.org/show_bug.cgi?id=432406

BUG: https://github.com/nextcloud/desktop/issues/3755

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
