### PR TITLE
Only check for call state when receiving push notification (if supported by server)

### DIFF
--- a/src/gui/callstatechecker.h
+++ b/src/gui/callstatechecker.h
@@ -51,6 +51,7 @@ public slots:
 private slots:
     void slotStatusCheckTimerElapsed();
     void slotNotificationTimerElapsed();
+    void slotReceivedPushNotification(Account *account);
     void slotCallStateReceived(const QJsonDocument &json, const int statusCode);
     void reset();
 

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -216,20 +216,17 @@ void User::connectPushNotifications() const
 
 bool User::checkPushNotificationsAreReady() const
 {
-    const auto pushNotifications = _account->account()->pushNotifications();
+    const auto pushActivitiesReady = _account->account()->pushNotificationActivitiesReady();
+    const auto pushNotificationsReady = _account->account()->pushNotificationNotificationsReady();
+    const auto bothNotificationTypesReady = pushActivitiesReady && pushNotificationsReady;
 
-    const auto pushActivitiesAvailable = _account->account()->capabilities().availablePushNotifications() & PushNotificationType::Activities;
-    const auto pushNotificationsAvailable = _account->account()->capabilities().availablePushNotifications() & PushNotificationType::Notifications;
-
-    const auto pushActivitiesAndNotificationsAvailable = pushActivitiesAvailable && pushNotificationsAvailable;
-
-    if (pushActivitiesAndNotificationsAvailable && pushNotifications && pushNotifications->isReady()) {
+    if (bothNotificationTypesReady) {
         connectPushNotifications();
-        return true;
     } else {
         connect(_account->account().data(), &Account::pushNotificationsReady, this, &User::slotPushNotificationsReady, Qt::UniqueConnection);
-        return false;
     }
+
+    return bothNotificationTypesReady;
 }
 
 void User::slotRefreshImmediately() {

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -850,6 +850,18 @@ PushNotifications *Account::pushNotifications() const
     return _pushNotifications;
 }
 
+bool Account::pushNotificationNotificationsReady() const
+{
+    const auto pushNotificationsAvailable = capabilities().availablePushNotifications() & PushNotificationType::Notifications;
+    return _pushNotifications && _pushNotifications->isReady() && pushNotificationsAvailable;
+}
+
+bool Account::pushNotificationActivitiesReady() const
+{
+    const auto pushActivitiesAvailable = capabilities().availablePushNotifications() & PushNotificationType::Activities;
+    return _pushNotifications && _pushNotifications->isReady() && pushActivitiesAvailable;
+}
+
 std::shared_ptr<UserStatusConnector> Account::userStatusConnector() const
 {
     return _userStatusConnector;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -279,6 +279,8 @@ public:
     void trySetupPushNotifications();
     PushNotifications *pushNotifications() const;
     void setPushNotificationsReconnectInterval(int interval);
+    bool pushNotificationNotificationsReady() const;
+    bool pushNotificationActivitiesReady() const;
 
     std::shared_ptr<UserStatusConnector> userStatusConnector() const;
 


### PR DESCRIPTION
This should hopefully limit the load on the server, while also providing a more immediate closing of the call notification dialog when the server emits a push notification about notifications.

NOTE: this requires some changes on the server side

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>