### PR TITLE
Prevent call dialogs from being presented when do not disturb is set as the user status

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -130,10 +130,18 @@ void User::slotBuildNotificationDisplay(const ActivityList &list)
 
 void User::slotBuildIncomingCallDialogs(const ActivityList &list)
 {
-    const auto systray = Systray::instance();
     const ConfigFile cfg;
+    const auto userStatus = _account->account()->userStatusConnector()->userStatus().state();
+    if (userStatus == OCC::UserStatus::OnlineStatus::DoNotDisturb ||
+            !cfg.optionalServerNotifications() ||
+            !cfg.showCallNotifications() ||
+            !isDesktopNotificationsAllowed()) {
+        return;
+    }
 
-    if(systray && cfg.showCallNotifications()) {
+    const auto systray = Systray::instance();
+
+    if(systray) {
         for(const auto &activity : list) {
             systray->createCallDialog(activity);
         }


### PR DESCRIPTION
Closes #4607 