### PR TITLE
Remove Ubuntu Focal

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -18,7 +18,7 @@ if test "${DRONE_TARGET_BRANCH}" = "stable-2.6"; then
     UBUNTU_DISTRIBUTIONS="bionic focal jammy kinetic"
     DEBIAN_DISTRIBUTIONS="buster stretch testing"
 else
-    UBUNTU_DISTRIBUTIONS="focal jammy kinetic"
+    UBUNTU_DISTRIBUTIONS="jammy kinetic"
     DEBIAN_DISTRIBUTIONS="bullseye testing"
 fi
 


### PR DESCRIPTION
As discussed, Focal should be not supported from 3.6 on. Since master has been moved to 3.6.0, this PR removes building for Focal.