### PR TITLE
Feature/syncjournaldb handle errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0071 NEW) # Enable use of QtQuick compiler/generated code
 
 project(client)

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1722,7 +1722,7 @@ void SyncJournalDb::deleteStaleFlagsEntries()
 
     SqlQuery delQuery("DELETE FROM flags WHERE path != '' AND path NOT IN (SELECT path from metadata);", _db);
     if (!delQuery.exec()) {
-        qCWarning(lcDb) << QStringLiteral("deleteStaleFlagsEntries") << delQuery.error();
+        sqlFail(QStringLiteral("deleteStaleFlagsEntries"), delQuery);
     }
 }
 
@@ -1865,7 +1865,7 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo &info)
         SqlQuery query("DELETE FROM async_poll WHERE path=?", _db);
         query.bindValue(1, info._file);
         if (!query.exec()) {
-            qCWarning(lcDb) << QStringLiteral("setPollInfo DELETE FROM async_poll") << query.error();
+            sqlFail(QStringLiteral("setPollInfo DELETE FROM async_poll"), query);
         }
     } else {
         SqlQuery query("INSERT OR REPLACE INTO async_poll (path, modtime, filesize, pollpath) VALUES( ? , ? , ? , ? )", _db);
@@ -1874,7 +1874,7 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo &info)
         query.bindValue(3, info._fileSize);
         query.bindValue(4, info._url);
         if (!query.exec()) {
-            qCWarning(lcDb) << QStringLiteral("setPollInfo INSERT OR REPLACE INTO async_poll") << query.error();
+            sqlFail(QStringLiteral("setPollInfo INSERT OR REPLACE INTO async_poll"), query);
         }
     }
 }
@@ -1963,7 +1963,7 @@ void SyncJournalDb::avoidRenamesOnNextSync(const QByteArray &path)
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        qCWarning(lcDb) << QStringLiteral("avoidRenamesOnNextSync path: %1").arg(QString::fromUtf8(path)) << query.error();
+        sqlFail(QStringLiteral("avoidRenamesOnNextSync path: %1").arg(QString::fromUtf8(path)), query);
     }
 
     // We also need to remove the ETags so the update phase refreshes the directory paths
@@ -1991,7 +1991,7 @@ void SyncJournalDb::schedulePathForRemoteDiscovery(const QByteArray &fileName)
     query.bindValue(1, argument);
 
     if (!query.exec()) {
-        qCWarning(lcDb) << QStringLiteral("schedulePathForRemoteDiscovery path: %11").arg(QString::fromUtf8(fileName)) << query.error();
+        sqlFail(QStringLiteral("schedulePathForRemoteDiscovery path: %1").arg(QString::fromUtf8(fileName)), query);
     }
 
     // Prevent future overwrite of the etags of this folder and all
@@ -2023,7 +2023,7 @@ void SyncJournalDb::forceRemoteDiscoveryNextSyncLocked()
     deleteRemoteFolderEtagsQuery.prepare("UPDATE metadata SET md5='_invalid_' WHERE type=2;");
 
     if (!deleteRemoteFolderEtagsQuery.exec()) {
-        qCWarning(lcDb) << QStringLiteral("forceRemoteDiscoveryNextSyncLocked") << deleteRemoteFolderEtagsQuery.error();
+        sqlFail(QStringLiteral("forceRemoteDiscoveryNextSyncLocked"), deleteRemoteFolderEtagsQuery);
     }
 }
 
@@ -2233,7 +2233,7 @@ void SyncJournalDb::clearFileTable()
     query.prepare("DELETE FROM metadata;");
 
     if (!query.exec()) {
-        qCWarning(lcDb) << QStringLiteral("clearFileTable") << query.error();
+        sqlFail(QStringLiteral("clearFileTable"), query);
     }
 }
 
@@ -2250,7 +2250,7 @@ void SyncJournalDb::markVirtualFileForDownloadRecursively(const QByteArray &path
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        qCWarning(lcDb) << QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET type=5 path: %1").arg(QString::fromUtf8(path)) << query.error();
+        sqlFail(QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET type=5 path: %1").arg(QString::fromUtf8(path)), query);
     }
 
     // We also must make sure we do not read the files from the database (same logic as in schedulePathForRemoteDiscovery)
@@ -2261,7 +2261,7 @@ void SyncJournalDb::markVirtualFileForDownloadRecursively(const QByteArray &path
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        qCWarning(lcDb) << QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET md5='_invalid_' path: %1").arg(QString::fromUtf8(path)) << query.error();
+        sqlFail(QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET md5='_invalid_' path: %1").arg(QString::fromUtf8(path)), query);
     }
 }
 
@@ -2395,6 +2395,8 @@ SyncJournalDb::PinStateInterface::rawList()
 
     if (!query.exec()) {
         qCWarning(lcDb) << "SQL Error" << "PinStateInterface::rawList" << query.error();
+        _db->close();
+        ASSERT(false);
     }
 
     QVector<QPair<QByteArray, PinState>> result;

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1722,7 +1722,7 @@ void SyncJournalDb::deleteStaleFlagsEntries()
 
     SqlQuery delQuery("DELETE FROM flags WHERE path != '' AND path NOT IN (SELECT path from metadata);", _db);
     if (!delQuery.exec()) {
-        sqlFail(QStringLiteral("deleteStaleFlagsEntries"), delQuery);
+        qCWarning(lcDb) << QStringLiteral("deleteStaleFlagsEntries") << delQuery.error();
     }
 }
 
@@ -1865,7 +1865,7 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo &info)
         SqlQuery query("DELETE FROM async_poll WHERE path=?", _db);
         query.bindValue(1, info._file);
         if (!query.exec()) {
-            sqlFail(QStringLiteral("setPollInfo DELETE FROM async_poll"), query);
+            qCWarning(lcDb) << QStringLiteral("setPollInfo DELETE FROM async_poll") << query.error();
         }
     } else {
         SqlQuery query("INSERT OR REPLACE INTO async_poll (path, modtime, filesize, pollpath) VALUES( ? , ? , ? , ? )", _db);
@@ -1874,7 +1874,7 @@ void SyncJournalDb::setPollInfo(const SyncJournalDb::PollInfo &info)
         query.bindValue(3, info._fileSize);
         query.bindValue(4, info._url);
         if (!query.exec()) {
-            sqlFail(QStringLiteral("setPollInfo INSERT OR REPLACE INTO async_poll"), query);
+            qCWarning(lcDb) << QStringLiteral("setPollInfo INSERT OR REPLACE INTO async_poll") << query.error();
         }
     }
 }
@@ -1963,7 +1963,7 @@ void SyncJournalDb::avoidRenamesOnNextSync(const QByteArray &path)
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        sqlFail(QStringLiteral("avoidRenamesOnNextSync path: %1").arg(QString::fromUtf8(path)), query);
+        qCWarning(lcDb) << QStringLiteral("avoidRenamesOnNextSync path: %1").arg(QString::fromUtf8(path)) << query.error();
     }
 
     // We also need to remove the ETags so the update phase refreshes the directory paths
@@ -1991,7 +1991,7 @@ void SyncJournalDb::schedulePathForRemoteDiscovery(const QByteArray &fileName)
     query.bindValue(1, argument);
 
     if (!query.exec()) {
-        sqlFail(QStringLiteral("schedulePathForRemoteDiscovery path: %1").arg(QString::fromUtf8(fileName)), query);
+        qCWarning(lcDb) << QStringLiteral("schedulePathForRemoteDiscovery path: %11").arg(QString::fromUtf8(fileName)) << query.error();
     }
 
     // Prevent future overwrite of the etags of this folder and all
