### PR TITLE
Add a nix flake for easy building and dev environments 

### DIFF
--- a/admin/nix/flake.nix
+++ b/admin/nix/flake.nix
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+{
+  description = "A flake for the Nextcloud desktop client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    with flake-utils.lib;
+    eachSystem [ "aarch64-linux" "x86_64-linux" ] (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          inherit (pkgs.lib.lists) optional optionals;
+          inherit (pkgs.lib.strings) hasPrefix hasSuffix;
+          isMacOS = hasSuffix "darwin" system;
+          isARM = hasPrefix "aarch64" system;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            extra-cmake-modules
+            pkg-config
+            qt5.wrapQtAppsHook
+          ];
+
+          buildInputs = with pkgs; [
+            sqlite
+            openssl
+            pcre
+            inkscape
+
+            qt5.qtbase
+            qt5.qtquickcontrols2
+            qt5.qtsvg
+            qt5.qtgraphicaleffects
+            qt5.qtdeclarative
+            qt5.qttools
+            qt5.qtwebsockets
+
+            libsForQt5.karchive
+            libsForQt5.qtkeychain
+          ] ++ optionals (!isARM) [
+            # Qt WebEngine not available on ARM
+            qt5.qtwebengine
+          ] ++ optionals (stdenv.isLinux) [
+            inotify-tools
+            libcloudproviders
+            libsecret
+
+            libsForQt5.breeze-icons
+            libsForQt5.qqc2-desktop-style
+            libsForQt5.kio
+          ];
+
+          packages.default = with pkgs; stdenv.mkDerivation rec {
+            inherit nativeBuildInputs buildInputs;
+            pname = "nextcloud-client";
+            version = "dev";
+            src = ../../.;
+            dontStrip = true;
+            enableDebugging = true;
+            separateDebugInfo = false;
+            cmakeFlags = if(stdenv.isLinux) then [
+                "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
+                "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
+            ] else [];
+            postPatch = if(stdenv.isLinux) then ''
+              for file in src/libsync/vfs/*/CMakeLists.txt; do
+                substituteInPlace $file \
+                  --replace "PLUGINDIR" "KDE_INSTALL_PLUGINDIR"
+              done
+            '' else "";
+            postFixup = if(stdenv.isLinux) then ''
+              wrapProgram "$out/bin/nextcloud" \
+                --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ libsecret ]} \
+                --set PATH ${lib.makeBinPath [ xdg-utils ]} \
+                --set QML_DISABLE_DISK_CACHE "1"
+            '' else "";
+          };
+
+          apps.default = mkApp {
+            name = "nextcloud";
+            drv = packages.default;
+          };
+
+        in {
+          inherit packages apps;
+          devShell = pkgs.mkShell {
+            inherit buildInputs;
+            nativeBuildInputs = with pkgs; nativeBuildInputs ++[
+              gdb
+              qtcreator
+            ];
+            name = "nextcloud-client-dev-shell";
+          };
+        }
+    );
+}

--- a/admin/nix/flake.nix
+++ b/admin/nix/flake.nix
@@ -22,29 +22,35 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     with flake-utils.lib;
-    eachSystem [ "aarch64-linux" "x86_64-linux" ] (system:
+    eachSystem [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ] (system:
         let
           pkgs = import nixpkgs {
             inherit system;
           };
 
           inherit (pkgs.lib.lists) optional optionals;
-          inherit (pkgs.lib.strings) hasPrefix hasSuffix;
-          isMacOS = hasSuffix "darwin" system;
+          inherit (pkgs.lib.strings) hasPrefix optionalString;
           isARM = hasPrefix "aarch64" system;
+
+          buildMacOSSymlinks = pkgs.runCommand "nextcloud-build-symlinks" {} ''
+            mkdir -p $out/bin
+            ln -s /usr/bin/xcrun /usr/bin/xcodebuild /usr/bin/iconutil $out/bin
+          '';
 
           nativeBuildInputs = with pkgs; [
             cmake
             extra-cmake-modules
             pkg-config
+            inkscape
             qt5.wrapQtAppsHook
+          ] ++ optionals stdenv.isDarwin [
+            buildMacOSSymlinks
           ];
 
           buildInputs = with pkgs; [
             sqlite
             openssl
             pcre
-            inkscape
 
             qt5.qtbase
             qt5.qtquickcontrols2
@@ -59,7 +65,7 @@
           ] ++ optionals (!isARM) [
             # Qt WebEngine not available on ARM
             qt5.qtwebengine
-          ] ++ optionals (stdenv.isLinux) [
+          ] ++ optionals stdenv.isLinux [
             inotify-tools
             libcloudproviders
             libsecret
@@ -67,6 +73,10 @@
             libsForQt5.breeze-icons
             libsForQt5.qqc2-desktop-style
             libsForQt5.kio
+          ] ++ optionals stdenv.isDarwin [
+            libsForQt5.qt5.qtmacextras
+
+            darwin.apple_sdk.frameworks.UserNotifications
           ];
 
           packages.default = with pkgs; stdenv.mkDerivation rec {
@@ -74,25 +84,43 @@
             pname = "nextcloud-client";
             version = "dev";
             src = ../../.;
+
             dontStrip = true;
             enableDebugging = true;
             separateDebugInfo = false;
-            cmakeFlags = if(stdenv.isLinux) then [
-                "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
-                "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
-            ] else [];
-            postPatch = if(stdenv.isLinux) then ''
+            enableParallelBuilding = true;
+
+            preConfigure = optionals stdenv.isLinux [
+            ''
+              substituteInPlace shell_integration/libcloudproviders/CMakeLists.txt \
+                --replace "PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)" "set(_install_dir "\$\{CMAKE_INSTALL_DATADIR\}/dbus-1/service")"
+            ''
+            ] ++ optionals stdenv.isDarwin [
+            ''
+              substituteInPlace shell_integration/MacOSX/CMakeLists.txt \
+                --replace "-target FinderSyncExt -configuration Release" "-scheme FinderSyncExt -configuration Release -derivedDataPath $ENV{NIX_BUILD_TOP}/derivedData"
+            ''
+            ];
+
+            cmakeFlags = optionals stdenv.isLinux [
+              "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
+              "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
+            ] ++ optionals stdenv.isDarwin [
+              "-DQT_ENABLE_VERBOSE_DEPLOYMENT=TRUE"
+              "-DBUILD_OWNCLOUD_OSX_BUNDLE=OFF"
+            ];
+            postPatch = optionalString stdenv.isLinux ''
               for file in src/libsync/vfs/*/CMakeLists.txt; do
                 substituteInPlace $file \
                   --replace "PLUGINDIR" "KDE_INSTALL_PLUGINDIR"
               done
-            '' else "";
-            postFixup = if(stdenv.isLinux) then ''
+            '';
+            postFixup = optionalString stdenv.isLinux ''
               wrapProgram "$out/bin/nextcloud" \
                 --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ libsecret ]} \
                 --set PATH ${lib.makeBinPath [ xdg-utils ]} \
                 --set QML_DISABLE_DISK_CACHE "1"
