### PR TITLE
Generates pot files automatically.

### DIFF
--- a/.github/workflows/generates_locales.yml
+++ b/.github/workflows/generates_locales.yml
@@ -1,0 +1,25 @@
+name: L10n
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'doc/**'
+    - '!doc/locale/**'
+jobs:
+  generates_locales:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/"
+        pre-build-command: pip install -r requirements.txt
+        build-command: make gettext
+    - uses: actions/checkout@v2
+      - name: Commit report
+        run: |
+          git config --global user.name 'Nextcloud Bot'
+          git config --global user.email 'bot@nextcloud.com'
+          git commit -am "Updates catalog templates (POT files fetched automatically by transifex)"
+          git push


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

starts to implement this https://github.com/nextcloud/desktop/issues/3234

(I think this action will work, but well, this is the issue with dev actions, you never know before you run them :man_shrugging: )

Once pot files are in the git master branch, I'll configure [this folder in transifex](https://www.transifex.com/nextcloud/nextcloud-client-documentation/settings/integrations/) to come and pull from git automatically.

Then we'll have to modify the doc build to fetch from transifex at build time.
(and add a menu in the doc to choose lang in the doc template, we might need to change sphinx theme to ease that part)
