### PR TITLE
bugfix/share-dialog

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -20,8 +20,6 @@ MouseArea {
     property color adjustedHeaderColor: Theme.darkMode ? Qt.lighter(UserModel.currentUser.headerColor, 2)
                                                        : Qt.darker(UserModel.currentUser.headerColor, 1.5)
 
-    signal fileActivityButtonClicked(string absolutePath)
-
     enabled: (model.path !== "" || model.link !== "" || model.isCurrentUserFileActivity === true)
     hoverEnabled: true
 

--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -79,7 +79,8 @@ MouseArea {
 
             adjustedHeaderColor: root.adjustedHeaderColor
 
-            onShareButtonClicked: Systray.openShareDialog(model.displayPath, model.absolutePath)
+            onShareButtonClicked: Systray.openShareDialog(model.displayPath, model.path)
+
             onDismissButtonClicked: activityModel.slotTriggerDismiss(model.index)
         }
 


### PR DESCRIPTION
mode.absolutePath being undefined prevented the share dialog from being opened by the user.

It probably fixes #4455.
