### PR TITLE
Do not format text in QML components as HTML

### DIFF
--- a/src/gui/BasicComboBox.qml
+++ b/src/gui/BasicComboBox.qml
@@ -36,6 +36,7 @@ ComboBox {
         rightPadding: clearComboBox.indicator.width + clearComboBox.spacing
 
         text: clearComboBox.displayText
+        textFormat: Text.PlainText
         color: Style.ncTextColor
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
@@ -87,6 +88,7 @@ ComboBox {
         width: clearComboBox.width
         contentItem: Label {
             text: modelData.display
+            textFormat: Text.PlainText
             color: Style.ncTextColor
             elide: Text.ElideRight
             verticalAlignment: Text.AlignVCenter

--- a/src/gui/ErrorBox.qml
+++ b/src/gui/ErrorBox.qml
@@ -29,5 +29,6 @@ Item {
         color: errorBox.color
         wrapMode: Text.WordWrap
         text: errorBox.text
+        textFormat: Text.PlainText
     }
 }

--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -43,12 +43,14 @@ AbstractButton {
         Label {
             width: root.emojiWidth > 0 ? root.emojiWidth : implicitWidth
             text: emoji
+            textFormat: Text.PlainText
             horizontalAlignment: Image.AlignHCenter
             verticalAlignment: Image.AlignVCenter
         }
 
         Label {
             text: root.text
+            textFormat: Text.PlainText
             color: Style.ncTextColor
             verticalAlignment: Text.AlignVCenter
         }

--- a/src/gui/UserStatusSelectorButton.qml
+++ b/src/gui/UserStatusSelectorButton.qml
@@ -69,6 +69,7 @@ AbstractButton {
             verticalAlignment: Text.AlignVCenter
 
             text: root.text
+            textFormat: Text.PlainText
             wrapMode: Text.Wrap
             color: root.colored ? Style.ncHeaderTextColor : Style.ncTextColor
             font.bold: root.primary
@@ -83,6 +84,7 @@ AbstractButton {
             verticalAlignment: Text.AlignVCenter
 
             text: root.secondaryText
+            textFormat: Text.PlainText
             wrapMode: Text.Wrap
             color: Style.ncSecondaryTextColor
             visible: root.secondaryText !== ""

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -129,6 +129,7 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
+            textFormat: Text.PlainText
             color: Style.ncTextColor
             visible: text !== ""
         }
@@ -145,6 +146,7 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
+            textFormat: Text.PlainText
             color: Style.ncTextColor
             visible: text !== ""
         }
@@ -158,6 +160,7 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
+            textFormat: Text.PlainText
             color: Style.ncSecondaryTextColor
             visible: text !== ""
         }
@@ -171,6 +174,7 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
+            textFormat: Text.PlainText
             color: Style.ncSecondaryTextColor
             visible: text !== ""
         }

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -195,6 +195,7 @@ Window {
             Label {
                 id: message
                 text: root.subject
+                textFormat: Text.PlainText
                 color: root.usingUserAvatar ? "white" : Style.ncTextColor
                 font.pixelSize: Style.topLinePixelSize
                 wrapMode: Text.WordWrap

--- a/src/gui/tray/CustomButton.qml
+++ b/src/gui/tray/CustomButton.qml
@@ -51,6 +51,7 @@ Button {
             Layout.fillWidth: icon.status !== Image.Ready
 
             text: root.text
+            textFormat: Text.PlainText
             font.bold: root.bold
 
             visible: root.text !== ""

--- a/src/gui/tray/CustomTextButton.qml
+++ b/src/gui/tray/CustomTextButton.qml
@@ -20,6 +20,7 @@ Label {
     Accessible.onPressAction: root.clicked(null)
 
     text: action ? action.text : ""
+    textFormat: Text.PlainText
     enabled: !action || action.enabled
     onClicked: if (action) action.trigger()
 

--- a/src/gui/tray/NCToolTip.qml
+++ b/src/gui/tray/NCToolTip.qml
@@ -24,6 +24,7 @@ ToolTip {
     delay: Qt.styleHints.mousePressAndHoldInterval
     contentItem: Label {
         text: toolTip.text
+        textFormat: Text.PlainText
         color: Style.ncTextColor
         wrapMode: Text.Wrap
     }


### PR DESCRIPTION
Not a source of any vulnerabilities as the supported subset of HTML is very limited (see https://doc.qt.io/qt-5/richtext-html-subset.html) but should still eliminate any potential weirdness

Closes https://github.com/nextcloud-gmbh/h1/issues/267

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
