### PR TITLE
Reset the _scheduleSelfTimer each time the FolderWatcher detects a ne…

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -108,7 +108,7 @@ Folder::Folder(const FolderDefinition &definition,
     connect(_engine.data(), &SyncEngine::addErrorToGui, this, &Folder::slotAddErrorToGui);
 
     _scheduleSelfTimer.setSingleShot(true);
-    _scheduleSelfTimer.setInterval(SyncEngine::minimumFileAgeForUpload);
+    _scheduleSelfTimer.setInterval(5000);
     connect(&_scheduleSelfTimer, &QTimer::timeout,
         this, &Folder::slotScheduleThisFolder);
 
@@ -1222,6 +1222,9 @@ void Folder::slotHydrationDone()
 void Folder::scheduleThisFolderSoon()
 {
     if (!_scheduleSelfTimer.isActive()) {
+        _scheduleSelfTimer.start();
+    } else {
+        _scheduleSelfTimer.stop();
         _scheduleSelfTimer.start();
     }
 }

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -144,6 +144,8 @@ public:
 
     auto getPropagator() { return _propagator; } // for the test
 
+    ProgressInfo* progressInfo() const { return _progressInfo.get(); }
+
 signals:
     // During update, before reconcile
     void rootEtag(const QByteArray &, const QDateTime &);


### PR DESCRIPTION
…w path changed. Increase the _scheduleSelfTimer interval.

Signed-off-by: alex-z <blackslayer4@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
