### PR TITLE
Fix predefined status text formatting

### DIFF
--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -31,6 +31,8 @@ AbstractButton {
     property int emojiWidth: -1
     property int internalSpacing: Style.standardSpacing
     property string emoji: ""
+    property string statusText: ""
+    property string clearAtText: ""
 
     background: Rectangle {
         color: root.hovered || root.checked ? Style.lightHover : "transparent"
@@ -48,11 +50,28 @@ AbstractButton {
             verticalAlignment: Image.AlignVCenter
         }
 
-        Label {
-            text: root.text
-            textFormat: Text.PlainText
-            color: Style.ncTextColor
-            verticalAlignment: Text.AlignVCenter
+        Row {
+            spacing: Style.smallSpacing
+            Label {
+                text: root.statusText
+                textFormat: Text.PlainText
+                color: Style.ncTextColor
+                verticalAlignment: Text.AlignVCenter
+                font.bold: true
+            }
+
+            Label {
+                text: "-"
+                color: Style.ncTextColor
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            Label {
+                text: root.clearAtText
+                textFormat: Text.PlainText
+                color: Style.ncTextColor
+                verticalAlignment: Text.AlignVCenter
+            }
         }
     }
 }

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -261,7 +261,8 @@ ColumnLayout {
                     internalSpacing: statusFieldLayout.spacing + userStatusMessageTextField.leftPadding
 
                     emoji: modelData.icon
-                    text: "<b>%1</b> – %2".arg(modelData.message).arg(userStatusSelectorModel.clearAtReadable(modelData))
+                    statusText: modelData.message
+                    clearAtText: userStatusSelectorModel.clearAtReadable(modelData)
                     onClicked: userStatusSelectorModel.setPredefinedStatus(modelData)
                 }
             }
@@ -303,7 +304,7 @@ ColumnLayout {
         width: parent.width
 
         visible: userStatusSelectorModel.errorMessage != ""
-        text: "<b>Error:</b> " + userStatusSelectorModel.errorMessage
+        text: "Error: " + userStatusSelectorModel.errorMessage
     }
 
     RowLayout {


### PR DESCRIPTION
With recent changes to text formatting being set to plain text rather than rich HTML text, some of the internal styling used for predefined status messages has broken. This PR fixes it.

With fix:

![Screenshot 2022-09-29 at 19 38 12](https://user-images.githubusercontent.com/70155116/193103816-7cb422d8-02fa-4646-9b29-2780c6421d91.png)


Before fix:

![Screenshot 2022-09-29 at 19 38 52](https://user-images.githubusercontent.com/70155116/193103783-77fd2ae8-480c-41fe-b9d5-7c66a126727b.png)


Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
