### PR TITLE
Fix crash: 'Failed to create OpenGL context'.

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -58,9 +58,6 @@ void warnSystray()
 
 int main(int argc, char **argv)
 {
-    qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu --no-sandbox");
-    QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL, true);
-
 #ifdef Q_OS_WIN
     SetDllDirectory(L"");
 #endif


### PR DESCRIPTION
Signed-off-by: allexzander <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This is to fix the **"Error: Failed to create OpenGL context for format QSurfaceFormat(). This is most likely caused by not having the necessary graphics drivers installed"** on Windows 11.