### PR TITLE
Stop clearing notifications when new notifications are received

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -114,8 +114,6 @@ void User::showDesktopNotification(const QString &title, const QString &message,
 
 void User::slotBuildNotificationDisplay(const ActivityList &list)
 {
-    _activityModel->clearNotifications();
-
     const auto multipleAccounts = AccountManager::instance()->accounts().count() > 1;
     ActivityList toNotifyList;
 


### PR DESCRIPTION
With recent changes to notification handling we keep a set of already-notified notification ids and prevent these notifications from being emitted again

A hold-over from previous code is to clear all notifications and replace them with the new set of notifications. With the recent changes this causes a bug where all notifications except newly received ones are removed

This PR stops old notifications from being cleared