### PR TITLE
Add option of enabling QtQuick compiler

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror ../src
+    - cmake -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror ../src
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-4
   volumes:
@@ -53,7 +53,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Debug -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror ../src
+    - cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror ../src
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-4
   volumes:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 set(CMAKE_CXX_STANDARD 14)
+cmake_policy(SET CMP0071 NEW) # Enable use of QtQuick compiler/generated code
 
 project(client)
 
@@ -82,6 +83,10 @@ add_definitions(
     -DQT_MESSAGELOGCONTEXT #enable function name and line number in debug output
 )
 
+if(QUICK_COMPILER)
+    add_definitions(-DQUICK_COMPILER) # Enable use of QtQuick compiler
+endif()
+
 # if we cannot get it from git, directly try .tag (packages)
 # this will work if the tar balls have been properly created
 # via git-archive.
@@ -105,6 +110,9 @@ if(APPLE AND BUILD_OWNCLOUD_OSX_BUNDLE)
     set(LIB_INSTALL_DIR "${APPLICATION_NAME}.app/Contents/MacOS")
     set(BIN_INSTALL_DIR "${APPLICATION_NAME}.app/Contents/MacOS")
 endif()
+
+
+option(QUICK_COMPILER "Use QtQuick compiler to improve performance" OFF)
 
 # this option removes Http authentication, keychain, shibboleth etc and is intended for
 # external authentication mechanisms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(APPLE AND BUILD_OWNCLOUD_OSX_BUNDLE)
 endif()
 
 
-option(QUICK_COMPILER "Use QtQuick compiler to improve performance" OFF)
+option(QUICK_COMPILER "Use QtQuick compiler to improve performance" ON)
 
 # this option removes Http authentication, keychain, shibboleth etc and is intended for
 # external authentication mechanisms

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,10 +83,6 @@ add_definitions(
     -DQT_MESSAGELOGCONTEXT #enable function name and line number in debug output
 )
 
-if(QUICK_COMPILER)
-    add_definitions(-DQUICK_COMPILER) # Enable use of QtQuick compiler
-endif()
-
 # if we cannot get it from git, directly try .tag (packages)
 # this will work if the tar balls have been properly created
 # via git-archive.

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -447,7 +447,6 @@ endif()
 set_target_properties(nextcloudCore
   PROPERTIES
   AUTOUIC ON
-  AUTORCC ON
   AUTOMOC ON
 )
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,14 @@
 project(gui)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2 Xml Network)
+
+if(QUICK_COMPILER)
+        find_package(Qt5QuickCompiler)
+        set_package_properties(Qt5QuickCompiler PROPERTIES
+                DESCRIPTION "Compile QML at build time"
+                TYPE OPTIONAL
+        )
+endif()
+
 if (NOT TARGET Qt5::GuiPrivate)
     message(FATAL_ERROR "Could not find GuiPrivate component of Qt5. It might be shipped as a separate package, please check that.")
 endif()
@@ -13,9 +22,6 @@ IF(BUILD_UPDATER)
 endif()
 
 configure_file(${CMAKE_SOURCE_DIR}/theme.qrc.in ${CMAKE_SOURCE_DIR}/theme.qrc)
-
-set(MIRALL_RC_SRC ../../resources.qrc)
-list(APPEND MIRALL_RC_SRC ${CMAKE_SOURCE_DIR}/theme.qrc)
 set(theme_dir ${CMAKE_SOURCE_DIR}/theme)
 
 set(client_UI_SRCS
@@ -39,21 +45,6 @@ set(client_UI_SRCS
     addcertificatedialog.ui
     proxyauthdialog.ui
     mnemonicdialog.ui
-    UserStatusSelector.qml
-    UserStatusSelectorDialog.qml
-    tray/ActivityActionButton.qml
-    tray/ActivityItem.qml
-    tray/ActivityList.qml
-    tray/Window.qml
-    tray/UserLine.qml
-    tray/UnifiedSearchInputContainer.qml
-    tray/UnifiedSearchResultFetchMoreTrigger.qml
-    tray/UnifiedSearchResultItem.qml
-    tray/UnifiedSearchResultItemSkeleton.qml
-    tray/UnifiedSearchResultItemSkeletonContainer.qml
-    tray/UnifiedSearchResultListItem.qml
-    tray/UnifiedSearchResultNothingFound.qml
-    tray/UnifiedSearchResultSectionItem.qml
     wizard/flow2authwidget.ui
     wizard/owncloudadvancedsetuppage.ui
     wizard/owncloudconnectionmethoddialog.ui
@@ -63,6 +54,12 @@ set(client_UI_SRCS
     wizard/webview.ui
     wizard/welcomepage.ui
 )
+
+if(QUICK_COMPILER)
+    qtquick_compiler_add_resources(client_UI_SRCS ../../resources.qrc ${CMAKE_SOURCE_DIR}/theme.qrc)
+else()
+     qt_add_resources(client_UI_SRCS ../../resources.qrc ${CMAKE_SOURCE_DIR}/theme.qrc)
+endif()
 
 set(client_SRCS
     accountmanager.cpp
@@ -232,7 +229,6 @@ IF( WIN32 )
 ENDIF()
 
 set( final_src
-    ${MIRALL_RC_SRC}
     ${client_SRCS}
     ${client_UI_SRCS}
     ${guiMoc}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -5,7 +5,7 @@ if(QUICK_COMPILER)
         find_package(Qt5QuickCompiler)
         set_package_properties(Qt5QuickCompiler PROPERTIES
                 DESCRIPTION "Compile QML at build time"
-                TYPE OPTIONAL
+                TYPE REQUIRED
         )
 endif()
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -58,7 +58,7 @@ set(client_UI_SRCS
 if(QUICK_COMPILER)
     qtquick_compiler_add_resources(client_UI_SRCS ../../resources.qrc ${CMAKE_SOURCE_DIR}/theme.qrc)
 else()
-     qt_add_resources(client_UI_SRCS ../../resources.qrc ${CMAKE_SOURCE_DIR}/theme.qrc)
+    qt_add_resources(client_UI_SRCS ../../resources.qrc ${CMAKE_SOURCE_DIR}/theme.qrc)
 endif()
 
 set(client_SRCS


### PR DESCRIPTION
This PR adds the option of compiling the tray's QML code when compiling the client with CMake