### PR TITLE
Sharingfeature integration

### DIFF
--- a/.tx/nextcloud.client-desktop/de_translation
+++ b/.tx/nextcloud.client-desktop/de_translation
@@ -21,7 +21,7 @@ Icon=@APPLICATION_EXECUTABLE@
 
 
 # Translations
-Icon[de]=@APPLICATION_ICON_NAME@
-Name[de]=@APPLICATION_NAME@ Desktop
-Comment[de]=@APPLICATION_NAME@ Client zur Desktop-Synchronisierung
-GenericName[de]=Ordner-Synchronisation
+Icon[de_DE]=@APPLICATION_ICON_NAME@
+Name[de_DE]=@APPLICATION_NAME@ Client zur Desktop-Synchronisierung
+Comment[de_DE]=@APPLICATION_NAME@ Client zur Desktop-Synchronisierung
+GenericName[de_DE]=Ordnersynchronisierung

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -202,7 +202,7 @@ void ShareLinkWidget::setupUiOptions()
         permissionMenu->addAction(_readOnlyLinkAction);
 
         checked = (perm & SharePermissionRead) && (perm & SharePermissionUpdate);
-        _allowEditingLinkAction =  permissionsGroup->addAction(tr("Can Edit"));
+        _allowEditingLinkAction = permissionsGroup->addAction(tr("Can Edit"));
         _allowEditingLinkAction->setCheckable(true);
         _allowEditingLinkAction->setChecked(checked);
          permissionMenu->addAction(_allowEditingLinkAction);
@@ -521,7 +521,8 @@ void ShareLinkWidget::toggleExpireDateOptions(const bool enable)
     }
 }
 
