### PR TITLE
Fix sync progress bar colours in dark mode

### DIFF
--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -68,6 +68,21 @@ RowLayout {
             sourceComponent: ProgressBar {
                 id: syncProgressBar
 
+                // TODO: Rather than setting all these palette colours manually,
+                // create a custom style and do it for all components globally
+                palette {
+                    text: Style.ncTextColor
+                    windowText: Style.ncTextColor
+                    buttonText: Style.ncTextColor
+                    light: Style.lightHover
+                    midlight: Style.lightHover
+                    mid: Style.ncSecondaryTextColor
+                    dark: Style.menuBorder
+                    button: Style.menuBorder
+                    window: Style.backgroundColor
+                    base: Style.backgroundColor
+                }
+
                 value: syncStatus.syncProgress
             }
         }


### PR DESCRIPTION
|            | Dark | Light |
|------------|------|-------|
| With fix   |   ![Screenshot 2022-09-29 at 19 18 53](https://user-images.githubusercontent.com/70155116/193100729-0a7f4bf4-ab89-4719-a118-2296abe0044f.png)   |   ![Screenshot 2022-09-29 at 19 18 46](https://user-images.githubusercontent.com/70155116/193100779-3bae80ed-bbcc-449f-8e40-870bdf6a823e.png)   |
| Before fix | ![Screenshot 2022-09-29 at 19 20 48](https://user-images.githubusercontent.com/70155116/193100813-d4d982f4-13ec-439c-94c1-63d783301bda.png)   |  ![Screenshot 2022-09-29 at 19 20 54](https://user-images.githubusercontent.com/70155116/193100855-c83633e3-93e1-4a77-b4b4-0f36640ce686.png)   |


Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
