### PR TITLE
Ensure that throttled notifications still appear in tray activity model

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -138,6 +138,7 @@ void User::slotBuildNotificationDisplay(const ActivityList &list)
         // Set these activities as notified here, rather than in showDesktopNotification
         for(const auto &activity : toNotifyList) {
             _notifiedNotifications.insert(activity._id);
+            _activityModel->addNotificationToActivityList(activity);
         }
 
         return;
@@ -146,6 +147,7 @@ void User::slotBuildNotificationDisplay(const ActivityList &list)
     for(const auto &activity : toNotifyList) {
         const auto message = activity._objectType == QStringLiteral("chat")
             ? activity._message : AccountManager::instance()->accounts().count() == 1 ? "" : activity._accName;
+
         showDesktopNotification(activity._subject, message, activity._id); // We assigned the notif. id to the activity id
         _activityModel->addNotificationToActivityList(activity);
     }


### PR DESCRIPTION
#4706 introduced a bug where throttled notifications would not be added to the `ActivityListModel` correctly

This fixes that issue
