### PR TITLE
Replace private API QZipWriter with KArchive

### DIFF
--- a/src/csync/std/c_private.h
+++ b/src/csync/std/c_private.h
@@ -67,7 +67,7 @@
 #define getuid() 0
 #define geteuid() 0
 #elif defined(_WIN32)
-#define mode_t int
+typedef int mode_t;
 #else
 #include <fcntl.h>
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(gui)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2 Xml Network)
+find_package(KF5Archive REQUIRED)
 
 if(QUICK_COMPILER)
         find_package(Qt5QuickCompiler)
@@ -566,6 +567,7 @@ target_link_libraries(nextcloudCore
   Qt5::Qml
   Qt5::Quick
   Qt5::QuickControls2
+  KF5::Archive
   )
 
 add_subdirectory(socketapi)


### PR DESCRIPTION
Qt doesn't provide any public utilities for creating ZIP archives, and by using QZipWriter we are at the mercy of this API changing without warning. From `qzipwriter.h`:

```
//
//  W A R N I N G
//  -------------
//
// This file is not part of the Qt API.  It exists for the convenience
// of the QZipWriter class.  This header file may change from
// version to version without notice, or even be removed.
//
// We mean it.
//
```

KArchive exists as a Qt add-on that should let us easily replace our use of QZipWriter without dragging in any other dependencies. This will likely require a small addition to our build andCI infra to add KArchive to our CMake build, but it should fully eliminate the risk of depending on the private API.

Fixes #3723 

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
