### PR TITLE
ensure any errors after calling FileSystem::getModTime are handled

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -164,6 +164,12 @@ void BulkPropagatorJob::doStartUpload(SyncFileItemPtr item,
         fileToUpload._file = item->_file = item->_renameTarget;
         fileToUpload._path = propagator()->fullLocalPath(fileToUpload._file);
         item->_modtime = FileSystem::getModTime(newFilePathAbsolute);
+        if (item->_modtime <= 0) {
+            _pendingChecksumFiles.remove(item->_file);
+            slotOnErrorStartFolderUnlock(item, SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(item->_file)));
+            checkPropagationIsDone();
+            return;
+        }
     }
 
     const auto remotePath = propagator()->fullRemotePath(fileToUpload._file);

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -772,6 +772,10 @@ bool OwncloudPropagator::createConflict(const SyncFileItemPtr &item,
 
     QString renameError;
     auto conflictModTime = FileSystem::getModTime(fn);
+    if (conflictModTime <= 0) {
+        *error = tr("Impossible to get modification time for file in conflict %1)").arg(fn);
+        return false;
+    }
     QString conflictUserName;
     if (account()->capabilities().uploadConflictFiles())
         conflictUserName = account()->davDisplayName();

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -599,6 +599,7 @@ void PropagateDownloadFile::conflictChecksumComputed(const QByteArray &checksumT
         Q_ASSERT(_item->_modtime > 0);
         if (_item->_modtime <= 0) {
             qCWarning(lcPropagateDownload()) << "invalid modified time" << _item->_file << _item->_modtime;
+            return;
         }
         if (_item->_modtime != _item->_previousModtime) {
             Q_ASSERT(_item->_modtime > 0);
@@ -609,6 +610,7 @@ void PropagateDownloadFile::conflictChecksumComputed(const QByteArray &checksumT
         Q_ASSERT(_item->_modtime > 0);
         if (_item->_modtime <= 0) {
             qCWarning(lcPropagateDownload()) << "invalid modified time" << _item->_file << _item->_modtime;
+            return;
         }
         updateMetadata(/*isConflict=*/false);
         return;

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -213,6 +213,8 @@ void PropagateUploadFileCommon::start()
         Q_ASSERT(_item->_modtime > 0);
         if (_item->_modtime <= 0) {
             qCWarning(lcPropagateUpload()) << "invalid modified time" << _item->_file << _item->_modtime;
+            slotOnErrorStartFolderUnlock(SyncFileItem::NormalError, tr("File %1 has invalid modified time. Do not upload to the server.").arg(QDir::toNativeSeparators(_item->_file)));
+            return;
         }
     }
 


### PR DESCRIPTION
be sure that even in release mode no errors when calling getModTime
could be ignored

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
