### PR TITLE
Make account setup wizard's adjustWizardSize resize to current page size instead of largest wizard page

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -126,9 +126,8 @@ void OwncloudSetupWizard::startWizard()
     const auto startPage = WizardCommon::Page_ServerSetup;
 #endif // WITH_PROVIDERS
     _ocWizard->setStartId(startPage);
-
     _ocWizard->restart();
-
+    _ocWizard->adjustWizardSize();
     _ocWizard->open();
     _ocWizard->raise();
 }

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -134,9 +134,16 @@ void OwncloudWizard::centerWindow()
 void OwncloudWizard::adjustWizardSize()
 {
     const auto pageSizes = calculateWizardPageSizes();
-    const auto longestSide = calculateLongestSideOfWizardPages(pageSizes);
+    const auto currentPageIndex = currentId();
 
-    resize(QSize(longestSide, longestSide));
+    // If we can, just use the size of the current page
+    if(currentPageIndex > -1 && currentPageIndex < pageSizes.count()) {
+        resize(pageSizes.at(currentPageIndex));
+        return;
+    }
+
+    // As a backup, resize to largest page
+    resize(calculateLargestSizeOfWizardPages(pageSizes));
 }
 
 QList<QSize> OwncloudWizard::calculateWizardPageSizes() const
@@ -153,11 +160,17 @@ QList<QSize> OwncloudWizard::calculateWizardPageSizes() const
     return pageSizes;
 }
 
-int OwncloudWizard::calculateLongestSideOfWizardPages(const QList<QSize> &pageSizes) const
+QSize OwncloudWizard::calculateLargestSizeOfWizardPages(const QList<QSize> &pageSizes) const
 {
-    return std::accumulate(std::cbegin(pageSizes), std::cend(pageSizes), 0, [](int current, const QSize &size) {
-        return std::max({ current, size.width(), size.height() });
-    });
+    QSize largestSize;
+    for(const auto size : pageSizes) {
+        const auto largerWidth = qMax(largestSize.width(), size.width());
+        const auto largerHeight = qMax(largestSize.height(), size.height());
+
+        largestSize = QSize(largerWidth, largerHeight);
+    }
+
+    return largestSize;
 }
 
 void OwncloudWizard::setAccount(AccountPtr account)

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -96,6 +96,7 @@ public slots:
     void slotCurrentPageChanged(int);
     void successfulStep();
     void slotCustomButtonClicked(const int which);
+    void adjustWizardSize();
 
 signals:
     void clearPendingRequests();
@@ -114,8 +115,7 @@ protected:
 
 private:
     void customizeStyle();
-    void adjustWizardSize();
-    int calculateLongestSideOfWizardPages(const QList<QSize> &pageSizes) const;
+    QSize calculateLargestSizeOfWizardPages(const QList<QSize> &pageSizes) const;
     QList<QSize> calculateWizardPageSizes() const;
 
     AccountPtr _account;


### PR DESCRIPTION
This PR prevents the account setup wizard from being overly large for its first view. It can resize as needed as the pages are progressed

![Screenshot 2022-09-07 at 18 04 38](https://user-images.githubusercontent.com/70155116/188927978-f5f74647-2288-4491-b971-42d755b9c7aa.png)

Compared to master:

![Screenshot 2022-09-07 at 18 14 41](https://user-images.githubusercontent.com/70155116/188928357-4d8b6a9f-0ad6-4057-bb49-e52d4344efec.png)

Addresses point 2 in  #4896

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
