### PR TITLE
Deallocate call notification dialog objects when closed

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -205,6 +205,12 @@ void Systray::setupContextMenu()
     });
 }
 
+void Systray::destroyDialog(QQuickWindow *dialog) const
+{
+    dialog->destroy();
+    dialog->deleteLater();
+}
+
 void Systray::createCallDialog(const Activity &callNotification, const AccountStatePtr accountState)
 {
     qCDebug(lcSystray) << "Starting a new call dialog for notification with id: " << callNotification._id << "with text: " << callNotification._subject;
@@ -244,6 +250,8 @@ void Systray::createCallDialog(const Activity &callNotification, const AccountSt
             return;
         }
 
+        // This call dialog gets deallocated on close conditions
+        // by a call from the QML side to the destroyDialog slot
         callDialog->createWithInitialProperties(initialProperties);
         _callsAlreadyNotified.insert(callNotification._id);
     }

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -118,6 +118,10 @@ public slots:
     void positionWindowAtScreenCenter(QQuickWindow *window) const;
     void positionNotificationWindow(QQuickWindow *window) const;
 
+    // Do not use this for QQuickWindow components managed by the QML engine,
+    // only for those managed by the C++ engine
+    void destroyDialog(QQuickWindow *window) const;
+
     void showWindow(WindowPosition position = WindowPosition::Default);
     void hideWindow();
 

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -48,6 +48,8 @@ Window {
         callStateChecker.checking = false;
         ringSound.stop();
         root.close();
+
+        Systray.destroyDialog(root);
     }
 
     width: root.windowWidth


### PR DESCRIPTION
This prevents already-notified and closed call notification dialogs from remaining allocated

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
