### PR TITLE
Fix icon color and highlight color issues

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -241,7 +241,7 @@ bool Systray::darkMode()
     if (!Utility::registryKeyExists(HKEY_CURRENT_USER, darkModeSubkey)) {
         return false;
     }
-    const auto darkMode = Utility::registryGetKeyValue(HKEY_CURRENT_USER, darkModeSubkey, QStringLiteral("AppsUseLightTheme")).toBool();
+    const auto darkMode = !Utility::registryGetKeyValue(HKEY_CURRENT_USER, darkModeSubkey, QStringLiteral("AppsUseLightTheme")).toBool();
     return darkMode;
 // Probably Linux
 #else

--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -64,7 +64,7 @@ MouseArea {
 
             activityData: model
 
-            Layout.preferredHeight: Style.trayWindowHeaderHeight
+            Layout.minimumHeight: Style.trayWindowHeaderHeight
 
             onShareButtonClicked: Systray.openShareDialog(model.displayPath, model.absolutePath)
             onDismissButtonClicked: activityModel.slotTriggerDismiss(model.index)

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -12,7 +12,7 @@ QtObject {
     readonly property color ncTextColor: Theme.systemPalette.windowText
     readonly property color ncSecondaryTextColor: "#808080"
     readonly property color ncHeaderTextColor: "white"
-    readonly property color lightHover:  Theme.systemPalette.highlight
+    readonly property color lightHover:  Systray.darkMode ? Qt.lighter(backgroundColor, 2) : Qt.darker(backgroundColor, 1.05)
     readonly property color menuBorder:  Systray.darkMode ? Qt.lighter(backgroundColor, 3) : Qt.darker(backgroundColor, 1.5)
     readonly property color backgroundColor: Theme.systemPalette.base
 


### PR DESCRIPTION
This PR should fix:

- Wrong colour of activity icons on Windows
- Too strong hihglight colour on Windows, obscuring accented buttons
- Some warnings not being highlighted properly

![image](https://user-images.githubusercontent.com/70155116/159121624-39d02907-31b6-441e-9f9b-bdbe7671b52a.png)
