### PR TITLE
Fix files not unlocking after lock time expired

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1379,9 +1379,9 @@ bool SyncJournalDb::updateLocalMetadata(const QString &filename,
     query->bindValue(3, modtime);
     query->bindValue(4, size);
     query->bindValue(5, lockInfo._locked ? 1 : 0);
-    query->bindValue(6, lockInfo._lockOwnerDisplayName);
-    query->bindValue(7, lockInfo._lockOwnerId);
-    query->bindValue(8, lockInfo._lockOwnerType);
+    query->bindValue(6, lockInfo._lockOwnerType);
+    query->bindValue(7, lockInfo._lockOwnerDisplayName);
+    query->bindValue(8, lockInfo._lockOwnerId);
     query->bindValue(9, lockInfo._lockEditorApp);
     query->bindValue(10, lockInfo._lockTime);
     query->bindValue(11, lockInfo._lockTimeout);

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -78,7 +78,7 @@ public:
         const QByteArray &contentChecksum,
         const QByteArray &contentChecksumType);
     [[nodiscard]] bool updateLocalMetadata(const QString &filename,
-        qint64 modtime, qint64 size, quint64 inode);
+        qint64 modtime, qint64 size, quint64 inode, const SyncJournalFileLockInfo &lockInfo);
 
     /// Return value for hasHydratedOrDehydratedFiles()
     struct HasHydratedDehydrated

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -284,6 +284,7 @@ public:
     QByteArray _dataFingerprint;
     bool _anotherSyncNeeded = false;
     QHash<QString, long long> _filesNeedingScheduledSync;
+    QVector<QString> _filesUnscheduleSync;
 
 signals:
     void fatalError(const QString &errorString);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -283,7 +283,7 @@ public:
     // output
     QByteArray _dataFingerprint;
     bool _anotherSyncNeeded = false;
-    int _scheduleSyncInSecs = -1;
+    QHash<QString, long long> _filesNeedingScheduledSync;
 
 signals:
     void fatalError(const QString &errorString);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -283,6 +283,7 @@ public:
     // output
     QByteArray _dataFingerprint;
     bool _anotherSyncNeeded = false;
+    int _scheduleSyncInSecs = -1;
 
 signals:
     void fatalError(const QString &errorString);

--- a/test/testlocaldiscovery.cpp
+++ b/test/testlocaldiscovery.cpp
@@ -620,14 +620,16 @@ private slots:
         const QString barFileAaaSubFolder("aaa/subfolder/bar");
 
         fakeFolder.remoteModifier().insert(fooFileRootFolder);
-
         fakeFolder.remoteModifier().insert(barFileRootFolder);
-        fakeFolder.remoteModifier().find("bar")->extraDavProperties = "<nc:lock>1</nc:lock>"
-                                                                      "<nc:lock-owner-type>0</nc:lock-owner-type>"
-                                                                      "<nc:lock-owner>user1</nc:lock-owner>"
-                                                                      "<nc:lock-owner-displayname>user1</nc:lock-owner-displayname>"
-                                                                      "<nc:lock-owner-editor>user1</nc:lock-owner-editor>"
-                                                                      "<nc:lock-time>1648046707</nc:lock-time>";
+
+        const auto lockedFileDavProps = QByteArray("<nc:lock>1</nc:lock>"
+                                                   "<nc:lock-owner-type>0</nc:lock-owner-type>"
+                                                   "<nc:lock-owner>user1</nc:lock-owner>"
+                                                   "<nc:lock-owner-displayname>user1</nc:lock-owner-displayname>"
+                                                   "<nc:lock-owner-editor>user1</nc:lock-owner-editor>"
+                                                   "<nc:lock-time>1648046707</nc:lock-time>");
+
+        fakeFolder.remoteModifier().find("bar")->extraDavProperties = lockedFileDavProps;
 
         fakeFolder.remoteModifier().mkdir(QStringLiteral("subfolder"));
         fakeFolder.remoteModifier().insert(fooFileSubFolder);
@@ -637,12 +639,26 @@ private slots:
         fakeFolder.remoteModifier().insert(fooFileAaaSubFolder);
         fakeFolder.remoteModifier().insert(barFileAaaSubFolder);
 
-        QVERIFY(fakeFolder.syncOnce());
+        ItemCompletedSpy completeSpy(fakeFolder);
 
-        fakeFolder.remoteModifier().find("bar")->extraDavProperties = "<nc:lock>0</nc:lock>";
+        completeSpy.clear();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(completeSpy.findItem("bar")->_locked, OCC::SyncFileItem::LockStatus::LockedItem);
+        SyncJournalFileRecord fileRecordBefore;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("bar"), &fileRecordBefore));
+        QVERIFY(fileRecordBefore._lockstate._locked);
+
+        const auto unlockedFileDavProps = QByteArray("<nc:lock>0</nc:lock>");
+        fakeFolder.remoteModifier().find("bar")->extraDavProperties = unlockedFileDavProps;
 
         fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::DatabaseAndFilesystem);
+
+        completeSpy.clear();
         QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(completeSpy.findItem("bar")->_locked, OCC::SyncFileItem::LockStatus::UnlockedItem);
+        SyncJournalFileRecord fileRecordAfter;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("bar"), &fileRecordAfter));
+        QVERIFY(!fileRecordAfter._lockstate._locked);
     }
 };
 


### PR DESCRIPTION
We have a bug where files are not unlocked after the lock timer expires. This is because there is no indication to the sync engine that a local lock state different to the server lock state needs to be acted on; on top of that, the call to update a file's metadata does not update the lock state of a file.

This PR fixes both of these issues by setting the instruction of an item with a local lock state different to the server to `CSYNC_INSTRUCTION_UPDATE_METADATA`, and also ensures that lock state is updated in the database in the call to `updateLocalMetadata`. It also starts a remote check when the file lock expires.

EDIT: This PR now also schedules sync runs for files that need one to check lock status after the lock times out. Sync runs are minimised by grouping files into buckets of files that need sync runs within 60 seconds of each other, with sync occurring at the latest time possible (i.e. the file in that bucket with the latest sync run request time). Scheduled sync runs are also unscheduled if the file becomes unlocked by the user.

Closes #4956

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
