### PR TITLE
Improve activity list highlighting/keyboard item selection

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -27,10 +27,6 @@ ItemDelegate {
     Accessible.name: (model.path !== "" && model.displayPath !== "") ? qsTr("Open %1 locally").arg(model.displayPath) : model.message
     Accessible.onPressAction: root.clicked()
 
-    background: Rectangle {
-        color: root.hovered ? Style.lightHover : "transparent"
-    }
-
     NCToolTip {
         visible: root.hovered && !activityContent.childHovered && model.displayLocation !== ""
         text: qsTr("In %1").arg(model.displayLocation)

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 import com.nextcloud.desktopclient 1.0 as NC
+import Style 1.0
 
 ScrollView {
     id: controlRoot
@@ -14,6 +15,7 @@ ScrollView {
 
     contentWidth: availableWidth
     padding: 1
+    focus: false
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
@@ -24,19 +26,49 @@ ScrollView {
     ListView {
         id: activityList
 
-        keyNavigationEnabled: true
-
         Accessible.role: Accessible.List
         Accessible.name: qsTr("Activity list")
 
         clip: true
-
         spacing: 0
+        currentIndex: -1
+        interactive: true
+
+        highlight: Rectangle {
+            id: activityHover
+            width: activityList.currentItem.width
+            height: activityList.currentItem.height
+            color: Style.lightHover
+            visible: activityList.activeFocus
+        }
+        highlightFollowsCurrentItem: true
+        highlightMoveDuration: 0
+        highlightResizeDuration: 0
+        highlightRangeMode: ListView.ApplyRange
+        preferredHighlightBegin: 0
+        preferredHighlightEnd: controlRoot.height
 
         delegate: ActivityItem {
             isFileActivityList: controlRoot.isFileActivityList
             width: activityList.contentWidth
             flickable: activityList
+            onEntered: {
+                // When we set the currentIndex the list view will scroll...
+                // unless we tamper with the preferred highlight points to stop this.
+                const savedPreferredHighlightBegin = activityList.preferredHighlightBegin;
+                const savedPreferredHighlightEnd = activityList.preferredHighlightEnd;
+                // Set overkill values to make sure no scroll happens when we hover with mouse
+                activityList.preferredHighlightBegin = -controlRoot.height;
+                activityList.preferredHighlightEnd = controlRoot.height * 2;
+
+                activityList.currentIndex = index
+
+                // Reset original values so keyboard navigation makes list view scroll
+                activityList.preferredHighlightBegin = savedPreferredHighlightBegin;
+                activityList.preferredHighlightEnd = savedPreferredHighlightEnd;
+
+                forceActiveFocus();
+            }
             onClicked: {
                 if (model.isCurrentUserFileActivity && model.openablePath) {
                     openFile("file://" + model.openablePath);


### PR DESCRIPTION
This PR improves our keyboard navigation of activity list items in the activity list (especially in terms of highlights).

This partially addresses #4220 (navigation within activity list items, such as to highlight action buttons, is still a bit funky)


https://user-images.githubusercontent.com/70155116/181247416-a3a07e65-24e6-4ff3-bf0b-9f3929f10dbf.mov



Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>