### PR TITLE
Don't log encryption data in release mode

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1667,7 +1667,6 @@ bool EncryptionHelper::fileEncryption(const QByteArray &key, const QByteArray &i
             return false;
         }
 
-        qCDebug(lcCse) << "Encrypting " << data;
         if(!EVP_EncryptUpdate(ctx, unsignedData(out), &len, (unsigned char *)data.constData(), data.size())) {
             qCInfo(lcCse()) << "Could not encrypt";
             return false;


### PR DESCRIPTION
We deliver our builds to users with debug logging enabled to have an
easier time finding problems. However, logging all the encryption data
in this loop is too much and should not be done in release mode.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

Helps with

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
