### PR TITLE
Fix crashing of finder sync extension caused by dispatch_source_cancel of nullptr

### DIFF
--- a/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/LocalSocketClient.m
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/LocalSocketClient.m
@@ -137,10 +137,17 @@
 - (void)closeConnection
 {
     NSLog(@"Closing connection.");
-    dispatch_source_cancel(self.readSource);
-    dispatch_source_cancel(self.writeSource);
-    self.readSource = nil;
-    self.writeSource = nil;
+    
+    if(self.readSource) {
+        dispatch_source_cancel(self.readSource);
+        self.readSource = nil;
+    }
+    
+    if(self.writeSource) {
+        dispatch_source_cancel(self.writeSource);
+        self.writeSource = nil;
+    }
+
     [self.inBuffer setLength:0];
     [self.outBuffer setLength: 0];
     


### PR DESCRIPTION
This PR addresses crashing faced by some users of the Finder Sync extension. Stack traces indicate this crashing originates from a bad dispatch queue call, so we are guarding the calls to ensure they are only called if the `readSource` and `writeSource` queues are not null.

Addresses #4459 