### PR TITLE
Clean up systray methods, make more QML-friendly

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -280,11 +280,6 @@ void Systray::setPauseOnAllFoldersHelper(bool pause)
     }
 }
 
-bool Systray::isOpen()
-{
-    return _isOpen;
-}
-
 QString Systray::windowTitle() const
 {
     return Theme::instance()->appNameGUI();
@@ -300,14 +295,15 @@ bool Systray::useNormalWindow() const
     return cfg.showMainDialogAsNormalWindow();
 }
 
-Q_INVOKABLE void Systray::setOpened()
+bool Systray::isOpen() const
 {
-    _isOpen = true;
+    return _isOpen;
 }
 
-Q_INVOKABLE void Systray::setClosed()
+void Systray::setIsOpen(const bool isOpen)
 {
-    _isOpen = false;
+    _isOpen = isOpen;
+    Q_EMIT isOpenChanged();
 }
 
 void Systray::showMessage(const QString &title, const QString &message, MessageIcon icon)
@@ -347,19 +343,18 @@ void Systray::setToolTip(const QString &tip)
     QSystemTrayIcon::setToolTip(tr("%1: %2").arg(Theme::instance()->appNameGUI(), tip));
 }
 
-bool Systray::syncIsPaused()
+bool Systray::syncIsPaused() const
 {
     return _syncIsPaused;
 }
 
-void Systray::pauseResumeSync()
+void Systray::setSyncIsPaused(const bool syncIsPaused)
 {
+    _syncIsPaused = syncIsPaused;
     if (_syncIsPaused) {
-        _syncIsPaused = false;
-        slotUnpauseAllFolders();
-    } else {
-        _syncIsPaused = true;
         slotPauseAllFolders();
+    } else {
+        slotUnpauseAllFolders();
     }
 }
 

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -66,6 +66,8 @@ class Systray
 
     Q_PROPERTY(QString windowTitle READ windowTitle CONSTANT)
     Q_PROPERTY(bool useNormalWindow READ useNormalWindow CONSTANT)
+    Q_PROPERTY(bool syncIsPaused READ syncIsPaused WRITE setSyncIsPaused NOTIFY syncIsPausedChanged)
+    Q_PROPERTY(bool isOpen READ isOpen WRITE setIsOpen NOTIFY isOpenChanged)
 
 public:
     static Systray *instance();
@@ -85,17 +87,13 @@ public:
     void showMessage(const QString &title, const QString &message, MessageIcon icon = Information);
     void showUpdateMessage(const QString &title, const QString &message, const QUrl &webUrl);
     void setToolTip(const QString &tip);
-    bool isOpen();
-    QString windowTitle() const;
-    bool useNormalWindow() const;
     void createCallDialog(const Activity &callNotification, const AccountStatePtr accountState);
 
-    Q_INVOKABLE void pauseResumeSync();
-    Q_INVOKABLE bool syncIsPaused();
-    Q_INVOKABLE void setOpened();
-    Q_INVOKABLE void setClosed();
-    Q_INVOKABLE void forceWindowInit(QQuickWindow *window) const;
-    Q_INVOKABLE void positionNotificationWindow(QQuickWindow *window) const;
+    Q_REQUIRED_RESULT QString windowTitle() const;
+    Q_REQUIRED_RESULT bool useNormalWindow() const;
+
+    Q_REQUIRED_RESULT bool syncIsPaused() const;
+    Q_REQUIRED_RESULT bool isOpen() const;
 
 signals:
     void currentUserChanged();
@@ -114,10 +112,19 @@ signals:
     void sendChatMessage(const QString &token, const QString &message, const QString &replyTo);
     void showErrorMessageDialog(const QString &error);
 
+    void syncIsPausedChanged();
+    void isOpenChanged();
+
 public slots:
     void slotNewUserSelected();
     void positionWindowAtTray(QQuickWindow *window) const;
     void positionWindowAtScreenCenter(QQuickWindow *window) const;
+
+    void setSyncIsPaused(const bool syncIsPaused);
+    void setIsOpen(const bool isOpen);
+
+    void forceWindowInit(QQuickWindow *window) const;
+    void positionNotificationWindow(QQuickWindow *window) const;
 
 private slots:
     void slotUnpauseAllFolders();

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -39,13 +39,11 @@ Window {
     onActiveChanged: {
         if (!Systray.useNormalWindow && !active) {
             hide();
-            Systray.setClosed();
+            Systray.isOpen = false;
         }
    }
 
-    onClosing: {
-        Systray.setClosed()
-    }
+    onClosing: Systray.isOpen = false
 
     onVisibleChanged: {
         // HACK: reload account Instantiator immediately by restting it - could be done better I guess
@@ -97,13 +95,13 @@ Window {
             trayWindow.raise();
             trayWindow.requestActivate();
 
-            Systray.setOpened();
+            Systray.isOpen = true;
             UserModel.fetchCurrentActivityModel();
         }
 
         function onHideWindow() {
             trayWindow.hide();
-            Systray.setClosed();
+            Systray.isOpen = false;
         }
 
         function onShowFileActivityDialog(objectName, objectId) {
@@ -178,7 +176,7 @@ Window {
                     // We call open() instead of popup() because we want to position it
                     // exactly below the dropdown button, not the mouse
                     onClicked: {
-                        syncPauseButton.text = Systray.syncIsPaused() ? qsTr("Resume sync for all") : qsTr("Pause sync for all")
+                        syncPauseButton.text = Systray.syncIsPaused ? qsTr("Resume sync for all") : qsTr("Pause sync for all")
                         if (accountMenu.visible) {
                             accountMenu.close()
                         } else {
@@ -322,7 +320,7 @@ Window {
                             font.pixelSize: Style.topLinePixelSize
                             palette.windowText: Style.ncTextColor
                             hoverEnabled: true
-                            onClicked: Systray.pauseResumeSync()
+                            onClicked: Systray.syncIsPaused = !Systray.syncIsPaused
 
                             background: Item {
                                 height: parent.height
@@ -335,7 +333,7 @@ Window {
                             }
 
                             Accessible.role: Accessible.MenuItem
-                            Accessible.name: Systray.syncIsPaused() ? qsTr("Resume sync for all") : qsTr("Pause sync for all")
+                            Accessible.name: Systray.syncIsPaused ? qsTr("Resume sync for all") : qsTr("Pause sync for all")
                             Accessible.onPressAction: syncPauseButton.clicked()
                         }
 


### PR DESCRIPTION
The `Systray` class has at the moment several unnecessary `Q_INVOKABLE` methods, and other methods that could be simplified into properties

This PR cleans up and refactors these methods to make the code cleaner and more QML-friendly 

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>
