### PR TITLE
Clicking on an activity list item for a file opens the local file if available

### DIFF
--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -9,7 +9,7 @@ ScrollView {
 
     property bool isFileActivityList: false
 
-    signal showFileActivity(string objectName, int objectId)
+    signal openFile(string filePath)
     signal activityItemClicked(int index)
 
     contentWidth: availableWidth
@@ -38,8 +38,8 @@ ScrollView {
             width: activityList.contentWidth
             flickable: activityList
             onClicked: {
-                if (model.isCurrentUserFileActivity) {
-                    showFileActivity(model.objectName, model.objectId)
+                if (model.isCurrentUserFileActivity && model.openablePath) {
+                    openFile("file://" + model.openablePath);
                 } else {
                     activityItemClicked(model.index)
                 }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -798,9 +798,7 @@ Window {
 
             activeFocusOnTab: true
             model: activityModel
-            onShowFileActivity: {
-                openFileActivityDialog(objectName, objectId)
-            }
+            onOpenFile: Qt.openUrlExternally(filePath);
             onActivityItemClicked: {
                 model.slotTriggerDefaultAction(index)
             }

--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -65,6 +65,7 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountP
     activity._dateTime = QDateTime::fromString(json.value(QStringLiteral("datetime")).toString(), Qt::ISODate);
     activity._icon = json.value(QStringLiteral("icon")).toString();
     activity._isCurrentUserFileActivity = activity._objectType == QStringLiteral("files") && activityUser == account->davUser();
+    activity._isMultiObjectActivity = json.value("objects").toObject().count() > 1;
 
     auto richSubjectData = json.value(QStringLiteral("subject_rich")).toArray();
 

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -102,6 +102,7 @@ public:
     static Activity fromActivityJson(const QJsonObject &json, const AccountPtr account);
 
     static QString relativeServerFileTypeIconPath(const QMimeType &mimeType);
+    static QString localFilePathForActivity(const Activity &activity, const AccountPtr account);
 
     struct RichSubjectParameter {
         QString type;    // Required
@@ -133,6 +134,7 @@ public:
     QString _folder;
     QString _file;
     QString _renamedFile;
+    bool _isMultiObjectActivity;
     QUrl _link;
     QDateTime _dateTime;
     qint64 _expireAtMsecs = -1;

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -59,6 +59,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     auto roles = QAbstractListModel::roleNames();
     roles[DisplayPathRole] = "displayPath";
     roles[PathRole] = "path";
+    roles[OpenablePathRole] = "openablePath";
     roles[DisplayLocationRole] = "displayLocation";
     roles[LinkRole] = "link";
     roles[MessageRole] = "message";
@@ -76,6 +77,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[PointInTimeRole] = "dateTime";
     roles[DisplayActions] = "displayActions";
     roles[ShareableRole] = "isShareable";
+    roles[IsCurrentUserFileActivityRole] = "isCurrentUserFileActivity";
     roles[IsCurrentUserFileActivityRole] = "isCurrentUserFileActivity";
     roles[ThumbnailRole] = "thumbnail";
     roles[TalkNotificationConversationTokenRole] = "conversationToken";
@@ -263,6 +265,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return getDisplayPath();
     case PathRole:
         return QFileInfo(getFilePath()).path();
+    case OpenablePathRole:
+        return a._isMultiObjectActivity ? QFileInfo(getFilePath()).canonicalPath() : QFileInfo(getFilePath()).canonicalFilePath();
     case DisplayLocationRole:
         return displayLocation();
     case ActionsLinksRole: {

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -60,6 +60,7 @@ public:
         MessageRole,
         DisplayPathRole,
         PathRole,
+        OpenablePathRole,
         DisplayLocationRole, // Provides the display path to a file's parent folder, relative to Nextcloud root
         LinkRole,
         PointInTimeRole,


### PR DESCRIPTION
If the activity refers to more than one item, it will open the containing folder (since activities with several files will contain files that are within the same folder)

Addresses a point in #4433 and fixes #4063

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
