### PR TITLE
Don't do a connection checks when using push notifications

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -34,6 +34,7 @@
 #include "sharedialog.h"
 #include "accountmanager.h"
 #include "creds/abstractcredentials.h"
+#include "pushnotifications.h"
 
 #if defined(BUILD_UPDATER)
 #include "updater/ocupdater.h"
@@ -459,9 +460,10 @@ void Application::slotCheckConnection()
 
         // Don't check if we're manually signed out or
         // when the error is permanent.
-        if (state != AccountState::SignedOut
-            && state != AccountState::ConfigurationError
-            && state != AccountState::AskingCredentials) {
+        const auto pushNotifications = accountState->account()->pushNotifications();
+        const auto pushNotificationsAvailable = (pushNotifications && pushNotifications->isReady());
+        if (state != AccountState::SignedOut && state != AccountState::ConfigurationError
+            && state != AccountState::AskingCredentials && !pushNotificationsAvailable) {
             accountState->checkConnectivity();
         }
     }


### PR DESCRIPTION
When using push notifications, it is not necessary to do regular
connection checks because the push notifications will take care of it.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

I will remove the log statements once the logic is ready.