@@ -2023,7 +2023,7 @@ void SyncJournalDb::forceRemoteDiscoveryNextSyncLocked()
     deleteRemoteFolderEtagsQuery.prepare("UPDATE metadata SET md5='_invalid_' WHERE type=2;");
 
     if (!deleteRemoteFolderEtagsQuery.exec()) {
-        sqlFail(QStringLiteral("forceRemoteDiscoveryNextSyncLocked"), deleteRemoteFolderEtagsQuery);
+        qCWarning(lcDb) << QStringLiteral("forceRemoteDiscoveryNextSyncLocked") << deleteRemoteFolderEtagsQuery.error();
     }
 }
 
@@ -2233,7 +2233,7 @@ void SyncJournalDb::clearFileTable()
     query.prepare("DELETE FROM metadata;");
 
     if (!query.exec()) {
-        sqlFail(QStringLiteral("clearFileTable"), query);
+        qCWarning(lcDb) << QStringLiteral("clearFileTable") << query.error();
     }
 }
 
@@ -2250,7 +2250,7 @@ void SyncJournalDb::markVirtualFileForDownloadRecursively(const QByteArray &path
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        sqlFail(QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET type=5 path: %1").arg(QString::fromUtf8(path)), query);
+        qCWarning(lcDb) << QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET type=5 path: %1").arg(QString::fromUtf8(path)) << query.error();
     }
 
     // We also must make sure we do not read the files from the database (same logic as in schedulePathForRemoteDiscovery)
@@ -2261,7 +2261,7 @@ void SyncJournalDb::markVirtualFileForDownloadRecursively(const QByteArray &path
     query.bindValue(1, path);
 
     if (!query.exec()) {
-        sqlFail(QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET md5='_invalid_' path: %1").arg(QString::fromUtf8(path)), query);
+        qCWarning(lcDb) << QStringLiteral("markVirtualFileForDownloadRecursively UPDATE metadata SET md5='_invalid_' path: %1").arg(QString::fromUtf8(path)) << query.error();
     }
 }
 
@@ -2395,8 +2395,6 @@ SyncJournalDb::PinStateInterface::rawList()
 
     if (!query.exec()) {
         qCWarning(lcDb) << "SQL Error" << "PinStateInterface::rawList" << query.error();
-        _db->close();
-        ASSERT(false);
     }
 
     QVector<QPair<QByteArray, PinState>> result;

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -2212,10 +2212,12 @@ QByteArray SyncJournalDb::conflictFileBaseName(const QByteArray &conflictName)
     auto conflict = conflictRecord(conflictName);
     QByteArray result;
     if (conflict.isValid()) {
-        getFileRecordsByFileId(conflict.baseFileId, [&result](const SyncJournalFileRecord &record) {
+        if (!getFileRecordsByFileId(conflict.baseFileId, [&result](const SyncJournalFileRecord &record) {
             if (!record._path.isEmpty())
                 result = record._path;
-        });
+        })) {
+            qCWarning(lcDb) << "conflictFileBaseName failed to getFileRecordsByFileId: " << conflictName;
+        }
     }
 
     if (result.isEmpty()) {

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -59,24 +59,25 @@ public:
     static bool maybeMigrateDb(const QString &localPath, const QString &absoluteJournalPath);
 
     // To verify that the record could be found check with SyncJournalFileRecord::isValid()
-    bool getFileRecord(const QString &filename, SyncJournalFileRecord *rec) { return getFileRecord(filename.toUtf8(), rec); }
-    bool getFileRecord(const QByteArray &filename, SyncJournalFileRecord *rec);
-    bool getFileRecordByE2eMangledName(const QString &mangledName, SyncJournalFileRecord *rec);
-    bool getFileRecordByInode(quint64 inode, SyncJournalFileRecord *rec);
-    bool getFileRecordsByFileId(const QByteArray &fileId, const std::function<void(const SyncJournalFileRecord &)> &rowCallback);
-    bool getFilesBelowPath(const QByteArray &path, const std::function<void(const SyncJournalFileRecord&)> &rowCallback);
-    bool listFilesInPath(const QByteArray &path, const std::function<void(const SyncJournalFileRecord&)> &rowCallback);
-    Result<void, QString> setFileRecord(const SyncJournalFileRecord &record);
+    [[nodiscard]] bool getFileRecord(const QString &filename, SyncJournalFileRecord *rec) { return getFileRecord(filename.toUtf8(), rec); }
+    [[nodiscard]] bool getFileRecord(const QByteArray &filename, SyncJournalFileRecord *rec);
+    [[nodiscard]] bool getFileRecordByE2eMangledName(const QString &mangledName, SyncJournalFileRecord *rec);
+    [[nodiscard]] bool getFileRecordByInode(quint64 inode, SyncJournalFileRecord *rec);
+    [[nodiscard]] bool getFileRecordsByFileId(const QByteArray &fileId, const std::function<void(const SyncJournalFileRecord &)> &rowCallback);
+    [[nodiscard]] bool getFilesBelowPath(const QByteArray &path, const std::function<void(const SyncJournalFileRecord&)> &rowCallback);
+    [[nodiscard]] bool listFilesInPath(const QByteArray &path, const std::function<void(const SyncJournalFileRecord&)> &rowCallback);
+    [[nodiscard]] Result<void, QString> setFileRecord(const SyncJournalFileRecord &record);
 
     void keyValueStoreSet(const QString &key, QVariant value);
-    qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
+    [[nodiscard]] qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
     void keyValueStoreDelete(const QString &key);
 
-    bool deleteFileRecord(const QString &filename, bool recursively = false);
-    bool updateFileRecordChecksum(const QString &filename,
+    [[nodiscard]] bool deleteFileRecord(const QString &filename, bool recursively = false);
+    [[nodiscard]] bool updateFileRecordChecksum(
+        const QString &filename,
         const QByteArray &contentChecksum,
         const QByteArray &contentChecksumType);
-    bool updateLocalMetadata(const QString &filename,
+    [[nodiscard]] bool updateLocalMetadata(const QString &filename,
         qint64 modtime, qint64 size, quint64 inode);
 
     /// Return value for hasHydratedOrDehydratedFiles()
@@ -99,7 +100,7 @@ public:
     void setErrorBlacklistEntry(const SyncJournalErrorBlacklistRecord &item);
     void wipeErrorBlacklistEntry(const QString &file);
     void wipeErrorBlacklistCategory(SyncJournalErrorBlacklistRecord::Category category);
-    int wipeErrorBlacklist();
+    [[nodiscard]] int wipeErrorBlacklist();
     int errorBlackListEntryCount();
 
     struct DownloadInfo
@@ -145,7 +146,7 @@ public:
     QVector<uint> deleteStaleUploadInfos(const QSet<QString> &keep);
 
     SyncJournalErrorBlacklistRecord errorBlacklistEntry(const QString &);
-    bool deleteStaleErrorBlacklistEntries(const QSet<QString> &keep);
+    [[nodiscard]] bool deleteStaleErrorBlacklistEntries(const QSet<QString> &keep);
 
     /// Delete flags table entries that have no metadata correspondent
     void deleteStaleFlagsEntries();
@@ -372,9 +373,9 @@ public:
 
 private:
     int getFileRecordCount();
-    bool updateDatabaseStructure();
-    bool updateMetadataTableStructure();
-    bool updateErrorBlacklistTableStructure();
+    [[nodiscard]] bool updateDatabaseStructure();
+    [[nodiscard]] bool updateMetadataTableStructure();
+    [[nodiscard]] bool updateErrorBlacklistTableStructure();
     bool sqlFail(const QString &log, const SqlQuery &query);
     void commitInternal(const QString &context, bool startTrans = true);
     void startTransaction();
@@ -388,7 +389,7 @@ private:
     // Returns the integer id of the checksum type
     //
     // Returns 0 on failure and for empty checksum types.
-    int mapChecksumType(const QByteArray &checksumType);
+    [[nodiscard]] int mapChecksumType(const QByteArray &checksumType);
 
     SqlDatabase _db;
     QString _dbFile;

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -507,7 +507,9 @@ void AccountSettings::slotSubfolderContextMenuRequested(const QModelIndex& index
         // It might be an E2EE mangled path, so let's try to demangle it
         const auto journal = folder->journalDb();
         SyncJournalFileRecord rec;
-        journal->getFileRecordByE2eMangledName(remotePath, &rec);
+        if (!journal->getFileRecordByE2eMangledName(remotePath, &rec)) {
+            qCWarning(lcFolderStatus) << "Could not get file record by E2E Mangled Name from local DB" << remotePath;
+        }
 
         const auto path = rec.isValid() ? rec._path : remotePath;
 

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -278,7 +278,7 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
     if (auto job = qobject_cast<AbstractNetworkJob *>(sender())) {
         if (auto reply = job->reply()) {
             _account->setHttp2Supported(
-                reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool());
+                reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool());
         }
     }
 #endif

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -618,7 +618,6 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
     ;
     if (!_journal.getFileRecord(relativepath.toUtf8(), &record)) {
         qCWarning(lcFolder) << "could not get file from local DB" << relativepath;
-        return;
     }
     if (!record.isValid()) {
         qCInfo(lcFolder) << "Did not find file in db";
@@ -634,7 +633,6 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
     const auto result = _journal.setFileRecord(record);
     if (!result) {
         qCWarning(lcFolder) << "Error when setting the file record to the database" << record._path << result.error();
-        return;
     }
 
     // Change the file's pin state if it's contradictory to being hydrated

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -577,7 +577,9 @@ void Folder::slotWatchedPathChanged(const QString &path, ChangeReason reason)
 
 
     SyncJournalFileRecord record;
-    _journal.getFileRecord(relativePathBytes, &record);
+    if (!_journal.getFileRecord(relativePathBytes, &record)) {
+        qCWarning(lcFolder) << "could not get file from local DB" << relativePathBytes;
+    }
     if (reason != ChangeReason::UnLock) {
         // Check that the mtime/size actually changed or there was
         // an attribute change (pin state) that caused the notification
@@ -613,7 +615,11 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
 
     // Set in the database that we should download the file
     SyncJournalFileRecord record;
-    _journal.getFileRecord(relativepath.toUtf8(), &record);
+    ;
+    if (!_journal.getFileRecord(relativepath.toUtf8(), &record)) {
+        qCWarning(lcFolder) << "could not get file from local DB" << relativepath;
+        return;
+    }
     if (!record.isValid()) {
         qCInfo(lcFolder) << "Did not find file in db";
         return;
@@ -622,8 +628,14 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
         qCInfo(lcFolder) << "The file is not virtual";
         return;
     }
+
     record._type = ItemTypeVirtualFileDownload;
-    _journal.setFileRecord(record);
+
+    const auto result = _journal.setFileRecord(record);
+    if (!result) {
+        qCWarning(lcFolder) << "Error when setting the file record to the database" << record._path << result.error();
+        return;
+    }
 
     // Change the file's pin state if it's contradictory to being hydrated
     // (suffix-virtual file's pin state is stored at the hydrated path)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -618,6 +618,7 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
     ;
     if (!_journal.getFileRecord(relativepath.toUtf8(), &record)) {
         qCWarning(lcFolder) << "could not get file from local DB" << relativepath;
+        return;
     }
     if (!record.isValid()) {
         qCInfo(lcFolder) << "Did not find file in db";
@@ -633,6 +634,7 @@ void Folder::implicitlyHydrateFile(const QString &relativepath)
     const auto result = _journal.setFileRecord(record);
     if (!result) {
         qCWarning(lcFolder) << "Error when setting the file record to the database" << record._path << result.error();
+        return;
     }
 
     // Change the file's pin state if it's contradictory to being hydrated

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -400,7 +400,7 @@ QRect FolderStatusDelegate::optionsButtonRect(QRect within, Qt::LayoutDirection 
     opt.rect.setSize(QSize(e,e));
     QSize size = QApplication::style()->sizeFromContents(QStyle::CT_ToolButton, &opt, opt.rect.size()).expandedTo(QApplication::globalStrut());
 
-    int margin = QApplication::style()->pixelMetric(QStyle::PM_DefaultLayoutSpacing);
+    int margin = QApplication::style()->pixelMetric(QStyle::PM_LayoutHorizontalSpacing);
     QRect r(QPoint(within.right() - size.width() - margin,
                 within.top() + within.height() / 2 - size.height() / 2),
         size);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -743,7 +743,9 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
         newInfo._path = relativePath;
 
         SyncJournalFileRecord rec;
-        parentInfo->_folder->journalDb()->getFileRecordByE2eMangledName(removeTrailingSlash(relativePath), &rec);
+        if (!parentInfo->_folder->journalDb()->getFileRecordByE2eMangledName(removeTrailingSlash(relativePath), &rec)) {
+            qCWarning(lcFolderStatus) << "Could not get file record by E2E Mangled Name from local DB" << removeTrailingSlash(relativePath);
+        }
         if (rec.isValid()) {
             newInfo._name = removeTrailingSlash(rec._path).split('/').last();
             if (rec._isE2eEncrypted && !rec._e2eMangledName.isEmpty()) {

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1149,7 +1149,9 @@ SyncJournalFileRecord SocketApi::FileData::journalRecord() const
     SyncJournalFileRecord record;
     if (!folder)
         return record;
-    folder->journalDb()->getFileRecord(folderRelativePath, &record);
+    if (!folder->journalDb()->getFileRecord(folderRelativePath, &record)) {
+        qCWarning(lcSocketApi) << "Failed to get journal record for path" << folderRelativePath;
+    }
     return record;
 }
 

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -156,7 +156,9 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             // If this is an E2EE file or folder, pretend we got no path, hiding the share button which is what we want
             if (folder) {
                 SyncJournalFileRecord rec;
-                folder->journalDb()->getFileRecord(fileName.mid(1), &rec);
+                if (!folder->journalDb()->getFileRecord(fileName.mid(1), &rec)) {
+                    qCWarning(lcActivity) << "could not get file from local DB" << fileName.mid(1);
+                }
                 if (rec.isValid() && (rec._isE2eEncrypted || !rec._e2eMangledName.isEmpty())) {
                     return QString();
                 }

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -188,7 +188,7 @@ void AbstractNetworkJob::slotFinished()
     const auto maxHttp2Resends = 3;
     QByteArray verb = HttpLogger::requestVerb(*reply());
     if (_reply->error() == QNetworkReply::ContentReSendError
-        && _reply->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()) {
+        && _reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool()) {
 
         if ((_requestBody && !_requestBody->isSequential()) || verb.isEmpty()) {
             qCWarning(lcNetworkJob) << "Can't resend HTTP2 request, verb or body not suitable"

--- a/src/libsync/abstractpropagateremotedeleteencrypted.cpp
+++ b/src/libsync/abstractpropagateremotedeleteencrypted.cpp
@@ -144,7 +144,9 @@ void AbstractPropagateRemoteDeleteEncrypted::slotDeleteRemoteItemFinished()
         return;
     }
 
-    _propagator->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory());
+    if (!_propagator->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
+        qCWarning(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED) << "Failed to delete file record from local DB" << _item->_originalFile;
+    }
     _propagator->_journal->commit("Remote Remove");
 
     unlockFolder();

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -84,7 +84,7 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         // http2 seems to cause issues, as with our recommended server setup we don't support http2, disable it by default for now
         static const bool http2EnabledEnv = qEnvironmentVariableIntValue("OWNCLOUD_HTTP2_ENABLED") == 1;
 
-        newRequest.setAttribute(QNetworkRequest::HTTP2AllowedAttribute, http2EnabledEnv);
+        newRequest.setAttribute(QNetworkRequest::Http2AllowedAttribute, http2EnabledEnv);
     }
 #endif
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -915,7 +915,6 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             // Not locally, not on the server. The entry is stale!
             qCInfo(lcDisco) << "Stale DB entry";
             if (!_discoveryData->_statedb->deleteFileRecord(path._original, true)) {
-                _discoveryData->fatalError(tr("Error while deleting file record %1 from the database").arg(path._original));
                 qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
             }
             return;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -915,6 +915,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             // Not locally, not on the server. The entry is stale!
             qCInfo(lcDisco) << "Stale DB entry";
             if (!_discoveryData->_statedb->deleteFileRecord(path._original, true)) {
+                _discoveryData->fatalError(tr("Error while deleting file record %1 from the database").arg(path._original));
                 qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
             }
             return;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1430,7 +1430,7 @@ void ProcessDirectoryJob::processFileConflict(const SyncFileItemPtr &item, Proce
             rec._checksumHeader = serverEntry.checksumHeader;
             const auto result = _discoveryData->_statedb->setFileRecord(rec);
             if (!result) {
-                qCWarning(lcDisco) << "Error when setting the file record to the database" << result.error();
+                qCWarning(lcDisco) << "Error when setting the file record to the database" << rec._path << result.error();
             }
         }
         return;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -914,7 +914,10 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         } else if (noServerEntry) {
             // Not locally, not on the server. The entry is stale!
             qCInfo(lcDisco) << "Stale DB entry";
-            _discoveryData->_statedb->deleteFileRecord(path._original, true);
+            if (!_discoveryData->_statedb->deleteFileRecord(path._original, true)) {
+                _discoveryData->fatalError(tr("Error while deleting file record %1 from the database").arg(path._original));
+                qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
+            }
             return;
         } else if (dbEntry._type == ItemTypeVirtualFile && isVfsWithSuffix()) {
             // If the virtual file is removed, recreate it.
@@ -1270,7 +1273,9 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         if (wasDeletedOnClient.first) {
             // More complicated. The REMOVE is canceled. Restore will happen next sync.
             qCInfo(lcDisco) << "Undid remove instruction on source" << originalPath;
-            _discoveryData->_statedb->deleteFileRecord(originalPath, true);
+            if (!_discoveryData->_statedb->deleteFileRecord(originalPath, true)) {
+                qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << originalPath;
+            }
             _discoveryData->_statedb->schedulePathForRemoteDiscovery(originalPath);
             _discoveryData->_anotherSyncNeeded = true;
         } else {
@@ -1423,7 +1428,10 @@ void ProcessDirectoryJob::processFileConflict(const SyncFileItemPtr &item, Proce
             rec._fileSize = serverEntry.size;
             rec._remotePerm = serverEntry.remotePerm;
             rec._checksumHeader = serverEntry.checksumHeader;
-            _discoveryData->_statedb->setFileRecord(rec);
+            const auto result = _discoveryData->_statedb->setFileRecord(rec);
+            if (!result) {
+                qCWarning(lcDisco) << "Error when setting the file record to the database" << result.error();
+            }
         }
         return;
     }

--- a/src/libsync/iconjob.cpp
+++ b/src/libsync/iconjob.cpp
@@ -21,7 +21,7 @@ IconJob::IconJob(AccountPtr account, const QUrl &url, QObject *parent)
 {
     QNetworkRequest request(url);
 #if (QT_VERSION >= 0x050600)
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
 #endif
     const auto reply = account->sendRawRequest(QByteArrayLiteral("GET"), url, request);
     connect(reply, &QNetworkReply::finished, this, &IconJob::finished);

--- a/src/libsync/lockfilejobs.cpp
+++ b/src/libsync/lockfilejobs.cpp
@@ -171,7 +171,10 @@ SyncJournalFileRecord LockFileJob::handleReply()
                 _userId != account()->davUser()) {
             FileSystem::setFileReadOnly(relativePath, true);
         }
-        _journal->setFileRecord(record);
+        const auto result = _journal->setFileRecord(record);
+        if (!result) {
+            qCWarning(lcLockFileJob) << "Error when setting the file record to the database" << record._path << result.error();
+        }
         _journal->commit("lock file job");
     }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -319,7 +319,11 @@ bool PropagateItemJob::hasEncryptedAncestor() const
     auto pathComponents = parentPath.split('/');
     while (!pathComponents.isEmpty()) {
         SyncJournalFileRecord rec;
-        propagator()->_journal->getFileRecord(pathComponents.join('/'), &rec);
+        const auto pathCompontentsJointed = pathComponents.join('/');
+        if (!propagator()->_journal->getFileRecord(pathCompontentsJointed, &rec)) {
+            qCWarning(lcPropagator) << "could not get file from local DB" << pathCompontentsJointed;
+        }
+
         if (rec.isValid() && rec._isE2eEncrypted) {
             return true;
         }
@@ -1194,7 +1198,11 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
         // that may still exist below the old path.
         if (_item->_instruction == CSYNC_INSTRUCTION_RENAME
             && _item->_originalFile != _item->_renameTarget) {
-            propagator()->_journal->deleteFileRecord(_item->_originalFile, true);
+
+            if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, true)) {
+                qCWarning(lcDirectory) << "could not delete file from local DB" << _item->_originalFile;
+                return;
+            }
         }
 
         if (_item->_instruction == CSYNC_INSTRUCTION_NEW && _item->_direction == SyncFileItem::Down) {

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1199,13 +1199,6 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
         if (_item->_instruction == CSYNC_INSTRUCTION_RENAME && _item->_originalFile != _item->_renameTarget) {
             if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, true)) {
                 qCWarning(lcDirectory) << "could not delete file from local DB" << _item->_originalFile;
-                _state = Finished;
-                status = _item->_status = SyncFileItem::FatalError;
-                _item->_errorString = tr("could not delete file %1 from local DB").arg(_item->_originalFile);
-                qCInfo(lcPropagator) << "PropagateDirectory::slotSubJobsFinished"
-                                     << "emit finished" << status;
-                emit finished(status);
-                return;
             }
         }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1199,6 +1199,13 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
         if (_item->_instruction == CSYNC_INSTRUCTION_RENAME && _item->_originalFile != _item->_renameTarget) {
             if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, true)) {
                 qCWarning(lcDirectory) << "could not delete file from local DB" << _item->_originalFile;
+                _state = Finished;
+                status = _item->_status = SyncFileItem::FatalError;
+                _item->_errorString = tr("could not delete file %1 from local DB").arg(_item->_originalFile);
+                qCInfo(lcPropagator) << "PropagateDirectory::slotSubJobsFinished"
+                                     << "emit finished" << status;
+                emit finished(status);
+                return;
             }
         }
 

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1196,11 +1196,15 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
     if (!_item->isEmpty() && status == SyncFileItem::Success) {
         // If a directory is renamed, recursively delete any stale items
         // that may still exist below the old path.
-        if (_item->_instruction == CSYNC_INSTRUCTION_RENAME
-            && _item->_originalFile != _item->_renameTarget) {
-
+        if (_item->_instruction == CSYNC_INSTRUCTION_RENAME && _item->_originalFile != _item->_renameTarget) {
             if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, true)) {
                 qCWarning(lcDirectory) << "could not delete file from local DB" << _item->_originalFile;
+                _state = Finished;
+                status = _item->_status = SyncFileItem::FatalError;
+                _item->_errorString = tr("could not delete file %1 from local DB").arg(_item->_originalFile);
+                qCInfo(lcPropagator) << "PropagateDirectory::slotSubJobsFinished"
+                                     << "emit finished" << status;
+                emit finished(status);
                 return;
             }
         }

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -461,8 +461,6 @@ void PropagateDownloadFile::start()
     SyncJournalFileRecord parentRec;
     if (!propagator()->_journal->getFileRecord(parentPath, &parentRec)) {
         qCWarning(lcPropagateDownload) << "could not get file from local DB" << parentPath;
-        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(parentPath));
-        return;
     }
 
     const auto account = propagator()->account();
@@ -509,8 +507,6 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
 
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateDownload) << "could not delete file from local DB" << _item->_originalFile;
-            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
-            return;
         }
 
         updateMetadata(false);
@@ -1249,8 +1245,6 @@ void PropagateDownloadFile::downloadFinished()
 
             if (!propagator()->_journal->deleteFileRecord(virtualFile)) {
                 qCWarning(lcPropagateDownload) << "could not delete file from local DB" << virtualFile;
-                done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(virtualFile));
-                return;
             }
 
             // Move the pin state to the new location

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -509,7 +509,7 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
 
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateDownload) << "could not delete file from local DB" << _item->_originalFile;
-            done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
             return;
         }
 
