### PR TITLE
feat: support Nautilus 4.0 API

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -26,7 +26,7 @@ import socket
 import tempfile
 import time
 
-from gi.repository import GObject, Nautilus
+from repository import GObject, Nautilus
 
 # Note: setappname.sh will search and replace 'ownCloud' on this file to update this line and other
 # occurrences of the name
@@ -200,8 +200,11 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
                 break
         return (topLevelFolder, internalFile)
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
         # Show the menu extension to share a file or folder
+        
+        # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
+        files = args[0] if len(args) == 1 else args[1]
 
         # Get usable file paths from the uris
         all_internal_files = True


### PR DESCRIPTION
As explained in the comment, the Nautilus 4.0 API just passes files without the window object (which was unused anyway). This small fix keeps compatibility with the 3.0 API and checks the number of arguments.

Would be really nice if you could make this count towards hacktoberfest as well!

Signed-off-by: Gabriele Musco <emaildigabry@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
