### PR TITLE
Bugfix. Re-init sharing manager to enable link sharing UI when receivng sharing permissions.

### DIFF
--- a/src/gui/sharedialog.h
+++ b/src/gui/sharedialog.h
@@ -78,6 +78,7 @@ protected:
 
 private:
     void showSharingUi();
+    void initShareManager();
     ShareLinkWidget *addLinkShareWidget(const QSharedPointer<LinkShare> &linkShare);
     void initLinkShareWidget();
 


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

This should fix https://github.com/nextcloud/desktop/issues/4107
