### PR TITLE
enable reversed locale layout in QML

### DIFF
--- a/src/gui/ResolveConflictsDialog.qml
+++ b/src/gui/ResolveConflictsDialog.qml
@@ -30,6 +30,9 @@ ApplicationWindow {
     flags: Qt.Window | Qt.Dialog
     visible: true
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     width: Style.minimumWidthResolveConflictsDialog
     height: Style.minimumHeightResolveConflictsDialog
     minimumWidth: Style.minimumWidthResolveConflictsDialog

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -101,7 +101,8 @@ namespace {
         "  --isvfsenabled             : whether to set a VFS or non-VFS folder (1 for 'yes' or 0 for 'no') when creating an account via command-line.\n"
         "  --remotedirpath            : (optional) path to a remote subfolder when creating an account via command-line.\n"
         "  --serverurl                : a server URL to use when creating an account via command-line.\n"
-        "  --forcelegacyconfigimport  : forcefully import account configurations from legacy clients (if available).\n";
+        "  --forcelegacyconfigimport  : forcefully import account configurations from legacy clients (if available).\n"
+        "  --reverse            : use a reverse layout direction.\n";
 
     QString applicationTrPath()
     {
@@ -814,6 +815,8 @@ void Application::parseOptions(const QStringList &options)
             _backgroundMode = true;
         } else if (option == QLatin1String("--version") || option == QLatin1String("-v")) {
             _versionOnly = true;
+        } else if (option == QLatin1String("--reverse")) {
+            setLayoutDirection(layoutDirection() == Qt::LeftToRight ? Qt::RightToLeft : Qt::LeftToRight);
         } else if (option.endsWith(QStringLiteral(APPLICATION_DOTVIRTUALFILE_SUFFIX))) {
             // virtual file, open it after the Folder were created (if the app is not terminated)
             QTimer::singleShot(0, this, [this, option] { openVirtualFile(option); });

--- a/src/gui/filedetails/FileDetailsWindow.qml
+++ b/src/gui/filedetails/FileDetailsWindow.qml
@@ -26,6 +26,9 @@ ApplicationWindow {
     property var accountState
     property string localPath: ""
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     width: 400
     height: 500
     minimumWidth: 300

--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -30,6 +30,9 @@ ApplicationWindow {
     property var materialisedItemsModel: null
     property string accountUserIdAtHost: ""
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     title: qsTr("Evict materialised files")
     color: palette.base
     flags: Qt.Dialog | Qt.WindowStaysOnTopHint

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -52,6 +52,9 @@ ApplicationWindow {
         Systray.destroyDialog(root);
     }
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     width: root.windowWidth
     height: rootBackground.height
 

--- a/src/gui/tray/EditFileLocallyLoadingDialog.qml
+++ b/src/gui/tray/EditFileLocallyLoadingDialog.qml
@@ -11,6 +11,9 @@ ApplicationWindow {
 
     color: palette.base
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     width: 320
     height: contentLayout.implicitHeight
 

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -31,6 +31,9 @@ import com.nextcloud.desktopclient
 ApplicationWindow {
     id:         trayWindow
 
+    LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
+    LayoutMirroring.childrenInherit: true
+
     title:      Systray.windowTitle
     // If the main dialog is displayed as a regular window we want it to be quadratic
     width:      Systray.useNormalWindow ? Style.trayWindowHeight : Style.trayWindowWidth


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
