### PR TITLE
Fix BUILD_TESTING on non Linux unices

### DIFF
--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -23,7 +23,7 @@ macro(nextcloud_add_test test_class)
         )
     endif()
 
-    if (UNIX)
+    if (LINUX)
         target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
             nextcloudsync_vfs_xattr
         )


### PR DESCRIPTION
vfs_xattr is build only if LINUX is defined, but when building tests it is depended upon when UNIX is defined.

This patch requires it only when LINUX is defined.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
