### PR TITLE
Add a placeholder item for empty activity list

### DIFF
--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -77,5 +77,31 @@ ScrollView {
                 }
             }
         }
+
+        Column {
+            id: placeholderColumn
+            width: parent.width * 0.8
+            anchors.centerIn: parent
+            visible: activityList.count === 0
+            spacing: Style.standardSpacing
+
+            Image {
+                width: parent.width
+                verticalAlignment: Image.AlignVCenter
+                horizontalAlignment: Image.AlignHCenter
+                fillMode: Image.PreserveAspectFit
+                source: "image://svgimage-custom-color/activity.svg/" + Style.ncSecondaryTextColor
+            }
+
+            Label {
+               width: parent.width
+               text: qsTr("No activities yet")
+               color: Style.ncSecondaryTextColor
+               font.bold: true
+               wrapMode: Text.Wrap
+               horizontalAlignment: Text.AlignHCenter
+               verticalAlignment: Text.AlignVCenter
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a placeholder item for empty activity lists (e.g. file has no recent activities)

Below screenshot is a simulated example of an empty activity list in the system tray as I didn't have any files not modified in the past 6 months

![Screenshot 2022-09-20 at 17 54 36](https://user-images.githubusercontent.com/70155116/191314814-95613ed7-4117-4060-b5ed-229e221efe36.png)

Closes #4342

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
