### PR TITLE
Accept valid lsColJob reply XML content types

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -583,14 +583,20 @@ void DiscoverySingleDirectoryJob::lsJobFinishedWithoutErrorSlot()
 
 void DiscoverySingleDirectoryJob::lsJobFinishedWithErrorSlot(QNetworkReply *r)
 {
-    QString contentType = r->header(QNetworkRequest::ContentTypeHeader).toString();
-    int httpCode = r->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    QString msg = r->errorString();
+    const auto contentType = r->header(QNetworkRequest::ContentTypeHeader).toString();
+    const auto invalidContentType = !contentType.contains("application/xml; charset=utf-8") &&
+                                    !contentType.contains("application/xml; charset=\"utf-8\"") &&
+                                    !contentType.contains("text/xml; charset=utf-8") &&
+                                    !contentType.contains("text/xml; charset=\"utf-8\"");
+    const auto httpCode = r->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    auto msg = r->errorString();
+
     qCWarning(lcDiscovery) << "LSCOL job error" << r->errorString() << httpCode << r->error();
-    if (r->error() == QNetworkReply::NoError
-        && !contentType.contains("application/xml; charset=utf-8")) {
+
+    if (r->error() == QNetworkReply::NoError && invalidContentType) {
         msg = tr("Server error: PROPFIND reply is not XML formatted!");
     }
+
     emit finished(HttpError{ httpCode, msg });
     deleteLater();
 }

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -395,9 +395,14 @@ bool LsColJob::finished()
     qCInfo(lcLsColJob) << "LSCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
                        << replyStatusString();
 
-    QString contentType = reply()->header(QNetworkRequest::ContentTypeHeader).toString();
-    int httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    if (httpCode == 207 && contentType.contains("application/xml; charset=utf-8")) {
+    const auto contentType = reply()->header(QNetworkRequest::ContentTypeHeader).toString();
+    const auto httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const auto validContentType = contentType.contains("application/xml; charset=utf-8") ||
+                                  contentType.contains("application/xml; charset=\"utf-8\"") ||
+                                  contentType.contains("text/xml; charset=utf-8") ||
+                                  contentType.contains("text/xml; charset=\"utf-8\"");
+
+    if (httpCode == 207 && validContentType) {
         LsColXMLParser parser;
         connect(&parser, &LsColXMLParser::directoryListingSubfolders,
             this, &LsColJob::directoryListingSubfolders);


### PR DESCRIPTION
It seems we refuse some XML content type formats even though they are still valid and can be parsed by the parser

Fixes #4873

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
