### PR TITLE
Add .sync-exclude.lst to exclude files

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -232,18 +232,16 @@ ExcludedFiles::ExcludedFiles(const QString &localPath)
     // We're in a detached exclude probably coming from a partial sync or test
     if (_localPath.isEmpty())
         return;
-
-    // Load exclude file from base dir
-    QFileInfo fi(_localPath + QStringLiteral(".sync-exclude.lst"));
-    if (fi.isReadable())
-        addInTreeExcludeFilePath(fi.absoluteFilePath());
 }
 
 ExcludedFiles::~ExcludedFiles() = default;
 
 void ExcludedFiles::addExcludeFilePath(const QString &path)
 {
-    _excludeFiles[_localPath].append(path);
+    auto &excludeFilesLocalPath = _excludeFiles[_localPath];
+    if (std::find(excludeFilesLocalPath.cbegin(), excludeFilesLocalPath.cend(), path) == excludeFilesLocalPath.cend()) {
+        excludeFilesLocalPath.append(path);
+    }
 }
 
 void ExcludedFiles::addInTreeExcludeFilePath(const QString &path)

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -544,6 +544,11 @@ void SyncEngine::startSync()
     _discoveryPhase.reset(new DiscoveryPhase);
     _discoveryPhase->_account = _account;
     _discoveryPhase->_excludes = _excludedFiles.data();
+    const QString excludeFilePath = _localPath + QStringLiteral(".sync-exclude.lst");
+    if (QFile::exists(excludeFilePath)) {
+        _discoveryPhase->_excludes->addExcludeFilePath(excludeFilePath);
+        _discoveryPhase->_excludes->reloadExcludeFiles();
+    }
     _discoveryPhase->_statedb = _journal;
     _discoveryPhase->_localDir = _localPath;
     if (!_discoveryPhase->_localDir.endsWith('/'))


### PR DESCRIPTION
Previously the .sync-exclude.lst file of the sync root directory was
not added to the exclude files, because the current logic did only
recognize .sync-exclude.lst files when their containing directory was
discovered during the discovery phase. Therefore the sync root
.sync-exclude.lst file was never discovered. See also
ExcludedFiles::traversalPatternMatch().

Fix: #3830, #2728

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
