### PR TITLE
No longer assume status bar height, calculate, fixing notch borking

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -389,8 +389,9 @@ QRect Systray::taskbarGeometry() const
     return tbRect;
 #elif defined(Q_OS_MACOS)
     // Finder bar is always 22px height on macOS (when treating as effective pixels)
-    auto screenWidth = currentScreenRect().width();
-    return {0, 0, screenWidth, 22};
+    const auto screenWidth = currentScreenRect().width();
+    const auto statusBarHeight = static_cast<int>(OCC::statusBarThickness());
+    return {0, 0, screenWidth, statusBarHeight};
 #else
     if (taskbarOrientation() == TaskBarPosition::Bottom || taskbarOrientation() == TaskBarPosition::Top) {
         auto screenWidth = currentScreenRect().width();

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -42,6 +42,7 @@ public:
 bool canOsXSendUserNotification();
 void sendOsXUserNotification(const QString &title, const QString &message);
 void setTrayWindowLevelAndVisibleOnAllSpaces(QWindow *window);
+double statusBarThickness();
 #endif
 
 /**

--- a/src/gui/systray.mm
+++ b/src/gui/systray.mm
@@ -17,6 +17,11 @@
 
 namespace OCC {
 
+double statusBarThickness()
+{
+    return [NSStatusBar systemStatusBar].thickness;
+}
+
 bool canOsXSendUserNotification()
 {
     return NSClassFromString(@"NSUserNotificationCenter") != nil;


### PR DESCRIPTION
This fixes #4163 as we now get the actual height of the status bar rather than assume its 22px high