### PR TITLE
Fix file activity dialog

### DIFF
--- a/src/gui/fileactivitylistmodel.cpp
+++ b/src/gui/fileactivitylistmodel.cpp
@@ -26,7 +26,7 @@ FileActivityListModel::FileActivityListModel(QObject *parent)
     setDisplayActions(false);
 }
 
-void FileActivityListModel::load(AccountState *accountState, const QString &localPath)
+void FileActivityListModel::load(AccountState *accountState, const int objectId)
 {
     Q_ASSERT(accountState);
     if (!accountState || currentlyFetching()) {
@@ -34,18 +34,7 @@ void FileActivityListModel::load(AccountState *accountState, const QString &loca
     }
     setAccountState(accountState);
 
-    const auto folder = FolderMan::instance()->folderForPath(localPath);
-    if (!folder) {
-        return;
-    }
-
-    const auto file = folder->fileFromLocalPath(localPath);
-    SyncJournalFileRecord fileRecord;
-    if (!folder->journalDb()->getFileRecord(file, &fileRecord) || !fileRecord.isValid()) {
-        return;
-    }
-
-    _fileId = fileRecord._fileId;
+    _objectId = objectId;
     slotRefreshActivity();
 }
 
@@ -64,7 +53,7 @@ void FileActivityListModel::startFetchJob()
     QUrlQuery params;
     params.addQueryItem(QStringLiteral("sort"), QStringLiteral("asc"));
     params.addQueryItem(QStringLiteral("object_type"), "files");
-    params.addQueryItem(QStringLiteral("object_id"), _fileId);
+    params.addQueryItem(QStringLiteral("object_id"), QString::number(_objectId));
     job->addQueryParams(params);
     setDoneFetching(true);
     setHideOldActivities(true);

--- a/src/gui/fileactivitylistmodel.h
+++ b/src/gui/fileactivitylistmodel.h
@@ -27,12 +27,12 @@ public:
     explicit FileActivityListModel(QObject *parent = nullptr);
 
 public slots:
-    void load(AccountState *accountState, const QString &fileId);
+    void load(AccountState *accountState, const int objectId);
 
 protected:
     void startFetchJob() override;
 
 private:
-    QString _fileId;
+    int _objectId;
 };
 }

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -497,7 +497,7 @@ void SocketApi::broadcastMessage(const QString &msg, bool doWait)
 void SocketApi::processFileActivityRequest(const QString &localFile)
 {
     const auto fileData = FileData::get(localFile);
-    emit fileActivityCommandReceived(fileData.serverRelativePath, fileData.localPath);
+    emit fileActivityCommandReceived(fileData.serverRelativePath, fileData.journalRecord().numericFileId().toInt());
 }
 
 void SocketApi::processShareRequest(const QString &localFile, SocketListener *listener, ShareDialogStartPage startPage)

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -64,7 +64,7 @@ public slots:
 
 signals:
     void shareCommandReceived(const QString &sharePath, const QString &localPath, ShareDialogStartPage startPage);
-    void fileActivityCommandReceived(const QString &sharePath, const QString &localPath);
+    void fileActivityCommandReceived(const QString &objectName, const int objectId);
 
 private slots:
     void slotNewConnection();

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -90,7 +90,7 @@ signals:
     void hideWindow();
     void showWindow();
     void openShareDialog(const QString &sharePath, const QString &localPath);
