### PR TITLE
Fix crashing when selecting user status and predefined statuses not appearing

### DIFF
--- a/src/gui/UserStatusSelectorDialog.qml
+++ b/src/gui/UserStatusSelectorDialog.qml
@@ -4,10 +4,14 @@ import com.nextcloud.desktopclient 1.0 as NC
 
 Window {
     id: dialog
+
+    title: qsTr("Set user status")
     
     property NC.UserStatusSelectorModel model: NC.UserStatusSelectorModel {
         onFinished: dialog.close()
     }
+    property int userIndex
+    onUserIndexChanged: model.load(userIndex)
 
     minimumWidth: view.implicitWidth
     minimumHeight: view.implicitHeight

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -184,10 +184,7 @@ MenuItem {
                     font.pixelSize: Style.topLinePixelSize
                     palette.windowText: Style.ncTextColor
                     hoverEnabled: true
-                    onClicked: {
-                        showUserStatusSelectorDialog(index)
-                        accountMenu.close()
-                    }
+                    onClicked: showUserStatusSelectorDialog(index)
 
                     background: Item {
                         height: parent.height

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -175,10 +175,6 @@ Window {
                         }
                     }
 
-                    Loader {
-                        id: userStatusSelectorDialogLoader
-                    }
-
                     Menu {
                         id: accountMenu
 
@@ -221,15 +217,36 @@ Window {
                             userLineInstantiator.active = true;
                         }
 
+                        Loader {
+                            id: userStatusSelectorDialogLoader
+
+                            property int userIndex
+
+                            function openDialog(newUserIndex) {
+                                console.log(`About to show dialog for user with index ${newUserIndex}`);
+                                userIndex = newUserIndex;
+                                active = true;
+                                item.show();
+                            }
+
+                            active: false
+                            sourceComponent: UserStatusSelectorDialog {
+                                userIndex: userStatusSelectorDialogLoader.userIndex
+                            }
+
+                            onLoaded: {
+                                item.model.load(userIndex);
+                                item.show();
+                            }
+                        }
+
                         Instantiator {
                             id: userLineInstantiator
                             model: UserModel
                             delegate: UserLine {
                                 onShowUserStatusSelectorDialog: {
-                                    userStatusSelectorDialogLoader.source = "qrc:/qml/src/gui/UserStatusSelectorDialog.qml"
-                                    userStatusSelectorDialogLoader.item.title = qsTr("Set user status")
-                                    userStatusSelectorDialogLoader.item.model.load(index)
-                                    userStatusSelectorDialogLoader.item.show()
+                                    userStatusSelectorDialogLoader.openDialog(model.index);
+                                    accountMenu.close();
                                 }
                             }
                             onObjectAdded: accountMenu.insertItem(index, object)

--- a/src/gui/userstatusselectormodel.cpp
+++ b/src/gui/userstatusselectormodel.cpp
@@ -301,7 +301,6 @@ Optional<ClearAt> UserStatusSelectorModel::clearStageTypeToDateTime(ClearStageTy
 
 void UserStatusSelectorModel::setUserStatus()
 {
-    Q_ASSERT(_userStatusConnector);
     if (!_userStatusConnector) {
         return;
     }
@@ -312,7 +311,6 @@ void UserStatusSelectorModel::setUserStatus()
 
 void UserStatusSelectorModel::clearUserStatus()
 {
-    Q_ASSERT(_userStatusConnector);
     if (!_userStatusConnector) {
         return;
     }

--- a/src/gui/userstatusselectormodel.cpp
+++ b/src/gui/userstatusselectormodel.cpp
@@ -79,6 +79,7 @@ UserStatusSelectorModel::UserStatusSelectorModel(const UserStatus &userStatus,
 void UserStatusSelectorModel::load(int id)
 {
     reset();
+    qCDebug(lcUserStatusDialogModel) << "Loading user status connector for user with index: " << id;
     _userStatusConnector = UserModel::instance()->userStatusConnector(id);
     init();
 }
@@ -177,7 +178,7 @@ void UserStatusSelectorModel::clearError()
 
 void UserStatusSelectorModel::setOnlineStatus(UserStatus::OnlineStatus status)
 {
-    if (status == _userStatus.state()) {
+    if (!_userStatusConnector || status == _userStatus.state()) {
         return;
     }
 


### PR DESCRIPTION
Previously, the signal handler for opening the user status selector dialog would try to trigger the loading of the selected user's user status connector for the user status selector model before the dialog had finished loading. This would cause the loading to never be triggered and the pointer to remain null, which, combined with the lack of a check for a null pointer, would cause a crash.

This PR fixes the user status connector loading behaviour to not be subject to this race condition, and adds checks for the null pointer in the user status selector model.

EDIT: upon testing this PR also fixes an issue where predefined statuses don't appear the first time the user status selector is invoked