### PR TITLE
Hide share button for deleted files and ignored files in tray activity 

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -152,7 +152,7 @@ MouseArea {
                 Layout.alignment: Qt.AlignRight
                 flat: true
                 hoverEnabled: true
-                visible: displayActions && (path !== "")
+                visible: isShareable
                 display: AbstractButton.IconOnly
                 icon.source: "qrc:///client/theme/share.svg"
                 icon.color: "transparent"

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -68,6 +68,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[ObjectTypeRole] = "objectType";
     roles[PointInTimeRole] = "dateTime";
     roles[DisplayActions] = "displayActions";
+    roles[ShareableRole] = "isShareable";
     return roles;
 }
 
@@ -262,6 +263,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return (ast && ast->isConnected());
     case DisplayActions:
         return _displayActions;
+    case ShareableRole:
+        return !data(index, PathRole).toString().isEmpty() && _displayActions && a._fileAction != "file_deleted" && a._status != SyncFileItem::FileIgnored;
     default:
         return QVariant();
     }

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -60,6 +60,7 @@ public:
         AccountConnectedRole,
         SyncFileStatusRole,
         DisplayActions,
+        ShareableRole,
     };
     Q_ENUM(DataRole)
 


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

This fixes one of the issues brought up by #3660
