### PR TITLE
Display the right endpoint in the warning in case of error

### DIFF
--- a/src/gui/creds/flow2auth.cpp
+++ b/src/gui/creds/flow2auth.cpp
@@ -100,7 +100,7 @@ void Flow2Auth::fetchNewToken(const TokenAction action)
             pollToken = json.value("poll").toObject().value("token").toString();
             pollEndpoint = json.value("poll").toObject().value("endpoint").toString();
             if (_enforceHttps && QUrl(pollEndpoint).scheme() != QStringLiteral("https")) {
-                qCWarning(lcFlow2auth) << "Can not poll endpoint because the returned url" << _pollEndpoint << "does not start with https";
+                qCWarning(lcFlow2auth) << "Can not poll endpoint because the returned url" << pollEndpoint << "does not start with https";
                 emit result(Error, tr("The polling URL does not start with HTTPS despite the login URL started with HTTPS. Login will not be possible because this might be a security issue. Please contact your administrator."));
                 return;
             }


### PR DESCRIPTION
At that point in time _pollEndpoint isn't set yet. All the checks are
against pollEndpoint so display that one in the warning. Otherwise one
always end up with an empty URL in the logs which is not very useful for
debugging purposes.

Signed-off-by: Kevin Ottens <kevin.ottens@enioka.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
