### PR TITLE
Reduce spacing above the buttons: spacing should be same as space between lines in the text above

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -62,7 +62,7 @@ MouseArea {
         anchors.leftMargin: Style.standardSpacing
         anchors.verticalCenter: parent.verticalCenter
 
-        spacing: 10
+        spacing: Style.activityContentSpace
 
         ActivityItemContent {
             id: activityContent

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -106,11 +106,11 @@ RowLayout {
     Column {
         id: activityTextColumn
 
-        Layout.topMargin: 4
+        Layout.topMargin: Style.activityContentSpace
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
 
-        spacing: 4
+        spacing: Style.activityContentSpace
 
         Label {
             id: activityTextTitle

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -97,6 +97,8 @@ QtObject {
 
     readonly property var fontMetrics: FontMetrics {}
 
+    readonly property int activityContentSpace: 4
+
     function variableSize(size) {
         return size * (1 + Math.min(pixelSize / 100, 1));       
     }


### PR DESCRIPTION
Spacing is now the  same as space between lines in the text above.

It address the second item in https://github.com/nextcloud/desktop/issues/4435.

Before:
![before](https://user-images.githubusercontent.com/241266/169283855-edea232e-8194-4b02-99b1-9f0342209442.png)

After:
![after](https://user-images.githubusercontent.com/241266/169283879-d0323367-40f7-44c6-8ed6-9ef67fd2a127.png)
