### PR TITLE
Bump up minimum macOS version

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -34,7 +34,7 @@ System Requirements
 ----------------------------------
 
 - Windows 8.1+
-- macOS 10.12+ (64-bit only)
+- macOS 10.14+ (64-bit only)
 - Linux
 - FreeBSD
 


### PR DESCRIPTION
The new notifications require a minimum macOS version of 10.14