@@ -1249,7 +1249,7 @@ void PropagateDownloadFile::downloadFinished()
 
             if (!propagator()->_journal->deleteFileRecord(virtualFile)) {
                 qCWarning(lcPropagateDownload) << "could not delete file from local DB" << virtualFile;
-                done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(virtualFile));
+                done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(virtualFile));
                 return;
             }
 

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -459,7 +459,11 @@ void PropagateDownloadFile::start()
     const auto parentPath = slashPosition >= 0 ? path.left(slashPosition) : QString();
 
     SyncJournalFileRecord parentRec;
-    propagator()->_journal->getFileRecord(parentPath, &parentRec);
+    if (!propagator()->_journal->getFileRecord(parentPath, &parentRec)) {
+        qCWarning(lcPropagateDownload) << "could not get file from local DB" << parentPath;
+        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(parentPath));
+        return;
+    }
 
     const auto account = propagator()->account();
     if (!account->capabilities().clientSideEncryptionAvailable() ||
@@ -502,7 +506,13 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
             done(SyncFileItem::NormalError, r.error());
             return;
         }
-        propagator()->_journal->deleteFileRecord(_item->_originalFile);
+
+        if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
+            qCWarning(lcPropagateDownload) << "could not delete file from local DB" << _item->_originalFile;
+            done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+            return;
+        }
+
         updateMetadata(false);
 
         if (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) {
@@ -1236,7 +1246,12 @@ void PropagateDownloadFile::downloadFinished()
             auto fn = propagator()->fullLocalPath(virtualFile);
             qCDebug(lcPropagateDownload) << "Download of previous virtual file finished" << fn;
             QFile::remove(fn);
-            propagator()->_journal->deleteFileRecord(virtualFile);
+
+            if (!propagator()->_journal->deleteFileRecord(virtualFile)) {
+                qCWarning(lcPropagateDownload) << "could not delete file from local DB" << virtualFile;
+                done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(virtualFile));
+                return;
+            }
 
             // Move the pin state to the new location
             auto pin = propagator()->_journal->internalPinStates().rawForPath(virtualFile.toUtf8());

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -865,7 +865,7 @@ void PropagateDownloadFile::slotGetFinished()
     // of the compressed data. See QTBUG-73364.
     const auto contentEncoding = job->reply()->rawHeader("content-encoding").toLower();
     if ((contentEncoding == "gzip" || contentEncoding == "deflate")
-        && (job->reply()->attribute(QNetworkRequest::HTTP2WasUsedAttribute).toBool()
+        && (job->reply()->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool()
          || job->reply()->attribute(QNetworkRequest::SpdyWasUsedAttribute).toBool())) {
         bodySize = 0;
         hasSizeHeader = false;

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -461,6 +461,8 @@ void PropagateDownloadFile::start()
     SyncJournalFileRecord parentRec;
     if (!propagator()->_journal->getFileRecord(parentPath, &parentRec)) {
         qCWarning(lcPropagateDownload) << "could not get file from local DB" << parentPath;
+        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(parentPath));
+        return;
     }
 
     const auto account = propagator()->account();
@@ -507,6 +509,8 @@ void PropagateDownloadFile::startAfterIsEncryptedIsChecked()
 
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateDownload) << "could not delete file from local DB" << _item->_originalFile;
+            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+            return;
         }
 
         updateMetadata(false);