-void ShareLinkWidget::confirmAndDeleteShare(){
+void ShareLinkWidget::confirmAndDeleteShare()
+{
     auto messageBox = new QMessageBox(
         QMessageBox::Question,
         tr("Confirm Link Share Deletion"),
@@ -569,10 +570,7 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
         emit createLinkShare();
 
     } else if (action == _readOnlyLinkAction && state) {
-        if(_isFile)
-            _ui->currentPermission->setEnabled(false);
-        else
-            _ui->currentPermission->setEnabled(true);
+        _ui->currentPermission->setEnabled(_isFile);
         _linkShare->setPermissions(perm);
         _ui->currentPermission->setText(action->text());
 

--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -70,7 +70,6 @@ ShareLinkWidget::ShareLinkWidget(AccountPtr account,
 
     _ui->shareLinkToolButton->hide();
 
-
     //Is this a file or folder?
     QFileInfo fi(localPath);
     _isFile = fi.isFile();
@@ -202,7 +201,6 @@ void ShareLinkWidget::setupUiOptions()
         _readOnlyLinkAction->setChecked(checked);
         permissionMenu->addAction(_readOnlyLinkAction);
 
-
         checked = (perm & SharePermissionRead) && (perm & SharePermissionUpdate);
         _allowEditingLinkAction =  permissionsGroup->addAction(tr("Can Edit"));
         _allowEditingLinkAction->setCheckable(true);
@@ -229,8 +227,6 @@ void ShareLinkWidget::setupUiOptions()
     _ui->permissionMenu->setPopupMode(QToolButton::InstantPopup);
     _ui->permissionMenu->setStyleSheet("QToolButton::menu-indicator { image: none; }");
 
-
-    
     _shareLinkElidedLabel = new OCC::ElidedLabel(this);
     _shareLinkElidedLabel->setElideMode(Qt::ElideRight);
     displayShareLinkLabel();
@@ -274,8 +270,7 @@ void ShareLinkWidget::setupUiOptions()
         _linkContextMenu->addAction(_allowEditingLinkAction);
         _linkContextMenu->addAction(_allowUploadLinkAction);
     }
-
-      _linkContextMenu->addAction(_shareLinkWidgetAction);
+    _linkContextMenu->addAction(_shareLinkWidgetAction);
 
     // Adds action to display note widget (check box)
     _noteLinkAction = _linkContextMenu->addAction(tr("Note to recipient"));
@@ -570,7 +565,6 @@ void ShareLinkWidget::slotLinkContextMenuActionTriggered(QAction *action)
     SharePermissions perm = SharePermissionRead;
 
     _ui->currentPermission->setElideMode(Qt::ElideRight);
-
     if (action == _addAnotherLinkAction.data()) {
         emit createLinkShare();
 

--- a/src/gui/sharelinkwidget.ui
+++ b/src/gui/sharelinkwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>238</height>
+    <height>254</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -141,6 +141,59 @@
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>38</width>
+         <height>23</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="OCC::ElidedLabel" name="currentPermission">
+       <property name="text">
+        <string>Read only</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="permissionMenu">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+       <property name="arrowType">
+        <enum>Qt::DownArrow</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>
@@ -430,6 +483,11 @@
    <extends>QWidget</extends>
    <header>QProgressIndicator.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>OCC::ElidedLabel</class>
+   <extends>QLabel</extends>
+   <header>elidedlabel.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -474,7 +474,7 @@ ShareUserLine::ShareUserLine(AccountPtr account, QSharedPointer<UserGroupShare> 
     if(!_isFile) enabled = enabled && (maxSharingPermissions & SharePermissionCreate &&
                                       maxSharingPermissions & SharePermissionDelete);
    // _ui->permissionsEdit->setEnabled(enabled);
-   // connect(_ui->permissionsEdit, &QAbstractButton::clicked, this, &ShareUserLine::slotEditPermissionsChanged);
+  // connect(_ui->permissionsEdit, &QAbstractButton::clicked, this, &ShareUserLine::slotEditPermissionsChanged);
     connect(_ui->noteConfirmButton, &QAbstractButton::clicked, this, &ShareUserLine::onNoteConfirmButtonClicked);
     connect(_ui->calendar, &QDateTimeEdit::dateChanged, this, &ShareUserLine::setExpireDate);
 
@@ -488,7 +488,6 @@ ShareUserLine::ShareUserLine(AccountPtr account, QSharedPointer<UserGroupShare> 
     // create menu with checkable permissions
     auto *menu = new QMenu(this);
     auto *permissionMenu = new QMenu(this);
-
 
     auto *permissionsGroup = new QActionGroup(this);
     permissionsGroup->setExclusive(true);
@@ -556,30 +555,6 @@ ShareUserLine::ShareUserLine(AccountPtr account, QSharedPointer<UserGroupShare> 
     menu->addAction(_deleteShareButton);
     connect(_deleteShareButton, &QAction::triggered, this, &ShareUserLine::on_deleteShareButton_clicked);
 
-    /*
-     * Files can't have create or delete permissions
-     */
-   /* if (!_isFile) {
-        _permissionCreate = new QAction(tr("Can create"), this);
-        _permissionCreate->setCheckable(true);
-        _permissionCreate->setEnabled(maxSharingPermissions & SharePermissionCreate);
-        menu->addAction(_permissionCreate);
-        connect(_permissionCreate, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
-
-        _permissionChange = new QAction(tr("Can change"), this);
-        _permissionChange->setCheckable(true);
-        _permissionChange->setVisible(true);
-        _permissionChange->setEnabled(maxSharingPermissions & SharePermissionUpdate);
-        menu->addAction(_permissionChange);
-        connect(_permissionChange, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
-
-        _permissionDelete = new QAction(tr("Can delete"), this);
-        _permissionDelete->setCheckable(true);
-        _permissionDelete->setEnabled(maxSharingPermissions & SharePermissionDelete);
-        menu->addAction(_permissionDelete);
-        connect(_permissionDelete, &QAction::triggered, this, &ShareUserLine::slotPermissionsChanged);
-    }*/
-
     // Adds action to display password widget (check box)
     if (_share->getShareType() == Share::TypeEmail && (_share->isPasswordSet() || _account->capabilities().shareEmailPasswordEnabled())) {
         _passwordProtectLinkAction = new QAction(tr("Password protect"), this);
@@ -604,11 +579,9 @@ ShareUserLine::ShareUserLine(AccountPtr account, QSharedPointer<UserGroupShare> 
     _ui->permissionToolButton->setMenu(menu);
     _ui->permissionToolButton->setPopupMode(QToolButton::InstantPopup);
 
-
     _ui->permissionMenu->setMenu(permissionMenu);
     _ui->permissionMenu->setPopupMode(QToolButton::InstantPopup);
     _ui->permissionMenu->setStyleSheet("QToolButton::menu-indicator { image: none; }");
-
 
     _ui->passwordProgressIndicator->setVisible(false);
 
@@ -717,14 +690,12 @@ void ShareUserLine::slotAvatarLoaded(QImage avatar)
     _ui->avatar->setStyleSheet("");
 }
 
-void ShareUserLine::on_deleteShareButton_clicked()
-{
+void ShareUserLine::on_deleteShareButton_clicked(){
     setEnabled(false);
     _share->deleteShare();
 }
 
-ShareUserLine::~ShareUserLine()
-{
+ShareUserLine::~ShareUserLine(){
     delete _ui;
 }
 
@@ -743,7 +714,6 @@ void ShareUserLine::slotEditPermissionsChanged()
 
     //  folders edit = CREATE, READ, UPDATE, DELETE
     //  files edit = READ + UPDATE
-  //  if (_ui->permissionsEdit->checkState() == Qt::Checked) {
 
         /*
          * Files can't have create or delete permisisons
@@ -761,7 +731,6 @@ void ShareUserLine::slotEditPermissionsChanged()
             permissions |= SharePermissionUpdate;
 
         }
-  //  }
 
     if(_isFile && _permissionReshare->isEnabled() && _permissionReshare->isChecked())
         permissions |= SharePermissionShare;
@@ -769,8 +738,7 @@ void ShareUserLine::slotEditPermissionsChanged()
     _share->setPermissions(permissions);
 }
 
-void ShareUserLine::slotPermissionsChanged()
-{
+void ShareUserLine::slotPermissionsChanged(){
     setEnabled(false);
 
     Share::Permissions permissions = SharePermissionRead;

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -716,7 +716,7 @@ void ShareUserLine::slotEditPermissionsChanged()
          * Files can't have create or delete permisisons
          */
         if (!_isFile) {
-            if (_permissionChange->isEnabled()){
+            if (_permissionChange->isEnabled()) {
                 permissions |= SharePermissionUpdate;
                _ui->currentPermission->setText("Can Edit");
             }
@@ -737,15 +737,14 @@ void ShareUserLine::slotPermissionsChanged()
 
     Share::Permissions permissions = SharePermissionRead;
 
-    if (_permissionReshare->isChecked()){
+    if (_permissionReshare->isChecked()) {
         permissions |= SharePermissionShare;
          _share->setPermissions(permissions);
-    }else if(_permissionRead->isChecked()){
+    } else if(_permissionRead->isChecked()) {
         permissions |= SharePermissionRead;
         _ui->currentPermission->setText("Read Only");
          _share->setPermissions(permissions);
-    }
-    else if(_permissionChange->isChecked()){
+    } else if(_permissionChange->isChecked()) {
         permissions |= SharePermissionUpdate;
         _ui->currentPermission->setText("Can Edit");
          _share->setPermissions(permissions);
@@ -877,10 +876,11 @@ void ShareUserLine::displayPermissions()
 //  files edit = READ + UPDATE
 
 //  edit is independent of reshare
-    if (perm & SharePermissionShare)
+    if (perm & SharePermissionShare) {
         _permissionReshare->setChecked(true);
+    }
 
-    if(!_isFile){
+    if (!_isFile) {
         _permissionChange->setChecked(perm & SharePermissionUpdate);
     }
 }

--- a/src/gui/shareusergroupwidget.cpp
+++ b/src/gui/shareusergroupwidget.cpp
@@ -473,8 +473,6 @@ ShareUserLine::ShareUserLine(AccountPtr account, QSharedPointer<UserGroupShare> 
     bool enabled = (maxSharingPermissions & SharePermissionUpdate);
     if(!_isFile) enabled = enabled && (maxSharingPermissions & SharePermissionCreate &&
                                       maxSharingPermissions & SharePermissionDelete);
-   // _ui->permissionsEdit->setEnabled(enabled);
-  // connect(_ui->permissionsEdit, &QAbstractButton::clicked, this, &ShareUserLine::slotEditPermissionsChanged);
     connect(_ui->noteConfirmButton, &QAbstractButton::clicked, this, &ShareUserLine::onNoteConfirmButtonClicked);
     connect(_ui->calendar, &QDateTimeEdit::dateChanged, this, &ShareUserLine::setExpireDate);
 
@@ -690,12 +688,14 @@ void ShareUserLine::slotAvatarLoaded(QImage avatar)
     _ui->avatar->setStyleSheet("");
 }
 
-void ShareUserLine::on_deleteShareButton_clicked(){
+void ShareUserLine::on_deleteShareButton_clicked()
+{
     setEnabled(false);
     _share->deleteShare();
 }
 
-ShareUserLine::~ShareUserLine(){
+ShareUserLine::~ShareUserLine()
+{
     delete _ui;
 }
 
@@ -706,9 +706,6 @@ void ShareUserLine::slotEditPermissionsChanged()
     // Can never manually be set to "partial".
     // This works because the state cycle for clicking is
     // unchecked -> partial -> checked -> unchecked.
-//    if (_ui->permissionsEdit->checkState() == Qt::PartiallyChecked) {
-//        _ui->permissionsEdit->setCheckState(Qt::Checked);
-//    }
 
     Share::Permissions permissions = SharePermissionRead;
 
@@ -723,10 +720,6 @@ void ShareUserLine::slotEditPermissionsChanged()
                 permissions |= SharePermissionUpdate;
                _ui->currentPermission->setText("Can Edit");
             }
-            /*if (_permissionCreate->isEnabled())
-                permissions |= SharePermissionCreate;
-            if (_permissionDelete->isEnabled())
-                permissions |= SharePermissionDelete;*/
         } else {
             permissions |= SharePermissionUpdate;
 
@@ -738,7 +731,8 @@ void ShareUserLine::slotEditPermissionsChanged()
     _share->setPermissions(permissions);
 }
 
-void ShareUserLine::slotPermissionsChanged(){
+void ShareUserLine::slotPermissionsChanged()
+{
     setEnabled(false);
 
     Share::Permissions permissions = SharePermissionRead;
@@ -746,8 +740,7 @@ void ShareUserLine::slotPermissionsChanged(){
     if (_permissionReshare->isChecked()){
         permissions |= SharePermissionShare;
          _share->setPermissions(permissions);
-    }
-    else if(_permissionRead->isChecked()){
+    }else if(_permissionRead->isChecked()){
         permissions |= SharePermissionRead;
         _ui->currentPermission->setText("Read Only");
          _share->setPermissions(permissions);
@@ -757,7 +750,6 @@ void ShareUserLine::slotPermissionsChanged(){
         _ui->currentPermission->setText("Can Edit");
          _share->setPermissions(permissions);
     }
-   // _share->setPermissions(permissions);
 }
 
 void ShareUserLine::slotPasswordCheckboxChanged()
@@ -883,23 +875,13 @@ void ShareUserLine::displayPermissions()
 
 //  folders edit = CREATE, READ, UPDATE, DELETE
 //  files edit = READ + UPDATE
-  /*  if (perm & SharePermissionUpdate && (_isFile ||
-                                         (perm & SharePermissionCreate && perm & SharePermissionDelete))) {
-        _ui->permissionsEdit->setCheckState(Qt::Checked);
-    } else if (!_isFile && perm & (SharePermissionUpdate | SharePermissionCreate | SharePermissionDelete)) {
-        _ui->permissionsEdit->setCheckState(Qt::PartiallyChecked);
-    } else if(perm & SharePermissionRead) {
-        _ui->permissionsEdit->setCheckState(Qt::Unchecked);
-    }*/
 
 //  edit is independent of reshare
     if (perm & SharePermissionShare)
         _permissionReshare->setChecked(true);
 
     if(!_isFile){
-        //_permissionCreate->setChecked(perm & SharePermissionCreate);
         _permissionChange->setChecked(perm & SharePermissionUpdate);
-        //_permissionDelete->setChecked(perm & SharePermissionDelete);
     }
 }
 

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -130,7 +130,6 @@ private:
     bool _disableCompleterActivated; // in order to avoid that we share the contents twice
     ShareManager *_manager;
 
-
     QProgressIndicator _pi_sharee;
 
     QString _lastCreatedShareId;

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -130,6 +130,7 @@ private:
     bool _disableCompleterActivated; // in order to avoid that we share the contents twice
     ShareManager *_manager;
 
+
     QProgressIndicator _pi_sharee;
 
     QString _lastCreatedShareId;
@@ -220,13 +221,16 @@ private:
   bool _isFile;
 
   ProfilePageMenu _profilePageMenu;
+  QString _permission;
 
   // _permissionEdit is a checkbox
   QAction *_permissionReshare;
   QAction *_deleteShareButton;
-  QAction *_permissionCreate;
+//  QAction *_permissionCreate;
+  QAction *_permissionRead;
+  QAction *_permissionCanEdit;
   QAction *_permissionChange;
-  QAction *_permissionDelete;
+//  QAction *_permissionDelete;
   QAction *_noteLinkAction;
   QAction *_expirationDateLinkAction;
   QAction *_passwordProtectLinkAction;

--- a/src/gui/shareusergroupwidget.h
+++ b/src/gui/shareusergroupwidget.h
@@ -226,11 +226,9 @@ private:
   // _permissionEdit is a checkbox
   QAction *_permissionReshare;
   QAction *_deleteShareButton;
-//  QAction *_permissionCreate;
   QAction *_permissionRead;
   QAction *_permissionCanEdit;
   QAction *_permissionChange;
-//  QAction *_permissionDelete;
   QAction *_noteLinkAction;
   QAction *_expirationDateLinkAction;
   QAction *_passwordProtectLinkAction;

--- a/src/gui/shareuserline.ui
+++ b/src/gui/shareuserline.ui
@@ -104,19 +104,6 @@
       </spacer>
      </item>
      <item>
-      <widget class="QCheckBox" name="permissionsEdit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Can edit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="permissionToolButton">
        <property name="icon">
         <iconset resource="../../theme.qrc">
@@ -126,6 +113,59 @@
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>38</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="OCC::ElidedLabel" name="currentPermission">
+       <property name="text">
+        <string>Read Only</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="permissionMenu">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+       <property name="arrowType">
+        <enum>Qt::DownArrow</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>
@@ -426,15 +466,6 @@
             </color>
            </brush>
           </colorrole>
-          <colorrole role="HighlightedText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </brush>
-          </colorrole>
           <colorrole role="Link">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -599,15 +630,6 @@
             </color>
            </brush>
           </colorrole>
-          <colorrole role="HighlightedText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </brush>
-          </colorrole>
           <colorrole role="Link">
            <brush brushstyle="SolidPattern">
             <color alpha="255">
@@ -769,15 +791,6 @@
              <red>82</red>
              <green>148</green>
              <blue>226</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="HighlightedText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
             </color>
            </brush>
           </colorrole>


### PR DESCRIPTION
In this ,we have harmonized the permission settings for sharing. Currently we have different options for internal, external and link shares as well as different option for files and folders.

1.We have added a radio button group containing the options for user(External) & sharelink for files and folder:
"Read only"  
"Can edit"  
we removed "can create", "can delete",
2.for link share on folder we have added one more option "Filedrop only"
3.Added dropdown containing the options of the radio button group for files and folder on user and share link
"Read only" 
"Can edit"  

Sample screenshot of added dropdown is herewith
![dropdownpermissionUI](https://user-images.githubusercontent.com/110465779/186882060-0c5bcd34-ec09-44fb-af04-d7344e91da5c.PNG)
![permissionChange](https://user-images.githubusercontent.com/110465779/186882083-854572b0-9608-4370-ad1c-b36e7a2f0886.PNG)


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
