### PR TITLE
Ensure file activity dialog appears in centre of screen

### DIFF
--- a/src/gui/tray/FileActivityDialog.qml
+++ b/src/gui/tray/FileActivityDialog.qml
@@ -1,3 +1,4 @@
+import QtQuick 2.15
 import QtQuick.Window 2.15
 
 import com.nextcloud.desktopclient 1.0 as NC
@@ -18,5 +19,11 @@ Window {
         isFileActivityList: true
         anchors.fill: parent
         model: dialog.model
+    }
+
+    Component.onCompleted: {
+        // Set this explicitly, otherwise on macOS it will appear behind the tray
+        x = screen.width / 2 - width / 2
+        y = screen.height / 2 - height / 2
     }
 }


### PR DESCRIPTION
This PR ensures that the file activity dialog appears in the centre of the screen on all platforms.

This is necessary as on macOS, the dialog would appear directly behind the tray popup