### PR TITLE
ensure we do properly failed hydration jobs

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -229,7 +229,7 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
         qCritical(lcCfApiWrapper) << "Failed to finalize hydration job for" << path << requestId;
     }
 
-    if (static_cast<OCC::HydrationJob::Status>(hydrationJobResult) == OCC::HydrationJob::Success) {
+    if (static_cast<OCC::HydrationJob::Status>(hydrationJobResult) != OCC::HydrationJob::Success) {
         sendTransferError();
     }
 }

--- a/src/libsync/vfs/cfapi/hydrationjob.cpp
+++ b/src/libsync/vfs/cfapi/hydrationjob.cpp
@@ -300,7 +300,16 @@ void OCC::HydrationJob::finalize(OCC::VfsCfApi *vfs)
         return;
     }
 
-    record._type = ItemTypeFile;
+    switch(_status) {
+    case Success:
+        record._type = ItemTypeFile;
+        break;
+    case Error:
+    case Cancelled:
+        record._type = CSyncEnums::ItemTypeVirtualFile;
+        break;
+    };
+
     // store the actual size of a file that has been decrypted as we will need its actual size when dehydrating it if requested
     record._fileSize = FileSystem::getSize(localPath() + folderPath());
 


### PR DESCRIPTION
report status when the job is in error at end of hydration request
instead of doing the opposite

properly set status in db when a file failed to hydrate (still a virtual
file not a real one)

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
