### PR TITLE
Refactor tray window opening code for clarity and efficiency

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -82,9 +82,6 @@ ownCloudGui::ownCloudGui(Application *parent)
     connect(_tray.data(), &Systray::openAccountWizard,
         this, &ownCloudGui::slotNewAccountWizard);
 
-    connect(_tray.data(), &Systray::openMainDialog,
-        this, &ownCloudGui::slotOpenMainDialog);
-
     connect(_tray.data(), &Systray::openSettings,
         this, &ownCloudGui::slotShowSettings);
 
@@ -157,9 +154,7 @@ void ownCloudGui::slotOpenSettingsDialog()
 
 void ownCloudGui::slotOpenMainDialog()
 {
-    if (!_tray->isOpen()) {
-        _tray->showWindow();
-    }
+    _tray->showWindow();
 }
 
 void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -75,7 +75,7 @@ public:
 
     enum class TaskBarPosition { Bottom, Left, Top, Right };
     Q_ENUM(TaskBarPosition);
-    
+
     enum class NotificationPosition { Default, TopLeft, TopRight, BottomLeft, BottomRight };
     Q_ENUM(NotificationPosition);
 
@@ -98,14 +98,9 @@ public:
 signals:
     void currentUserChanged();
     void openAccountWizard();
-    void openMainDialog();
     void openSettings();
     void openHelp();
     void shutdown();
-
-    // These window signals are listened to in Window.qml
-    void hideWindow();
-    void showWindow(WindowPosition position = WindowPosition::Default);
 
     void openShareDialog(const QString &sharePath, const QString &localPath);
     void showFileActivityDialog(const QString &objectName, const int objectId);
@@ -117,14 +112,17 @@ signals:
 
 public slots:
     void slotNewUserSelected();
+
+    void forceWindowInit(QQuickWindow *window) const;
     void positionWindowAtTray(QQuickWindow *window) const;
     void positionWindowAtScreenCenter(QQuickWindow *window) const;
+    void positionNotificationWindow(QQuickWindow *window) const;
+
+    void showWindow(WindowPosition position = WindowPosition::Default);
+    void hideWindow();
 
     void setSyncIsPaused(const bool syncIsPaused);
     void setIsOpen(const bool isOpen);
-
-    void forceWindowInit(QQuickWindow *window) const;
-    void positionNotificationWindow(QQuickWindow *window) const;
 
 private slots:
     void slotUnpauseAllFolders();
@@ -153,6 +151,7 @@ private:
     bool _syncIsPaused = true;
     QPointer<QQmlApplicationEngine> _trayEngine;
     QPointer<QMenu> _contextMenu;
+    QSharedPointer<QQuickWindow> _trayWindow;
 
     AccessManagerFactory _accessManagerFactory;
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -77,31 +77,11 @@ Window {
     Connections {
         target: Systray
 
-        function onShowWindow(position) {
-            if(trayWindow.visible) {
-                return;
+        function onIsOpenChanged() {
+            if(Systray.isOpen) {
+                accountMenu.close();
+                appsMenu.close();
             }
-
-            accountMenu.close();
-            appsMenu.close();
-
-            if(position === Systray.WindowPosition.Center) {
-                Systray.positionWindowAtScreenCenter(trayWindow);
-            } else {
-                Systray.positionWindowAtTray(trayWindow);
-            }
-
-            trayWindow.show();
-            trayWindow.raise();
-            trayWindow.requestActivate();
-
-            Systray.isOpen = true;
-            UserModel.fetchCurrentActivityModel();
-        }
-
-        function onHideWindow() {
-            trayWindow.hide();
-            Systray.isOpen = false;
         }
 
         function onShowFileActivityDialog(objectName, objectId) {


### PR DESCRIPTION
We now hold a reference to the QML tray window in `Systray` and handle window positioning, showing, and hiding within `Systray`

This makes what is going on much clearer 

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>