### PR TITLE
Let the macOS installer know that the application can run on Arm64

### DIFF
--- a/admin/osx/macosx.pkgproj.cmake
+++ b/admin/osx/macosx.pkgproj.cmake
@@ -695,7 +695,12 @@
 		<key>PROJECT_SETTINGS</key>
 		<dict>
 			<key>ADVANCED_OPTIONS</key>
-			<dict/>
+            <dict>
+                    <key>installer-script.options:hostArchitectures</key>
+                    <array>
+                            <string>x86_64,arm64</string>
+                    </array>
+			</dict>
 			<key>BUILD_FORMAT</key>
 			<integer>0</integer>
 			<key>BUILD_PATH</key>


### PR DESCRIPTION
Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

Ref: https://github.com/nextcloud/desktop/issues/2659

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
