### PR TITLE
Correct virtual files placeholder files if needed

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -996,69 +996,42 @@ void SyncJournalDb::keyValueStoreSet(const QString &key, QVariant value)
 
 qint64 SyncJournalDb::keyValueStoreGetInt(const QString &key, qint64 defaultValue)
 {
+    const auto sqlQuery = keyValueStoreExecuteSelectQuery(key);
+    if (sqlQuery.isValid()) {
+        return sqlQuery.get()->int64Value(0);
+    }
+    return defaultValue;
+}
+
+bool SyncJournalDb::keyValueStoreGetBool(const QString &key, const bool defaultValue)
+{
+    const auto sqlQuery = keyValueStoreExecuteSelectQuery(key);
+    if (sqlQuery.isValid()) {
+        return sqlQuery.get()->intValue(0);
+    }
+    return defaultValue;
+}
+
+OCC::Optional<PreparedSqlQuery> SyncJournalDb::keyValueStoreExecuteSelectQuery(const QString &key)
+{
     QMutexLocker locker(&_mutex);
     if (!checkConnect()) {
-        return defaultValue;
+        return {};
     }
 
     const auto query = _queryManager.get(PreparedSqlQueryManager::GetKeyValueStoreQuery, QByteArrayLiteral("SELECT value FROM key_value_store WHERE key = ?1;"), _db);
     if (!query) {
-        return defaultValue;
+        return {};
     }
 
     query->bindValue(1, key);
     query->exec();
 
     if (!query->next().hasData) {
-        return defaultValue;
+        return {};
     }
 
-    return query->int64Value(0);
-}
-
-bool SyncJournalDb::keyValueStoreGetBool(const QString &key, bool defaultValue)
-{
-    QMutexLocker locker(&_mutex);
-    if (!checkConnect()) {
-        return defaultValue;
-    }
-
-    const auto query = _queryManager.get(PreparedSqlQueryManager::GetKeyValueStoreQuery,
-        QByteArrayLiteral("SELECT value FROM key_value_store WHERE key = ?1;"), _db);
-    if (!query) {
-        return defaultValue;
-    }
-
-    query->bindValue(1, key);
-    query->exec();
-
-    if (!query->next().hasData) {
-        return defaultValue;
-    }
-
-    return query->intValue(0);
-}
-
-QVariant SyncJournalDb::keyValueStoreGet(const QString &key, QVariant defaultValue)
-{
-    QMutexLocker locker(&_mutex);
-    if (!checkConnect()) {
-        return defaultValue;
-    }
-
-    const auto query = _queryManager.get(PreparedSqlQueryManager::GetKeyValueStoreQuery, QByteArrayLiteral("SELECT value FROM key_value_store WHERE key = ?1;"), _db);
-    if (!query) {
-        return defaultValue;
-    }
-
-    query->bindValue(1, key);
-    query->exec();
-
-    if (!query->next().hasData) {
-        return defaultValue;
-    }
-
-    return query->stringValue(0);
+    return query;
 }
 
 void SyncJournalDb::keyValueStoreDelete(const QString &key)

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1016,6 +1016,29 @@ qint64 SyncJournalDb::keyValueStoreGetInt(const QString &key, qint64 defaultValu
     return query->int64Value(0);
 }
 
+bool SyncJournalDb::keyValueStoreGetBool(const QString &key, bool defaultValue)
+{
+    QMutexLocker locker(&_mutex);
+    if (!checkConnect()) {
+        return defaultValue;
+    }
+
+    const auto query = _queryManager.get(PreparedSqlQueryManager::GetKeyValueStoreQuery,
+        QByteArrayLiteral("SELECT value FROM key_value_store WHERE key = ?1;"), _db);
+    if (!query) {
+        return defaultValue;
+    }
+
+    query->bindValue(1, key);
+    query->exec();
+
+    if (!query->next().hasData) {
+        return defaultValue;
+    }
+
+    return query->intValue(0);
+}
+
 QVariant SyncJournalDb::keyValueStoreGet(const QString &key, QVariant defaultValue)
 {
     QMutexLocker locker(&_mutex);

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -70,6 +70,7 @@ public:
 
     void keyValueStoreSet(const QString &key, QVariant value);
     qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
+    bool keyValueStoreGetBool(const QString &key, bool defaultValue);
     QVariant keyValueStoreGet(const QString &key, QVariant defaultValue = {});
     void keyValueStoreDelete(const QString &key);
 

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -70,8 +70,7 @@ public:
 
     void keyValueStoreSet(const QString &key, QVariant value);
     qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
-    bool keyValueStoreGetBool(const QString &key, bool defaultValue);
-    QVariant keyValueStoreGet(const QString &key, QVariant defaultValue = {});
+    bool keyValueStoreGetBool(const QString &key, const bool defaultValue);
     void keyValueStoreDelete(const QString &key);
 
     bool deleteFileRecord(const QString &filename, bool recursively = false);
@@ -373,6 +372,7 @@ public:
     int autotestFailCounter = -1;
 
 private:
+    OCC::Optional<PreparedSqlQuery> keyValueStoreExecuteSelectQuery(const QString &key);
     int getFileRecordCount();
     bool updateDatabaseStructure();
     bool updateMetadataTableStructure();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -866,9 +866,25 @@ void Folder::startSync(const QStringList &pathList)
 
     _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
 
+    correctPlaceholderFiles();
+
     QMetaObject::invokeMethod(_engine.data(), "startSync", Qt::QueuedConnection);
 
     emit syncStarted();
+}
+
+void Folder::correctPlaceholderFiles()
+{
+    if (_definition.virtualFilesMode == Vfs::Off) {
+        return;
+    }
+    static const auto placeholdersCorrectedKey = QStringLiteral("placeholders_corrected");
+    const auto placeholdersCorrected = _journal.keyValueStoreGetBool(placeholdersCorrectedKey, false);
+    if (!placeholdersCorrected) {
+        qCDebug(lcFolder) << "Make sure all virtual files are placeholder files";
+        switchToVirtualFiles();
+        _journal.keyValueStoreSet(placeholdersCorrectedKey, true);
+    }
 }
 
 void Folder::setSyncOptions()

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -444,6 +444,8 @@ private:
 
     void startVfs();
 
+    void correctPlaceholderFiles();
+
     AccountStatePtr _accountState;
     FolderDefinition _definition;
     QString _canonicalLocalPath; // As returned with QFileInfo:canonicalFilePath.  Always ends with "/"


### PR DESCRIPTION
In the past not all files were converted to placeholder files when
converting an existing sync folder to a virtual files folder. Because
some files were not converted to placeholder files, the status would
be wrong on the files. This code makes sure that every file in a
virtual files folder is a placeholder file. It could be removed in the
future.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
