### PR TITLE
CMake: use ccache and sccache for compiler caching

### DIFF
--- a/cmake/modules/CompilerCaching.cmake
+++ b/cmake/modules/CompilerCaching.cmake
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2021 Tenacity Audio Editor contributors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#[=======================================================================[.rst:
+CompilerCaching
+---------------
+
+Search for sccache and ccache and use them for compiler caching for C & C++.
+ccache is preferred if both are found, but the user can override this by
+explicitly setting CCACHE=OFF to use sccache when both are installed.
+#]=======================================================================]
+
+# ccache does not support MSVC
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  find_program(CCACHE_PROGRAM ccache)
+  mark_as_advanced(FORCE CCACHE_PROGRAM)
+  if("${CCACHE_PROGRAM}" STREQUAL "CCACHE_PROGRAM-NOTFOUND")
+    message(STATUS "Could NOT find ccache")
+  else()
+    message(STATUS "Found ccache: ${CCACHE_PROGRAM}")
+    option(CCACHE "Use ccache for compiler caching to speed up rebuilds." ON)
+  endif()
+endif()
+
+find_program(SCCACHE_PROGRAM sccache)
+mark_as_advanced(FORCE SCCACHE_PROGRAM)
+if("${SCCACHE_PROGRAM}" STREQUAL "SCCACHE_PROGRAM-NOTFOUND")
+  message(STATUS "Could NOT find sccache")
+else()
+  message(STATUS "Found sccache: ${SCCACHE_PROGRAM}")
+  option(SCCACHE "Use sccache for compiler caching to speed up rebuilds." ON)
+endif()
+
+if(CCACHE)
+  message(STATUS "Using ccache for compiler caching to speed up rebuilds")
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+elseif(SCCACHE)
+  message(STATUS "Using sccache for compiler caching to speed up rebuilds")
+  set(CMAKE_C_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${SCCACHE_PROGRAM}")
+
+  # Instruct MSVC to generate symbolic debug information within object files for sccache
+  if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    if(IS_MULTI_CONFIG)
+      foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+        string(TOUPPER "${CONFIG}" CONFIG)
+        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_${CONFIG} "${CMAKE_CXX_FLAGS_${CONFIG}}")
+        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_${CONFIG} "${CMAKE_C_FLAGS_${CONFIG}}")
+      endforeach()
+    else()
+      string(TOUPPER "${CMAKE_BUILD_TYPE}" CONFIG)
+      string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_${CONFIG} "${CMAKE_CXX_FLAGS_${CONFIG}}")
+      string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_${CONFIG} "${CMAKE_C_FLAGS_${CONFIG}}")
+    endif()
+  endif()
+else()
+  if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    message(STATUS "No compiler caching enabled. Install sccache to speed up rebuilds.")
+  else()
+    message(STATUS "No compiler caching enabled. Install ccache or sccache to speed up rebuilds.")
+  endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(ECMEnableSanitizers)
+include(CompilerCaching)
 
 set(REQUIRED_QT_VERSION "6.5.0")
 


### PR DESCRIPTION
First build on Fedora 35 with an Intel Core i7 8550U: 4.5 minutes

Repeat build with ccache after deleting CMake build directory
and creating a new one: 1.5 minutes

This code is adapted from Tenacity, written by myself and
@emabrey, licensed GPLv2 or later.

ccache is easily available from Linux distribution packages and
Homebrew on macOS. sccache is the only currently maintained
compiler cache for MSVC and can be installed easily from
Chocolatey on Windows.

Signed-off-by: Be <be@mixxx.org>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
