### PR TITLE
Display only current user's connection status in tray and sync summary.

### DIFF
--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -333,8 +333,16 @@ void SyncStatusSummary::setAccountState(AccountStatePtr accountState)
 
 void SyncStatusSummary::initSyncState()
 {
+    const auto currentUser = UserModel::instance()->currentUser();
+    if (!currentUser) {
+        return;
+    }
+
     auto syncStateFallbackNeeded = true;
     for (const auto &folder : FolderMan::instance()->map()) {
+        if (!folder->accountState()->isConnected() && folder->accountState()->account() != currentUser->accountState()->account()) {
+            continue;
+        }
         onFolderSyncStateChanged(folder);
         syncStateFallbackNeeded = false;
     }


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
Now, only the selected account's offline status will get visible to the user in the tray and an account's summary. If all are connected, then, sync status will get displayed for all of them combined as before.
See the videos below for comparison.

### [OLD] User connection status tray icon and summary (see the discrepancy between the sync summary and a tray icon when switching between offline and online accounts):
https://user-images.githubusercontent.com/12224014/184156093-85b134e8-1dd9-431c-b605-47283b3b181c.mp4

### [NEW] User connection status tray icon and summary are now both updated to display only the currently selected account's connection status in the tray and status summary:
https://user-images.githubusercontent.com/12224014/184156436-5c450f1a-a366-4a9c-b96c-d490c9c68f06.mp4


