### PR TITLE
Fix warn colour in dark mode

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -77,6 +77,8 @@ FolderWizardLocalPath::FolderWizardLocalPath(const AccountPtr &account)
 
     _ui.warnLabel->setTextFormat(Qt::RichText);
     _ui.warnLabel->hide();
+
+    changeStyle();
 }
 
 FolderWizardLocalPath::~FolderWizardLocalPath() = default;
@@ -139,6 +141,31 @@ void FolderWizardLocalPath::slotChooseLocalFolder()
         _ui.localFolderLineEdit->setText(QDir::toNativeSeparators(dir));
     }
     emit completeChanged();
+}
+
+
+void FolderWizardLocalPath::changeEvent(QEvent *e)
+{
+    switch (e->type()) {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::ThemeChange:
+        // Notify the other widgets (Dark-/Light-Mode switching)
+        changeStyle();
+        break;
+    default:
+        break;
+    }
+
+    FormatWarningsWizardPage::changeEvent(e);
+}
+
+void FolderWizardLocalPath::changeStyle()
+{
+    const auto warnYellow = Theme::isDarkColor(QGuiApplication::palette().base().color()) ? QColor(63, 63, 0) : QColor(255, 255, 192);
+    auto modifiedPalette = _ui.warnLabel->palette();
+    modifiedPalette.setColor(QPalette::Window, warnYellow);
+    _ui.warnLabel->setPalette(modifiedPalette);
 }
 
 // =================================================================================

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -60,10 +60,16 @@ public:
     void cleanupPage() override;
 
     void setFolderMap(const Folder::Map &fm) { _folderMap = fm; }
+
+protected:
+    void changeEvent(QEvent *) override;
+
 protected slots:
     void slotChooseLocalFolder();
 
 private:
+    void changeStyle();
+
     Ui_FolderWizardSourcePage _ui;
     Folder::Map _folderMap;
     AccountPtr _account;


### PR DESCRIPTION
This PR fixes #3310 

How it looks with the fix:

Plasma:
![image](https://user-images.githubusercontent.com/70155116/154066220-d1d23827-c0f2-4a65-ac64-305fd788195f.png)

Mac:
![Screenshot 2022-02-15 at 14 12 50](https://user-images.githubusercontent.com/70155116/154069308-4f682a6b-828f-4fd1-bef2-37ce15cd946e.png)

Also responds to light/dark mode switching on Linux and macOS.
