### PR TITLE
fix script that upload AppImage to go in correct path

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
       from_secret: CI_UPLOAD_GIT_USERNAME
   commands:
     - BUILDNR=$DRONE_BUILD_NUMBER VERSION_SUFFIX=$DRONE_PULL_REQUEST BUILD_UPDATER=ON DESKTOP_CLIENT_ROOT=$DRONE_WORKSPACE /bin/bash -c "./admin/linux/build-appimage.sh"
-    - /bin/bash -c "./admin/linux/upload-appimage.sh" || echo "Upload failed, however this is an optional step."
+    - DESKTOP_CLIENT_ROOT=$DRONE_WORKSPACE /bin/bash -c "./admin/linux/upload-appimage.sh" || echo "Upload failed, however this is an optional step."
 trigger:
   branch:
     - master

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
       from_secret: CI_UPLOAD_GIT_USERNAME
   commands:
     - BUILDNR=$DRONE_BUILD_NUMBER VERSION_SUFFIX=$DRONE_PULL_REQUEST BUILD_UPDATER=ON DESKTOP_CLIENT_ROOT=$DRONE_WORKSPACE /bin/bash -c "./admin/linux/build-appimage.sh"
-    - DESKTOP_CLIENT_ROOT=$DRONE_WORKSPACE /bin/bash -c "./admin/linux/upload-appimage.sh" || echo "Upload failed, however this is an optional step."
+    - BUILDNR=$DRONE_BUILD_NUMBER VERSION_SUFFIX=$DRONE_PULL_REQUEST DESKTOP_CLIENT_ROOT=$DRONE_WORKSPACE /bin/bash -c "./admin/linux/upload-appimage.sh" || echo "Upload failed, however this is an optional step."
 trigger:
   branch:
     - master

--- a/admin/linux/upload-appimage.sh
+++ b/admin/linux/upload-appimage.sh
@@ -5,7 +5,14 @@ export BUILD=${DRONE_BUILD_NUMBER}
 export PR=${DRONE_PULL_REQUEST}
 export GIT_USERNAME=${CI_UPLOAD_GIT_USERNAME}
 export GIT_TOKEN=${CI_UPLOAD_GIT_TOKEN}
+
+# Needed to get it working on drone
+export SUFFIX=${DRONE_PULL_REQUEST:=master}
+if [ $SUFFIX != "master" ]; then
+    SUFFIX="PR-$SUFFIX"
+fi
 export DESKTOP_CLIENT_ROOT=${DESKTOP_CLIENT_ROOT:-/home/user}
+export APPNAME=${APPNAME:-nextcloud}
 
 # Defaults
 export GIT_REPO=ci-builds
@@ -26,7 +33,13 @@ echo `pwd`
 ls
 
 # AppImage
-export APPIMAGE=$(readlink -f ./Nextcloud*.AppImage)
+if [ ! -z "$DRONE_COMMIT" ]
+then
+    export APPIMAGE=$(readlink -f ./${APPNAME}-${SUFFIX}-${DRONE_COMMIT}-x86_64.AppImage)
+else
+    export APPIMAGE=$(readlink -f ./Nextcloud*.AppImage)
+fi
+
 export UPDATE=$(readlink -f ./Nextcloud*.AppImage.zsync)
 export BASENAME=$(basename ${APPIMAGE})
 

--- a/admin/linux/upload-appimage.sh
+++ b/admin/linux/upload-appimage.sh
@@ -22,6 +22,8 @@ if [ $TAG_NAME != "master" ]; then
 fi
 
 cd ${DESKTOP_CLIENT_ROOT}
+echo `pwd`
+ls
 
 # AppImage
 export APPIMAGE=$(readlink -f ./Nextcloud*.AppImage)
@@ -90,6 +92,7 @@ uploadUrl=$(echo $json | jq -r '.upload_url')
 if [[ "$uploadUrl" == "null" ]]; then
     # Try to create a release
     json=$(create_release)
+    echo $json
 
     releaseId=$(echo $json | jq -r '.id')
     uploadUrl=$(echo $json | jq -r '.upload_url')

--- a/admin/linux/upload-appimage.sh
+++ b/admin/linux/upload-appimage.sh
@@ -5,6 +5,7 @@ export BUILD=${DRONE_BUILD_NUMBER}
 export PR=${DRONE_PULL_REQUEST}
 export GIT_USERNAME=${CI_UPLOAD_GIT_USERNAME}
 export GIT_TOKEN=${CI_UPLOAD_GIT_TOKEN}
+export DESKTOP_CLIENT_ROOT=${DESKTOP_CLIENT_ROOT:-/home/user}
 
 # Defaults
 export GIT_REPO=ci-builds
@@ -20,7 +21,7 @@ if [ $TAG_NAME != "master" ]; then
     RELEASE_BODY="nextcloud/desktop#$PR"
 fi
 
-cd /build
+cd ${DESKTOP_CLIENT_ROOT}
 
 # AppImage
 export APPIMAGE=$(readlink -f ./Nextcloud*.AppImage)


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
