### PR TITLE
Display error message when creating a link share with compromised password.

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,6 +43,7 @@ set(client_UI_SRCS
     shareuserline.ui
     sslerrordialog.ui
     addcertificatedialog.ui
+    passwordinputdialog.ui
     proxyauthdialog.ui
     mnemonicdialog.ui
     wizard/flow2authwidget.ui
@@ -92,6 +93,7 @@ set(client_SRCS
     openfilemanager.cpp
     owncloudgui.cpp
     owncloudsetupwizard.cpp
+    passwordinputdialog.cpp
     selectivesyncdialog.cpp
     settingsdialog.cpp
     sharedialog.cpp

--- a/src/gui/passwordinputdialog.cpp
+++ b/src/gui/passwordinputdialog.cpp
@@ -36,6 +36,7 @@ PasswordInputDialog::~PasswordInputDialog()
 {
     delete ui;
 }
+
 QString PasswordInputDialog::password() const
 {
     return ui->passwordLineEdit->text();

--- a/src/gui/passwordinputdialog.cpp
+++ b/src/gui/passwordinputdialog.cpp
@@ -19,26 +19,21 @@ namespace OCC {
 
 PasswordInputDialog::PasswordInputDialog(const QString &description, const QString &error, QWidget *parent)
     : QDialog(parent)
-    , ui(new Ui::PasswordInputDialog)
+    , _ui(new Ui::PasswordInputDialog)
 {
-    ui->setupUi(this);
+    _ui->setupUi(this);
 
-    ui->passwordLineEditLabel->setText(description);
-    ui->passwordLineEditLabel->setVisible(!description.isEmpty());
+    _ui->passwordLineEditLabel->setText(description);
+    _ui->passwordLineEditLabel->setVisible(!description.isEmpty());
 
-    ui->labelErrorMessage->setText(error);
-    ui->labelErrorMessage->setVisible(!error.isEmpty());
+    _ui->labelErrorMessage->setText(error);
+    _ui->labelErrorMessage->setVisible(!error.isEmpty());
 
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
-PasswordInputDialog::~PasswordInputDialog()
-{
-    delete ui;
-}
-
 QString PasswordInputDialog::password() const
 {
-    return ui->passwordLineEdit->text();
+    return _ui->passwordLineEdit->text();
 }
 }

--- a/src/gui/passwordinputdialog.cpp
+++ b/src/gui/passwordinputdialog.cpp
@@ -32,6 +32,8 @@ PasswordInputDialog::PasswordInputDialog(const QString &description, const QStri
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
+PasswordInputDialog::~PasswordInputDialog() = default;
+
 QString PasswordInputDialog::password() const
 {
     return _ui->passwordLineEdit->text();

--- a/src/gui/passwordinputdialog.cpp
+++ b/src/gui/passwordinputdialog.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) by Oleksandr Zolotov <alex@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "passwordinputdialog.h"
+#include "ui_passwordinputdialog.h"
+
+namespace OCC {
+
+PasswordInputDialog::PasswordInputDialog(const QString &description, const QString &error, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::PasswordInputDialog)
+{
+    ui->setupUi(this);
+
+    ui->passwordLineEditLabel->setText(description);
+    ui->passwordLineEditLabel->setVisible(!description.isEmpty());
+
+    ui->labelErrorMessage->setText(error);
+    ui->labelErrorMessage->setVisible(!error.isEmpty());
+
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+}
+
+PasswordInputDialog::~PasswordInputDialog()
+{
+    delete ui;
+}
+QString PasswordInputDialog::password() const
+{
+    return ui->passwordLineEdit->text();
+}
+}

--- a/src/gui/passwordinputdialog.h
+++ b/src/gui/passwordinputdialog.h
@@ -28,12 +28,11 @@ class PasswordInputDialog : public QDialog
 
 public:
     explicit PasswordInputDialog(const QString &description, const QString &error, QWidget *parent = nullptr);
-    ~PasswordInputDialog() override;
 
     QString password() const;
 
 private:
-    Ui::PasswordInputDialog *ui;
+    std::unique_ptr<Ui::PasswordInputDialog> _ui;
 };
 
 }

--- a/src/gui/passwordinputdialog.h
+++ b/src/gui/passwordinputdialog.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) by Oleksandr Zolotov <alex@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include <QDialog>
+
+namespace OCC {
+
+namespace Ui {
+class PasswordInputDialog;
+}
+
+class PasswordInputDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PasswordInputDialog(const QString &description, const QString &error, QWidget *parent = nullptr);
+    ~PasswordInputDialog() override;
+
+    QString password() const;
+
+private:
+    Ui::PasswordInputDialog *ui;
+};
+
+}

--- a/src/gui/passwordinputdialog.h
+++ b/src/gui/passwordinputdialog.h
@@ -28,6 +28,7 @@ class PasswordInputDialog : public QDialog
 
 public:
     explicit PasswordInputDialog(const QString &description, const QString &error, QWidget *parent = nullptr);
+    ~PasswordInputDialog() override;
 
     QString password() const;
 

--- a/src/gui/passwordinputdialog.ui
+++ b/src/gui/passwordinputdialog.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OCC::PasswordInputDialog</class>
+ <widget class="QDialog" name="OCC::PasswordInputDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>276</width>
+    <height>125</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Password for share required</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="passwordLineEditLabel">
+     <property name="text">
+      <string>Please enter a password for your share:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="passwordLineEdit">
+     <property name="inputMask">
+      <string notr="true"/>
+     </property>
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelErrorMessage">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: rgb(255, 0, 0)</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OCC::PasswordInputDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OCC::PasswordInputDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/passwordinputdialog.ui
+++ b/src/gui/passwordinputdialog.ui
@@ -55,7 +55,7 @@
       <bool>true</bool>
      </property>
      <property name="styleSheet">
-      <string notr="true">color: rgb(255, 0, 0)</string>
+      <string notr="true">color: rgb(118, 118, 118)</string>
      </property>
      <property name="text">
       <string/>

--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -66,7 +66,7 @@ private slots:
     void slotCreateLinkShare();
     void slotCreatePasswordForLinkShare(const QString &password);
     void slotCreatePasswordForLinkShareProcessed();
-    void slotLinkShareRequiresPassword();
+    void slotLinkShareRequiresPassword(const QString &message);
     void slotAdjustScrollWidgetSize();
 
 signals:


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
![error_message_in_dialog](https://user-images.githubusercontent.com/12224014/148215936-10d1130f-b519-4d73-8881-e9e8660cf740.gif)
This will fix #4136 