### PR TITLE
Fix ActivityItem activityHover error

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -89,7 +89,6 @@ ItemDelegate {
             linksForActionButtons: model.linksForActionButtons
             linksContextMenu: model.linksContextMenu
 
-            moreActionsButtonColor: activityHover.color
             maxActionButtons: activityModel.maxActionButtons
 
             flickable: root.flickable


### PR DESCRIPTION
The `ActivityItem`'s `moreActionsButton` still pulls its colour from an item that now no longer exists, hence the error

Since we don't want it to have a background anyway, at least not when it isn't hovered, there is no need to set this value as internally in `ActivityItemActions` it is set to `transparent`, which is what we want anyway

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
