### PR TITLE
Use preprocessor directive rather than normal 'if' for UNNotification types

### DIFF
--- a/src/gui/systray.mm
+++ b/src/gui/systray.mm
@@ -18,11 +18,11 @@ Q_LOGGING_CATEGORY(lcMacSystray, "nextcloud.gui.macsystray")
     willPresentNotification:(UNNotification *)notification
     withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
-    if (@available(macOS 11.0, *)) {
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
         completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionBanner);
-    } else {
+#else
         completionHandler(UNNotificationPresentationOptionSound + UNNotificationPresentationOptionAlert);
-    }
+#endif
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center


### PR DESCRIPTION
While in #4563 we added an if statement to only send UNNotification types depending on the macOS version it seems that one of the values we used is not available at all on prior macOS versions.

This preprocessor directive should therefore fix compile on macOS 10.14-10.15
