### PR TITLE
Do not replace strings in action links coming from the notification api.

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -798,10 +798,6 @@ QVariant ActivityListModel::convertLinkToActionButton(const OCC::ActivityLink &a
             QString(replyButtonPath + "/" + OCC::Theme::instance()->wizardHeaderTitleColor().name());
     }
 
-    if (activityLink._verb == QStringLiteral("DELETE")) {
-        activityLinkCopy._label = QObject::tr("Mark as read");
-    }
-
     return QVariant::fromValue(activityLinkCopy);
 }
 

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -705,10 +705,10 @@ private slots:
                                 // in case total actions is longer than ActivityListModel::maxActionButtons, then a sum of action buttons and action menu entries must be equal to a total of action links
                                 QVERIFY(actionButtonsLinks.size() + actionsLinksContextMenu.size() == actionsLinks.size());
                             } else {
-                                // in case a total of actions is less or equal to than ActivityListModel::maxActionButtons, then the length of action buttons must be greater than 1 and should contain "Mark as read" button at the end
+                                // in case a total of actions is less or equal to than ActivityListModel::maxActionButtons, then the length of action buttons must be greater than 1 and should contain "Dismiss" button at the end
                                 QVERIFY(actionButtonsLinks.size() > 1);
                                 QVERIFY(actionButtonsLinks[1].value<OCC::ActivityLink>()._label
-                                    == QObject::tr("Mark as read"));
+                                    == QObject::tr("Dismiss"));
                             }
                         } else if ((objectType == QStringLiteral("call"))) {
                             QVERIFY(


### PR DESCRIPTION
Doing what I discussed with @nimishavijay in https://github.com/nextcloud/desktop/pull/4518#issuecomment-1124815066.

Just thought that we might not want to have this in a bugfix release so it would be better to have it in a different PR.

![dismiss](https://user-images.githubusercontent.com/241266/168053861-0b94ee23-7146-4bd8-9dd8-a5780c1f1124.png)
