### PR TITLE
do not build qt keychain already included in the CI images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ name: qt-5.15
 
 steps:
 - name: cmake
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -11,7 +11,7 @@ steps:
     - cd /drone/build
     - cmake -G Ninja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
 - name: compile
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -19,7 +19,7 @@ steps:
     - cd /drone/build
     - ninja
 - name: test
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -47,7 +47,7 @@ name: qt-5.15-clang
 
 steps:
 - name: cmake
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -55,7 +55,7 @@ steps:
     - cd /drone/build
     - cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
 - name: compile
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -63,7 +63,7 @@ steps:
     - cd /drone/build
     - ninja
 - name: test
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -73,7 +73,7 @@ steps:
     - chown -R test:test .
     - su -c 'ASAN_OPTIONS=detect_leaks=0 xvfb-run ctest --output-on-failure' test
 - name: clang-tidy
-  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+  image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
   volumes:
     - name: build
       path: /drone/build
@@ -98,7 +98,7 @@ name: AppImage
 
 steps:
 - name: build
-  image: ghcr.io/nextcloud/continuous-integration-client-appimage:client-appimage-4
+  image: ghcr.io/nextcloud/continuous-integration-client-appimage:client-appimage-5
   environment:
     CI_UPLOAD_GIT_TOKEN:
       from_secret: CI_UPLOAD_GIT_TOKEN

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client:client-5.15-8
+    container: ghcr.io/nextcloud/continuous-integration-client:client-5.15-9
     env:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed

--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -8,12 +8,10 @@ export BUILDNR=${BUILDNR:-0000}
 export DESKTOP_CLIENT_ROOT=${DESKTOP_CLIENT_ROOT:-/home/user}
 
 #Set Qt-5.15
-export QT_BASE_DIR=/opt/qt5.15
+export QT_BASE_DIR=/opt/kdeqt5.15
 
 export QTDIR=$QT_BASE_DIR
 export PATH=$QT_BASE_DIR/bin:$PATH
-export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
-export PKG_CONFIG_PATH=$QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
 
 # Set defaults
 export SUFFIX=${DRONE_PULL_REQUEST:=master}
@@ -25,17 +23,6 @@ if [ "$BUILD_UPDATER" != "OFF" ]; then
 fi
 
 mkdir /app
-
-# QtKeyChain
-git clone https://github.com/frankosterfeld/qtkeychain.git
-cd qtkeychain
-git checkout v0.10.0
-mkdir build
-cd build
-cmake -G Ninja -D CMAKE_INSTALL_PREFIX=/usr ..
-cmake --build . --target all
-DESTDIR=/app cmake --install .
-
 
 # Build client
 mkdir build-client
@@ -60,7 +47,6 @@ mkdir usr/plugins
 mv usr/lib/*sync_vfs_suffix.so usr/plugins
 mv usr/lib/*sync_vfs_xattr.so usr/plugins
 
-
 rm -rf usr/lib/cmake
 rm -rf usr/include
 rm -rf usr/mkspecs
@@ -80,7 +66,6 @@ DESKTOP_FILE=$(ls /app/usr/share/applications/*.desktop)
 sed -i -e 's|Icon=nextcloud|Icon=Nextcloud|g' ${DESKTOP_FILE} # Bug in desktop file?
 cp ./usr/share/icons/hicolor/512x512/apps/*.png . # Workaround for linuxeployqt bug, FIXME
 
-
 # Because distros need to get their shit together
 cp -R /usr/lib/x86_64-linux-gnu/libssl.so* ./usr/lib/
 cp -R /usr/lib/x86_64-linux-gnu/libcrypto.so* ./usr/lib/
@@ -98,7 +83,7 @@ chmod a+x linuxdeployqt.AppImage
 rm ./linuxdeployqt.AppImage
 cp -r ./squashfs-root ./linuxdeployqt-squashfs-root
 unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=/usr/lib/
+export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu
 ./squashfs-root/AppRun ${DESKTOP_FILE} -bundle-non-qt-libs -qmldir=${DESKTOP_CLIENT_ROOT}/src/gui
 
 # Set origin


### PR DESCRIPTION
clean up some cruft

adapt to the new paths in CI images

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