@@ -1245,6 +1249,8 @@ void PropagateDownloadFile::downloadFinished()
 
             if (!propagator()->_journal->deleteFileRecord(virtualFile)) {
                 qCWarning(lcPropagateDownload) << "could not delete file from local DB" << virtualFile;
+                done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(virtualFile));
+                return;
             }
 
             // Move the pin state to the new location

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -113,7 +113,12 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
         return;
     }
 
-    propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory());
+    if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
+        qCWarning(lcPropagateRemoteDelete) << "could not delete file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+        return;
+    }
+
     propagator()->_journal->commit("Remote Remove");
 
     done(SyncFileItem::Success);

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -115,6 +115,8 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
 
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(lcPropagateRemoteDelete) << "could not delete file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+        return;
     }
 
     propagator()->_journal->commit("Remote Remove");

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -115,8 +115,6 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
 
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(lcPropagateRemoteDelete) << "could not delete file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
-        return;
     }
 
     propagator()->_journal->commit("Remote Remove");

--- a/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
+++ b/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
@@ -116,7 +116,9 @@ void PropagateRemoteDeleteEncryptedRootFolder::slotDeleteNestedRemoteItemFinishe
         const auto nestedItem = _nestedItems.take(encryptedFileName);
 
         if (nestedItem.isValid()) {
-            _propagator->_journal->deleteFileRecord(nestedItem._path, nestedItem._type == ItemTypeDirectory);
+            if (!_propagator->_journal->deleteFileRecord(nestedItem._path, nestedItem._type == ItemTypeDirectory)) {
+                qCWarning(PROPAGATE_REMOVE_ENCRYPTED_ROOTFOLDER) << "Failed to delete file record from local DB" << nestedItem._path;
+            }
             _propagator->_journal->commit("Remote Remove");
         }
     }

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -247,6 +247,8 @@ void PropagateRemoteMove::finalize()
     SyncJournalFileRecord oldRecord;
     if (!propagator()->_journal->getFileRecord(_item->_originalFile, &oldRecord)) {
         qCWarning(lcPropagateRemoteMove) << "could not get file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(_item->_originalFile));
+        return;
     }
     auto &vfs = propagator()->syncOptions()._vfs;
     auto pinState = vfs->pinState(_item->_originalFile);
