### PR TITLE
Fix alignment of predefined status contents regardless of emoji fonts

### DIFF
--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -28,7 +28,8 @@ AbstractButton {
     leftPadding: Style.standardSpacing / 2
     rightPadding: Style.standardSpacing / 2
 
-    property real internalSpacing: Style.standardSpacing
+    property int emojiWidth: -1
+    property int internalSpacing: Style.standardSpacing
     property string emoji: ""
 
     background: Rectangle {
@@ -37,15 +38,19 @@ AbstractButton {
     }
 
     contentItem: Row {
-        spacing: internalSpacing
+        spacing: root.internalSpacing
 
         Label {
+            width: root.emojiWidth > 0 ? root.emojiWidth : implicitWidth
             text: emoji
+            horizontalAlignment: Image.AlignHCenter
+            verticalAlignment: Image.AlignVCenter
         }
 
         Label {
             text: root.text
             color: Style.ncTextColor
+            verticalAlignment: Text.AlignVCenter
         }
     }
 }

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -141,6 +141,7 @@ ColumnLayout {
             }
 
             RowLayout {
+                id: statusFieldLayout
                 Layout.fillWidth: true
                 spacing: 0
 
@@ -264,9 +265,11 @@ ColumnLayout {
                     model: userStatusSelectorModel.predefinedStatuses
 
                     PredefinedStatusButton {
-                        id: control
                         Layout.fillWidth: true
-                        internalSpacing: Style.standardSpacing + fieldButton.padding + userStatusMessageTextField.padding
+
+                        leftPadding: 0
+                        emojiWidth: fieldButton.width
+                        internalSpacing: statusFieldLayout.spacing + userStatusMessageTextField.leftPadding
 
                         emoji: modelData.icon
                         text: "<b>%1</b> – %2".arg(modelData.message).arg(userStatusSelectorModel.clearAtReadable(modelData))


### PR DESCRIPTION
This should make the alignment correct with any set of emoji fonts

Plasma emoji fonts:

![Screenshot_20220810_201705](https://user-images.githubusercontent.com/70155116/183987806-e8b80e21-dce5-4920-b9c7-fd738675fd07.png)

macOS emoji fonts:

![Screenshot 2022-08-10 at 20 23 50](https://user-images.githubusercontent.com/70155116/183988350-e7ebfaa3-74dc-4946-b0c1-abe7b68cb2c1.png)

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
