### PR TITLE
Fix link shares default expire date being enforced as maximum expire date even when maximum date enforcement is disabled on the server

### DIFF
--- a/src/gui/sharelinkwidget.cpp
+++ b/src/gui/sharelinkwidget.cpp
@@ -485,7 +485,7 @@ void ShareLinkWidget::toggleExpireDateOptions(const bool enable)
     _ui->calendar->setDate(date);
     _ui->calendar->setMinimumDate(QDate::currentDate().addDays(1));
 
-    if(_account->capabilities().sharePublicLinkExpireDateDays() > 0) {
+    if(_account->capabilities().sharePublicLinkEnforceExpireDate()) {
         _ui->calendar->setMaximumDate(QDate::currentDate().addDays(_account->capabilities().sharePublicLinkExpireDateDays()));
     }
 


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
