### PR TITLE
properly extract the file id when querying server

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -351,6 +351,7 @@ void DiscoverySingleDirectoryJob::start()
           << "getetag"
           << "http://owncloud.org/ns:size"
           << "http://owncloud.org/ns:id"
+          << "http://owncloud.org/ns:fileid"
           << "http://owncloud.org/ns:downloadURL"
           << "http://owncloud.org/ns:dDC"
           << "http://owncloud.org/ns:permissions"
@@ -453,6 +454,9 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(const QString &fi
                 _dataFingerprint = "[empty]";
             }
         }
+        if (map.contains(QStringLiteral("fileid"))) {
+            _localFileId = map.value(QStringLiteral("fileid")).toUtf8();
+        }
         if (map.contains("id")) {
             _fileId = map.value("id").toUtf8();
         }
@@ -529,7 +533,7 @@ void DiscoverySingleDirectoryJob::lsJobFinishedWithErrorSlot(QNetworkReply *r)
 
 void DiscoverySingleDirectoryJob::fetchE2eMetadata()
 {
-    auto job = new GetMetadataApiJob(_account, _fileId);
+    const auto job = new GetMetadataApiJob(_account, _localFileId);
     connect(job, &GetMetadataApiJob::jsonReceived,
             this, &DiscoverySingleDirectoryJob::metadataReceived);
     connect(job, &GetMetadataApiJob::error,

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -144,6 +144,7 @@ private:
     QString _subPath;
     QByteArray _firstEtag;
     QByteArray _fileId;
+    QByteArray _localFileId;
     AccountPtr _account;
     // The first result is for the directory itself and need to be ignored.
     // This flag is true if it was already ignored.


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
