### PR TITLE
Fix incorrect db name for nextcloud command line client.

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    QUrl hostUrl = QUrl::fromUserInput(options.target_url);
+    QUrl hostUrl = QUrl::fromUserInput(options.target_url.endsWith('/') ? options.target_url.chopped(1) : options.target_url);
 
     // Order of retrieval attempt (later attempts override earlier ones):
     // 1. From URL

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    QUrl hostUrl = QUrl::fromUserInput(options.target_url.endsWith('/') ? options.target_url.chopped(1) : options.target_url);
+    QUrl hostUrl = QUrl::fromUserInput((options.target_url.endsWith(QLatin1Char('/')) || options.target_url.endsWith(QLatin1Char('\\'))) ? options.target_url.chopped(1) : options.target_url);
 
     // Order of retrieval attempt (later attempts override earlier ones):
     // 1. From URL


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This should fix #3796