### PR TITLE
Fix argp references on FreeBSD

### DIFF
--- a/src/csync/ConfigureChecks.cmake
+++ b/src/csync/ConfigureChecks.cmake
@@ -22,6 +22,11 @@ if (NOT LINUX)
     check_library_exists(rt nanosleep "" HAVE_LIBRT)
 
     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} )
+
+    # Systems not using glibc require linker flag for argp
+    if(HAVE_ARGP_H)
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} argp)
+    endif()
 endif (NOT LINUX)
 
 if(WIN32)

--- a/src/csync/ConfigureChecks.cmake
+++ b/src/csync/ConfigureChecks.cmake
@@ -24,7 +24,8 @@ if (NOT LINUX)
     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} )
 
     # Systems not using glibc require linker flag for argp
-    if(HAVE_ARGP_H)
+    check_library_exists(argp argp_parse "" HAVE_LIBARGP)
+    if(HAVE_ARGP_H AND HAVE_LIBARGP)
         set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} argp)
     endif()
 endif (NOT LINUX)


### PR DESCRIPTION
Signed-off-by: Guido Falsi <madpilot@freebsd.org>

In reference to issue #3200

Looks like the argp dependency was dropped some time ago, but some code lingers in the tests and the cmake checks.

This causes problems on FreeBSD when building on a system where argp is actually present. It is picked up by the build system, but the required arguments to actually link to it are missing, and the cmdline test fails to link, causing the build to fail.

This patch removes any remaining reference to argp.

I understand this leaves cmdline as an empty shell, but this is what is going to be compiled anyway if argp is not available on the system.

Otherwise the argument parsing should be reimplemented without argp or the proper argp arguments passed at link time.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
