### PR TITLE
Always run MSI with full UI.

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -222,7 +222,7 @@ void OCUpdater::slotStartInstaller()
         };
 
         QString msiLogFile = cfg.configPath() + "msi.log";
-        QString command = QString("&{msiexec /norestart /passive /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
+        QString command = QString("&{msiexec /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
              .arg(preparePathForPowershell(updateFile))
              .arg(preparePathForPowershell(msiLogFile))
              .arg(preparePathForPowershell(QCoreApplication::applicationFilePath()));


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
Not rebooting when running the MSI may result in Explorer.exe failing to restart even though it is registered with Restart Manager by default. Running the MSI with full UI allows displaying the restart prompt and allows to cancel the update if accidentally started when not needed.
The downside is - the full UI sequence needs to be controlled by the user (selecting a folder, clicking next, etc.) making the update a bit less convenient, but, fully-controlled and reliable.
Switching to MSIX in future, would allows us to have a better UX with updates.