### PR TITLE
build script for AppImage should not assume Nextcloud is the name

### DIFF
--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -109,7 +109,7 @@ export LD_LIBRARY_PATH=/usr/lib/
 
 # Workaround issue #103
 rm -rf ./squashfs-root
-APPIMAGE=$(ls Nextcloud*.AppImage)
+APPIMAGE=$(ls *.AppImage)
 "./${APPIMAGE}" --appimage-extract
 rm "./${APPIMAGE}"
 rm ./squashfs-root/usr/lib/libglib-2.0.so.0
@@ -119,6 +119,6 @@ PATH=./linuxdeployqt-squashfs-root/usr/bin:$PATH appimagetool -n ./squashfs-root
 #move AppImage
 if [ ! -z "$DRONE_COMMIT" ]
 then
-    mv Nextcloud*.AppImage Nextcloud-${SUFFIX}-${DRONE_COMMIT}-x86_64.AppImage
+    mv *.AppImage ${APPNAME}-${SUFFIX}-${DRONE_COMMIT}-x86_64.AppImage
 fi
 mv *.AppImage ${DESKTOP_CLIENT_ROOT}/


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