-            '' else "";
+            '';
           };
 
           apps.default = mkApp {
@@ -104,7 +132,7 @@
           inherit packages apps;
           devShell = pkgs.mkShell {
             inherit buildInputs;
-            nativeBuildInputs = with pkgs; nativeBuildInputs ++[
+            nativeBuildInputs = with pkgs; nativeBuildInputs ++ optionals (stdenv.isLinux) [
               gdb
               qtcreator
             ];

--- a/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj/project.pbxproj
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj/project.pbxproj
@@ -33,14 +33,14 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		C2B573E11B1CD9CE00303B36 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
 				C2B573E21B1CD9CE00303B36 /* FinderSyncExt.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
@@ -198,10 +198,12 @@
 					C2B573B01B1CD91E00303B36 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = 9B5WD74GWJ;
+						ProvisioningStyle = Manual;
 					};
 					C2B573D61B1CD9CE00303B36 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = 9B5WD74GWJ;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.Mac = {
 								enabled = 1;
@@ -384,6 +386,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -433,6 +436,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -475,6 +479,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = FinderSyncExt/FinderSyncExt.entitlements;
 				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -529,7 +534,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_ENTITLEMENTS = FinderSyncExt/FinderSyncExt.entitlements;
 				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj/xcshareddata/xcschemes/FinderSyncExt.xcscheme
+++ b/shell_integration/MacOSX/OwnCloudFinderSync/OwnCloudFinderSync.xcodeproj/xcshareddata/xcschemes/FinderSyncExt.xcscheme
@@ -83,6 +83,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Nix flakes makes it very easy to create builds and dev shells of the desktop client with minimal maintenance load, by using nix and nixpkgs.

This nix flake includes support for both macOS and Linux.  The Linux build is fully reproducible — nix downloads and builds the necessary dependencies independently of system packages. Unfortunately the macOS build is “impure” as we need to use the system Xcode to build the finder sync extension, but besides that everything else is shared with the Linux build

Adopting this will make it easier to build the desktop client and create a dev environment for contributors and for ourselves, as well as make it easier to package the desktop client if we adopt this for our build infra

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
