### PR TITLE
Remove tooltip because it is only repeating the label of the link.

### DIFF
--- a/src/gui/tray/ActivityItemActions.qml
+++ b/src/gui/tray/ActivityItemActions.qml
@@ -42,7 +42,6 @@ RowLayout {
             Layout.preferredWidth: primary ? -1 : parent.height
 
             text: model.modelData.label
-            toolTipText: model.modelData.label
 
             imageSource: model.modelData.imageSource ? model.modelData.imageSource + root.adjustedHeaderColor : ""
             imageSourceHover: model.modelData.imageSourceHovered ? model.modelData.imageSourceHovered + UserModel.currentUser.headerTextColor : ""


### PR DESCRIPTION
It is bad for accessibility.

See @jancborchardt 's comment: https://github.com/nextcloud/desktop/pull/4641#pullrequestreview-1009166937
