### PR TITLE
Prevent crashing when trying to create error-ing QML component in systray.cpp, output error to log

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -140,7 +140,12 @@ void Systray::create()
         }
 
         QQmlComponent trayWindowComponent(_trayEngine, QStringLiteral("qrc:/qml/src/gui/tray/Window.qml"));
-        _trayWindow.reset(qobject_cast<QQuickWindow*>(trayWindowComponent.create()));
+
+        if(trayWindowComponent.isError()) {
+            qCWarning(lcSystray) << trayWindowComponent.errorString();
+        } else {
+            _trayWindow.reset(qobject_cast<QQuickWindow*>(trayWindowComponent.create()));
+        }
     }
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
@@ -260,8 +265,13 @@ void Systray::createCallDialog(const Activity &callNotification, const AccountSt
         };
 
         const auto callDialog = new QQmlComponent(_trayEngine, QStringLiteral("qrc:/qml/src/gui/tray/CallNotificationDialog.qml"));
-        callDialog->createWithInitialProperties(initialProperties);
 
+        if(callDialog->isError()) {
+            qCWarning(lcSystray) << callDialog->errorString();
+            return;
+        }
+
+        callDialog->createWithInitialProperties(initialProperties);
         _callsAlreadyNotified.insert(callNotification._id);
     }
 }


### PR DESCRIPTION
At the moment if we try to create a QML component (such as the call notification dialog) in systray.cpp which has an error, the client crashes. 

When we try to open the tray window, the client does not crash, but it always provides a generic and unhelpful "QQMLApplicationEngine failed to load component" error.

This PR fixes both of these issues by checking `QQmlComponent`s for errors before trying to create them, and logging the error message if there is one.

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
