### PR TITLE
Fix the system tray menu not being correctly replaced in setupContextMenu on GNOME

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -150,6 +150,9 @@ void Systray::setupContextMenu()
     }
 
     _contextMenu = new QMenu();
+    // NOTE: for reasons unclear, setting the the new menu after adding all the actions
+    // will not work on GNOME, as the old menu will not be correctly replaced.
+    setContextMenu(_contextMenu);
 
     if (AccountManager::instance()->accounts().isEmpty()) {
         _contextMenu->addAction(tr("Add account"), this, &Systray::openAccountWizard);
@@ -162,7 +165,6 @@ void Systray::setupContextMenu()
     _contextMenu->addAction(tr("Settings"), this, &Systray::openSettings);
     _contextMenu->addAction(tr("Help"), this, &Systray::openHelp);
     _contextMenu->addAction(tr("Exit %1").arg(Theme::instance()->appNameGUI()), this, &Systray::shutdown);
-    setContextMenu(_contextMenu);
 
     connect(_contextMenu, &QMenu::aboutToShow, [=] {
         const auto folders = FolderMan::instance()->map();


### PR DESCRIPTION
For some weird reason, setting the `QSystemTrayIcon`'s context menu after adding all the right actions will stop the previous context menu from being correctly replaced. This PR works around that by setting the context menu before all the actions are added. 

It's not clear why this issue happens -- maybe there is a faulty comparison checks when comparing the current menu and the one to be set, or some signals aren't correctly emitted in the background -- but I have double, triple, and quadruple checked and indeed changing when the context menu is set fixes the issue. 

This took quite a while to discover 😅 so I have added a comment explaining the issue

Fixes #3573
