### PR TITLE
Fix activity list item issues with colours/layout/etc.

### DIFF
--- a/src/gui/tray/ActivityItemActions.qml
+++ b/src/gui/tray/ActivityItemActions.qml
@@ -22,6 +22,7 @@ RowLayout {
     property Flickable flickable
 
     signal triggerAction(int actionIndex)
+    signal showReplyField()
 
     Repeater {
         id: actionsRepeater
@@ -42,15 +43,15 @@ RowLayout {
             text: model.modelData.label
             toolTipText: model.modelData.label
 
-            imageSource: model.modelData.imageSource
-            imageSourceHover: model.modelData.imageSourceHovered
+            imageSource: model.modelData.imageSource ? model.modelData.imageSource + UserModel.currentUser.headerColor : ""
+            imageSourceHover: model.modelData.imageSourceHovered ? model.modelData.imageSourceHovered + UserModel.currentUser.headerTextColor : ""
 
             textColor: imageSource !== "" ? UserModel.currentUser.headerColor : Style.ncTextColor
-            textColorHovered: imageSource !== "" ? Style.lightHover : Style.ncTextColor
+            textColorHovered: imageSource !== "" ? UserModel.currentUser.headerTextColor : Style.ncTextColor
 
             bold: primary
 
-            onClicked: !isTalkReplyButton? root.triggerAction(model.index) : showReplyOptions(model.index)
+            onClicked: !isTalkReplyButton ? root.triggerAction(model.index) : root.showReplyField()
         }
     }
 

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -26,10 +26,10 @@ RowLayout {
         id: thumbnailItem
         Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
         Layout.preferredWidth: Style.trayListItemIconSize
-        Layout.preferredHeight: model.thumbnail.isMimeTypeIcon ? Style.trayListItemIconSize * 0.9 : Style.trayListItemIconSize
+        Layout.preferredHeight: model.thumbnail && model.thumbnail.isMimeTypeIcon ? Style.trayListItemIconSize * 0.9 : Style.trayListItemIconSize
         readonly property int imageWidth: width * (1 - Style.thumbnailImageSizeReduction)
         readonly property int imageHeight: height * (1 - Style.thumbnailImageSizeReduction)
-        readonly property int thumbnailRadius: model.thumbnail.isUserAvatar ? width / 2 : 3
+        readonly property int thumbnailRadius: model.thumbnail && model.thumbnail.isUserAvatar ? width / 2 : 3
 
         Loader {
             id: thumbnailImageLoader
@@ -165,20 +165,6 @@ RowLayout {
             font.pixelSize: Style.topLinePixelSize
             color: Style.ncSecondaryTextColor
             visible: text !== ""
-        }
-
-        Loader {
-            id: talkReplyTextFieldLoader
-            active: isChatActivity && isTalkReplyPossible
-            visible: isTalkReplyOptionVisible
-
-            anchors.top: activityTextDateTime.bottom
-            anchors.topMargin: 10
-
-            sourceComponent: TalkReplyTextField {
-                id: talkReplyMessage
-                anchors.fill: parent
-            }
         }
     }
 

--- a/src/gui/tray/TalkReplyTextField.qml
+++ b/src/gui/tray/TalkReplyTextField.qml
@@ -7,28 +7,31 @@ import com.nextcloud.desktopclient 1.0
 Item {
     id: root
 
+    signal sendReply(string reply)
+
     function sendReplyMessage() {
         if (replyMessageTextField.text === "") {
             return;
         }
 
-        UserModel.currentUser.sendReplyMessage(model.index, model.conversationToken, replyMessageTextField.text, model.messageId);
-        replyMessageTextField.visible = false
+        root.sendReply(replyMessageTextField.text);
     }
+
+    height: 38
+    width: 250
 
     TextField {
         id: replyMessageTextField
+
+        anchors.fill: parent
+        topPadding: 4
+        rightPadding: sendReplyMessageButton.width
         visible: model.messageSent === ""
 
-        // TODO use Layout to manage width/height. The Layout.minimunWidth does not apply to the width set.
-        height: 38
-        width: 250
+        color: Style.ncSecondaryTextColor
+        placeholderText: qsTr("Reply to …")
 
         onAccepted: root.sendReplyMessage()
-
-        topPadding: 4
-
-        placeholderText: qsTr("Reply to …")
 
         background: Rectangle {
             id: replyMessageTextFieldBorder

--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -63,24 +63,8 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountP
     activity._file = json.value(QStringLiteral("object_name")).toString();
     activity._link = QUrl(json.value(QStringLiteral("link")).toString());
     activity._dateTime = QDateTime::fromString(json.value(QStringLiteral("datetime")).toString(), Qt::ISODate);
-    activity._darkIcon = json.value(QStringLiteral("icon")).toString();  // We have both dark and light for theming purposes
-    activity._lightIcon = json.value(QStringLiteral("icon")).toString(); // Some icons get changed in the ActivityListModel
+    activity._icon = json.value(QStringLiteral("icon")).toString();
     activity._isCurrentUserFileActivity = activity._objectType == QStringLiteral("files") && activityUser == account->davUser();
-
-    const auto darkIconPath = QStringLiteral("qrc://:/client/theme/white/");
-    const auto lightIconPath = QStringLiteral("qrc://:/client/theme/black/");
-    if(activity._darkIcon.contains("change.svg")) {
-        activity._darkIcon = darkIconPath + QStringLiteral("change.svg");
-        activity._lightIcon = lightIconPath + QStringLiteral("change.svg");
-    } else if(activity._darkIcon.contains("calendar.svg")) {
-        activity._darkIcon = darkIconPath + QStringLiteral("calendar.svg");
-        activity._lightIcon = lightIconPath + QStringLiteral("calendar.svg");
-    } else if(activity._darkIcon.contains("personal.svg")) {
-        activity._darkIcon = darkIconPath + QStringLiteral("user.svg");
-        activity._lightIcon = lightIconPath + QStringLiteral("user.svg");
-    }  else if(activity._darkIcon.contains("core/img/actions")) {
-        activity._darkIcon.insert(activity._darkIcon.indexOf(".svg"), "-white");
-    }
 
     auto richSubjectData = json.value(QStringLiteral("subject_rich")).toArray();
 
@@ -144,15 +128,12 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountP
     }
 
     if(!previewsData.isEmpty()) {
-        if(activity._darkIcon.contains(QStringLiteral("add-color.svg"))) {
-            activity._darkIcon = "qrc:///client/theme/colored/add-bordered.svg";
-            activity._lightIcon = "qrc:///client/theme/colored/add-bordered.svg";
-        } else if(activity._darkIcon.contains(QStringLiteral("delete-color.svg"))) {
-            activity._darkIcon = "qrc:///client/theme/colored/delete-bordered.svg";
-            activity._lightIcon = "qrc:///client/theme/colored/add-bordered.svg";
-        } else if(activity._darkIcon.contains(QStringLiteral("change.svg"))) {
-            activity._darkIcon = "qrc:///client/theme/colored/change-bordered.svg";
-            activity._lightIcon = "qrc:///client/theme/colored/add-bordered.svg";
+        if(activity._icon.contains(QStringLiteral("add-color.svg"))) {
+            activity._icon = "qrc:///client/theme/colored/add-bordered.svg";
+        } else if(activity._icon.contains(QStringLiteral("delete-color.svg"))) {
+            activity._icon = "qrc:///client/theme/colored/delete-bordered.svg";
+        } else if(activity._icon.contains(QStringLiteral("change.svg"))) {
+            activity._icon = "qrc:///client/theme/colored/change-bordered.svg";
         }
     }
 

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -137,8 +137,7 @@ public:
     QDateTime _dateTime;
     qint64 _expireAtMsecs = -1;
     QString _accName;
-    QString _darkIcon;
-    QString _lightIcon;
+    QString _icon;
     bool _isCurrentUserFileActivity = false;
     QVector<PreviewData> _previews;
 

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -248,11 +248,13 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             }
         } else {
             // We have an activity
-            if (a._darkIcon.isEmpty()) {
+            if (a._icon.isEmpty()) {
                 colorIconPath.append("activity.svg");
                 return colorIconPath;
             }
-            return role == DarkIconRole ? a._darkIcon : a._lightIcon;
+
+            const QString basePath = QStringLiteral("image://tray-image-provider/") % a._icon % QStringLiteral("/");
+            return role == DarkIconRole ? QString(basePath + QStringLiteral("white")) : QString(basePath + QStringLiteral("black"));
         }
     };
 
@@ -485,8 +487,7 @@ void ActivityListModel::insertOrRemoveDummyFetchingActivity()
         a._objectType = dummyFetchingActivityObjectType;
         a._subject = tr("Fetching activities…");
         a._dateTime = QDateTime::currentDateTime();
-        a._darkIcon = QLatin1String("qrc:///client/theme/colored/change-bordered.svg");
-        a._lightIcon = QLatin1String("qrc:///client/theme/colored/change-bordered.svg");
+        a._icon = QLatin1String("qrc:///client/theme/colored/change-bordered.svg");
 
         beginInsertRows({}, 0, 0);
         _finalList.prepend(a);
@@ -792,10 +793,8 @@ QVariant ActivityListModel::convertLinkToActionButton(const OCC::ActivityLink &a
     const QString replyButtonPath = QStringLiteral("image://svgimage-custom-color/reply.svg");
 
     if (isReplyIconApplicable) {
-        activityLinkCopy._imageSource =
-            QString(replyButtonPath + "/" + OCC::Theme::instance()->wizardHeaderBackgroundColor().name());
-        activityLinkCopy._imageSourceHovered =
-            QString(replyButtonPath + "/" + OCC::Theme::instance()->wizardHeaderTitleColor().name());
+        activityLinkCopy._imageSource = QString(replyButtonPath + "/");
+        activityLinkCopy._imageSourceHovered = QString(replyButtonPath + "/");
     }
 
     return QVariant::fromValue(activityLinkCopy);

--- a/src/gui/tray/asyncimageresponse.h
+++ b/src/gui/tray/asyncimageresponse.h
@@ -33,5 +33,6 @@ private slots:
     QImage _image;
     QStringList _imagePaths;
     QSize _requestedImageSize;
+    QColor _svgRecolor;
     int _index = 0;
 };


### PR DESCRIPTION
This PR includes fixes for several critical issues with the activity list items, mainly:

- Wrong colouration of primary activity actions (e.g. the Reply button)
- Incorrect activity icon colour in dark mode (changes should also make the code around correct icon selection much cleaner and future proof, as the tray image provider can now recolour SVGs too)
- Several issues with the talk reply field relating to layout, particularly location of text field and height of activity item once the textfield is invoked and once the message has been sent, as well as readability of text

After fixes:

<img width="497" alt="Screenshot 2022-05-02 at 21 55 12" src="https://user-images.githubusercontent.com/70155116/166316279-db408775-d301-45f0-9291-49b9554e7dda.png">

<img width="497" alt="Screenshot 2022-05-02 at 21 54 22" src="https://user-images.githubusercontent.com/70155116/166316193-c09c910b-a49c-49ad-8e31-1b7cdc475527.png">

Before fixes:

<img width="497" alt="Screenshot 2022-05-02 at 18 36 40" src="https://user-images.githubusercontent.com/70155116/166315740-7d569022-197a-43fe-baa7-e1cfd5146474.png">
