### PR TITLE
When resynchronizing files, avoid truncating timestamp.

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -73,6 +73,15 @@ time_t FileSystem::getModTime(const QString &filename)
 bool FileSystem::setModTime(const QString &filename, time_t modTime)
 {
     struct timeval times[2];
+    csync_file_stat_t stat;
+
+    /* Avoid truncating modTime to nearest second when resynchronizing locally changed file */
+    if (csync_vio_local_stat(filename, &stat) != -1
+        && (stat.modtime == modTime)
+        && (stat.type == ItemTypeFile)) {
+        return true;
+    }
+
     times[0].tv_sec = times[1].tv_sec = modTime;
     times[0].tv_usec = times[1].tv_usec = 0;
     int rc = c_utimes(filename, times);


### PR DESCRIPTION
#4139, #3456

Signed-off-by: Donald Gordon <donald@gordon.nz>