### PR TITLE
Prevent the 'Cancel' button of the user status selector getting squashed

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -323,19 +323,23 @@ ColumnLayout {
         Layout.alignment: Qt.AlignBottom
 
         UserStatusSelectorButton {
-            Layout.fillWidth: true
+            // Prevent being squashed by the other buttons with larger text
+            Layout.minimumWidth: implicitWidth
+            Layout.fillHeight: true
             primary: true
             text: qsTr("Cancel")
             onClicked: finished()
         }
         UserStatusSelectorButton {
             Layout.fillWidth: true
+            Layout.fillHeight: true
             primary: true
             text: qsTr("Clear status message")
             onClicked: userStatusSelectorModel.clearUserStatus()
         }
         UserStatusSelectorButton {
             Layout.fillWidth: true
+            Layout.fillHeight: true
             primary: true
             colored: true
             text: qsTr("Set status message")


### PR DESCRIPTION
This PR:

![Screenshot_20220810_175713](https://user-images.githubusercontent.com/70155116/183956655-6ae23e8a-eaae-4dfb-a459-9e6adbb7adbf.png)

Master:

![Screenshot_20220810_175937](https://user-images.githubusercontent.com/70155116/183957153-1b2de00d-4a26-4cfe-ba60-5b8564c1c57c.png)


Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

