### PR TITLE
CMake: fail if `Qt5::GuiPrivate` is not found

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(gui)
-find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2)
+find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2 Xml Network)
+if (NOT TARGET Qt5::GuiPrivate)
+    message(FATAL_ERROR "Could not find GuiPrivate component of Qt5. It might be shipped as a separate package, please check that.")
+endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DQT_QML_DEBUG)


### PR DESCRIPTION
I attempted to build this project on Debian, `cmake` succeeded, but then compilation failed because of missing `private/qzipwriter_p.h` header. Only then did I notice that CMake actually printed out a warning that `Qt5::GuiPrivate` target was not found. From there, it took me a minute to find out that I had to install qt5base-private-dev package.

This PR makes all of this easier by turning that warning into an error. I don't know how other distributions ship GuiPrivate, so I decided not to mention a specific Debian package in the error package.

I also updated `find_package` to mention all the components that `nextcloud` and `nextcloudCore` link against.