### PR TITLE
add a network access factory to qml engine

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -22,6 +22,7 @@
 #include "wheelhandler.h"
 #include "tray/unifiedsearchresultimageprovider.h"
 #include "configfile.h"
+#include "accessmanager.h"
 
 #include <QCursor>
 #include <QGuiApplication>
@@ -58,6 +59,8 @@ Systray *Systray::instance()
 void Systray::setTrayEngine(QQmlApplicationEngine *trayEngine)
 {
     _trayEngine = trayEngine;
+
+    _trayEngine->setNetworkAccessManagerFactory(&_accessManagerFactory);
 
     _trayEngine->addImportPath("qrc:/qml/theme");
     _trayEngine->addImageProvider("avatars", new ImageProvider);
@@ -503,6 +506,16 @@ QPoint Systray::calcTrayIconCenter() const
     // On Linux, fall back to mouse position (assuming tray icon is activated by mouse click)
     return QCursor::pos(currentScreen());
 #endif
+}
+
+AccessManagerFactory::AccessManagerFactory()
+    : QQmlNetworkAccessManagerFactory()
+{
+}
+
+QNetworkAccessManager* AccessManagerFactory::create(QObject *parent)
+{
+    return new AccessManager(parent);
 }
 
 } // namespace OCC

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -20,6 +20,8 @@
 #include "accountmanager.h"
 #include "tray/usermodel.h"
 
+#include <QQmlNetworkAccessManagerFactory>
+
 class QScreen;
 class QQmlApplicationEngine;
 class QQuickWindow;
@@ -27,6 +29,14 @@ class QWindow;
 class QQuickWindow;
 
 namespace OCC {
+
+class AccessManagerFactory : public QQmlNetworkAccessManagerFactory
+{
+public:
+    AccessManagerFactory();
+
+    QNetworkAccessManager* create(QObject *parent) override;
+};
 
 #ifdef Q_OS_OSX
 bool canOsXSendUserNotification();
@@ -105,6 +115,8 @@ private:
     bool _isOpen = false;
     bool _syncIsPaused = true;
     QPointer<QQmlApplicationEngine> _trayEngine;
+
+    AccessManagerFactory _accessManagerFactory;
 };
 
 } // namespace OCC


### PR DESCRIPTION
ensure network access made via qml are using our user agent

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
