### PR TITLE
Clean up QML type and singleton registration

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -16,7 +16,6 @@
 
 #include <cmath>
 #include <csignal>
-#include <qqml.h>
 
 #ifdef Q_OS_UNIX
 #include <sys/time.h>
@@ -24,14 +23,9 @@
 #endif
 
 #include "application.h"
-#include "fileactivitylistmodel.h"
+#include "cocoainitializer.h"
 #include "theme.h"
 #include "common/utility.h"
-#include "cocoainitializer.h"
-#include "userstatusselectormodel.h"
-#include "emojimodel.h"
-#include "tray/syncstatussummary.h"
-#include "tray/unifiedsearchresultslistmodel.h"
 
 #if defined(BUILD_UPDATER)
 #include "updater/updater.h"
@@ -66,22 +60,6 @@ int main(int argc, char **argv)
 #endif
     Q_INIT_RESOURCE(resources);
     Q_INIT_RESOURCE(theme);
-
-    qmlRegisterType<SyncStatusSummary>("com.nextcloud.desktopclient", 1, 0, "SyncStatusSummary");
-    qmlRegisterType<EmojiModel>("com.nextcloud.desktopclient", 1, 0, "EmojiModel");
-    qmlRegisterType<UserStatusSelectorModel>("com.nextcloud.desktopclient", 1, 0, "UserStatusSelectorModel");
-    qmlRegisterType<OCC::ActivityListModel>("com.nextcloud.desktopclient", 1, 0, "ActivityListModel");
-    qmlRegisterType<OCC::FileActivityListModel>("com.nextcloud.desktopclient", 1, 0, "FileActivityListModel");
-    qmlRegisterType<Theme>("com.nextcloud.desktopclient", 1, 0, "Theme");
-    qmlRegisterUncreatableType<OCC::UnifiedSearchResultsListModel>(
-        "com.nextcloud.desktopclient", 1, 0, "UnifiedSearchResultsListModel", "UnifiedSearchResultsListModel");
-    qRegisterMetaType<UnifiedSearchResultsListModel *>("UnifiedSearchResultsListModel*");
-
-    qmlRegisterUncreatableType<OCC::UserStatus>("com.nextcloud.desktopclient", 1, 0, "UserStatus", "Access to Status enum");
-
-    qRegisterMetaTypeStreamOperators<Emoji>();
-    qRegisterMetaType<OCC::UserStatus>("UserStatus");
-
 
     // Work around a bug in KDE's qqc2-desktop-style which breaks
     // buttons with icons not based on a name, by forcing a style name

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -12,23 +12,31 @@
  * for more details.
  */
 
-#include "application.h"
 #include "owncloudgui.h"
-#include "theme.h"
-#include "folderman.h"
-#include "progressdispatcher.h"
-#include "owncloudsetupwizard.h"
-#include "sharedialog.h"
-#include "settingsdialog.h"
-#include "logger.h"
-#include "logbrowser.h"
+
 #include "account.h"
-#include "accountstate.h"
-#include "openfilemanager.h"
 #include "accountmanager.h"
+#include "accountstate.h"
+#include "application.h"
+#include "callstatechecker.h"
+#include "emojimodel.h"
+#include "fileactivitylistmodel.h"
+#include "folderman.h"
+#include "guiutility.h"
+#include "logbrowser.h"
+#include "logger.h"
+#include "openfilemanager.h"
+#include "owncloudsetupwizard.h"
+#include "progressdispatcher.h"
+#include "settingsdialog.h"
+#include "sharedialog.h"
+#include "theme.h"
+#include "wheelhandler.h"
 #include "common/syncjournalfilerecord.h"
 #include "creds/abstractcredentials.h"
-#include "guiutility.h"
+#include "tray/syncstatussummary.h"
+#include "tray/unifiedsearchresultslistmodel.h"
+
 #ifdef WITH_LIBCLOUDPROVIDERS
 #include "cloudproviders/cloudprovidermanager.h"
 #endif
