### PR TITLE
Rollback local move on server move failure

### DIFF
--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -208,6 +208,17 @@ void PropagateRemoteMove::slotMoveJobFinished()
     if (err != QNetworkReply::NoError) {
         SyncFileItem::Status status = classifyError(err, _item->_httpErrorCode,
             &propagator()->_anotherSyncNeeded);
+        const auto filePath = propagator()->fullLocalPath(_item->_renameTarget);
+        const auto filePathOriginal = propagator()->fullLocalPath(_item->_originalFile);
+        QFile file(filePath);
+        if (!file.rename(filePathOriginal)) {
+            qCWarning(lcPropagateRemoteMove) << "Could not MOVE file" << filePathOriginal << " to" << filePath
+                                             << " with error:" << _job->errorString() << " and failed to restore it !";
+        } else {
+            qCWarning(lcPropagateRemoteMove)
+                << "Could not MOVE file" << filePathOriginal << " to" << filePath
+                << " with error:" << _job->errorString() << " and successfully restored it.";
+        }
         done(status, _job->errorString());
         return;
     }

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -982,6 +982,106 @@ private slots:
         QCOMPARE(nPOST, 0);
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    void testRemoteMoveFailedInsufficientStorageLocalMoveRolledBack()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+
+        // create a big shared folder with some files
+        fakeFolder.remoteModifier().mkdir("big_shared_folder");
+        fakeFolder.remoteModifier().mkdir("big_shared_folder/shared_files");
+        fakeFolder.remoteModifier().insert("big_shared_folder/shared_files/big_shared_file_A.data", 1000);
+        fakeFolder.remoteModifier().insert("big_shared_folder/shared_files/big_shared_file_B.data", 1000);
+
+        // make sure big shared folder is synced
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_A.data"));
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_B.data"));
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        // try to move from a big shared folder to your own folder
+        fakeFolder.localModifier().mkdir("own_folder");
+        fakeFolder.localModifier().rename(
+            "big_shared_folder/shared_files/big_shared_file_A.data", "own_folder/big_shared_file_A.data");
+        fakeFolder.localModifier().rename(
+            "big_shared_folder/shared_files/big_shared_file_B.data", "own_folder/big_shared_file_B.data");
+
+        // emulate server MOVE 507 error
+        QObject parent;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request,
+                                         QIODevice *outgoingData) -> QNetworkReply * {
+            Q_UNUSED(outgoingData)
+
+            if (op == QNetworkAccessManager::CustomOperation
+                && request.attribute(QNetworkRequest::CustomVerbAttribute).toString() == QStringLiteral("MOVE")) {
+                return new FakeErrorReply(op, request, &parent, 507);
+            }
+            return nullptr;
+        });
+
+        // make sure the first sync failes and files get restored to original folder
+        QVERIFY(!fakeFolder.syncOnce());
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_A.data"));
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_B.data"));
+        QVERIFY(!fakeFolder.currentLocalState().find("own_folder/big_shared_file_A.data"));
+        QVERIFY(!fakeFolder.currentLocalState().find("own_folder/big_shared_file_B.data"));
+
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
+
+    void testRemoteMoveFailedForbiddenLocalMoveRolledBack()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+
+        // create a big shared folder with some files
+        fakeFolder.remoteModifier().mkdir("big_shared_folder");
+        fakeFolder.remoteModifier().mkdir("big_shared_folder/shared_files");
+        fakeFolder.remoteModifier().insert("big_shared_folder/shared_files/big_shared_file_A.data", 1000);
+        fakeFolder.remoteModifier().insert("big_shared_folder/shared_files/big_shared_file_B.data", 1000);
+
+        // make sure big shared folder is synced
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_A.data"));
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_B.data"));
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        // try to move from a big shared folder to your own folder
+        fakeFolder.localModifier().mkdir("own_folder");
+        fakeFolder.localModifier().rename(
+            "big_shared_folder/shared_files/big_shared_file_A.data", "own_folder/big_shared_file_A.data");
+        fakeFolder.localModifier().rename(
+            "big_shared_folder/shared_files/big_shared_file_B.data", "own_folder/big_shared_file_B.data");
+
+        // emulate server MOVE 507 error
+        QObject parent;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op, const QNetworkRequest &request,
+                                         QIODevice *outgoingData) -> QNetworkReply * {
+            Q_UNUSED(outgoingData)
+
+            auto attributeCustomVerb = request.attribute(QNetworkRequest::CustomVerbAttribute).toString();
+
+            if (op == QNetworkAccessManager::CustomOperation
+                && request.attribute(QNetworkRequest::CustomVerbAttribute).toString() == QStringLiteral("MOVE")) {
+                return new FakeErrorReply(op, request, &parent, 403);
+            }
+            return nullptr;
+        });
+
+        // make sure the first sync failes and files get restored to original folder
+        QVERIFY(!fakeFolder.syncOnce());
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_A.data"));
+        QVERIFY(fakeFolder.currentLocalState().find("big_shared_folder/shared_files/big_shared_file_B.data"));
+        QVERIFY(!fakeFolder.currentLocalState().find("own_folder/big_shared_file_A.data"));
+        QVERIFY(!fakeFolder.currentLocalState().find("own_folder/big_shared_file_B.data"));
+
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -958,12 +958,12 @@ private slots:
             fakeFolder.syncOnce();
         }
 
-        QVERIFY(!fakeFolder.currentLocalState().find(src));
-        QVERIFY(fakeFolder.currentLocalState().find(getName(dest)));
+        QVERIFY(fakeFolder.currentLocalState().find(getName(src)));
+        QVERIFY(!fakeFolder.currentLocalState().find(getName(dest)));
         if (vfsMode == Vfs::WithSuffix)
         {
             // the placeholder was not restored as it is still in error state
-            QVERIFY(!fakeFolder.currentLocalState().find(dest));
+            QVERIFY(!fakeFolder.currentLocalState().find(getName(dest)));
         }
         QVERIFY(fakeFolder.currentRemoteState().find(src));
         QVERIFY(!fakeFolder.currentRemoteState().find(dest));


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This should fix #4266