### PR TITLE
ensure SyncEngine use an initialized instance of SyncOptions

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -504,7 +504,7 @@ restart_sync:
     SyncOptions opt;
     opt.fillFromEnvironmentVariables();
     opt.verifyChunkSizes();
-    SyncEngine engine(account, options.source_dir, folder, &db);
+    SyncEngine engine(account, options.source_dir, opt, folder, &db);
     engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
     engine.setNetworkLimits(options.uplimit, options.downlimit);
     QObject::connect(&engine, &SyncEngine::finished,

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -79,7 +79,7 @@ Folder::Folder(const FolderDefinition &definition,
 
     _syncResult.setFolder(_definition.alias);
 
-    _engine.reset(new SyncEngine(_accountState->account(), path(), remotePath(), &_journal));
+    _engine.reset(new SyncEngine(_accountState->account(), path(), initializeSyncOptions(), remotePath(), &_journal));
     // pass the setting if hidden files are to be ignored, will be read in csync_update
     _engine->setIgnoreHiddenFiles(_definition.ignoreHiddenFiles);
 
@@ -846,7 +846,7 @@ void Folder::startSync(const QStringList &pathList)
     }
 
     setDirtyNetworkLimits();
-    setSyncOptions();
+    syncEngine().setSyncOptions(initializeSyncOptions());
 
     static std::chrono::milliseconds fullLocalDiscoveryInterval = []() {
         auto interval = ConfigFile().fullLocalDiscoveryInterval();
@@ -897,7 +897,7 @@ void Folder::correctPlaceholderFiles()
     }
 }
 
-void Folder::setSyncOptions()
+SyncOptions Folder::initializeSyncOptions() const
 {
     SyncOptions opt;
     ConfigFile cfgFile;
@@ -917,7 +917,7 @@ void Folder::setSyncOptions()
     opt.fillFromEnvironmentVariables();
     opt.verifyChunkSizes();
 
-    _engine->setSyncOptions(opt);
+    return opt;
 }
 
 void Folder::setDirtyNetworkLimits()

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -430,7 +430,7 @@ private:
 
     void checkLocalPath();
 
-    void setSyncOptions();
+    SyncOptions initializeSyncOptions() const;
 
     enum LogStatus {
         LogStatusRemove,

--- a/src/gui/socketapi/socketuploadjob.cpp
+++ b/src/gui/socketapi/socketuploadjob.cpp
@@ -51,7 +51,11 @@ SocketUploadJob::SocketUploadJob(const QSharedPointer<SocketApiJobV2> &job)
     }
 
     _db = new SyncJournalDb(_tmp.fileName(), this);
-    _engine = new SyncEngine(account->account(), _localPath.endsWith(QLatin1Char('/')) ? _localPath : _localPath + QLatin1Char('/'), _remotePath, _db);
+
+    SyncOptions opt;
+    opt.fillFromEnvironmentVariables();
+    opt.verifyChunkSizes();
+    _engine = new SyncEngine(account->account(), _localPath.endsWith(QLatin1Char('/')) ? _localPath : _localPath + QLatin1Char('/'), opt, _remotePath, _db);
     _engine->setParent(_db);
 
     connect(_engine, &OCC::SyncEngine::itemCompleted, this, [this](const OCC::SyncFileItemPtr item) {

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -81,8 +81,11 @@ static const std::chrono::milliseconds s_touchedFilesMaxAgeMs(3 * 1000);
 // doc in header
 std::chrono::milliseconds SyncEngine::minimumFileAgeForUpload(2000);
 
-SyncEngine::SyncEngine(AccountPtr account, const QString &localPath,
-    const QString &remotePath, OCC::SyncJournalDb *journal)
+SyncEngine::SyncEngine(AccountPtr account,
+                       const QString &localPath,
+                       const SyncOptions &syncOptions,
+                       const QString &remotePath,
+                       OCC::SyncJournalDb *journal)
     : _account(account)
     , _needsUpdate(false)
     , _syncRunning(false)
@@ -94,6 +97,7 @@ SyncEngine::SyncEngine(AccountPtr account, const QString &localPath,
     , _hasRemoveFile(false)
     , _uploadLimit(0)
     , _downloadLimit(0)
+    , _syncOptions(syncOptions)
     , _anotherSyncNeeded(NoFollowUpSync)
 {
     qRegisterMetaType<SyncFileItem>("SyncFileItem");

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -57,8 +57,12 @@ class OWNCLOUDSYNC_EXPORT SyncEngine : public QObject
 {
     Q_OBJECT
 public:
-    SyncEngine(AccountPtr account, const QString &localPath,
-        const QString &remotePath, SyncJournalDb *journal);
+    SyncEngine(AccountPtr account,
+               const QString &localPath,
+               const SyncOptions &syncOptions,
+               const QString &remotePath,
+               SyncJournalDb *journal);
+
     ~SyncEngine() override;
 
     Q_INVOKABLE void startSync();

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -1050,7 +1050,7 @@ FakeFolder::FakeFolder(const FileInfo &fileTemplate, const OCC::Optional<FileInf
     _account->setServerVersion(QStringLiteral("10.0.0"));
 
     _journalDb = std::make_unique<OCC::SyncJournalDb>(localPath() + QStringLiteral(".sync_test.db"));
-    _syncEngine = std::make_unique<OCC::SyncEngine>(_account, localPath(), remotePath, _journalDb.get());
+    _syncEngine = std::make_unique<OCC::SyncEngine>(_account, localPath(), OCC::SyncOptions{}, remotePath, _journalDb.get());
     // Ignore temporary files from the download. (This is in the default exclude list, but we don't load it)
     _syncEngine->excludedFiles().addManualExclude(QStringLiteral("]*.~*"));
 


### PR DESCRIPTION
will prevent nextcloudcmd command line client from ignoring the settings
handled by SyncOptions

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
