### PR TITLE
avoid adding icon data in a cache we never use

### DIFF
--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -17,7 +17,6 @@ const QString notificationsPath = QLatin1String("ocs/v2.php/apps/notifications/a
 const char propertyAccountStateC[] = "oc_account_state";
 const int successStatusCode = 200;
 const int notModifiedStatusCode = 304;
-QMap<int, QByteArray> ServerNotificationHandler::iconCache;
 
 ServerNotificationHandler::ServerNotificationHandler(AccountState *accountState, QObject *parent)
     : QObject(parent)
@@ -72,11 +71,6 @@ void ServerNotificationHandler::slotAllowDesktopNotificationsChanged(bool isAllo
     }
 }
 
-void ServerNotificationHandler::slotIconDownloaded(QByteArray iconData)
-{
-    iconCache.insert(sender()->property("activityId").toInt(),iconData);
-}
-
 void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &json, int statusCode)
 {
     if (statusCode != successStatusCode && statusCode != notModifiedStatusCode) {
@@ -111,12 +105,6 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         a._subject = json.value("subject").toString();
         a._message = json.value("message").toString();
         a._icon = json.value("icon").toString();
-
-        if (!a._icon.isEmpty()) {
-            auto *iconJob = new IconJob(_accountState->account(), QUrl(a._icon));
-            iconJob->setProperty("activityId", a._id);
-            connect(iconJob, &IconJob::jobFinished, this, &ServerNotificationHandler::slotIconDownloaded);
-        }
 
         QUrl link(json.value("link").toString());
         if (!link.isEmpty()) {

--- a/src/gui/tray/notificationhandler.h
+++ b/src/gui/tray/notificationhandler.h
@@ -14,7 +14,6 @@ class ServerNotificationHandler : public QObject
     Q_OBJECT
 public:
     explicit ServerNotificationHandler(AccountState *accountState, QObject *parent = nullptr);
-    static QMap<int, QByteArray> iconCache;
 
 signals:
     void newNotificationList(ActivityList);
@@ -25,7 +24,6 @@ public slots:
 private slots:
     void slotNotificationsReceived(const QJsonDocument &json, int statusCode);
     void slotEtagResponseHeaderReceived(const QByteArray &value, int statusCode);
-    void slotIconDownloaded(QByteArray iconData);
     void slotAllowDesktopNotificationsChanged(bool isAllowed);
 
 private:


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
