### PR TITLE
Bugfix/two factor notification

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -778,9 +778,9 @@ QVariantList ActivityListModel::convertLinksToActionButtons(const Activity &acti
     }
 
     for (const auto &activityLink : activity._links) {
-        if (activityLink._verb == QStringLiteral("DELETE")
-            || (activity._objectType == QStringLiteral("chat") || activity._objectType == QStringLiteral("call")
-                || activity._objectType == QStringLiteral("room"))) {
+        if (activityLink._primary
+            || activityLink._verb == QStringLiteral("DELETE")
+            || activityLink._verb == QStringLiteral("WEB")) {
             customList << ActivityListModel::convertLinkToActionButton(activityLink);
         }
     }

--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -149,12 +149,17 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
 
         // Add another action to dismiss notification on server
         // https://github.com/owncloud/notifications/blob/master/docs/ocs-endpoint-v1.md#deleting-a-notification-for-a-user
-        ActivityLink al;
-        al._label = tr("Dismiss");
-        al._link = Utility::concatUrlPath(ai->account()->url(), notificationsPath + "/" + QString::number(a._id)).toString();
-        al._verb = "DELETE";
-        al._primary = false;
-        a._links.append(al);
+        constexpr auto deleteVerb = "DELETE";
+        if (std::find_if(std::cbegin(a._links), std::cend(a._links), [](const ActivityLink& link) {
+                return link._verb == deleteVerb;
+            }) == std::cend(a._links)) {
+            ActivityLink al;
+            al._label = tr("Dismiss");
+            al._link = Utility::concatUrlPath(ai->account()->url(), notificationsPath + "/" + QString::number(a._id)).toString();
+            al._verb = deleteVerb;
+            al._primary = false;
+            a._links.append(al);
+        }
 
         list.append(a);
     }


### PR DESCRIPTION
Before:
![bug](https://user-images.githubusercontent.com/241266/167924062-3b729de3-024b-4585-bcdb-ad5a127631d6.png)

After:
![two-factor-auth](https://user-images.githubusercontent.com/241266/167949016-b8e22e4f-5fe2-4b60-83ce-5577808f6267.png)

@nimishavijay We are always using 'Mark as Read' in all notifications. May I suggest to simply always use what comes with the notification, like in this case it should be 'Cancel'. That was one of the reasons that we had this bug.


