### PR TITLE
l10n: Changed spelling

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -673,7 +673,7 @@ void BulkPropagatorJob::handleFileRestoration(SyncFileItemPtr item,
             || item->_status == SyncFileItem::Conflict) {
             item->_status = SyncFileItem::Restoration;
         } else {
-            item->_errorString += tr("; Restoration Failed: %1").arg(errorString);
+            item->_errorString += tr("Restoration failed: %1").arg(errorString);
         }
     } else {
         if (item->_errorString.isEmpty()) {


### PR DESCRIPTION
Reported at Transifex.

Fix for #4004 

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
