### PR TITLE
if BulkPropagatorJob abort after an error emit finished signal

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -194,8 +194,10 @@ void BulkPropagatorJob::triggerUpload()
             if (FileSystem::isFileLocked(singleFile._localPath)) {
                 emit propagator()->seenLockedFile(singleFile._localPath);
             }
-            // Soft error because this is likely caused by the user modifying his files while syncing
-            abortWithError(singleFile._item, SyncFileItem::SoftError, device->errorString());
+
+            abortWithError(singleFile._item, SyncFileItem::NormalError, device->errorString());
+            emit finished(SyncFileItem::NormalError);
+
             return;
         }
         singleFile._headers["X-File-Path"] = singleFile._remotePath.toUtf8();


### PR DESCRIPTION
prevent sync engine being stuck because of an error when preparing bulk
upload

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
