### PR TITLE
Fix add account window text clipping, enlarge text

### DIFF
--- a/src/gui/wizard/slideshow.cpp
+++ b/src/gui/wizard/slideshow.cpp
@@ -19,8 +19,6 @@
 #include <QStyle>
 #include <QStyleHints>
 
-#define HASQT5_11 (QT_VERSION >= QT_VERSION_CHECK(5,11,0))
-
 namespace OCC {
 
 static const int Spacing = 6;
@@ -30,6 +28,7 @@ static const int SlideDistance = 400;
 SlideShow::SlideShow(QWidget *parent) : QWidget(parent)
 {
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+    setStyleSheet(QStringLiteral("font: bold 18pt"));
 }
 
 void SlideShow::addSlide(const QPixmap &pixmap, const QString &label)
@@ -87,20 +86,20 @@ void SlideShow::setCurrentSlide(int index)
 
 QSize SlideShow::sizeHint() const
 {
-    QFontMetrics fm = fontMetrics();
-    QSize labelSize(0, fm.height());
-    for (const QString &label : _labels) {
-#if (HASQT5_11)
-        labelSize.setWidth(std::max(fm.horizontalAdvance(label), labelSize.width()));
-#else
-        labelSize.setWidth(std::max(fm.width(label), labelSize.width()));
-#endif
+    const auto fm = fontMetrics();
+    QSize labelSize;
+    for (const auto &label : _labels) {
+        const auto labelBoundingRect = fm.boundingRect(rect(), Qt::TextWordWrap, label);
+        labelSize.setWidth(std::max(labelBoundingRect.width(), labelSize.width()));
+        labelSize.setHeight(std::max(labelBoundingRect.height(), labelSize.height()));
     }
+
     QSize pixmapSize;
-    for (const QPixmap &pixmap : _pixmaps) {
+    for (const auto &pixmap : _pixmaps) {
         pixmapSize.setWidth(std::max(pixmap.width(), pixmapSize.width()));
         pixmapSize.setHeight(std::max(pixmap.height(), pixmapSize.height()));
     }
+
     return {
         std::max(labelSize.width(), pixmapSize.width()),
         labelSize.height() + Spacing + pixmapSize.height()
@@ -189,14 +188,29 @@ void SlideShow::maybeRestartTimer()
 }
 
 void SlideShow::drawSlide(QPainter *painter, int index)
-{
-    QString label = _labels.value(index);
-    QRect labelRect = style()->itemTextRect(fontMetrics(), rect(), Qt::AlignBottom | Qt::AlignHCenter, isEnabled(), label);
-    style()->drawItemText(painter, labelRect, Qt::AlignCenter, palette(), isEnabled(), label, QPalette::WindowText);
+{    
+    const auto label = _labels.value(index);
+    const auto labelRect = style()->itemTextRect(fontMetrics(),
+                                                 rect(),
+                                                 Qt::AlignBottom | Qt::AlignHCenter | Qt::TextWordWrap,
+                                                 isEnabled(),
+                                                 label);
+    style()->drawItemText(painter,
+                          labelRect,
+                          Qt::AlignCenter | Qt::TextWordWrap,
+                          palette(),
+                          isEnabled(),
+                          label,
+                          QPalette::WindowText);
 
-    QPixmap pixmap = _pixmaps.value(index);
-    QRect pixmapRect = style()->itemPixmapRect(QRect(0, 0, width(), labelRect.top() - Spacing), Qt::AlignCenter, pixmap);
-    style()->drawItemPixmap(painter, pixmapRect, Qt::AlignCenter, pixmap);
+    const auto pixmap = _pixmaps.value(index);
+    const auto pixmapRect = style()->itemPixmapRect(QRect(0, 0, width(), labelRect.top() - Spacing),
+                                                    Qt::AlignCenter,
+                                                    pixmap);
+    style()->drawItemPixmap(painter,
+                            pixmapRect,
+                            Qt::AlignCenter,
+                            pixmap);
 }
 
 } // namespace OCC


### PR DESCRIPTION
The enlargement of the text partially addresses #4896

Fixing the text layouting should make it easier for translators to change the text without the text view being broken. It also lets us use larger lettering without having to be careful not to break the text view

https://user-images.githubusercontent.com/70155116/188909214-1a7fc6b6-06b3-45b4-81f4-b708202df9df.mov

Below is master:

https://user-images.githubusercontent.com/70155116/188909971-b87e1fd8-1625-44ba-a9af-0d0557935bfc.mov

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
