### PR TITLE
Fix menu bar height calculation on macOS

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -513,9 +513,8 @@ QRect Systray::taskbarGeometry() const
     }
     return tbRect;
 #elif defined(Q_OS_MACOS)
-    // Finder bar is always 22px height on macOS (when treating as effective pixels)
     const auto screenWidth = currentScreenRect().width();
-    const auto statusBarHeight = static_cast<int>(OCC::statusBarThickness());
+    const auto statusBarHeight = static_cast<int>(OCC::menuBarThickness());
     return {0, 0, screenWidth, statusBarHeight};
 #else
     if (taskbarOrientation() == TaskBarPosition::Bottom || taskbarOrientation() == TaskBarPosition::Top) {

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -52,7 +52,7 @@ bool canOsXSendUserNotification();
 void sendOsXUserNotification(const QString &title, const QString &message);
 void sendOsXUpdateNotification(const QString &title, const QString &message, const QUrl &webUrl);
 void setTrayWindowLevelAndVisibleOnAllSpaces(QWindow *window);
-double statusBarThickness();
+double menuBarThickness();
 #endif
 
 /**

--- a/src/gui/systray.mm
+++ b/src/gui/systray.mm
@@ -52,9 +52,18 @@ enum MacNotificationAuthorizationOptions {
     Provisional
 };
 
-double statusBarThickness()
+double menuBarThickness()
 {
-    return [NSStatusBar systemStatusBar].thickness;
+    const NSMenu *mainMenu = [[NSApplication sharedApplication] mainMenu];
+
+    if (mainMenu == nil) {
+        // Return this educated guess if something goes wrong.
+        // As of macOS 12.4 this will always return 22, even on notched Macbooks.
+        qCWarning(lcMacSystray) << "Got nil for main menu. Going with reasonable menu bar height guess.";
+        return [[NSStatusBar systemStatusBar] thickness];
+    }
+
+    return mainMenu.menuBarHeight;
 }
 
 // TODO: Get this to actually check for permissions


### PR DESCRIPTION
This should fix some of the issues in #4897

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
