### PR TITLE
add explicit capture for lambda

### DIFF
--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -150,9 +150,11 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         // Add another action to dismiss notification on server
         // https://github.com/owncloud/notifications/blob/master/docs/ocs-endpoint-v1.md#deleting-a-notification-for-a-user
         constexpr auto deleteVerb = "DELETE";
-        if (std::find_if(std::cbegin(a._links), std::cend(a._links), [](const ActivityLink& link) {
-                return link._verb == deleteVerb;
-            }) == std::cend(a._links)) {
+        const auto itLink = std::find_if(std::cbegin(a._links), std::cend(a._links), [deleteVerb](const ActivityLink& link) {
+            Q_UNUSED(deleteVerb)
+            return link._verb == deleteVerb;
+        });
+        if (itLink == std::cend(a._links)) {
             ActivityLink al;
             al._label = tr("Dismiss");
             al._link = Utility::concatUrlPath(ai->account()->url(), notificationsPath + "/" + QString::number(a._id)).toString();


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
