### PR TITLE
Improve contrast on server color themed elements

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -212,7 +212,7 @@ RowLayout {
         visible: root.activityData.isShareable
 
         imageSource: "image://svgimage-custom-color/share.svg" + "/" + UserModel.currentUser.headerColor
-        imageSourceHover: "image://svgimage-custom-color/share.svg" + "/" + Style.ncTextColor
+        imageSourceHover: "image://svgimage-custom-color/share.svg" + "/" + UserModel.currentUser.headerTextColor
 
         toolTipText: qsTr("Open share dialog")
 

--- a/src/gui/tray/HeaderButton.qml
+++ b/src/gui/tray/HeaderButton.qml
@@ -8,6 +8,7 @@ import QtGraphicalEffects 1.0
 
 // Custom qml modules are in /theme (and included by resources.qrc)
 import Style 1.0
+import com.nextcloud.desktopclient 1.0
 
 Button {
     id: root
@@ -25,7 +26,7 @@ Button {
     Layout.preferredHeight: Style.trayWindowHeaderHeight
 
     background: Rectangle {
-        color: root.hovered || root.visualFocus ? "white" : "transparent"
+        color: root.hovered || root.visualFocus ? UserModel.currentUser.headerTextColor : "transparent"
         opacity: 0.2
     }
 }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -339,7 +339,7 @@ Window {
                     }
 
                     background: Rectangle {
-                        color: parent.hovered || parent.visualFocus ? "white" : "transparent"
+                        color: parent.hovered || parent.visualFocus ? UserModel.currentUser.headerTextColor : "transparent"
                         opacity: 0.2
                     }
 
@@ -383,7 +383,7 @@ Window {
                                 height: width
                                 anchors.bottom: currentAccountAvatar.bottom
                                 anchors.right: currentAccountAvatar.right
-                                color: currentAccountButton.hovered ? "white" : "transparent"
+                                color: currentAccountButton.hovered ? UserModel.currentUser.headerTextColor : "transparent"
                                 opacity: 0.2
                                 radius: width*0.5
                             }
@@ -526,7 +526,7 @@ Window {
                                 width: Style.folderStateIndicatorSize + 2
                                 height: width
                                 anchors.centerIn: parent
-                                color: openLocalFolderButton.hovered ? "white" : "transparent"
+                                color: openLocalFolderButton.hovered ? UserModel.currentUser.headerTextColor : "transparent"
                                 opacity: 0.2
                                 radius: width*0.5
                                 z: -1


### PR DESCRIPTION
Mainly pertains to the header bar and share icons -- these are now coloured with contrasting black or white depending on the server theme colour.

<img width="497" alt="Screenshot 2022-04-14 at 00 16 12" src="https://user-images.githubusercontent.com/70155116/163279305-405a52f1-6df8-4e34-b96c-d62839a91889.png">

<img width="497" alt="Screenshot 2022-04-14 at 00 18 25" src="https://user-images.githubusercontent.com/70155116/163279532-c0c8c321-0817-42e5-9510-4a3f23ed92ef.png">

<img width="497" alt="Screenshot 2022-04-14 at 00 16 19" src="https://user-images.githubusercontent.com/70155116/163279322-f8746818-a171-4cd4-9b13-d3ccf5530a40.png">

<img width="497" alt="Screenshot 2022-04-14 at 00 18 37" src="https://user-images.githubusercontent.com/70155116/163279510-41b8b19b-6b31-414b-8a6b-8e6d64aff8c9.png">
