### PR TITLE
Write logs to local, not config dir

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -951,7 +951,7 @@ void ConfigFile::setAutomaticLogDir(bool enabled)
 
 QString ConfigFile::logDir() const
 {
-    const auto defaultLogDir = QString(configPath() + QStringLiteral("/logs"));
+    const auto defaultLogDir = QString(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + QStringLiteral("/logs"));
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(logDirC), defaultLogDir).toString();
 }


### PR DESCRIPTION
As discussed in #3406

Tested:

- Platforms:
  - [x] Linux
  - [ ] Windows
  - [ ] Mac OS
 - Features:
   - [x] Dir structure and files created and written to as normal
   - [x] Old logs are gzipped correctly
   - [x] Creating a debug archive still includes log files
