### PR TITLE
check our code with clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,10 +14,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y clang-tidy
-        sudo apt-get install -y zlib1g-dev texlive-latex-base qtwebengine5-dev qttools5-dev-tools qttools5-dev qtquickcontrols2-5-dev qt5keychain-dev qtdeclarative5-dev qtbase5-dev python3-sphinx libssl-dev libsqlite3-dev libqt5websockets5-dev libqt5svg5-dev pkg-config libkf5archive-dev libcloudproviders-dev libcmocka-dev libdbus-1-dev qtbase5-private-dev qt5-qmake inkscape
+        sudo apt-get install -y ninja-build zlib1g-dev texlive-latex-base qtwebengine5-dev qttools5-dev-tools qttools5-dev qtquickcontrols2-5-dev qt5keychain-dev qtdeclarative5-dev qtbase5-dev python3-sphinx libssl-dev libsqlite3-dev libqt5websockets5-dev libqt5svg5-dev pkg-config libkf5archive-dev libcloudproviders-dev libcmocka-dev libdbus-1-dev qtbase5-private-dev qt5-qmake inkscape
     - name: Prepare compile_commands.json
       run: |
-        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1
+        cmake -G Ninja -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1
+        cd build && ninja
     - name: Create results directory
       run: |
         mkdir clang-tidy-result


### PR DESCRIPTION
should allow to keep our code tidy and maybe simplify reviews

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
