### PR TITLE
Ensure file activity dialog is centered on screen and appears at top of window stack

### DIFF
--- a/src/gui/tray/FileActivityDialog.qml
+++ b/src/gui/tray/FileActivityDialog.qml
@@ -30,8 +30,11 @@ Window {
     }
 
     Component.onCompleted: {
-        // Set this explicitly, otherwise on macOS it will appear behind the tray
-        x = screen.width / 2 - width / 2
-        y = screen.height / 2 - height / 2
+        Systray.forceWindowInit(dialog);
+        Systray.positionWindowAtScreenCenter(dialog);
+
+        dialog.show();
+        dialog.raise();
+        dialog.requestActivate();
     }
 }


### PR DESCRIPTION
This should fix the file activity dialog window appearing underneath other windows and in weird places

@karlitschek 

With fix:


https://user-images.githubusercontent.com/70155116/185109189-e268a20c-4c7c-4026-805e-44011058d986.mov



Master:


https://user-images.githubusercontent.com/70155116/185109143-1a278826-e644-409e-8d1f-c5baff12a35c.mov



Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
