### PR TITLE
Don't set up tray context menu on macOS, even if not building app bundle

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -78,7 +78,7 @@ Systray::Systray()
     setUserNotificationCenterDelegate();
     checkNotificationAuth(MacNotificationAuthorizationOptions::Default); // No provisional auth, ask user explicitly first time
     registerNotificationCategories(QString(tr("Download")));
-#else
+#elif !defined(Q_OS_MACOS)
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, &Systray::setupContextMenu);
     connect(AccountManager::instance(), &AccountManager::accountRemoved,


### PR DESCRIPTION
This PR prevents the context menu from being opened when the tray icon is clicked, in situations where the desktop client is build without the macOS application bundle. 

This prevents the following bug:

![Screenshot 2022-09-29 at 20 03 42](https://user-images.githubusercontent.com/70155116/193108161-0dc8d4aa-8e55-46cf-9990-3311ed7cdb7a.png)


Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
