### PR TITLE
QML-ify the UserModel, use properties rather than setter methods

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -226,7 +226,7 @@ void SettingsDialog::showIssuesList(AccountState *account)
 {
     const auto userModel = UserModel::instance();
     const auto id = userModel->findUserIdForAccount(account);
-    UserModel::instance()->switchCurrentUser(id);
+    UserModel::instance()->setCurrentUserId(id);
     emit Systray::instance()->showWindow();
 }
 

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -113,8 +113,8 @@ Systray::Systray()
     setupContextMenu();
 #endif
 
-    connect(UserModel::instance(), &UserModel::newUserSelected,
-        this, &Systray::slotNewUserSelected);
+    connect(UserModel::instance(), &UserModel::currentUserChanged,
+        this, &Systray::slotCurrentUserChanged);
     connect(UserModel::instance(), &UserModel::addAccount,
             this, &Systray::openAccountWizard);
 
@@ -266,7 +266,7 @@ void Systray::createCallDialog(const Activity &callNotification, const AccountSt
     }
 }
 
-void Systray::slotNewUserSelected()
+void Systray::slotCurrentUserChanged()
 {
     if (_trayEngine) {
         // Change ActivityModel

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -111,7 +111,7 @@ signals:
     void isOpenChanged();
 
 public slots:
-    void slotNewUserSelected();
+    void slotCurrentUserChanged();
 
     void forceWindowInit(QQuickWindow *window) const;
     void positionWindowAtTray(QQuickWindow *window) const;

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -36,10 +36,9 @@ MenuItem {
             Accessible.role: Accessible.Button
             Accessible.name: qsTr("Switch to account") + " " + name
 
-            onClicked: if (!isCurrentUser) {
-                UserModel.switchCurrentUser(id)
-            } else {
-                accountMenu.close()
+            onClicked: {
+                UserModel.currentUserId = id;
+                accountMenu.close();
             }
 
             background: Item {

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -895,17 +895,17 @@ void UserModel::buildUserList()
     }
 }
 
-Q_INVOKABLE int UserModel::numUsers()
+int UserModel::numUsers()
 {
     return _users.size();
 }
 
-Q_INVOKABLE int UserModel::currentUserId() const
+int UserModel::currentUserId() const
 {
     return _currentUserId;
 }
 
-Q_INVOKABLE bool UserModel::isUserConnected(const int id)
+bool UserModel::isUserConnected(const int id)
 {
     if (id < 0 || id >= _users.size())
         return false;
@@ -921,7 +921,7 @@ QImage UserModel::avatarById(const int id)
     return _users[id]->avatar();
 }
 
-Q_INVOKABLE QString UserModel::currentUserServer()
+QString UserModel::currentUserServer()
 {
     if (_currentUserId < 0 || _currentUserId >= _users.size())
         return {};
@@ -971,7 +971,7 @@ void UserModel::addUser(AccountStatePtr &user, const bool &isCurrent)
         endInsertRows();
         ConfigFile cfg;
         u->setNotificationRefreshInterval(cfg.notificationRefreshInterval());
-        emit newUserSelected();
+        emit currentUserChanged();
     }
 }
 
@@ -980,7 +980,7 @@ int UserModel::currentUserIndex()
     return _currentUserId;
 }
 
-Q_INVOKABLE void UserModel::openCurrentAccountLocalFolder()
+void UserModel::openCurrentAccountLocalFolder()
 {
     if (_currentUserId < 0 || _currentUserId >= _users.size())
         return;
@@ -988,7 +988,7 @@ Q_INVOKABLE void UserModel::openCurrentAccountLocalFolder()
     _users[_currentUserId]->openLocalFolder();
 }
 
-Q_INVOKABLE void UserModel::openCurrentAccountTalk()
+void UserModel::openCurrentAccountTalk()
 {
     if (!currentUser())
         return;
@@ -1001,7 +1001,7 @@ Q_INVOKABLE void UserModel::openCurrentAccountTalk()
     }
 }
 
-Q_INVOKABLE void UserModel::openCurrentAccountServer()
+void UserModel::openCurrentAccountServer()
 {
     if (_currentUserId < 0 || _currentUserId >= _users.size())
         return;
@@ -1014,18 +1014,18 @@ Q_INVOKABLE void UserModel::openCurrentAccountServer()
     QDesktopServices::openUrl(url);
 }
 
