### PR TITLE
provide logs of SSL errors including the certificate chain

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -456,6 +456,9 @@ void Account::slotHandleSslErrors(QNetworkReply *reply, QList<QSslError> errors)
                      << "\n";
     }
 
+    qCInfo(lcAccount()) << "ssl errors" << out;
+    qCInfo(lcAccount()) << reply->sslConfiguration().peerCertificateChain();
+
     bool allPreviouslyRejected = true;
     foreach (const QSslError &error, errors) {
         if (!_rejectedCertificates.contains(error.certificate())) {


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
