### PR TITLE
Show only filenames in tray activity items, with full path in tooltip

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -20,6 +20,10 @@ MouseArea {
         anchors.fill: parent
         color: (parent.containsMouse ? Style.lightHover : "transparent")
     }
+
+    ToolTip.visible: containsMouse && displayLocation !== ""
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("In %1").arg(displayLocation)
         
     RowLayout {
         id: activityItem

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -61,11 +61,22 @@ public:
         SyncFileItemType
     };
 
+    struct RichSubjectParameter {
+        QString type;    // Required
+        QString id;      // Required
+        QString name;    // Required
+        QString path;    // Required (for files only)
+        QUrl link;    // Optional (files only)
+    };
+
     Type _type;
     qlonglong _id;
     QString _fileAction;
     QString _objectType;
     QString _subject;
+    QString _subjectRich;
+    QHash<QString, RichSubjectParameter> _subjectRichParameters;
+    QString _subjectDisplay;
     QString _message;
     QString _folder;
     QString _file;

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -55,6 +55,7 @@ public:
         DisplayPathRole,
         PathRole,
         AbsolutePathRole,
+        DisplayLocationRole, // Provides the display path to a file's parent folder, relative to Nextcloud root
         LinkRole,
         PointInTimeRole,
         AccountConnectedRole,

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -506,6 +506,8 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
     activity._folder = folder->alias();
     activity._fileAction = "";
 
+    const auto fileName = QFileInfo(item->_originalFile).fileName();
+
     if (item->_instruction == CSYNC_INSTRUCTION_REMOVE) {
         activity._fileAction = "file_deleted";
     } else if (item->_instruction == CSYNC_INSTRUCTION_NEW) {
@@ -520,15 +522,15 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
         qCWarning(lcActivity) << "Item " << item->_file << " retrieved successfully.";
 
         if (item->_direction != SyncFileItem::Up) {
-            activity._message = tr("Synced %1").arg(item->_originalFile);
+            activity._message = tr("Synced %1").arg(fileName);
         } else if (activity._fileAction == "file_renamed") {
-            activity._message = tr("You renamed %1").arg(item->_originalFile);
+            activity._message = tr("You renamed %1").arg(fileName);
         } else if (activity._fileAction == "file_deleted") {
-            activity._message = tr("You deleted %1").arg(item->_originalFile);
+            activity._message = tr("You deleted %1").arg(fileName);
         } else if (activity._fileAction == "file_created") {
-            activity._message = tr("You created %1").arg(item->_originalFile);
+            activity._message = tr("You created %1").arg(fileName);
         } else {
-            activity._message = tr("You changed %1").arg(item->_originalFile);
+            activity._message = tr("You changed %1").arg(fileName);
         }
 
         _activityModel->addSyncFileItemToActivityList(activity);


### PR DESCRIPTION
Showing the full filepath for files in the tray's activity view often makes it pretty difficult to tell exactly what files has been changed/added/deleted. This has been mentioned in #3660 .

This PR modifies the tray's activity items to behave like Nextcloud's activity items in the web UI. Only the filenames are shown in the item text, and on hover a tooltip displays the full path to the files in question.

To do this, the Activity class now stores data relating to subject rich text, including the parameters used by these rich text strings. Using these rich text strings not only allows us to change how files are displayed in the activity item subject text, but we should also be able to more easily format them if we choose to do so in the future

![image](https://user-images.githubusercontent.com/70155116/146805360-a149d01d-1065-4394-a9c9-ad1f1a803b4a.png)
