### PR TITLE
makes sure that sync engine terminates when an error happen

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -290,7 +290,10 @@ void BulkPropagatorJob::slotStartUpload(SyncFileItemPtr item,
     const QString originalFilePath = propagator()->fullLocalPath(item->_file);
 
     if (!FileSystem::fileExists(fullFilePath)) {
-        return slotOnErrorStartFolderUnlock(item, SyncFileItem::SoftError, tr("File Removed (start upload) %1").arg(fullFilePath));
+        _pendingChecksumFiles.remove(item->_file);
+        slotOnErrorStartFolderUnlock(item, SyncFileItem::SoftError, tr("File Removed (start upload) %1").arg(fullFilePath));
+        checkPropagationIsDone();
+        return;
     }
     const time_t prevModtime = item->_modtime; // the _item value was set in PropagateUploadFile::start()
     // but a potential checksum calculation could have taken some time during which the file could


### PR DESCRIPTION
makes sure that an error in bulk upload protocol jobs will be propagated
to sync engine and that the sync run will properly terminate

missing in a backport PR #4080

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
