### PR TITLE
Fixed share link expiration box being ineditable and always attempting to set invalid date

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -487,8 +487,11 @@ void ShareLinkWidget::toggleExpireDateOptions(const bool enable)
     const auto date = enable ? _linkShare->getExpireDate() : QDate::currentDate().addDays(1);
     _ui->calendar->setDate(date);
     _ui->calendar->setMinimumDate(QDate::currentDate().addDays(1));
-    _ui->calendar->setMaximumDate(
-        QDate::currentDate().addDays(_account->capabilities().sharePublicLinkExpireDateDays()));
+
+    if(_account->capabilities().sharePublicLinkExpireDateDays() > 0) {
+        _ui->calendar->setMaximumDate(QDate::currentDate().addDays(_account->capabilities().sharePublicLinkExpireDateDays()));
+    }
+
     _ui->calendar->setFocus();
     
     if (!enable && _linkShare && _linkShare->getExpireDate().isValid()) {


### PR DESCRIPTION
This PR fixes a bug where on servers with no set share link expire days, the date input box for the expiry of the link would have its maximum date set to the current date, which is considered invalid by the server. With a higher minimum than maximum date the box would also be uneditable, preventing the user from fixing the date.

This PR fixes this by only applying a maximum date if the server has a set number of days to expire (i.e. if this value is larger than 0), 

Fixes #4068