@@ -257,6 +259,8 @@ void PropagateRemoteMove::finalize()
         // Delete old db data.
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateRemoteMove) << "could not delete file from local DB" << _item->_originalFile;
+            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+            return;
         }
         if (!vfs->setPinState(_item->_originalFile, PinState::Inherited)) {
             qCWarning(lcPropagateRemoteMove) << "Could not set pin state of" << _item->_originalFile << "to inherited";

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -259,7 +259,7 @@ void PropagateRemoteMove::finalize()
         // Delete old db data.
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateRemoteMove) << "could not delete file from local DB" << _item->_originalFile;
-            done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
             return;
         }
         if (!vfs->setPinState(_item->_originalFile, PinState::Inherited)) {

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -247,8 +247,6 @@ void PropagateRemoteMove::finalize()
     SyncJournalFileRecord oldRecord;
     if (!propagator()->_journal->getFileRecord(_item->_originalFile, &oldRecord)) {
         qCWarning(lcPropagateRemoteMove) << "could not get file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(_item->_originalFile));
-        return;
     }
     auto &vfs = propagator()->syncOptions()._vfs;
     auto pinState = vfs->pinState(_item->_originalFile);
@@ -259,8 +257,6 @@ void PropagateRemoteMove::finalize()
         // Delete old db data.
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateRemoteMove) << "could not delete file from local DB" << _item->_originalFile;
-            done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
-            return;
         }
         if (!vfs->setPinState(_item->_originalFile, PinState::Inherited)) {
             qCWarning(lcPropagateRemoteMove) << "Could not set pin state of" << _item->_originalFile << "to inherited";

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -130,8 +130,6 @@ void PropagateLocalRemove::start()
     propagator()->reportProgress(*_item, 0);
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
-        return;
     }
     propagator()->_journal->commit("Local remove");
     done(SyncFileItem::Success);