-Q_INVOKABLE void UserModel::switchCurrentUser(const int id)
+void UserModel::setCurrentUserId(const int id)
 {
-    if (_currentUserId < 0 || _currentUserId >= _users.size())
+    if (_currentUserId == id || _currentUserId < 0 || _currentUserId >= _users.size())
         return;
     
     _users[_currentUserId]->setCurrentUser(false);
     _users[id]->setCurrentUser(true);
     _currentUserId = id;
-    emit newUserSelected();
+    emit currentUserChanged();
 }
 
-Q_INVOKABLE void UserModel::login(const int id)
+void UserModel::login(const int id)
 {
     if (id < 0 || id >= _users.size())
         return;
@@ -1033,7 +1033,7 @@ Q_INVOKABLE void UserModel::login(const int id)
     _users[id]->login();
 }
 
-Q_INVOKABLE void UserModel::logout(const int id)
+void UserModel::logout(const int id)
 {
     if (id < 0 || id >= _users.size())
         return;
@@ -1041,7 +1041,7 @@ Q_INVOKABLE void UserModel::logout(const int id)
     _users[id]->logout();
 }
 
-Q_INVOKABLE void UserModel::removeAccount(const int id)
+void UserModel::removeAccount(const int id)
 {
     if (id < 0 || id >= _users.size())
         return;
@@ -1062,7 +1062,7 @@ Q_INVOKABLE void UserModel::removeAccount(const int id)
     }
 
     if (_users[id]->isCurrentUser() && _users.count() > 1) {
-        id == 0 ? switchCurrentUser(1) : switchCurrentUser(0);
+        id == 0 ? setCurrentUserId(1) : setCurrentUserId(0);
     }
 
     _users[id]->logout();

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -147,8 +147,8 @@ private:
 class UserModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_PROPERTY(User* currentUser READ currentUser NOTIFY newUserSelected)
-    Q_PROPERTY(int currentUserId READ currentUserId NOTIFY newUserSelected)
+    Q_PROPERTY(User* currentUser READ currentUser NOTIFY currentUserChanged)
+    Q_PROPERTY(int currentUserId READ currentUserId WRITE setCurrentUserId NOTIFY currentUserChanged)
 public:
     static UserModel *instance();
     ~UserModel() override = default;
@@ -157,7 +157,6 @@ public:
     int currentUserIndex();
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     QImage avatarById(const int id);
@@ -166,18 +165,11 @@ public:
 
     int findUserIdForAccount(AccountState *account) const;
 
-    Q_INVOKABLE void fetchCurrentActivityModel();
-    Q_INVOKABLE void openCurrentAccountLocalFolder();
-    Q_INVOKABLE void openCurrentAccountTalk();
-    Q_INVOKABLE void openCurrentAccountServer();
     Q_INVOKABLE int numUsers();
     Q_INVOKABLE QString currentUserServer();
     int currentUserId() const;
+
     Q_INVOKABLE bool isUserConnected(const int id);
-    Q_INVOKABLE void switchCurrentUser(const int id);
-    Q_INVOKABLE void login(const int id);
-    Q_INVOKABLE void logout(const int id);
-    Q_INVOKABLE void removeAccount(const int id);
 
     Q_INVOKABLE std::shared_ptr<OCC::UserStatusConnector> userStatusConnector(int id);
 
@@ -200,8 +192,18 @@ public:
     AccountAppList appList() const;
 
 signals:
-    Q_INVOKABLE void addAccount();
-    Q_INVOKABLE void newUserSelected();
+    void addAccount();
+    void currentUserChanged();
+
+public slots:
+    void fetchCurrentActivityModel();
+    void openCurrentAccountLocalFolder();
+    void openCurrentAccountTalk();
+    void openCurrentAccountServer();
+    void setCurrentUserId(const int id);
+    void login(const int id);
+    void logout(const int id);
+    void removeAccount(const int id);
 
 protected:
     QHash<int, QByteArray> roleNames() const override;


### PR DESCRIPTION
Make more use of properties over setter methods, move `Q_INVOKABLE void` methods to slots

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>
