### PR TITLE
Use same tooltip component everywhere, fix tooltip clipping bugs

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -34,5 +34,6 @@
         <file>src/gui/tray/TalkReplyTextField.qml</file>
         <file>src/gui/tray/CallNotificationDialog.qml</file>
         <file>src/gui/tray/NCBusyIndicator.qml</file>
+        <file>src/gui/tray/NCToolTip.qml</file>
     </qresource>
 </RCC>

--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -40,19 +40,9 @@ MouseArea {
         color: (parent.containsMouse ? Style.lightHover : "transparent")
     }
 
-    ToolTip {
-        id: activityMouseAreaTooltip
-        visible: containsMouse && !activityContent.childHovered && model.displayLocation !== ""
-        delay: Qt.styleHints.mousePressAndHoldInterval
+    NCToolTip {
+        visible: root.containsMouse && !activityContent.childHovered && model.displayLocation !== ""
         text: qsTr("In %1").arg(model.displayLocation)
-        contentItem: Label {
-            text: activityMouseAreaTooltip.text
-            color: Style.ncTextColor
-        }
-        background: Rectangle {
-            border.color: Style.menuBorder
-            color: Style.backgroundColor
-        }
     }
 
     ColumnLayout {

--- a/src/gui/tray/ActivityItemActions.qml
+++ b/src/gui/tray/ActivityItemActions.qml
@@ -77,19 +77,9 @@ RowLayout {
                 radius: width / 2
             }
 
-            ToolTip {
-                id: moreActionsButtonTooltip
+            NCToolTip {
                 visible: parent.hovered
-                delay: Qt.styleHints.mousePressAndHoldInterval
                 text: qsTr("Show more actions")
-                contentItem: Label {
-                    text: moreActionsButtonTooltip.text
-                    color: Style.ncTextColor
-                }
-                background: Rectangle {
-                    border.color: Style.menuBorder
-                    color: Style.backgroundColor
-                }
             }
 
             Accessible.name: qsTr("Show more actions")

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -185,19 +185,9 @@ RowLayout {
 
         Layout.margins: Style.roundButtonBackgroundVerticalMargins
 
-        ToolTip {
-            id: dismissActionButtonTooltip
+        NCToolTip {
             visible: parent.hovered
-            delay: Qt.styleHints.mousePressAndHoldInterval
             text: qsTr("Dismiss")
-            contentItem: Label {
-                text: dismissActionButtonTooltip.text
-                color: Style.ncTextColor
-            }
-            background: Rectangle {
-                border.color: Style.menuBorder
-                color: Style.backgroundColor
-            }
         }
 
         Accessible.name: qsTr("Dismiss")

--- a/src/gui/tray/CustomButton.qml
+++ b/src/gui/tray/CustomButton.qml
@@ -31,19 +31,9 @@ Button {
     leftPadding: root.text === "" ? 5 : 10
     rightPadding: root.text === "" ? 5 : 10
 
-    ToolTip {
-        id: customButtonTooltip
+    NCToolTip {
         text: root.toolTipText
-        delay: Qt.styleHints.mousePressAndHoldInterval
         visible: root.toolTipText !== "" && root.hovered
-        contentItem: Label {
-            text: customButtonTooltip.text
-            color: Style.ncTextColor
-        }
-        background: Rectangle {
-            border.color: Style.menuBorder
-            color: Style.backgroundColor
-        }
     }
 
     contentItem: RowLayout {

--- a/src/gui/tray/CustomTextButton.qml
+++ b/src/gui/tray/CustomTextButton.qml
@@ -32,19 +32,9 @@ Label {
     signal pressed(QtObject mouse)
     signal clicked(QtObject mouse)
 
-    ToolTip {
-        id: customTextButtonTooltip
+    NCToolTip {
         text: root.toolTipText
-        delay: Qt.styleHints.mousePressAndHoldInterval
         visible: root.toolTipText !== "" && root.hovered
-        contentItem: Label {
-            text: customTextButtonTooltip.text
-            color: Style.ncTextColor
-        }
-        background: Rectangle {
-            border.color: Style.menuBorder
-            color: Style.backgroundColor
-        }
     }
 
     MouseArea {

--- a/src/gui/tray/NCToolTip.qml
+++ b/src/gui/tray/NCToolTip.qml
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+import QtQml 2.15
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import Style 1.0
+
+ToolTip {
+    id: toolTip
+    clip: true
+    delay: Qt.styleHints.mousePressAndHoldInterval
+    contentItem: Label {
+        text: toolTip.text
+        color: Style.ncTextColor
+        wrapMode: Text.Wrap
+    }
+    background: Rectangle {
+        border.color: Style.menuBorder
+        color: Style.backgroundColor
+    }
+}

--- a/src/gui/tray/TalkReplyTextField.qml
+++ b/src/gui/tray/TalkReplyTextField.qml
@@ -48,9 +48,8 @@ TextField {
             top: replyMessageTextField.top
         }
 
-        ToolTip {
+        NCToolTip {
             visible: sendReplyMessageButton.hovered
-            delay: Qt.styleHints.mousePressAndHoldInterval
             text:  qsTr("Send reply to chat message")
         }
     }

--- a/src/gui/tray/UnifiedSearchResultListItem.qml
+++ b/src/gui/tray/UnifiedSearchResultListItem.qml
@@ -24,19 +24,9 @@ MouseArea {
 
     height: Style.unifiedSearchItemHeight
 
-    ToolTip {
-        id: unifiedSearchResultMouseAreaTooltip
+    NCToolTip {
         visible: unifiedSearchResultMouseArea.containsMouse
         text: isFetchMoreTrigger ? qsTr("Load more results") : model.resultTitle + "\n\n" + model.subline
-        delay: Qt.styleHints.mousePressAndHoldInterval
-        contentItem: Label {
-            text: unifiedSearchResultMouseAreaTooltip.text
-            color: Style.ncTextColor
-        }
-        background: Rectangle {
-            border.color: Style.menuBorder
-            color: Style.backgroundColor
-        }
     }
 
     Rectangle {


### PR DESCRIPTION
This prevents the need to duplicate our tooltip code (like setting the content item and background) everywhere.

This tangentially also fixes an issue with tooltip text in unified search list items clipping through the tooltip

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
