### PR TITLE
Ensure placeholder message in emoji picker wraps correctly

### DIFF
--- a/src/gui/EmojiPicker.qml
+++ b/src/gui/EmojiPicker.qml
@@ -128,6 +128,7 @@ ColumnLayout {
 
         Label {
             id: placeholderMessage
+            width: parent.width * 0.8
             anchors.centerIn: parent
             text: qsTr("No recent emojis")
             color: Style.ncSecondaryTextColor


### PR DESCRIPTION
Word wrap requires the label to have a set width

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
