### PR TITLE
avoid deleting renamed file with spaces in name

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1054,6 +1054,10 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
     if (!localEntry.renameName.isEmpty()) {
         handleInvalidSpaceRename(SyncFileItem::Down);
+        item->_instruction = CSYNC_INSTRUCTION_NEW;
+        item->_direction = SyncFileItem::Up;
+        item->_originalFile = item->_file;
+        item->_file = item->_renameTarget;
         finalize();
         return;
     }

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -194,6 +194,18 @@ void PropagateUploadFileCommon::setDeleteExisting(bool enabled)
 
 void PropagateUploadFileCommon::start()
 {
+    if (!_item->_originalFile.isEmpty() && !_item->_renameTarget.isEmpty() && _item->_renameTarget != _item->_originalFile) {
+        const auto existingFile = propagator()->fullLocalPath(propagator()->adjustRenamedPath(_item->_originalFile));
+        const auto targetFile = propagator()->fullLocalPath(_item->_renameTarget);
+        QString renameError;
+        if (!FileSystem::rename(existingFile, targetFile, &renameError)) {
+            done(SyncFileItem::NormalError, renameError);
+            return;
+        }
+        emit propagator()->touchedFile(existingFile);
+        emit propagator()->touchedFile(targetFile);
+    }
+
     const auto path = _item->_file;
     const auto slashPosition = path.lastIndexOf('/');
     const auto parentPath = slashPosition >= 0 ? path.left(slashPosition) : QString();

--- a/test/testlocaldiscovery.cpp
+++ b/test/testlocaldiscovery.cpp
@@ -223,6 +223,7 @@ private slots:
         fakeFolder.localModifier().insert(fileWithSpaces4);
         fakeFolder.localModifier().insert(fileWithSpaces5);
         fakeFolder.localModifier().insert(fileWithSpaces6);
+        fakeFolder.localModifier().mkdir(QStringLiteral("  with spaces  "));
 
         QVERIFY(fakeFolder.syncOnce());
 
@@ -244,6 +245,10 @@ private slots:
         QVERIFY(fakeFolder.currentLocalState().find("A/bla"));
         QVERIFY(!fakeFolder.currentLocalState().find(fileWithSpaces6));
 
+        QVERIFY(fakeFolder.currentLocalState().find(QStringLiteral("with spaces")));
+        QVERIFY(!fakeFolder.currentLocalState().find(QStringLiteral("  with spaces  ")));
+
+        fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::DatabaseAndFilesystem, {QStringLiteral("foo"), QStringLiteral("bar"), QStringLiteral("bla"), QStringLiteral("A/foo"), QStringLiteral("A/bar"), QStringLiteral("A/bla")});
         QVERIFY(fakeFolder.syncOnce());
 
         QVERIFY(fakeFolder.currentRemoteState().find(fileWithSpaces1.trimmed()));
@@ -275,6 +280,11 @@ private slots:
         QVERIFY(!fakeFolder.currentRemoteState().find(fileWithSpaces6));
         QVERIFY(fakeFolder.currentLocalState().find("A/bla"));
         QVERIFY(!fakeFolder.currentLocalState().find(fileWithSpaces6));
+
+        QVERIFY(fakeFolder.currentRemoteState().find(QStringLiteral("with spaces")));
+        QVERIFY(!fakeFolder.currentRemoteState().find(QStringLiteral("  with spaces  ")));
+        QVERIFY(fakeFolder.currentLocalState().find(QStringLiteral("with spaces")));
+        QVERIFY(!fakeFolder.currentLocalState().find(QStringLiteral("  with spaces  ")));
     }
 
     void testCreateFileWithTrailingSpaces_localAndRemoteTrimmedDoNotExist_renameFile()


### PR DESCRIPTION
ensure that normal sync engine will nto delete new file renamed due to
trailing/leading spaces in name

rename before upload in the same job to avoid having invalid state in
local desktop client database to ensure any subsequent run of the sync
engine will not make wrong decisions

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