@@ -251,13 +249,9 @@ void PropagateLocalRename::start()
     SyncJournalFileRecord oldRecord;
     if (!propagator()->_journal->getFileRecord(_item->_originalFile, &oldRecord)) {
         qCWarning(lcPropagateLocalRename) << "could not get file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(_item->_originalFile));
-        return;
     }
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
-        return;
     }
 
     auto &vfs = propagator()->syncOptions()._vfs;

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -257,6 +257,7 @@ void PropagateLocalRename::start()
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
         done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+        return;
     }
 
     auto &vfs = propagator()->syncOptions()._vfs;

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -130,6 +130,8 @@ void PropagateLocalRemove::start()
     propagator()->reportProgress(*_item, 0);
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+        return;
     }
     propagator()->_journal->commit("Local remove");
     done(SyncFileItem::Success);
@@ -249,9 +251,13 @@ void PropagateLocalRename::start()
     SyncJournalFileRecord oldRecord;
     if (!propagator()->_journal->getFileRecord(_item->_originalFile, &oldRecord)) {
         qCWarning(lcPropagateLocalRename) << "could not get file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("could not get file %1 from local DB").arg(_item->_originalFile));
+        return;
     }
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
+        return;
     }
 
     auto &vfs = propagator()->syncOptions()._vfs;

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -130,7 +130,7 @@ void PropagateLocalRemove::start()
     propagator()->reportProgress(*_item, 0);
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
         return;
     }
     propagator()->_journal->commit("Local remove");
@@ -256,7 +256,7 @@ void PropagateLocalRename::start()
     }
     if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
         qCWarning(lcPropagateLocalRename) << "could not delete file from local DB" << _item->_originalFile;
-        done(SyncFileItem::NormalError, tr("could not delete file %1 from local DB").arg(_item->_originalFile));
+        done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile));
         return;
     }
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -381,9 +381,6 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
 
             // Updating the db happens on success
             if (!_journal->setFileRecord(rec)) {
-                item->_status = SyncFileItem::Status::NormalError;
-                item->_instruction = CSYNC_INSTRUCTION_ERROR;
-                item->_errorString = tr("Could not set file record to local DB: %1").arg(rec.path());
                 qCWarning(lcEngine) << "Could not set file record to local DB" << rec.path();
             }
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -268,7 +268,9 @@ void SyncEngine::deleteStaleErrorBlacklistEntries(const SyncFileItemVector &sync
     }
 
     // Delete from journal.
-    _journal->deleteStaleErrorBlacklistEntries(blacklist_file_paths);
+    if (!_journal->deleteStaleErrorBlacklistEntries(blacklist_file_paths)) {
+        qCWarning(lcEngine) << "Could not delete StaleErrorBlacklistEntries from DB";
+    }
 }
 
 #if (QT_VERSION < 0x050600)
@@ -378,13 +380,20 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
             }
 
             // Updating the db happens on success
-            _journal->setFileRecord(rec);
+            if (!_journal->setFileRecord(rec)) {
+                item->_status = SyncFileItem::Status::NormalError;
+                item->_instruction = CSYNC_INSTRUCTION_ERROR;
+                item->_errorString = tr("Could not set file record to local DB: %1").arg(rec.path());
+                qCWarning(lcEngine) << "Could not set file record to local DB" << rec.path();
+            }
 
             // This might have changed the shared flag, so we must notify SyncFileStatusTracker for example
             emit itemCompleted(item);
         } else {
             // Update only outdated data from the disk.
-            _journal->updateLocalMetadata(item->_file, item->_modtime, item->_size, item->_inode);
+            if (!_journal->updateLocalMetadata(item->_file, item->_modtime, item->_size, item->_inode)) {
+                qCWarning(lcEngine) << "Could not update local metadata for file" << item->_file;
+            }
         }
         _hasNoneFiles = true;
         return;
