### PR TITLE
Add macOS *.textClipping files to ignore list

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -8,6 +8,7 @@
 ]Icon\r*
 ].DS_Store
 ].ds_store
+*.textClipping
 ._*
 ]Thumbs.db
 ]photothumb.db


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

When dragging highlighted text to a folder or desktop location, macOS creates a file with a .textClipping. This file does not, howver, contain any data. "The files cannot easily be shared between Macs or sent to other machines like an attachment. Opening the textClipping file in most applications will show a 0 byte empty data file. " 

https://en.wikipedia.org/wiki/TextClipping

This produces errors during sync. Solution here is to add these files to the ignore list.

Fixes #1076

