### PR TITLE
Fix bugs with setting 'Away' user status

### DIFF
--- a/src/libsync/ocsuserstatusconnector.cpp
+++ b/src/libsync/ocsuserstatusconnector.cpp
@@ -59,7 +59,7 @@ QString onlineStatusToString(OCC::UserStatus::OnlineStatus status)
     case OCC::UserStatus::OnlineStatus::DoNotDisturb:
         return QStringLiteral("dnd");
     case OCC::UserStatus::OnlineStatus::Away:
-        return QStringLiteral("offline");
+        return QStringLiteral("away");
     case OCC::UserStatus::OnlineStatus::Offline:
         return QStringLiteral("offline");
     case OCC::UserStatus::OnlineStatus::Invisible:


### PR DESCRIPTION
We have some bugs around setting the `Away` status due to bad parsing to string, this PR fixes these issues

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>
