### PR TITLE
Ensure the dispatch source only gets deallocated after the dispatch_source_cancel is done, avoiding crashing of the Finder Sync Extension on macOS

### DIFF
--- a/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/LocalSocketClient.m
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/FinderSyncExt/LocalSocketClient.m
@@ -139,11 +139,24 @@
     NSLog(@"Closing connection.");
     
     if(self.readSource) {
+        // Since dispatch_source_cancel works asynchronously, if we deallocate the dispatch source here then we can
+        // cause a crash. So instead we strongly hold a reference to the read source and deallocate it asynchronously
+        // with the handler.
+        __block dispatch_source_t previousReadSource = self.readSource;
+        dispatch_source_set_cancel_handler(self.readSource, ^{
+            previousReadSource = nil;
+        });
         dispatch_source_cancel(self.readSource);
+        // The readSource is still alive due to the other reference and will be deallocated by the cancel handler
         self.readSource = nil;
     }
     
     if(self.writeSource) {
+        // Same deal with the write source
+        __block dispatch_source_t previousWriteSource = self.writeSource;
+        dispatch_source_set_cancel_handler(self.writeSource, ^{
+            previousWriteSource = nil;
+        });
         dispatch_source_cancel(self.writeSource);
         self.writeSource = nil;
     }


### PR DESCRIPTION
Since `dispatch_source_cancel` works asynchronously, deallocating the dispatch source synchronously runs the risk of deallocating it before `dispatch_source_cancel` has completed, causing a crash.

This PR sets a completion handler that holds a strong reference to the dispatch source to be deallocated, ensuring that the dispatch source is only deallocated after the `dispatch_source_cancel` is done.

Close #4459 