### PR TITLE
cloudproviders elide text for recent files activity submenu

### DIFF
--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -13,6 +13,7 @@
 #include <account.h>
 #include <folder.h>
 #include <accountstate.h>
+#include <QApplication>
 #include <QDesktopServices>
 #include "openfilemanager.h"
 #include "owncloudgui.h"
@@ -21,6 +22,7 @@
 using namespace OCC;
 
 GSimpleActionGroup *actionGroup = nullptr;
+int preferredTextWidth = 0;
 
 CloudProviderWrapper::CloudProviderWrapper(QObject *parent, Folder *folder, int folderId, CloudProvidersProviderExporter* cloudprovider) : QObject(parent)
   , _folder(folder)
@@ -198,6 +200,13 @@ void CloudProviderWrapper::slotSyncFinished(const SyncResult &result)
     updateStatusText(result.statusString());
 }
 
+static GMenuItem* addMenuItem(const QString text, const gchar *action)
+{
+    QFontMetrics fm = QApplication::fontMetrics();
+    preferredTextWidth = MAX (preferredTextWidth, (fm.boundingRect (text)).width ());
+    return menu_item_new (text, action);
+}
+
 GMenuModel* CloudProviderWrapper::getMenuModel() {
 
     GMenu* section = nullptr;
@@ -207,14 +216,14 @@ GMenuModel* CloudProviderWrapper::getMenuModel() {
     _mainMenu = g_menu_new();
 
     section = g_menu_new();
-    item = menu_item_new(tr("Open website"), "cloudprovider.openwebsite");
+    item = addMenuItem(tr("Open website"), "cloudprovider.openwebsite");
     g_menu_append_item(section, item);
     g_clear_object (&item);
     g_menu_append_section(_mainMenu, nullptr, G_MENU_MODEL(section));
     g_clear_object (&section);
 
     _recentMenu = g_menu_new();
-    item = menu_item_new(tr("No recently changed files"), nullptr);
+    item = addMenuItem(tr("No recently changed files"), nullptr);
     g_menu_append_item(_recentMenu, item);
     g_clear_object (&item);
 
@@ -226,23 +235,23 @@ GMenuModel* CloudProviderWrapper::getMenuModel() {
     g_clear_object (&section);
 
     section = g_menu_new();
-    item = menu_item_new(tr("Pause synchronization"), "cloudprovider.pause");
+    item = addMenuItem (tr("Pause synchronization"), "cloudprovider.pause");
     g_menu_append_item(section, item);
     g_clear_object (&item);
     g_menu_append_section(_mainMenu, nullptr, G_MENU_MODEL(section));
     g_clear_object (&section);
 
     section = g_menu_new();
-    item = menu_item_new(tr("Help"), "cloudprovider.openhelp");
+    item = addMenuItem(tr("Help"), "cloudprovider.openhelp");
     g_menu_append_item(section, item);
     g_clear_object (&item);
-    item = menu_item_new(tr("Settings"), "cloudprovider.opensettings");
+    item = addMenuItem(tr("Settings"), "cloudprovider.opensettings");
     g_menu_append_item(section, item);
     g_clear_object (&item);
-    item = menu_item_new(tr("Log out"), "cloudprovider.logout");
+    item = addMenuItem(tr("Log out"), "cloudprovider.logout");
     g_menu_append_item(section, item);
     g_clear_object (&item);
-    item = menu_item_new(tr("Quit sync client"), "cloudprovider.quit");
+    item = addMenuItem(tr("Quit sync client"), "cloudprovider.quit");
     g_menu_append_item(section, item);
     g_clear_object (&item);
     g_menu_append_section(_mainMenu, nullptr, G_MENU_MODEL(section));

--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -94,11 +94,15 @@ void CloudProviderWrapper::slotUpdateProgress(const QString &folder, const Progr
 
     // Build recently changed files list
     if (!progress._lastCompletedItem.isEmpty() && shouldShowInRecentsMenu(progress._lastCompletedItem)) {
+        QFontMetrics fm = QApplication::fontMetrics();
         QString kindStr = Progress::asResultString(progress._lastCompletedItem);
+        QString elidedKindStr = fm.elidedText(kindStr, Qt::ElideRight, preferredTextWidth);
         QString timeStr = QTime::currentTime().toString("hh:mm");
-        QString actionText = tr("%1 (%2, %3)").arg(progress._lastCompletedItem._file, kindStr, timeStr);
+        QString fileName = progress._lastCompletedItem._file;
+        QString elidedFileName = fm.elidedText(fileName, Qt::ElideRight, preferredTextWidth);
+        QString actionText = tr("%1 (%2, %3)").arg(elidedFileName, elidedKindStr, timeStr);
         if (f) {
-            QString fullPath = f->path() + '/' + progress._lastCompletedItem._file;
+            QString fullPath = f->path() + '/' + fileName;
             if (QFile(fullPath).exists()) {
                 if (_recentlyChanged.length() > 5)
                     _recentlyChanged.removeFirst();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
As part of libcloudproviders, cloudproviderswrapper generates and provides a menu model for the menu to be used in a file manager.  Within that menu is a submenu of file activity.  Since the file activity includes full filenames, it can be extremely long and cause weird behavior (see linked issue below for Nautilus).  I arbitrarily chose to use the main menu width as a baseline for how wide the submenu should be (it can be up to twice as wide). 

https://gitlab.gnome.org/GNOME/nautilus/-/issues/2405

I apologize in advance, I don't spend much time programming c++ and have never used qt