### PR TITLE
Fix thumbnails for new files made while client open

### DIFF
--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -46,7 +46,7 @@ ActivityLink ActivityLink::createFomJsonObject(const QJsonObject &obj)
     return activityLink;
 }
 
-OCC::Activity Activity::fromActivityJson(const QJsonObject json, const AccountPtr account)
+OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountPtr account)
 {
     const auto activityUser = json.value(QStringLiteral("user")).toString();
 
@@ -118,8 +118,9 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject json, const AccountPt
     }
 
     const auto previewsData = json.value(QStringLiteral("previews")).toArray();
+    const QMimeDatabase mimeDb;
 
-    for(const auto preview : previewsData) {
+    for(const auto &preview : previewsData) {
         const auto jsonPreviewData = preview.toObject();
 
         PreviewData data;
@@ -129,11 +130,10 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject json, const AccountPt
         data._view = jsonPreviewData.value(QStringLiteral("view")).toString();
         data._filename = jsonPreviewData.value(QStringLiteral("filename")).toString();
 
-        if(data._mimeType.contains(QStringLiteral("text/"))) {
-            data._source = account->url().toString() + QStringLiteral("/index.php/apps/theming/img/core/filetypes/text.svg");
-            data._isMimeTypeIcon = true;
-        } else if (data._mimeType.contains(QStringLiteral("/pdf"))) {
-            data._source = account->url().toString() + QStringLiteral("/index.php/apps/theming/img/core/filetypes/application-pdf.svg");
+        const auto mimeType = mimeDb.mimeTypeForName(data._mimeType);
+
+        if(data._mimeType.contains(QStringLiteral("text/")) || data._mimeType.contains(QStringLiteral("/pdf"))) {
+            data._source = account->url().toString() + relativeServerFileTypeIconPath(mimeType);
             data._isMimeTypeIcon = true;
         } else {
             data._source = jsonPreviewData.value(QStringLiteral("source")).toString();
@@ -162,6 +162,54 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject json, const AccountPt
     }
 
     return activity;
+}
+
+QString Activity::relativeServerFileTypeIconPath(const QMimeType &mimeType)
+{
+    if(mimeType.isValid() && mimeType.inherits("text/plain")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/text.svg");
+    } else if (mimeType.isValid() && mimeType.name().startsWith("image")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/image.svg");
+    } else if (mimeType.isValid() && mimeType.name().startsWith("audio")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/audio.svg");
+    } else if (mimeType.isValid() && mimeType.name().startsWith("video")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/video.svg");
+    } else if (mimeType.isValid() && (mimeType.inherits("application/vnd.oasis.opendocument.text") ||
+                                      mimeType.inherits("application/msword") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.wordprocessingml.document") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.wordprocessingml.template")||
+                                      mimeType.inherits("application/vnd.ms-word.document.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-word.template.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.apple.pages"))) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/x-office-document.svg");
+    } else if (mimeType.isValid() && mimeType.inherits("application/vnd.oasis.opendocument.graphics")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/x-office-drawing.svg");
+    } else if (mimeType.isValid() && (mimeType.inherits("application/vnd.oasis.opendocument.presentation") ||
+                                      mimeType.inherits("application/vnd.ms-powerpoint") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.presentationml.presentation") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.presentationml.template") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.presentationml.slideshow") ||
+                                      mimeType.inherits("application/vnd.ms-powerpoint.addin.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-powerpoint.presentation.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-powerpoint.template.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-powerpoint.slideshow.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.apple.keynote"))) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/x-office-presentation.svg");
+    } else if (mimeType.isValid() && (mimeType.inherits("application/vnd.oasis.opendocument.spreadsheet") ||
+                                      mimeType.inherits("application/vnd.ms-excel") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") ||
+                                      mimeType.inherits("application/vnd.openxmlformats-officedocument.spreadsheetml.template") ||
+                                      mimeType.inherits("application/vnd.ms-excel.sheet.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-excel.template.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-excel.addin.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.ms-excel.sheet.binary.macroEnabled.12") ||
+                                      mimeType.inherits("application/vnd.apple.numbers"))) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/x-office-document.svg");
+    } else if (mimeType.isValid() && mimeType.inherits("application/pdf")) {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/application-pdf.svg");
+    } else {
+        return QStringLiteral("/index.php/apps/theming/img/core/filetypes/file.svg");
+    }
 }
 
 }

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -99,7 +99,9 @@ public:
         SyncFileItemType
     };
 
-    static Activity fromActivityJson(const QJsonObject json, const AccountPtr account);
+    static Activity fromActivityJson(const QJsonObject &json, const AccountPtr account);
+
+    static QString relativeServerFileTypeIconPath(const QMimeType &mimeType);
 
     struct RichSubjectParameter {
         QString type;    // Required

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -567,19 +567,12 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
                     PreviewData preview;
                     preview._mimeType = mimeType.name();
                     preview._filename = fileName;
+                    preview._isMimeTypeIcon = true;
 
                     if(item->isDirectory()) {
                         preview._source = account()->url().toString() + QStringLiteral("/index.php/apps/theming/img/core/filetypes/folder.svg");
-                        preview._isMimeTypeIcon = true;
-                    } else if(mimeType.isValid() && mimeType.inherits("text/plain")) {
-                        preview._source = account()->url().toString() + QStringLiteral("/index.php/apps/theming/img/core/filetypes/text.svg");
-                        preview._isMimeTypeIcon = true;
-                    } else if (mimeType.isValid() && mimeType.inherits("application/pdf")) {
-                        preview._source = account()->url().toString() + QStringLiteral("/index.php/apps/theming/img/core/filetypes/application-pdf.svg");
-                        preview._isMimeTypeIcon = true;
                     } else {
-                        preview._source = account()->url().toString() + QStringLiteral("/index.php/apps/files/api/v1/thumbnail/150/150/") + remotePath;
-                        preview._isMimeTypeIcon = false;
+                        preview._source = account()->url().toString() + Activity::relativeServerFileTypeIconPath(mimeType);
                     }
                     activity._previews.append(preview);
                 }


### PR DESCRIPTION
Previously, we would try to pull thumbnails for local changes made while the client was open. If this change was the creation of a new file, we would try to pull the thumbnail from the server before the thumbnail had been created there, leaving us with a blank square rather than the icon that we want.

This PR fixes this behaviour, ensuring that new files get an icon instead of a blank square