### PR TITLE
Do not remove files from a Group folder and its nested folders when it is renamed or removed while not allowed.

### DIFF
--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -193,6 +193,10 @@ private:
      */
     bool checkPermissions(const SyncFileItemPtr &item);
 
+    bool isAnyParentBeingRestored(const QString &file) const;
+
+    bool isRename(const QString &originalPath) const;
+
     struct MovePermissionResult
     {
         // whether moving/renaming the source is ok

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -203,6 +203,17 @@ QPair<bool, QByteArray> DiscoveryPhase::findAndCancelDeletedJob(const QString &o
     return { result, oldEtag };
 }
 
+void DiscoveryPhase::enqueueDirectoryToDelete(const QString &path, ProcessDirectoryJob* const directoryJob)
+{
+    _queuedDeletedDirectories[path] = directoryJob;
+
+    if (directoryJob->_dirItem && directoryJob->_dirItem->_isRestoration
+        && directoryJob->_dirItem->_direction == SyncFileItem::Down
+        && directoryJob->_dirItem->_instruction == CSYNC_INSTRUCTION_NEW) {
+        _directoryNamesToRestoreOnPropagation.push_back(path);
+    }
+}
+
 void DiscoveryPhase::startJob(ProcessDirectoryJob *job)
 {
     ENFORCE(!_currentRootJob);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -181,6 +181,8 @@ class DiscoveryPhase : public QObject
      */
     QMap<QString, SyncFileItemPtr> _deletedItem;
 
+    QVector<QString> _directoryNamesToRestoreOnPropagation;
+
     /** Maps the db-path of a deleted folder to its queued job.
      *
      * If a folder is deleted and must be recursed into, its job isn't
@@ -248,6 +250,8 @@ class DiscoveryPhase : public QObject
      * See _deletedItem and _queuedDeletedDirectories.
      */
     QPair<bool, QByteArray> findAndCancelDeletedJob(const QString &originalPath);
+
+    void enqueueDirectoryToDelete(const QString &path, ProcessDirectoryJob* const directoryJob);
 
 public:
     // input


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

This should fix https://github.com/nextcloud/groupfolders/issues/1816