### PR TITLE
Remove "…" from "Create Debug Archive" button

### DIFF
--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -316,7 +316,7 @@
         <item>
          <widget class="QPushButton" name="debugArchiveButton">
           <property name="text">
-           <string>Create Debug Archive …</string>
+           <string>Create Debug Archive</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Currently the button label for the debug archive creation, is: "Create debug archive ...".

The current label looks weird, since it makes it seem like something is missing / cut-off on that button.

The common UX approach with ellipsis in regards to menu option and buttons is that "..." is used to indicate that clicking the button requires then some further user input (but then the ellipsis should directly follow the label without a space in between). However, usually it is also said that buttons that open a dialog should not automatically have ellipsis.

In my current PR state, I removed them completely which might however be a step too far, so I would also be fine with adding them again, but getting rid of the blank in between => "Create debug archive..." to be in line with basically all commonly used applications and UX guides.

See as reference: https://docs.microsoft.com/en-us/windows/win32/uxguide/cmd-menus#using-ellipses

Are the translation files handled automatically somehow or would I need to remove the ellipsis there manually?

Signed-off-by: Philip Allgaier <philip.allgaier@gmx.de>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