@@ -107,6 +115,26 @@ ownCloudGui::ownCloudGui(Application *parent)
         this, &ownCloudGui::slotShowOptionalTrayMessage);
     connect(Logger::instance(), &Logger::guiMessage,
         this, &ownCloudGui::slotShowGuiMessage);
+
+    qmlRegisterType<SyncStatusSummary>("com.nextcloud.desktopclient", 1, 0, "SyncStatusSummary");
+    qmlRegisterType<EmojiModel>("com.nextcloud.desktopclient", 1, 0, "EmojiModel");
+    qmlRegisterType<UserStatusSelectorModel>("com.nextcloud.desktopclient", 1, 0, "UserStatusSelectorModel");
+    qmlRegisterType<ActivityListModel>("com.nextcloud.desktopclient", 1, 0, "ActivityListModel");
+    qmlRegisterType<ActivityListModel>("com.nextcloud.desktopclient", 1, 0, "FileActivityListModel");
+    qmlRegisterType<WheelHandler>("com.nextcloud.desktopclient", 1, 0, "WheelHandler");
+    qmlRegisterType<CallStateChecker>("com.nextcloud.desktopclient", 1, 0, "CallStateChecker");
+
+    qmlRegisterUncreatableType<UnifiedSearchResultsListModel>("com.nextcloud.desktopclient", 1, 0, "UnifiedSearchResultsListModel", "UnifiedSearchResultsListModel");
+    qmlRegisterUncreatableType<UserStatus>("com.nextcloud.desktopclient", 1, 0, "UserStatus", "Access to Status enum");
+
+    qRegisterMetaTypeStreamOperators<Emoji>();
+    qRegisterMetaType<UnifiedSearchResultsListModel *>("UnifiedSearchResultsListModel*");
+    qRegisterMetaType<UserStatus>("UserStatus");
+
+    qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "UserModel", UserModel::instance());
+    qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "UserAppsModel", UserAppsModel::instance());
+    qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "Theme", Theme::instance());
+    qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "Systray", Systray::instance());
 }
 
 void ownCloudGui::createTray()

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -74,33 +74,6 @@ void Systray::setTrayEngine(QQmlApplicationEngine *trayEngine)
 Systray::Systray()
     : QSystemTrayIcon(nullptr)
 {
-    qmlRegisterSingletonType<UserModel>("com.nextcloud.desktopclient", 1, 0, "UserModel",
-        [](QQmlEngine *, QJSEngine *) -> QObject * {
-            return UserModel::instance();
-        }
-    );
-
-    qmlRegisterSingletonType<UserAppsModel>("com.nextcloud.desktopclient", 1, 0, "UserAppsModel",
-        [](QQmlEngine *, QJSEngine *) -> QObject * {
-            return UserAppsModel::instance();
-        }
-    );
-
-    qmlRegisterSingletonType<Systray>("com.nextcloud.desktopclient", 1, 0, "Theme",
-        [](QQmlEngine *, QJSEngine *) -> QObject * {
-            return Theme::instance();
-        }
-    );
-
-    qmlRegisterSingletonType<Systray>("com.nextcloud.desktopclient", 1, 0, "Systray",
-        [](QQmlEngine *, QJSEngine *) -> QObject * {
-            return Systray::instance();
-        }
-    );
-
-    qmlRegisterType<WheelHandler>("com.nextcloud.desktopclient", 1, 0, "WheelHandler");
-    qmlRegisterType<CallStateChecker>("com.nextcloud.desktopclient", 1, 0, "CallStateChecker");
-
 #if defined(Q_OS_MACOS) && defined(BUILD_OWNCLOUD_OSX_BUNDLE)
     setUserNotificationCenterDelegate();
     checkNotificationAuth(MacNotificationAuthorizationOptions::Default); // No provisional auth, ask user explicitly first time


### PR DESCRIPTION
Currently we register QML types and singletons in two separate places, `main.cpp` and `systray.cpp`. I suppose this was done to prevent errors initialising things where they shouldn't be; unfortunately the result is that nothing is initialised in the code near to where the QML engine is actually started, and it is of course separated.

This PR declares all the QML types to register in `owncloudgui.cpp`, where the QML engine is started, and cleans up the registration of types and especially singletons.

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

