### PR TITLE
Reply button size should be same as the input field, smaller + text color

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -87,8 +87,9 @@ MouseArea {
             active: root.isChatActivity && root.isTalkReplyPossible && model.messageSent === ""
             visible: root.isTalkReplyOptionVisible
 
+            Layout.preferredWidth: Style.talkReplyTextFieldPreferredWidth
+            Layout.preferredHeight: Style.talkReplyTextFieldPreferredHeight
             Layout.leftMargin: Style.trayListItemIconSize + activityContent.spacing
-            Layout.preferredHeight: root.isTalkReplyOptionVisible ? implicitHeight : 0
 
             sourceComponent: TalkReplyTextField {
                 onSendReply: {

--- a/src/gui/tray/TalkReplyTextField.qml
+++ b/src/gui/tray/TalkReplyTextField.qml
@@ -17,7 +17,7 @@ Item {
         root.sendReply(replyMessageTextField.text);
     }
 
-    height: 38
+    height: 30
     width: 250
 
     TextField {

--- a/src/gui/tray/TalkReplyTextField.qml
+++ b/src/gui/tray/TalkReplyTextField.qml
@@ -17,15 +17,13 @@ Item {
         root.sendReply(replyMessageTextField.text);
     }
 
-    height: 30
-    width: 250
-
     TextField {
         id: replyMessageTextField
 
+        height: Style.talkReplyTextFieldPreferredHeight
+
         anchors.fill: parent
-        topPadding: 4
-        rightPadding: sendReplyMessageButton.width
+
         visible: model.messageSent === ""
 
         color: Style.ncTextColor
@@ -42,9 +40,11 @@ Item {
         }
 
         Button {
-            id: sendReplyMessageButton  
-            width: 32
+            id: sendReplyMessageButton
+
+            width: Style.talkReplyTextFieldPreferredWidth * 0.12
             height: parent.height
+
             opacity: 0.8
             flat: true
             enabled: replyMessageTextField.text !== ""
@@ -53,8 +53,6 @@ Item {
 
             icon {
                 source: "image://svgimage-custom-color/send.svg" + "/" + Style.menuBorder
-                width: 38
-                height: 38
                 color: hovered || !sendReplyMessageButton.enabled? Style.menuBorder : UserModel.currentUser.accentColor
             }
 

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -73,6 +73,9 @@ QtObject {
 
     property int activityLabelBaseWidth: 240
 
+    property int talkReplyTextFieldPreferredHeight: 34
+    property int talkReplyTextFieldPreferredWidth: 250
+
     property int activityItemActionPrimaryButtonMinWidth: 100
     property int activityItemActionSecondaryButtonMinWidth: 80
 


### PR DESCRIPTION
It should address the third and fourth item in https://github.com/nextcloud/desktop/issues/4435.

![textfield](https://user-images.githubusercontent.com/241266/169328957-4f968f07-a24f-4fcf-b59a-81229d600d29.png)

Text color:
![text](https://user-images.githubusercontent.com/241266/169371291-1a28729b-3485-4fb9-b1a5-23a4c940eb08.png)


