### PR TITLE
avoid possibly crashing static_cast

### DIFF
--- a/src/3rdparty/kirigami/wheelhandler.cpp
+++ b/src/3rdparty/kirigami/wheelhandler.cpp
@@ -37,12 +37,12 @@ void GlobalWheelFilter::setItemHandlerAssociation(QQuickItem *item, WheelHandler
     m_handlersForItem.insert(item, handler);
 
     connect(item, &QObject::destroyed, this, [this](QObject *obj) {
-        auto item = static_cast<QQuickItem *>(obj);
+        auto item = dynamic_cast<QQuickItem *>(obj);
         m_handlersForItem.remove(item);
     });
 
     connect(handler, &QObject::destroyed, this, [this](QObject *obj) {
-        auto handler = static_cast<WheelHandler *>(obj);
+        auto handler = dynamic_cast<WheelHandler *>(obj);
         removeItemHandlerAssociation(handler->target(), handler);
     });
 }
@@ -65,7 +65,7 @@ bool GlobalWheelFilter::eventFilter(QObject *watched, QEvent *event)
         if (!item || !item->isEnabled()) {
             return QObject::eventFilter(watched, event);
         }
-        auto we = static_cast<QWheelEvent *>(event);
+        auto we = dynamic_cast<QWheelEvent *>(event);
         m_wheelEvent.initializeFromEvent(we);
 
         bool shouldBlock = false;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -896,7 +896,7 @@ void Application::tryTrayAgain()
 bool Application::event(QEvent *event)
 {
     if (event->type() == QEvent::FileOpen) {
-        const auto openEvent = static_cast<QFileOpenEvent *>(event);
+        const auto openEvent = dynamic_cast<QFileOpenEvent *>(event);
         qCDebug(lcApplication) << "macOS: Received a QFileOpenEvent";
 
         if(!openEvent->file().isEmpty()) {

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -61,7 +61,7 @@ WebFlowCredentialsDialog::WebFlowCredentialsDialog(Account *account, bool useFlo
 #endif // WITH_WEBENGINE
     }
 
-    auto app = static_cast<Application *>(qApp);
+    auto app = dynamic_cast<Application *>(qApp);
     connect(app, &Application::isShowingSettingsDialog, this, &WebFlowCredentialsDialog::slotShowSettingsDialog);
 
     _errorLabel = new QLabel();

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -58,7 +58,7 @@ QSize FolderStatusDelegate::sizeHint(const QStyleOptionViewItem &option,
     QFontMetrics fm(font);
     QFontMetrics aliasFm(aliasFont);
 
-    auto classif = static_cast<const FolderStatusModel *>(index.model())->classify(index);
+    auto classif = dynamic_cast<const FolderStatusModel *>(index.model())->classify(index);
     if (classif == FolderStatusModel::AddButton) {
         const int margins = aliasFm.height(); // same as 2*aliasMargin of paint
         QFontMetrics fm(qApp->font("QPushButton"));
@@ -148,7 +148,7 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         return;
     }
 
-    if (static_cast<const FolderStatusModel *>(index.model())->classify(index) != FolderStatusModel::RootFolder) {
+    if (dynamic_cast<const FolderStatusModel *>(index.model())->classify(index) != FolderStatusModel::RootFolder) {
         return;
     }
     painter->save();
@@ -367,7 +367,7 @@ bool FolderStatusDelegate::editorEvent(QEvent *event, QAbstractItemModel *model,
     case QEvent::MouseButtonPress:
     case QEvent::MouseMove:
         if (const auto *view = qobject_cast<const QAbstractItemView *>(option.widget)) {
-            auto *me = static_cast<QMouseEvent *>(event);
+            auto *me = dynamic_cast<QMouseEvent *>(event);
             QModelIndex index;
             if (me->buttons()) {
                 index = view->indexAt(me->pos());

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -239,7 +239,7 @@ void FolderWizardRemotePath::slotCreateRemoteFolderFinished()
     qCDebug(lcWizard) << "webdav mkdir request finished";
     showWarn(tr("Folder was successfully created on %1.").arg(Theme::instance()->appNameGUI()));
     slotRefreshFolders();
-    _ui.folderEntry->setText(static_cast<MkColJob *>(sender())->path());
+    _ui.folderEntry->setText(dynamic_cast<MkColJob *>(sender())->path());
     slotLsColFolderEntry();
 }
 

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -163,7 +163,7 @@ void SelectiveSyncWidget::recursiveInsert(QTreeWidgetItem *parent, QStringList p
         parent->setToolTip(0, path);
         parent->setData(0, Qt::UserRole, path);
     } else {
-        auto *item = static_cast<SelectiveSyncTreeViewItem *>(findFirstChild(parent, pathTrail.first()));
+        auto *item = dynamic_cast<SelectiveSyncTreeViewItem *>(findFirstChild(parent, pathTrail.first()));
         if (!item) {
             item = new SelectiveSyncTreeViewItem(parent);
             if (parent->checkState(0) == Qt::Checked
@@ -201,7 +201,7 @@ void SelectiveSyncWidget::slotUpdateDirectories(QStringList list)
     QScopedValueRollback<bool> isInserting(_inserting);
     _inserting = true;
 
-    auto *root = static_cast<SelectiveSyncTreeViewItem *>(_folderTree->topLevelItem(0));
+    auto *root = dynamic_cast<SelectiveSyncTreeViewItem *>(_folderTree->topLevelItem(0));
 
     QUrl url = _account->davUrl();
     QString pathToRemove = url.path();

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -276,7 +276,7 @@ void SettingsDialog::accountAdded(AccountState *s)
 
 void SettingsDialog::slotAccountAvatarChanged()
 {
-    auto *account = static_cast<Account *>(sender());
+    auto *account = dynamic_cast<Account *>(sender());
     if (account && _actionForAccount.contains(account)) {
         QAction *action = _actionForAccount[account];
         if (action) {
@@ -290,7 +290,7 @@ void SettingsDialog::slotAccountAvatarChanged()
 
 void SettingsDialog::slotAccountDisplayNameChanged()
 {
-    auto *account = static_cast<Account *>(sender());
+    auto *account = dynamic_cast<Account *>(sender());
     if (account && _actionForAccount.contains(account)) {
         QAction *action = _actionForAccount[account];
         if (action) {

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -338,7 +338,7 @@ void SocketApi::onLostConnection()
 
 void SocketApi::slotSocketDestroyed(QObject *obj)
 {
-    auto *socket = static_cast<QIODevice *>(obj);
+    auto *socket = dynamic_cast<QIODevice *>(obj);
     _listeners.remove(socket);
 }
 

--- a/src/gui/tooltipupdater.cpp
+++ b/src/gui/tooltipupdater.cpp
@@ -32,7 +32,7 @@ ToolTipUpdater::ToolTipUpdater(QTreeView *treeView)
 bool ToolTipUpdater::eventFilter(QObject * /*obj*/, QEvent *ev)
 {
     if (ev->type() == QEvent::ToolTip) {
-        auto *helpEvent = static_cast<QHelpEvent *>(ev);
+        auto *helpEvent = dynamic_cast<QHelpEvent *>(ev);
         _toolTipPos = helpEvent->globalPos();
     }
     return false;

--- a/src/gui/tray/sortedactivitylistmodel.cpp
+++ b/src/gui/tray/sortedactivitylistmodel.cpp
@@ -30,7 +30,7 @@ void SortedActivityListModel::sortModel()
 
 ActivityListModel* SortedActivityListModel::activityListModel() const
 {
-    return static_cast<ActivityListModel*>(sourceModel());
+    return dynamic_cast<ActivityListModel*>(sourceModel());
 }
 
 void SortedActivityListModel::setActivityListModel(ActivityListModel* activityListModel)

--- a/src/gui/wizard/abstractcredswizardpage.cpp
+++ b/src/gui/wizard/abstractcredswizardpage.cpp
@@ -26,7 +26,7 @@ void AbstractCredentialsWizardPage::cleanupPage()
 {
     // Reset the credentials when the 'Back' button is used.
 
-    AccountPtr account = static_cast<OwncloudWizard *>(wizard())->account();
+    AccountPtr account = dynamic_cast<OwncloudWizard *>(wizard())->account();
     AbstractCredentials *creds = account->credentials();
     if (creds) {
         if (!creds->inherits("DummyCredentials")) {

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -159,7 +159,7 @@ void OwncloudAdvancedSetupPage::initializePage()
     // ensure "next" gets the focus, not obSelectLocalFolder
     QTimer::singleShot(0, wizard()->button(QWizard::FinishButton), qOverload<>(&QWidget::setFocus));
 
-    auto acc = static_cast<OwncloudWizard *>(wizard())->account();
+    auto acc = dynamic_cast<OwncloudWizard *>(wizard())->account();
     auto quotaJob = new PropfindJob(acc, _remoteFolder, this);
     quotaJob->setProperties(QList<QByteArray>() << "http://owncloud.org/ns:size");
 
@@ -331,8 +331,8 @@ void OwncloudAdvancedSetupPage::stopSpinner()
 
 QUrl OwncloudAdvancedSetupPage::serverUrl() const
 {
-    const QString urlString = static_cast<OwncloudWizard *>(wizard())->ocUrl();
-    const QString user = static_cast<OwncloudWizard *>(wizard())->getCredentials()->user();
+    const QString urlString = dynamic_cast<OwncloudWizard *>(wizard())->ocUrl();
+    const QString user = dynamic_cast<OwncloudWizard *>(wizard())->getCredentials()->user();
 
     QUrl url(urlString);
     url.setUserName(user);
@@ -447,7 +447,7 @@ void OwncloudAdvancedSetupPage::slotSelectFolder()
 
 void OwncloudAdvancedSetupPage::slotSelectiveSyncClicked()
 {
-    AccountPtr acc = static_cast<OwncloudWizard *>(wizard())->account();
+    AccountPtr acc = dynamic_cast<OwncloudWizard *>(wizard())->account();
     auto *dlg = new SelectiveSyncDialog(acc, _remoteFolder, _selectiveSyncBlacklist, this);
     dlg->setAttribute(Qt::WA_DeleteOnClose);
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -716,7 +716,7 @@ void Account::writeAppPasswordOnce(QString appPassword){
     job->setKey(kck);
     job->setBinaryData(appPassword.toLatin1());
     connect(job, &WritePasswordJob::finished, [this](Job *incoming) {
-        auto *writeJob = static_cast<WritePasswordJob *>(incoming);
+        auto *writeJob = dynamic_cast<WritePasswordJob *>(incoming);
         if (writeJob->error() == NoError)
             qCInfo(lcAccount) << "appPassword stored in keychain";
         else
@@ -739,7 +739,7 @@ void Account::retrieveAppPassword(){
     job->setInsecureFallback(false);
     job->setKey(kck);
     connect(job, &ReadPasswordJob::finished, [this](Job *incoming) {
-        auto *readJob = static_cast<ReadPasswordJob *>(incoming);
+        auto *readJob = dynamic_cast<ReadPasswordJob *>(incoming);
         QString pwd("");
         // Error or no valid public key error out
         if (readJob->error() == NoError &&
@@ -769,7 +769,7 @@ void Account::deleteAppPassword()
     job->setInsecureFallback(false);
     job->setKey(kck);
     connect(job, &DeletePasswordJob::finished, [this](Job *incoming) {
-        auto *deleteJob = static_cast<DeletePasswordJob *>(incoming);
+        auto *deleteJob = dynamic_cast<DeletePasswordJob *>(incoming);
         if (deleteJob->error() == NoError)
             qCInfo(lcAccount) << "appPassword deleted from keychain";
         else

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -906,7 +906,7 @@ bool ClientSideEncryption::checkServerPublicKeyValidity(const QByteArray &server
 
 void ClientSideEncryption::publicKeyFetched(Job *incoming)
 {
-    auto *readJob = static_cast<ReadPasswordJob *>(incoming);
+    auto *readJob = dynamic_cast<ReadPasswordJob *>(incoming);
     auto account = readJob->property(accountProperty).value<AccountPtr>();
     Q_ASSERT(account);
 
@@ -943,7 +943,7 @@ void ClientSideEncryption::publicKeyFetched(Job *incoming)
 
 void ClientSideEncryption::privateKeyFetched(Job *incoming)
 {
-    auto *readJob = static_cast<ReadPasswordJob *>(incoming);
+    auto *readJob = dynamic_cast<ReadPasswordJob *>(incoming);
     auto account = readJob->property(accountProperty).value<AccountPtr>();
     Q_ASSERT(account);
 
@@ -981,7 +981,7 @@ void ClientSideEncryption::privateKeyFetched(Job *incoming)
 
 void ClientSideEncryption::mnemonicKeyFetched(QKeychain::Job *incoming)
 {
-    auto *readJob = static_cast<ReadPasswordJob *>(incoming);
+    auto *readJob = dynamic_cast<ReadPasswordJob *>(incoming);
     auto account = readJob->property(accountProperty).value<AccountPtr>();
     Q_ASSERT(account);
 

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -357,7 +357,7 @@ bool HttpCredentials::stillValid(QNetworkReply *reply)
 
 void HttpCredentials::slotReadJobDone(QKeychain::Job *incoming)
 {
-    auto *job = static_cast<QKeychain::ReadPasswordJob *>(incoming);
+    auto *job = dynamic_cast<QKeychain::ReadPasswordJob *>(incoming);
     QKeychain::Error error = job->error();
 
     // If we can't find the credentials at the keys that include the account id,

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1076,7 +1076,7 @@ bool PropagatorCompositeJob::scheduleSelfOrChild()
 
 void PropagatorCompositeJob::slotSubJobFinished(SyncFileItem::Status status)
 {
-    auto *subJob = static_cast<PropagatorJob *>(sender());
+    auto *subJob = dynamic_cast<PropagatorJob *>(sender());
     ASSERT(subJob);
 
     // Delete the job and remove it from our list of jobs.


### PR DESCRIPTION
ran
run-clang-tidy-14.py -header-filter='.*' -checks='-*,cppcoreguidelines-pro-type-static-cast-downcast' -fix

this can prevent casting to a type that is unrelated to the real type and later cause a crash because you go into undefined behavior domain

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
