### PR TITLE
old submodule url does not work anylonger

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/3rdparty/libcrashreporter-qt"]
 	path = src/3rdparty/libcrashreporter-qt
-	url = git@github.com:dschmidt/libcrashreporter-qt.git
+	url = https://github.com/dschmidt/libcrashreporter-qt.git


### PR DESCRIPTION
We need to have an unauthenticated endpoint, otherwise our branding system will fail.

see https://github.blog/2021-09-01-improving-git-protocol-security-github/

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
