### PR TITLE
Fix two factor auth notification: activity item was disabled.

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -20,7 +20,7 @@ ItemDelegate {
     property color adjustedHeaderColor: Theme.darkMode ? Qt.lighter(UserModel.currentUser.headerColor, 2)
                                                        : Qt.darker(UserModel.currentUser.headerColor, 1.5)
 
-    enabled: (model.path !== "" || model.link !== "" || model.isCurrentUserFileActivity === true)
+    enabled: (model.path !== "" || model.link !== "" || model.links.length > 0 ||  model.isCurrentUserFileActivity === true)
     padding: Style.standardSpacing
 
     Accessible.role: Accessible.ListItem


### PR DESCRIPTION
User couldn't click on it.

Before:
![item-disabled](https://user-images.githubusercontent.com/241266/191319312-09ac0e94-91d5-4532-90e8-d10ead9b99eb.png)

After:
![item-enabled](https://user-images.githubusercontent.com/241266/191319317-2c3bc42c-17df-4ce9-8d5e-096d31364674.png)

Noticed after looking into #4841. Could reproduce it on Linux and Windows.