### PR TITLE
Rephrase login dialog button text to be in line with clients on other platforms

### DIFF
--- a/src/gui/wizard/welcomepage.cpp
+++ b/src/gui/wizard/welcomepage.cpp
@@ -84,9 +84,6 @@ void WelcomePage::setupSlideShow()
 
 void WelcomePage::setupLoginButton()
 {
-    const auto appName = Theme::instance()->appNameGUI();
-
-    _ui->loginButton->setText(tr("Log in to your %1").arg(appName));
     connect(_ui->loginButton, &QPushButton::clicked, this, [this](bool /*checked*/) {
         _nextPage = WizardCommon::Page_ServerSetup;
         _ocWizard->next();

--- a/src/gui/wizard/welcomepage.ui
+++ b/src/gui/wizard/welcomepage.ui
@@ -140,7 +140,7 @@
        <item>
         <widget class="QPushButton" name="loginButton">
          <property name="text">
-          <string>Log in to your %1</string>
+          <string>Log in</string>
          </property>
          <property name="autoDefault">
           <bool>true</bool>
@@ -153,7 +153,7 @@
        <item>
         <widget class="QPushButton" name="createAccountButton">
          <property name="text">
-          <string>Create account with Provider</string>
+          <string>Sign up with provider</string>
          </property>
          <property name="autoDefault">
           <bool>true</bool>


### PR DESCRIPTION
![Screenshot 2022-06-13 at 15 42 01](https://user-images.githubusercontent.com/70155116/173367415-52ad2d99-5c02-49c4-b5e7-510daeb7c792.png)

Closes #3693

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>
