### PR TITLE
l10n: Change "modified time" to "modification time"

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -302,7 +302,7 @@ void BulkPropagatorJob::slotStartUpload(SyncFileItemPtr item,
     item->_modtime = FileSystem::getModTime(originalFilePath);
     if (item->_modtime <= 0) {
         _pendingChecksumFiles.remove(item->_file);
-        slotOnErrorStartFolderUnlock(item, SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(item->_file)));
+        slotOnErrorStartFolderUnlock(item, SyncFileItem::NormalError, tr("File %1 has invalid modification time. Do not upload to the server.").arg(QDir::toNativeSeparators(item->_file)));
         checkPropagationIsDone();
         return;
     }

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1133,7 +1133,7 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
 
             if (_item->_modtime <= 0) {
                 status = _item->_status = SyncFileItem::NormalError;
-                _item->_errorString = tr("Error updating metadata due to invalid modified time");
+                _item->_errorString = tr("Error updating metadata due to invalid modification time");
                 qCWarning(lcDirectory) << "Error writing to the database for file" << _item->_file;
             }
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -319,7 +319,7 @@ void PropagateUploadFileCommon::slotComputeContentChecksum()
     // probably temporary one.
     _item->_modtime = FileSystem::getModTime(filePath);
     if (_item->_modtime <= 0) {
-        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
+        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modification time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
         return;
     }
 
@@ -394,7 +394,7 @@ void PropagateUploadFileCommon::slotStartUpload(const QByteArray &transmissionCh
         return slotOnErrorStartFolderUnlock(SyncFileItem::SoftError, tr("File Removed (start upload) %1").arg(fullFilePath));
     }
     if (_item->_modtime <= 0) {
-        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
+        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modification time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
         return;
     }
     Q_ASSERT(_item->_modtime > 0);
@@ -407,7 +407,7 @@ void PropagateUploadFileCommon::slotStartUpload(const QByteArray &transmissionCh
 
     _item->_modtime = FileSystem::getModTime(originalFilePath);
     if (_item->_modtime <= 0) {
-        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
+        slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modification time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
         return;
     }
     Q_ASSERT(_item->_modtime > 0);

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -650,7 +650,7 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::se
 OCC::Result<void, QString> OCC::CfApiWrapper::createPlaceholderInfo(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId)
 {
     if (modtime <= 0) {
-        return {QString{"Could not update metadata due to invalid modified time for %1: %2"}.arg(path).arg(modtime)};
+        return {QString{"Could not update metadata due to invalid modification time for %1: %2"}.arg(path).arg(modtime)};
     }
 
     const auto fileInfo = QFileInfo(path);
@@ -702,7 +702,7 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::up
     Q_ASSERT(handle);
 
     if (modtime <= 0) {
-        return {QString{"Could not update metadata due to invalid modified time for %1: %2"}.arg(pathForHandle(handle)).arg(modtime)};
+        return {QString{"Could not update metadata due to invalid modification time for %1: %2"}.arg(pathForHandle(handle)).arg(modtime)};
     }
 
     const auto info = replacesPath.isEmpty() ? findPlaceholderInfo(handle)

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -69,7 +69,7 @@ bool VfsSuffix::isHydrating() const
 Result<void, QString> VfsSuffix::updateMetadata(const QString &filePath, time_t modtime, qint64, const QByteArray &)
 {
     if (modtime <= 0) {
-        return {tr("Error updating metadata due to invalid modified time")};
+        return {tr("Error updating metadata due to invalid modification time")};
     }
 
     FileSystem::setModTime(filePath, modtime);
@@ -79,7 +79,7 @@ Result<void, QString> VfsSuffix::updateMetadata(const QString &filePath, time_t 
 Result<void, QString> VfsSuffix::createPlaceholder(const SyncFileItem &item)
 {
     if (item._modtime <= 0) {
-        return {tr("Error updating metadata due to invalid modified time")};
+        return {tr("Error updating metadata due to invalid modification time")};
     }
 
     // The concrete shape of the placeholder is also used in isDehydratedPlaceholder() below

--- a/src/libsync/vfs/xattr/vfs_xattr.cpp
+++ b/src/libsync/vfs/xattr/vfs_xattr.cpp
@@ -70,7 +70,7 @@ bool VfsXAttr::isHydrating() const
 Result<void, QString> VfsXAttr::updateMetadata(const QString &filePath, time_t modtime, qint64, const QByteArray &)
 {
     if (modtime <= 0) {
-        return {tr("Error updating metadata due to invalid modified time")};
+        return {tr("Error updating metadata due to invalid modification time")};
     }
 
     FileSystem::setModTime(filePath, modtime);
@@ -80,7 +80,7 @@ Result<void, QString> VfsXAttr::updateMetadata(const QString &filePath, time_t m
 Result<void, QString> VfsXAttr::createPlaceholder(const SyncFileItem &item)
 {
     if (item._modtime <= 0) {
-        return {tr("Error updating metadata due to invalid modified time")};
+        return {tr("Error updating metadata due to invalid modification time")};
     }
 
     const auto path = QString(_setupParams.filesystemPath + item._file);


### PR DESCRIPTION
The strings at Transifex are not using correct grammar.

I know from technical side "modified time" as stand alone is ok.

Read few articles like https://www.howtogeek.com/517098/linux-file-timestamps-explained-atime-mtime-and-ctime/ and https://www.geeksforgeeks.org/file-timestamps-mtime-ctime-and-atime-in-linux . After reviewing strings and talked to others at Transifex I propose changes of this PR.

