### PR TITLE
properly query sync journal DB to know when to run fix for VFS

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -70,7 +70,6 @@ public:
 
     void keyValueStoreSet(const QString &key, QVariant value);
     qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
-    bool keyValueStoreGetBool(const QString &key, const bool defaultValue);
     void keyValueStoreDelete(const QString &key);
 
     bool deleteFileRecord(const QString &filename, bool recursively = false);
@@ -372,7 +371,6 @@ public:
     int autotestFailCounter = -1;
 
 private:
-    OCC::Optional<PreparedSqlQuery> keyValueStoreExecuteSelectQuery(const QString &key);
     int getFileRecordCount();
     bool updateDatabaseStructure();
     bool updateMetadataTableStructure();

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -879,7 +879,7 @@ void Folder::correctPlaceholderFiles()
         return;
     }
     static const auto placeholdersCorrectedKey = QStringLiteral("placeholders_corrected");
-    const auto placeholdersCorrected = _journal.keyValueStoreGetBool(placeholdersCorrectedKey, false);
+    const auto placeholdersCorrected = _journal.keyValueStoreGetInt(placeholdersCorrectedKey, 0);
     if (!placeholdersCorrected) {
         qCDebug(lcFolder) << "Make sure all virtual files are placeholder files";
         switchToVirtualFiles();


### PR DESCRIPTION
the new method added to query the db is not working and so the fix for
vfs is executed at each sync run

the new method for bool was not really needed so let's just remove it
(and that will make the usage of SqlQuery be correct

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
