### PR TITLE
makes Qt WebEngine optional only on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,57 @@ endif()
 
 include(ECMEnableSanitizers)
 
-find_package(Qt5 5.15 COMPONENTS Core Network Xml Concurrent REQUIRED)
-find_package(Qt5 5.15 COMPONENTS WebEngineWidgets WebEngine)
+set(REQUIRED_QT_VERSION "5.15.0")
+
+find_package(Qt5Core ${REQUIRED_QT_VERSION} CONFIG QUIET)
+set_package_properties(Qt5Core PROPERTIES
+    DESCRIPTION "Qt5 Core component."
+    TYPE REQUIRED
+)
+
+find_package(Qt5Network ${REQUIRED_QT_VERSION} CONFIG QUIET)
+set_package_properties(Qt5Network PROPERTIES
+    DESCRIPTION "Qt5 Network component."
+    TYPE REQUIRED
+)
+
+find_package(Qt5Xml ${REQUIRED_QT_VERSION} CONFIG QUIET)
+set_package_properties(Qt5Xml PROPERTIES
+    DESCRIPTION "Qt5 Xml component."
+    TYPE REQUIRED
+)
+
+find_package(Qt5Concurrent ${REQUIRED_QT_VERSION} CONFIG QUIET)
+set_package_properties(Qt5Concurrent PROPERTIES
+    DESCRIPTION "Qt5 Concurrent component."
+    TYPE REQUIRED
+)
+
+find_package(Qt5WebEngineWidgets ${REQUIRED_QT_VERSION} CONFIG QUIET)
+if(APPLE)
+    set_package_properties(Qt5WebEngineWidgets PROPERTIES
+        DESCRIPTION "Qt5 WebEngineWidgets component."
+        TYPE RECOMMENDED
+    )
+else()
+    set_package_properties(Qt5WebEngineWidgets PROPERTIES
+        DESCRIPTION "Qt5 WebEngineWidgets component."
+        TYPE REQUIRED
+    )
+endif()
+
+find_package(Qt5WebEngine ${REQUIRED_QT_VERSION} CONFIG QUIET)
+if(APPLE)
+    set_package_properties(Qt5WebEngine PROPERTIES
+        DESCRIPTION "Qt5 WebEngine component."
+        TYPE RECOMMENDED
+    )
+else()
+    set_package_properties(Qt5WebEngine PROPERTIES
+        DESCRIPTION "Qt5 WebEngine component."
+        TYPE REQUIRED
+    )
+endif()
 
 if(Qt5WebEngine_FOUND AND Qt5WebEngineWidgets_FOUND)
   add_compile_definitions(WITH_WEBENGINE=1)


### PR DESCRIPTION
should avoid distributing broken builds missing out web flow login that
is required by some cusotmers

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
