### PR TITLE
More dark mode fixes

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -697,8 +697,8 @@ Window {
             itemHeight: trayWindowBackground.Style.unifiedSearchItemHeight
             titleFontSize: trayWindowBackground.Style.unifiedSearchResulTitleFontSize
             sublineFontSize: trayWindowBackground.Style.unifiedSearchResulSublineFontSize
-            titleColor: trayWindowBackground.Style.unifiedSearchResulTitleColor
-            sublineColor: trayWindowBackground.Style.unifiedSearchResulSublineColor
+            titleColor: Style.ncTextColor
+            sublineColor: Style.ncSecondaryTextColor
             iconColor: "#afafaf"
         }
 

--- a/theme.qrc.in
+++ b/theme.qrc.in
@@ -115,6 +115,7 @@
         <file>theme/black/state-warning-64.png</file>
         <file>theme/black/state-warning-128.png</file>
         <file>theme/black/state-warning-256.png</file>
+        <file>theme/white/activity.svg</file>
         <file>theme/white/bell.svg</file>
         <file>theme/white/calendar.svg</file>
         <file>theme/white/change.svg</file>


### PR DESCRIPTION
A couple of small dark mode fixes:

- Added the correct path to white activity icon in the theme.qrc.in file, activity.svg icon now shows up in dark mode
- Fixed the colouring of the loading indicators on the unified search area