### PR TITLE
Fix Windows Placeholder Shortcut Menu

### DIFF
--- a/shell_integration/windows/WinShellExt.wxs.in
+++ b/shell_integration/windows/WinShellExt.wxs.in
@@ -63,6 +63,7 @@
                 <File Id="NCContextMenu.dll" KeyPath="yes" Source="$(var.HarvestAppDir)\shellext\NCContextMenu.dll">
                     <Class Id="$(var.ContextMenuGuid)" Context="InprocServer32" Description="$(var.ContextMenuDescription)" ThreadingModel="apartment" />
                 </File>
+                <RegistryValue Root="HKCR" Key="CLSID\$(var.ContextMenuGuid)" Name="ContextMenuOptIn" Value="" Type="string" Action="write" />
                 <RegistryValue Root="HKCR" Key="AllFileSystemObjects\shellex\ContextMenuHandlers\$(var.ContextMenuRegKeyName)" Value="$(var.ContextMenuGuid)" Type="string" Action="write" />
             </Component>
 


### PR DESCRIPTION
I had a similar problem with my app and I was stumbling over your issue #3584. The fix for it I described here roughly: https://stackoverflow.com/questions/69191606/shortcut-menu-with-dynamic-verbs-for-file-attribute-offline/

During creating this PR I realized this project was doing it in the past right when the ShellExtension dll was registering itself. But during changing your install process, I guess this flag was forgotten or got lost during the merging of different PRs. To be honest, I was not testing the fix with NextCloud, but it should more or less working like this.