### PR TITLE
Eliminate padding around the menu separator in the account menu

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -288,11 +288,11 @@ Window {
                             Accessible.onPressAction: addAccountButton.clicked()
                         }
 
-                        MenuSeparator {
-                            contentItem: Rectangle {
-                                implicitHeight: 1
-                                color: Style.menuBorder
-                            }
+                        Rectangle {
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            implicitHeight: 1
+                            color: Style.menuBorder
                         }
 
                         MenuItem {


### PR DESCRIPTION
A small PR for the visual adjustment of a separator

After changes:

![Screenshot 2022-08-02 at 12 53 41](https://user-images.githubusercontent.com/70155116/182358267-99762a4c-fc6e-495b-8b83-88e4ee65716a.png)

Before changes:

![Screenshot 2022-08-02 at 12 56 41](https://user-images.githubusercontent.com/70155116/182358653-5e19bf46-5b8d-415e-99ea-3ccc58949aa2.png)

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

