### PR TITLE
Fix QML warnings

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -41,7 +41,7 @@ Window {
             hide();
             Systray.isOpen = false;
         }
-   }
+    }
 
     onClosing: Systray.isOpen = false
 
@@ -55,7 +55,7 @@ Window {
 
     Connections {
         target: UserModel
-        function onNewUserSelected() {
+        function onCurrentUserChanged() {
             accountMenu.close();
             syncStatus.model.load();
         }
@@ -612,7 +612,7 @@ Window {
                             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
                             data: WheelHandler {
-                                target: appMenuScrollView.contentItem
+                                target: appsMenuScrollView.contentItem
                             }
                             ListView {
                                 id: appsMenuListView


### PR DESCRIPTION
This PR fixes some QML warnings originating from a typo and a signal that had its name changed on the C++ side

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

