### PR TITLE
Replace unified search text field busy indicator with custom indicator

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -33,5 +33,6 @@
         <file>src/gui/tray/ActivityItemContent.qml</file>
         <file>src/gui/tray/TalkReplyTextField.qml</file>
         <file>src/gui/tray/CallNotificationDialog.qml</file>
+        <file>src/gui/tray/NCBusyIndicator.qml</file>
     </qresource>
 </RCC>

--- a/src/gui/tray/NCBusyIndicator.qml
+++ b/src/gui/tray/NCBusyIndicator.qml
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import Style 1.0
+
+BusyIndicator {
+    id: root
+
+    property color color: Style.ncSecondaryTextColor
+    property string imageSource: "image://svgimage-custom-color/change.svg/"
+
+    contentItem: Image {
+        id: contentImage
+
+        property bool colourableImage: root.color && root.imageSource.startsWith("image://svgimage-custom-color/")
+
+        horizontalAlignment: Image.AlignHCenter
+        verticalAlignment: Image.AlignVCenter
+
+        source: colourableImage ? root.imageSource + root.color : root.imageSource
+        sourceSize.width: 64
+        sourceSize.height: 64
+        fillMode: Image.PreserveAspectFit
+
+        mipmap: true
+
+        RotationAnimator {
+            target: contentImage
+            running: root.running
+            onRunningChanged: contentImage.rotation = 0
+            from: 0
+            to: 360
+            loops: Animation.Infinite
+            duration: 3000
+        }
+    }
+}

--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -17,7 +17,7 @@ RowLayout {
         id: syncStatus
     }
 
-    Image {
+    NCBusyIndicator {
         id: syncIcon
         property int size: Style.trayListItemIconSize * 0.6
         property int whiteSpace: (Style.trayListItemIconSize - size)
@@ -31,19 +31,10 @@ RowLayout {
         Layout.bottomMargin: 16
         Layout.leftMargin: Style.trayHorizontalMargin + (whiteSpace * (0.5 - Style.thumbnailImageSizeReduction))
 
-        source: syncStatus.syncIcon
-        sourceSize.width: 64
-        sourceSize.height: 64
-        rotation: syncStatus.syncing ? 0 : 0
-    }
- 
-    RotationAnimator {
-        target: syncIcon
-        running:  syncStatus.syncing
-        from: 0
-        to: 360
-        loops: Animation.Infinite
-        duration: 3000
+        padding: 0
+
+        imageSource: syncStatus.syncIcon
+        running: syncStatus.syncing
     }
 
     ColumnLayout {

--- a/src/gui/tray/UnifiedSearchInputContainer.qml
+++ b/src/gui/tray/UnifiedSearchInputContainer.qml
@@ -58,10 +58,9 @@ TextField {
         sourceSize: Qt.size(parent.height * parent.textFieldIconsScaleFactor, parent.height * parent.textFieldIconsScaleFactor)
     }
 
-    BusyIndicator {
-        id: trayWindowUnifiedSearchTextFieldIconInProgress
-        running: visible
-        visible: trayWindowUnifiedSearchTextField.isSearchInProgress
+    NCBusyIndicator {
+        id: busyIndicator
+
         anchors {
             left: trayWindowUnifiedSearchTextField.left
             bottom: trayWindowUnifiedSearchTextField.bottom
@@ -70,7 +69,11 @@ TextField {
             bottomMargin: 4
             verticalCenter: trayWindowUnifiedSearchTextField.verticalCenter
         }
+
         width: height
+        color: trayWindowUnifiedSearchTextField.textFieldIconsColor
+        visible: trayWindowUnifiedSearchTextField.isSearchInProgress
+        running: visible
     }
 
     Image {


### PR DESCRIPTION
Addresses a point in #4434 

New spinner:


https://user-images.githubusercontent.com/70155116/179546285-9cf6a3bc-f8b1-439c-92a8-ddb6e4a87669.mov

Old spinner:


https://user-images.githubusercontent.com/70155116/179546416-f1d7a79c-22b3-46b1-bcb6-f9f5e591e0a0.mov



<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
