### PR TITLE
Setup clang-format for cpp11 universal init

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,3 +61,5 @@ ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, forever, Q_FOREVER, QBENCH
 MaxEmptyLinesToKeep: 2
 KeepEmptyLinesAtTheStartOfBlocks: false
 
+SpaceBeforeCpp11BracedList: false
+Cpp11BracedListStyle: true

--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@
 BasedOnStyle: WebKit
 
 Standard: Cpp11
-ColumnLimit: 0
+ColumnLimit: 120
 
 # Disable reflow of qdoc comments: indentation rules are different.
 # Translation comments are also excluded


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