-    void showFileActivityDialog(const QString &sharePath, const QString &localPath);
+    void showFileActivityDialog(const QString &objectName, const int objectId);
 
 public slots:
     void slotNewUserSelected();

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -9,7 +9,7 @@ ScrollView {
 
     property bool isFileActivityList: false
 
-    signal showFileActivity(string displayPath, string absolutePath)
+    signal showFileActivity(string objectName, int objectId)
     signal activityItemClicked(int index)
 
     contentWidth: availableWidth
@@ -39,7 +39,7 @@ ScrollView {
             flickable: activityList
             onClicked: {
                 if (model.isCurrentUserFileActivity) {
-                    showFileActivity(model.displayPath, model.absolutePath)
+                    showFileActivity(model.objectName, model.objectId)
                 } else {
                     activityItemClicked(model.index)
                 }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -23,13 +23,13 @@ Window {
     flags:      Systray.useNormalWindow ? Qt.Window : Qt.Dialog | Qt.FramelessWindowHint
 
 
-    property var fileActivityDialogAbsolutePath: ""
+    property int fileActivityDialogObjectId: -1
     readonly property int maxMenuHeight: Style.trayWindowHeight - Style.trayWindowHeaderHeight - 2 * Style.trayWindowBorderWidth
 
-    function openFileActivityDialog(displayPath, absolutePath) {
-        fileActivityDialogLoader.displayPath = displayPath
-        fileActivityDialogLoader.absolutePath = absolutePath
-        fileActivityDialogLoader.refresh()
+    function openFileActivityDialog(objectName, objectId) {
+        fileActivityDialogLoader.objectName = objectName;
+        fileActivityDialogLoader.objectId = objectId;
+        fileActivityDialogLoader.refresh();
     }
 
     Component.onCompleted: Systray.forceWindowInit(trayWindow)
@@ -81,8 +81,8 @@ Window {
             Systray.setClosed();
         }
 
-        function onShowFileActivityDialog(displayPath, absolutePath) {
-            openFileActivityDialog(displayPath, absolutePath)
+        function onShowFileActivityDialog(objectName, objectId) {
+            openFileActivityDialog(objectName, objectId)
         }
     }
 
@@ -745,7 +745,7 @@ Window {
             activeFocusOnTab: true
             model: activityModel
             onShowFileActivity: {
-                openFileActivityDialog(displayPath, absolutePath)
+                openFileActivityDialog(objectName, objectId)
             }
             onActivityItemClicked: {
                 model.slotTriggerDefaultAction(index)
@@ -755,18 +755,18 @@ Window {
         Loader {
             id: fileActivityDialogLoader
 
-            property string displayPath: ""
-            property string absolutePath: ""
+            property string objectName: ""
+            property int objectId: -1
 
             function refresh() {
                 active = true
-                item.model.load(activityModel.accountState, absolutePath)
+                item.model.load(activityModel.accountState, objectId)
                 item.show()
             }
 
             active: false
             sourceComponent: FileActivityDialog {
-                title: qsTr("%1 - File activity").arg(fileActivityDialogLoader.displayPath)
+                title: qsTr("%1 - File activity").arg(fileActivityDialogLoader.objectName)
                 onClosing: fileActivityDialogLoader.active = false
             }
 

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -80,7 +80,9 @@ public:
     Type _type;
     qlonglong _id;
     QString _fileAction;
+    int _objectId;
     QString _objectType;
+    QString _objectName;
     QString _subject;
     QString _subjectRich;
     QHash<QString, RichSubjectParameter> _subjectRichParameters;

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -57,7 +57,6 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     auto roles = QAbstractListModel::roleNames();
     roles[DisplayPathRole] = "displayPath";
     roles[PathRole] = "path";
-    roles[AbsolutePathRole] = "absolutePath";
     roles[DisplayLocationRole] = "displayLocation";
     roles[LinkRole] = "link";
     roles[MessageRole] = "message";
@@ -69,6 +68,8 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[ActionsLinksForActionButtonsRole] = "linksForActionButtons";
     roles[ActionTextColorRole] = "activityTextTitleColor";
     roles[ObjectTypeRole] = "objectType";
+    roles[ObjectIdRole] = "objectId";
+    roles[ObjectNameRole] = "objectName";
     roles[PointInTimeRole] = "dateTime";
     roles[DisplayActions] = "displayActions";
     roles[ShareableRole] = "isShareable";
@@ -179,8 +180,6 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return getDisplayPath();
     case PathRole:
         return QFileInfo(getFilePath()).path();
-    case AbsolutePathRole:
-        return getFilePath();
     case DisplayLocationRole:
         return displayLocation();
     case ActionsLinksRole: {
@@ -239,6 +238,10 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     }
     case ObjectTypeRole:
         return a._objectType;
+    case ObjectIdRole:
+        return a._objectId;
+    case ObjectNameRole:
+        return a._objectName;
     case ActionRole: {
         switch (a._type) {
         case Activity::ActivityType:
@@ -371,6 +374,8 @@ void ActivityListModel::activitiesReceived(const QJsonDocument &json, int status
         const auto activityUser = json.value(QStringLiteral("user")).toString();
         a._type = Activity::ActivityType;
         a._objectType = json.value(QStringLiteral("object_type")).toString();
+        a._objectId = json.value(QStringLiteral("object_id")).toInt();
+        a._objectName = json.value(QStringLiteral("object_name")).toString();
         a._accName = ast->account()->displayName();
         a._id = json.value(QStringLiteral("activity_id")).toInt();
         a._fileAction = json.value(QStringLiteral("type")).toString();

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -48,6 +48,8 @@ public:
         ActionIconRole = Qt::UserRole + 1,
         AccountRole,
         ObjectTypeRole,
+        ObjectIdRole,
+        ObjectNameRole,
         ActionsLinksRole,
         ActionsLinksContextMenuRole,
         ActionsLinksForActionButtonsRole,
@@ -57,7 +59,6 @@ public:
         MessageRole,
         DisplayPathRole,
         PathRole,
-        AbsolutePathRole,
         DisplayLocationRole, // Provides the display path to a file's parent folder, relative to Nextcloud root
         LinkRole,
         PointInTimeRole,

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -505,6 +505,8 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
     activity._file = item->_file;
     activity._folder = folder->alias();
     activity._fileAction = "";
+    activity._objectId = item->_fileId.toInt();
+    activity._objectName = item->_file;
 
     const auto fileName = QFileInfo(item->_originalFile).fileName();
 

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -596,12 +596,14 @@ private slots:
             const auto type = index.data(OCC::ActivityListModel::ActionRole).toInt();
             QVERIFY(type >= OCC::Activity::ActivityType);
 
-            QVERIFY(!index.data(OCC::ActivityListModel::ObjectTypeRole).toInt());
             QVERIFY(!index.data(OCC::ActivityListModel::AccountRole).toString().isEmpty());
             QVERIFY(!index.data(OCC::ActivityListModel::ActionTextColorRole).toString().isEmpty());
             QVERIFY(!index.data(OCC::ActivityListModel::ActionIconRole).toString().isEmpty());
             QVERIFY(!index.data(OCC::ActivityListModel::PointInTimeRole).toString().isEmpty());
 
+            QVERIFY(index.data(OCC::ActivityListModel::ObjectTypeRole).canConvert<int>());
+            QVERIFY(index.data(OCC::ActivityListModel::ObjectNameRole).canConvert<QString>());
+            QVERIFY(index.data(OCC::ActivityListModel::ObjectIdRole).canConvert<int>());
             QVERIFY(index.data(OCC::ActivityListModel::ActionsLinksRole).canConvert<QList<QVariant>>());
             QVERIFY(index.data(OCC::ActivityListModel::ActionTextRole).canConvert<QString>());
             QVERIFY(index.data(OCC::ActivityListModel::MessageRole).canConvert<QString>());


### PR DESCRIPTION
This PR fixes the file activity dialog, which shows up blank when clicking on certain file activities (e.g. deleted file activities). 

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>
