### PR TITLE
Only build app bundle if requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,24 +98,13 @@ message(STATUS "GIT_SHA1 ${GIT_SHA1}")
 set(SYSCONFDIR ${SYSCONF_INSTALL_DIR})
 set(SHAREDIR ${CMAKE_INSTALL_DATADIR})
 
-#####
-## handle BUILD_OWNCLOUD_OSX_BUNDLE
-# BUILD_OWNCLOUD_OSX_BUNDLE was not initialized OR set to true on OSX
-if(APPLE AND (NOT DEFINED BUILD_OWNCLOUD_OSX_BUNDLE OR BUILD_OWNCLOUD_OSX_BUNDLE))
-    set(BUILD_OWNCLOUD_OSX_BUNDLE ON)
+# Build MacOS app bundle if wished
+if(APPLE AND BUILD_OWNCLOUD_OSX_BUNDLE)
+    message(STATUS "Build MacOS app bundle")
     set(OWNCLOUD_OSX_BUNDLE "${APPLICATION_NAME}.app")
     set(LIB_INSTALL_DIR "${APPLICATION_NAME}.app/Contents/MacOS")
     set(BIN_INSTALL_DIR "${APPLICATION_NAME}.app/Contents/MacOS")
-
-# BUILD_OWNCLOUD_OSX_BUNDLE was disabled on OSX
-elseif(APPLE AND NOT BUILD_OWNCLOUD_OSX_BUNDLE)
-    message(FATAL_ERROR "Building in non-bundle mode on OSX is currently not supported. Comment this error out if you want to work on/test it.")
-
-# any other platform
-else()
-    set(BUILD_OWNCLOUD_OSX_BUNDLE OFF)
 endif()
-#####
 
 # this option removes Http authentication, keychain, shibboleth etc and is intended for
 # external authentication mechanisms

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -185,6 +185,8 @@ Then, in Terminal:
    .. code-block:: bash
 
       % echo 'export CMAKE_INSTALL_PREFIX=~/Builds' >> ~/.nextcloud_build_variables
+      # If you want to build a macOS app bundle for distribution
+      % echo 'export BUILD_OWNCLOUD_OSX_BUNDLE=ON' >> ~/.nextcloud_build_variables
       
    Replace ``~/Builds`` with a different directory if you'd like the build to end up elsewhere.
    

--- a/shell_integration/MacOSX/CMakeLists.txt
+++ b/shell_integration/MacOSX/CMakeLists.txt
@@ -1,24 +1,26 @@
 if(APPLE)
-set(OC_OEM_SHARE_ICNS "${CMAKE_BINARY_DIR}/src/gui/${APPLICATION_ICON_NAME}.icns")
+  set(OC_OEM_SHARE_ICNS "${CMAKE_BINARY_DIR}/src/gui/${APPLICATION_ICON_NAME}.icns")
 
-# The bundle identifier and application group need to have compatible values with the client
-# to be able to open a Mach port across the extension's sandbox boundary.
-# Pass the info through the xcodebuild command line and make sure that the project uses
-# those user-defined settings to build the plist.
-add_custom_target( mac_overlayplugin ALL
-  xcodebuild ARCHS=${CMAKE_OSX_ARCHITECTURES} ONLY_ACTIVE_ARCH=NO
-        -project ${CMAKE_SOURCE_DIR}/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj
-        -target FinderSyncExt -configuration Release "SYMROOT=${CMAKE_CURRENT_BINARY_DIR}"
-        "OC_OEM_SHARE_ICNS=${OC_OEM_SHARE_ICNS}"
-        "OC_APPLICATION_NAME=${APPLICATION_NAME}"
-        "OC_APPLICATION_REV_DOMAIN=${APPLICATION_REV_DOMAIN}"
-        "OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX=${SOCKETAPI_TEAM_IDENTIFIER_PREFIX}"
+  # The bundle identifier and application group need to have compatible values with the client
+  # to be able to open a Mach port across the extension's sandbox boundary.
+  # Pass the info through the xcodebuild command line and make sure that the project uses
+  # those user-defined settings to build the plist.
+  add_custom_target( mac_overlayplugin ALL
+    xcodebuild ARCHS=${CMAKE_OSX_ARCHITECTURES} ONLY_ACTIVE_ARCH=NO
+    -project ${CMAKE_SOURCE_DIR}/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj
+    -target FinderSyncExt -configuration Release "SYMROOT=${CMAKE_CURRENT_BINARY_DIR}"
+    "OC_OEM_SHARE_ICNS=${OC_OEM_SHARE_ICNS}"
+    "OC_APPLICATION_NAME=${APPLICATION_NAME}"
+    "OC_APPLICATION_REV_DOMAIN=${APPLICATION_REV_DOMAIN}"
+    "OC_SOCKETAPI_TEAM_IDENTIFIER_PREFIX=${SOCKETAPI_TEAM_IDENTIFIER_PREFIX}"
     COMMENT building Mac Overlay icons
     VERBATIM)
-add_dependencies(mac_overlayplugin nextcloud) # for the ownCloud.icns to be generated
+  add_dependencies(mac_overlayplugin nextcloud) # for the ownCloud.icns to be generated
 
-INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Release/FinderSyncExt.appex
-    DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
-    USE_SOURCE_PERMISSIONS)
-endif(APPLE)
+  if (BUILD_OWNCLOUD_OSX_BUNDLE)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Release/FinderSyncExt.appex
+      DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
+      USE_SOURCE_PERMISSIONS)
+  endif()
+endif()
 


### PR DESCRIPTION
For development a app bundle is not needed. The app bundle is only
needed for distribution and macdeployqt takes a lot of time.

Signed-off-by: Felix Weilbach <felix.weilbach@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
