### PR TITLE
properly ask Qt to create qml opengl surface with proper options

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -93,6 +93,11 @@ int main(int argc, char **argv)
 #ifdef Q_OS_MAC
     Mac::CocoaInitializer cocoaInit; // RIIA
 #endif
+
+    auto surfaceFormat = QSurfaceFormat::defaultFormat();
+    surfaceFormat.setOption(QSurfaceFormat::ResetNotification);
+    QSurfaceFormat::setDefaultFormat(surfaceFormat);
+
     OCC::Application app(argc, argv);
 
 #ifdef Q_OS_WIN
@@ -125,10 +130,6 @@ int main(int argc, char **argv)
         QQuickWindow::setTextRenderType(QQuickWindow::NativeTextRendering);
     }
 #endif
-
-    auto surfaceFormat = QSurfaceFormat::defaultFormat();
-    surfaceFormat.setOption(QSurfaceFormat::ResetNotification);
-    QSurfaceFormat::setDefaultFormat(surfaceFormat);
 
 // check a environment variable for core dumps
 #ifdef Q_OS_UNIX


### PR DESCRIPTION
should prevent context losses error with some opengl drivers

should prevent corruptions to occur with come opengl drivers

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
