### PR TITLE
Fix positioning of activities in the activities list

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -95,13 +95,14 @@ RowLayout {
         Label {
             id: activityTextTitle
             text: (root.activityData.type === "Activity" || root.activityData.type === "Notification") ? root.activityData.subject : root.activityData.message
+            height: (text === "") ? 0 : implicitHeight
             width: parent.width
             elide: Text.ElideRight
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
             color: Style.ncTextColor
-            //color: root.activityData.activityTextTitleColor
+            visible: text !== ""
         }
 
         Label {
@@ -117,6 +118,7 @@ RowLayout {
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
             color: Style.ncTextColor
+            visible: text !== ""
         }
 
         Label {
@@ -129,18 +131,20 @@ RowLayout {
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
             color: Style.ncSecondaryTextColor
+            visible: text !== ""
         }
 
         Label {
             id: talkReplyMessageSent
             text: root.activityData.messageSent
-            height: implicitHeight
+            height: (text === "") ? 0 : implicitHeight
             width: parent.width
             elide: Text.ElideRight
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
             color: Style.ncSecondaryTextColor
+            visible: text !== ""
         }
 
         Loader {

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -31,7 +31,7 @@ ScrollView {
 
         clip: true
 
-        spacing: 10
+        spacing: 0
 
         delegate: ActivityItem {
             isFileActivityList: controlRoot.isFileActivityList


### PR DESCRIPTION
This PR removes activity spacing in the activity list view and fixes the activity label alignment, which is now ensured to be centred

![Screenshot 2022-04-14 at 00 28 14](https://user-images.githubusercontent.com/70155116/163280681-e49207d1-e3dd-4bc4-95d9-d4847ebd7377.png)
