### PR TITLE
set default format for QSurface to handle NVidia context loss events

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -39,6 +39,7 @@
 #include <QDebug>
 #include <QQuickStyle>
 #include <QQuickWindow>
+#include <QSurfaceFormat>
 
 using namespace OCC;
 
@@ -112,6 +113,10 @@ int main(int argc, char **argv)
         QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
     }
 #endif
+
+    auto surfaceFormat = QSurfaceFormat::defaultFormat();
+    surfaceFormat.setOption(QSurfaceFormat::ResetNotification);
+    QSurfaceFormat::setDefaultFormat(surfaceFormat);
 
 // check a environment variable for core dumps
 #ifdef Q_OS_UNIX


### PR DESCRIPTION
should fix wrong OpenGL rendering after suspend on Linux with NVidia
binary OpenGL driver

close #3759

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
