### PR TITLE
windows reserved word silently excluded - csync exclude.cpp

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -174,7 +174,7 @@ static CSYNC_EXCLUDE_TYPE _csync_excluded_common(const QString &path, bool exclu
     }
 
     if (csync_is_windows_reserved_word(bname)) {
-        return CSYNC_FILE_EXCLUDE_INVALID_CHAR;
+        return CSYNC_FILE_SILENTLY_EXCLUDED;
     }
 
     // Filter out characters not allowed in a filename on windows

--- a/test/testexcludedfiles.cpp
+++ b/test/testexcludedfiles.cpp
@@ -196,7 +196,7 @@ private slots:
         QCOMPARE(check_file_full("file_trailing_space "), CSYNC_NOT_EXCLUDED);
         QCOMPARE(check_file_full(" file_leading_and_trailing_space "), CSYNC_NOT_EXCLUDED);
         QCOMPARE(check_file_full("file_trailing_dot."), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
-        QCOMPARE(check_file_full("AUX"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
+        QCOMPARE(check_file_full("AUX"), CSYNC_FILE_SILENTLY_EXCLUDED);
         QCOMPARE(check_file_full("file_invalid_char<"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
         QCOMPARE(check_file_full("file_invalid_char\n"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     #endif

--- a/test/testexcludedfiles.cpp
+++ b/test/testexcludedfiles.cpp
@@ -352,7 +352,7 @@ private slots:
         QCOMPARE(check_file_traversal("file_trailing_space "), CSYNC_NOT_EXCLUDED);
         QCOMPARE(check_file_traversal(" file_leading_and_trailing_space "), CSYNC_NOT_EXCLUDED);
         QCOMPARE(check_file_traversal("file_trailing_dot."), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
-        QCOMPARE(check_file_traversal("AUX"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
+        QCOMPARE(check_file_traversal("AUX"), CSYNC_FILE_SILENTLY_EXCLUDED);
         QCOMPARE(check_file_traversal("file_invalid_char<"), CSYNC_FILE_EXCLUDE_INVALID_CHAR);
     #endif
 


### PR DESCRIPTION
Proposal to solve https://github.com/nextcloud/desktop/issues/3826, by excluding silently windows reserved word like $RECYCLE.BIN.

Signed-off-by: tomdereub <pbtom@lamonerie.net>