### PR TITLE
Ask for Desktop Client version

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -105,6 +105,14 @@ body:
       placeholder: 23.0.1
     validations:
       required: true
+  - type: input
+    id: client-version
+    attributes:
+      label: Nextcloud Desktop Client version
+      description: Nextcloud Desktop Client version.
+      placeholder: 3.5.0
+    validations:
+      required: true
   - type: dropdown
     id: fresh
     attributes:


### PR DESCRIPTION
Alongside with Server version.
Fix https://github.com/nextcloud/desktop/issues/4488

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Signed-off-by: solracsf <yipsenelto@tozya.com>