@@ -1014,12 +1023,14 @@ bool SyncEngine::shouldDiscoverLocally(const QString &path) const
 void SyncEngine::wipeVirtualFiles(const QString &localPath, SyncJournalDb &journal, Vfs &vfs)
 {
     qCInfo(lcEngine) << "Wiping virtual files inside" << localPath;
-    journal.getFilesBelowPath(QByteArray(), [&](const SyncJournalFileRecord &rec) {
+    const auto resGetFilesBelowPath = journal.getFilesBelowPath(QByteArray(), [&](const SyncJournalFileRecord &rec) {
         if (rec._type != ItemTypeVirtualFile && rec._type != ItemTypeVirtualFileDownload)
             return;
 
         qCDebug(lcEngine) << "Removing db record for" << rec.path();
-        journal.deleteFileRecord(rec._path);
+        if (!journal.deleteFileRecord(rec._path)) {
+            qCWarning(lcEngine) << "Could not update delete file record" << rec._path;
+        }
 
         // If the local file is a dehydrated placeholder, wipe it too.
         // Otherwise leave it to allow the next sync to have a new-new conflict.
@@ -1030,6 +1041,10 @@ void SyncEngine::wipeVirtualFiles(const QString &localPath, SyncJournalDb &journ
         }
     });
 
+    if (!resGetFilesBelowPath) {
+        qCWarning(lcEngine) << "Faied to get files below path" << localPath;
+    }
+
     journal.forceRemoteDiscoveryNextSync();
 
     // Postcondition: No ItemTypeVirtualFile / ItemTypeVirtualFileDownload left in the db.
@@ -1039,7 +1054,7 @@ void SyncEngine::wipeVirtualFiles(const QString &localPath, SyncJournalDb &journ
 void SyncEngine::switchToVirtualFiles(const QString &localPath, SyncJournalDb &journal, Vfs &vfs)
 {
     qCInfo(lcEngine) << "Convert to virtual files inside" << localPath;
-    journal.getFilesBelowPath({}, [&](const SyncJournalFileRecord &rec) {
+    const auto res = journal.getFilesBelowPath({}, [&](const SyncJournalFileRecord &rec) {
         const auto path = rec.path();
         const auto fileName = QFileInfo(path).fileName();
         if (FileSystem::isExcludeFile(fileName)) {
@@ -1052,6 +1067,10 @@ void SyncEngine::switchToVirtualFiles(const QString &localPath, SyncJournalDb &j
             qCWarning(lcEngine) << "Could not convert file to placeholder" << result.error();
         }
     });
+
+    if (!res) {
+        qCWarning(lcEngine) << "Faied to get files below path" << localPath;
+    }
 }
 
 void SyncEngine::abort()

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -381,6 +381,9 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
 
             // Updating the db happens on success
             if (!_journal->setFileRecord(rec)) {
+                item->_status = SyncFileItem::Status::NormalError;
+                item->_instruction = CSYNC_INSTRUCTION_ERROR;
+                item->_errorString = tr("Could not set file record to local DB: %1").arg(rec.path());
                 qCWarning(lcEngine) << "Could not set file record to local DB" << rec.path();
             }
 

--- a/src/libsync/vfs/cfapi/hydrationjob.cpp
+++ b/src/libsync/vfs/cfapi/hydrationjob.cpp
@@ -291,6 +291,7 @@ void OCC::HydrationJob::finalize(OCC::VfsCfApi *vfs)
     SyncJournalFileRecord record;
     if (!_journal->getFileRecord(_folderPath, &record)) {
         qCWarning(lcHydration) << "could not get file from local DB" << _folderPath;
+        return;
     }
     Q_ASSERT(record.isValid());
     if (!record.isValid()) {

--- a/src/libsync/vfs/cfapi/hydrationjob.cpp
+++ b/src/libsync/vfs/cfapi/hydrationjob.cpp
@@ -291,7 +291,6 @@ void OCC::HydrationJob::finalize(OCC::VfsCfApi *vfs)
     SyncJournalFileRecord record;
     if (!_journal->getFileRecord(_folderPath, &record)) {
         qCWarning(lcHydration) << "could not get file from local DB" << _folderPath;
-        return;
     }
     Q_ASSERT(record.isValid());
     if (!record.isValid()) {

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -1198,7 +1198,7 @@ static FileInfo &findOrCreateDirs(FileInfo &base, PathComponents components)
 FileInfo FakeFolder::dbState() const
 {
     FileInfo result;
-    _journalDb->getFilesBelowPath("", [&](const OCC::SyncJournalFileRecord &record) {
+    [[maybe_unused]] const auto journalDbResult =_journalDb->getFilesBelowPath("", [&](const OCC::SyncJournalFileRecord &record) {
         auto components = PathComponents(record.path());
         auto &parentDir = findOrCreateDirs(result, components.parentDirComponents());
         auto name = components.fileName();

--- a/test/testasyncop.cpp
+++ b/test/testasyncop.cpp
@@ -177,7 +177,7 @@ private slots:
                 return waitAndChain(waitForeverCallback)(tc, request);
             })));
 
-        fakeFolder.syncJournal().wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncJournal().wipeErrorBlacklist() != -1);
 
         // This second sync will redo the files that had errors
         // But the waiting folder will not complete before it is aborted.

--- a/test/testblacklist.cpp
+++ b/test/testblacklist.cpp
@@ -14,7 +14,7 @@ using namespace OCC;
 SyncJournalFileRecord journalRecord(FakeFolder &folder, const QByteArray &path)
 {
     SyncJournalFileRecord rec;
-    folder.syncJournal().getFileRecord(path, &rec);
+    [[maybe_unused]] const auto result = folder.syncJournal().getFileRecord(path, &rec);
     return rec;
 }
 

--- a/test/testcfapishellextensionsipc.cpp
+++ b/test/testcfapishellextensionsipc.cpp
@@ -150,7 +150,7 @@ private slots:
         QVERIFY(realFolder);
         for (const auto &dummyImageName : dummmyImageNames) {
             if (fakeFolder.syncJournal().getFileRecord(dummyImageName, &record)) {
-                realFolder->journalDb()->setFileRecord(record);
+                QVERIFY(realFolder->journalDb()->setFileRecord(record));
             }
         }
 

--- a/test/testdownload.cpp
+++ b/test/testdownload.cpp
@@ -220,7 +220,7 @@ private slots:
             if (op == QNetworkAccessManager::GetOperation && request.url().path().endsWith("A/resendme") && resendActual < resendExpected) {
                 auto errorReply = new FakeErrorReply(op, request, this, 400, "ignore this body");
                 errorReply->setError(QNetworkReply::ContentReSendError, serverMessage);
-                errorReply->setAttribute(QNetworkRequest::HTTP2WasUsedAttribute, true);
+                errorReply->setAttribute(QNetworkRequest::Http2WasUsedAttribute, true);
                 errorReply->setAttribute(QNetworkRequest::HttpStatusCodeAttribute, QVariant());
                 resendActual += 1;
                 return errorReply;

--- a/test/testlocaldiscovery.cpp
+++ b/test/testlocaldiscovery.cpp
@@ -153,7 +153,7 @@ private slots:
         QVERIFY(!trackerContains("A/spurious")); // removed due to full discovery
 
         fakeFolder.serverErrorPaths().clear();
-        fakeFolder.syncJournal().wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncJournal().wipeErrorBlacklist() != -1);
         tracker.addTouchedPath("A/newspurious"); // will be removed due to successful sync
 
         fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::DatabaseAndFilesystem, tracker.localDiscoveryPaths());

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -57,7 +57,7 @@ bool expectAndWipeConflict(FileModifier &local, FileInfo state, const QString pa
 SyncJournalFileRecord dbRecord(FakeFolder &folder, const QString &path)
 {
     SyncJournalFileRecord record;
-    folder.syncJournal().getFileRecord(path, &record);
+    [[maybe_unused]] const auto result = folder.syncJournal().getFileRecord(path, &record);
     return record;
 }
 

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -211,7 +211,7 @@ private slots:
 
         auto getDbChecksum = [&](QString path) {
             SyncJournalFileRecord record;
-            fakeFolder.syncJournal().getFileRecord(path, &record);
+            [[maybe_unused]] const auto result = fakeFolder.syncJournal().getFileRecord(path, &record);
             return record._checksumHeader;
         };
 
@@ -275,7 +275,7 @@ private slots:
         fakeFolder.syncEngine().journal()->schedulePathForRemoteDiscovery(QByteArrayLiteral("parentFolder/subFolderA/"));
         auto getEtag = [&](const QByteArray &file) {
             SyncJournalFileRecord rec;
-            fakeFolder.syncJournal().getFileRecord(file, &rec);
+            [[maybe_unused]] const auto result = fakeFolder.syncJournal().getFileRecord(file, &rec);
             return rec._etag;
         };
         QVERIFY(getEtag("parentFolder") == "_invalid_");
@@ -336,8 +336,7 @@ private slots:
         QVERIFY(!fakeFolder.syncOnce());
 
         SyncJournalFileRecord rec;
-        fakeFolder.syncJournal().getFileRecord(QByteArrayLiteral("NewFolder"), &rec);
-        QVERIFY(rec.isValid());
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArrayLiteral("NewFolder"), &rec) && rec.isValid());
         QCOMPARE(rec._etag, QByteArrayLiteral("_invalid_"));
         QVERIFY(!rec._fileId.isEmpty());
     }
@@ -454,7 +453,7 @@ private slots:
         // check that mtime in journal and filesystem agree
         QString a1path = fakeFolder.localPath() + "A/a1";
         SyncJournalFileRecord a1record;
-        fakeFolder.syncJournal().getFileRecord(QByteArray("A/a1"), &a1record);
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("A/a1"), &a1record));
         QCOMPARE(a1record._modtime, (qint64)FileSystem::getModTime(a1path));
 
         // Extra sync reads from db, no difference

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -68,7 +68,7 @@ private slots:
 
         // Update checksum
         record._checksumHeader = "Adler32:newchecksum";
-        _db.updateFileRecordChecksum("foo", "newchecksum", "Adler32");
+        QVERIFY(_db.updateFileRecordChecksum("foo", "newchecksum", "Adler32"));
         QVERIFY(_db.getFileRecord(QByteArrayLiteral("foo"), &storedRecord));
         QVERIFY(storedRecord == record);
 
@@ -81,7 +81,7 @@ private slots:
         record._fileId = "efg";
         record._remotePerm = RemotePermissions::fromDbValue("NV");
         record._fileSize = 289055;
-        _db.setFileRecord(record);
+        QVERIFY(_db.setFileRecord(record));
         QVERIFY(_db.getFileRecord(QByteArrayLiteral("foo"), &storedRecord));
         QVERIFY(storedRecord == record);
 
@@ -213,11 +213,11 @@ private slots:
             record._type = type;
             record._etag = initialEtag;
             record._remotePerm = RemotePermissions::fromDbValue("RW");
-            _db.setFileRecord(record);
+            QVERIFY(_db.setFileRecord(record));
         };
         auto getEtag = [&](const QByteArray &path) {
             SyncJournalFileRecord record;
-            _db.getFileRecord(path, &record);
+            [[maybe_unused]] const auto result = _db.getFileRecord(path, &record);
             return record._etag;
         };
 
@@ -275,7 +275,7 @@ private slots:
             SyncJournalFileRecord record;
             record._path = path;
             record._remotePerm = RemotePermissions::fromDbValue("RW");
-            _db.setFileRecord(record);
+            QVERIFY(_db.setFileRecord(record));
         };
 
         QByteArrayList elements;
@@ -296,8 +296,7 @@ private slots:
             bool ok = true;
             for (const auto& elem : elements) {
                 SyncJournalFileRecord record;
-                _db.getFileRecord(elem, &record);
-                if (!record.isValid()) {
+                if (!_db.getFileRecord(elem, &record) || !record.isValid()) {
                     qWarning() << "Missing record: " << elem;
                     ok = false;
                 }
@@ -305,17 +304,17 @@ private slots:
             return ok;
         };
 
-        _db.deleteFileRecord("moo", true);
+        QVERIFY(_db.deleteFileRecord("moo", true));
         elements.removeAll("moo");
         elements.removeAll("moo/file");
         QVERIFY(checkElements());
 
-        _db.deleteFileRecord("fo_", true);
+        QVERIFY(_db.deleteFileRecord("fo_", true));
         elements.removeAll("fo_");
         elements.removeAll("fo_/file");
         QVERIFY(checkElements());
 
-        _db.deleteFileRecord("foo%bar", true);
+        QVERIFY(_db.deleteFileRecord("foo%bar", true));
         elements.removeAll("foo%bar");
         QVERIFY(checkElements());
     }

--- a/test/testsyncxattr.cpp
+++ b/test/testsyncxattr.cpp
@@ -45,7 +45,7 @@ bool itemInstruction(const ItemCompletedSpy &spy, const QString &path, const Syn
 SyncJournalFileRecord dbRecord(FakeFolder &folder, const QString &path)
 {
     SyncJournalFileRecord record;
-    folder.syncJournal().getFileRecord(path, &record);
+    [[maybe_unused]] const auto result = folder.syncJournal().getFileRecord(path, &record);
     return record;
 }
 
@@ -53,11 +53,11 @@ void triggerDownload(FakeFolder &folder, const QByteArray &path)
 {
     auto &journal = folder.syncJournal();
     SyncJournalFileRecord record;
-    journal.getFileRecord(path, &record);
-    if (!record.isValid())
+    if (!journal.getFileRecord(path, &record) || !record.isValid()) {
         return;
+    }
     record._type = ItemTypeVirtualFileDownload;
-    journal.setFileRecord(record);
+    QVERIFY(journal.setFileRecord(record));
     journal.schedulePathForRemoteDiscovery(record._path);
 }
 
@@ -65,11 +65,11 @@ void markForDehydration(FakeFolder &folder, const QByteArray &path)
 {
     auto &journal = folder.syncJournal();
     SyncJournalFileRecord record;
-    journal.getFileRecord(path, &record);
-    if (!record.isValid())
+    if (!journal.getFileRecord(path, &record) || !record.isValid()) {
         return;
+    }
     record._type = ItemTypeVirtualFileDehydration;
-    journal.setFileRecord(record);
+    QVERIFY(journal.setFileRecord(record));
     journal.schedulePathForRemoteDiscovery(record._path);
 }
 
@@ -217,8 +217,8 @@ private slots:
         QCOMPARE(dbRecord(fakeFolder, "A/a3")._fileSize, 33);
         cleanup();
 
-        fakeFolder.syncEngine().journal()->deleteFileRecord("A/a2");
-        fakeFolder.syncEngine().journal()->deleteFileRecord("A/a3");
+        QVERIFY(fakeFolder.syncEngine().journal()->deleteFileRecord("A/a2"));
+        QVERIFY(fakeFolder.syncEngine().journal()->deleteFileRecord("A/a3"));
         fakeFolder.remoteModifier().remove("A/a3");
         fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::FilesystemOnly);
         QVERIFY(fakeFolder.syncOnce());
@@ -436,7 +436,7 @@ private slots:
 
         auto cleanup = [&]() {
             completeSpy.clear();
-            fakeFolder.syncJournal().wipeErrorBlacklist();
+            QVERIFY(fakeFolder.syncJournal().wipeErrorBlacklist() != -1);
         };
         cleanup();
 
@@ -708,8 +708,7 @@ private slots:
         };
         auto hasDehydratedDbEntries = [&](const QString &path) {
             SyncJournalFileRecord rec;
-            fakeFolder.syncJournal().getFileRecord(path, &rec);
-            return rec.isValid() && rec._type == ItemTypeVirtualFile;
+            return fakeFolder.syncJournal().getFileRecord(path, &rec) && rec.isValid() && rec._type == ItemTypeVirtualFile;
         };
 
         QVERIFY(isDehydrated("A/a1"));

--- a/test/testuploadreset.cpp
+++ b/test/testuploadreset.cpp
@@ -48,21 +48,21 @@ private slots:
         QCOMPARE(uploadInfo._errorCount, 1);
         QCOMPARE(uploadInfo._transferid, 1U);
 
-        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncEngine().journal()->wipeErrorBlacklist());
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 2);
         QCOMPARE(uploadInfo._transferid, 1U);
 
-        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncEngine().journal()->wipeErrorBlacklist());
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");
         QCOMPARE(uploadInfo._errorCount, 3);
         QCOMPARE(uploadInfo._transferid, 1U);
 
-        fakeFolder.syncEngine().journal()->wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncEngine().journal()->wipeErrorBlacklist());
         QVERIFY(!fakeFolder.syncOnce());
 
         uploadInfo = fakeFolder.syncEngine().journal()->getUploadInfo("A/a0");


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Here's what I did:
- Always check the SqlQuery.exec() return value (prepare() does not need to be checked as it asserts in any case and then the exec() will fail if prepare() has failed
- Enable CXX Standard 17 to allow using [[nodiscard]]
- Fix every warning for [[nodiscard]] methods
- Fix Qt deprecation warnings that trigger errors in the CI
- Try to not modify the behavior to prevent regressions