### PR TITLE
Fix File Activities dialog not showing up.

### DIFF
--- a/src/gui/tray/FileActivityDialog.qml
+++ b/src/gui/tray/FileActivityDialog.qml
@@ -33,5 +33,8 @@ Window {
         dialog.show();
         dialog.raise();
         dialog.requestActivate();
+
+        Systray.forceWindowInit(dialog);
+        Systray.positionWindowAtScreenCenter(dialog);
     }
 }

--- a/src/gui/tray/FileActivityDialog.qml
+++ b/src/gui/tray/FileActivityDialog.qml
@@ -30,9 +30,6 @@ Window {
     }
 
     Component.onCompleted: {
-        Systray.forceWindowInit(dialog);
-        Systray.positionWindowAtScreenCenter(dialog);
-
         dialog.show();
         dialog.raise();
         dialog.requestActivate();


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
Playing around with Systray by calling the following methods
```
Systray.forceWindowInit(dialog);
Systray.positionWindowAtScreenCenter(dialog);
```
leads to FileActivityDialog sometimes showing up and sometimes no, completely randomly.

I am not completely sure why this happens, but, removing those calls seems to fix the issue. The dialog shows up in the center of the screen without centering it.

**UPDATE:** I have added a second commit with an alternative solution.

### The bug can be observed in a video:

https://user-images.githubusercontent.com/12224014/186694980-0f37bffc-5278-47f4-9fbb-c9ee3a084a17.mp4