### PR TITLE
Fix Finder sidebar icon to work as a "template" image

### DIFF
--- a/theme/colored/Nextcloud-macOS-sidebar.svg
+++ b/theme/colored/Nextcloud-macOS-sidebar.svg
@@ -1,22 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1"
-	 id="svg2" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1024 1024"
-	 style="enable-background:new 0 0 1024 1024;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#FFFFFF;}
-</style>
-<sodipodi:namedview  bordercolor="#666666" borderopacity="1" fit-margin-bottom="0" fit-margin-left="0" fit-margin-right="0" fit-margin-top="0" gridtolerance="10" guidetolerance="10" id="namedview8" inkscape:current-layer="svg2" inkscape:cx="-225.44227" inkscape:cy="284.0991" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-height="480" inkscape:window-width="640" inkscape:zoom="0.32" objecttolerance="10" pagecolor="#ffffff" showgrid="false">
-	</sodipodi:namedview>
-<g>
-</g>
-<path id="path6" inkscape:connector-curvature="0" class="st0" d="M513.6,266.9c-106.7,0-196.3,73.1-223.6,171.3
-	c-23.9-52.6-76.5-89.8-137.6-89.8C69.2,348.5,0.8,416.9,0.8,500c0,83.2,68.4,151.6,151.6,151.6c61.1,0,113.7-37.3,137.5-89.9
-	c27.4,98.3,117,171.4,223.7,171.4c106.1,0,195.2-72.3,223.2-169.7c24.3,51.6,76.1,88.2,136.5,88.2c83.2,0,151.6-68.4,151.6-151.6
-	c0-83.2-68.4-151.6-151.6-151.6c-60.4,0-112.2,36.6-136.5,88.2C708.8,339.2,619.7,266.9,513.6,266.9L513.6,266.9z M513.6,355.9
-	c80.1,0,144.1,64,144.1,144.1c0,80.1-64,144.2-144.1,144.1c-80.1,0-144.1-64-144.1-144.1C369.5,419.9,433.5,355.9,513.6,355.9
-	L513.6,355.9z M152.3,437.4c35.1,0,62.6,27.5,62.6,62.6c0,35.1-27.5,62.6-62.6,62.6c-35.1,0-62.6-27.5-62.6-62.6
-	C89.8,464.9,117.2,437.4,152.3,437.4L152.3,437.4z M873.2,437.4c35.1,0,62.6,27.5,62.6,62.6c0,35.1-27.5,62.6-62.6,62.6
-	c-35.1,0-62.6-27.5-62.6-62.6C810.6,464.9,838.1,437.4,873.2,437.4L873.2,437.4z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="black" stroke-width="7px">
+    <circle id="right" cx="102.5" cy="64" r="14"/>
+    <circle id="center" cx="64" cy="64" r="24.5"/>
+    <circle id="left" cx="25.5" cy="64" r="14"/>
 </svg>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/desktop/issues/3695

According to the Apple documentation, "template" images must be exclusively ["monochromatic images that are drawn just using black and transparency"](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Finder.html), but `desktop/theme/colored/Nextcloud-sidebar.svg` looks like this:

<img width="256px" src="https://github.com/nextcloud/desktop/raw/d2b67ffea20b296a512e68f967e77c38a7ff2a4c/theme/colored/Nextcloud-sidebar.svg">

Since this bug popped up without changes in the code or assets in question, my guess is that the current version of Xcode or macOS is being clever and interpreting the white as a color to be inverted, while previously it treated the white as just an opaque transparency mask. This seems to be due to a change in how non-monochrome "template" images are supported with the release of SF Symbols 3. Among other things, SVG images now seem to be natively supported, as best I can tell from the documentation [here](https://developer.apple.com/documentation/uikit/uiimage/creating_custom_symbol_images_for_your_app).

I can't test this theory [because macOS builds are currently broken](https://github.com/nextcloud/desktop/issues/4366), so I'm posting an updated version of `Nextcloud-sidebar.svg` that should work properly as a conventional "template" image without actually put it through a build first.