### PR TITLE
Improve "pretty user name"-related strings, display in webflow credentials

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -29,16 +29,16 @@
 #include "ui_mnemonicdialog.h"
 
 namespace {
-static const char urlC[] = "url";
-static const char authTypeC[] = "authType";
-static const char userC[] = "user";
-static const char displayNameC[] = "displayName";
-static const char httpUserC[] = "http_user";
-static const char davUserC[] = "dav_user";
-static const char caCertsKeyC[] = "CaCertificates";
-static const char accountsC[] = "Accounts";
-static const char versionC[] = "version";
-static const char serverVersionC[] = "serverVersion";
+constexpr auto urlC = "url";
+constexpr auto authTypeC = "authType";
+constexpr auto userC = "user";
+constexpr auto displayNameC = "displayName";
+constexpr auto httpUserC = "http_user";
+constexpr auto davUserC = "dav_user";
+constexpr auto caCertsKeyC = "CaCertificates";
+constexpr auto accountsC = "Accounts";
+constexpr auto versionC = "version";
+constexpr auto serverVersionC = "serverVersion";
 
 // The maximum versions that this client can read
 static const int maxAccountsVersion = 2;

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -32,6 +32,7 @@ namespace {
 static const char urlC[] = "url";
 static const char authTypeC[] = "authType";
 static const char userC[] = "user";
+static const char displayNameC[] = "displayName";
 static const char httpUserC[] = "http_user";
 static const char davUserC[] = "dav_user";
 static const char caCertsKeyC[] = "CaCertificates";
@@ -222,7 +223,9 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.setValue(QLatin1String(versionC), maxAccountVersion);
     settings.setValue(QLatin1String(urlC), acc->_url.toString());
     settings.setValue(QLatin1String(davUserC), acc->_davUser);
+    settings.setValue(QLatin1String(displayNameC), acc->_displayName);
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
+
     if (acc->_credentials) {
         if (saveCredentials) {
             // Only persist the credentials if the parameter is set, on migration from 1.8.x
@@ -321,6 +324,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 
     // We want to only restore settings for that auth type and the user value
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));
+    acc->_displayName = settings.value(QLatin1String(displayNameC), "").toString();
     QString authTypePrefix = authType + "_";
     for (const auto &key : settings.childKeys()) {
         if (!key.startsWith(authTypePrefix))

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -164,7 +164,7 @@ void WebFlowCredentials::askFromUser() {
         }
 
         QString msg = tr("You have been logged out of your account %1 at %2. Please login again.")
-                          .arg(_account->davUser(), _account->url().toDisplayString());
+                          .arg(_account->prettyName(), _account->url().toDisplayString());
         _askDialog->setInfo(msg);
 
         _askDialog->show();
@@ -188,7 +188,7 @@ void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user,
         qCInfo(lcWebFlowCredentials()) << "Authed with the wrong user!";
 
         QString msg = tr("Please login with the account: %1")
-                .arg(_account->davUser());
+                .arg(_account->prettyName());
         _askDialog->setError(msg);
 
         if (!_askDialog->isUsingFlow2()) {

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -164,7 +164,7 @@ void WebFlowCredentials::askFromUser() {
         }
 
         QString msg = tr("You have been logged out of your account %1 at %2. Please login again.")
-                          .arg(_user, _account->displayName());
+                          .arg(_account->davUser(), _account->url().toDisplayString());
         _askDialog->setInfo(msg);
 
         _askDialog->show();
@@ -188,7 +188,7 @@ void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user,
         qCInfo(lcWebFlowCredentials()) << "Authed with the wrong user!";
 
         QString msg = tr("Please login with the account: %1")
-                .arg(_user);
+                .arg(_account->davUser());
         _askDialog->setError(msg);
 
         if (!_askDialog->isUsingFlow2()) {

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -57,10 +57,7 @@ const float buttonSizeRatio = 1.618f; // golden ratio
  */
 QString shortDisplayNameForSettings(OCC::Account *account, int width)
 {
-    QString user = account->davDisplayName();
-    if (user.isEmpty()) {
-        user = account->credentials()->user();
-    }
+    QString user = account->prettyName();
     QString host = account->url().host();
     int port = account->url().port();
     if (port > 0 && port != 80 && port != 443) {

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -733,12 +733,7 @@ void User::logout() const
 
 QString User::name() const
 {
-    // If davDisplayName is empty (can be several reasons, simplest is missing login at startup), fall back to username
-    QString name = _account->account()->davDisplayName();
-    if (name == "") {
-        name = _account->account()->credentials()->user();
-    }
-    return name;
+    return _account->account()->prettyName();
 }
 
 QString User::server(bool shortened) const

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -131,6 +131,7 @@ void Account::setDavUser(const QString &newDavUser)
         return;
     _davUser = newDavUser;
     emit wantsAccountSaved(this);
+    emit prettyNameChanged();
 }
 
 #ifndef TOKEN_AUTH_ONLY
@@ -165,6 +166,19 @@ void Account::setDavDisplayName(const QString &newDisplayName)
 {
     _displayName = newDisplayName;
     emit accountChangedDisplayName();
+    emit prettyNameChanged();
+}
+
+QString Account::prettyName() const
+{
+    // If davDisplayName is empty (can be several reasons, simplest is missing login at startup), fall back to username
+    auto name = davDisplayName();
+
+    if (name.isEmpty()) {
+        name = davUser();
+    }
+
+    return name;
 }
 
 QColor Account::headerColor() const

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -83,6 +83,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
     Q_PROPERTY(QString id MEMBER _id)
     Q_PROPERTY(QString davUser MEMBER _davUser)
     Q_PROPERTY(QString displayName MEMBER _displayName)
+    Q_PROPERTY(QString prettyName READ prettyName NOTIFY prettyNameChanged)
     Q_PROPERTY(QUrl url MEMBER _url)
 
 public:
@@ -112,6 +113,11 @@ public:
 
     /// The name of the account as shown in the toolbar
     [[nodiscard]] QString displayName() const;
+
+    /// The name of the account that is displayed as nicely as possible,
+    /// e.g. the actual name of the user (John Doe). If this cannot be
+    /// provided, defaults to davUser (e.g. johndoe)
+    [[nodiscard]] QString prettyName() const;
 
     [[nodiscard]] QColor accentColor() const;
     [[nodiscard]] QColor headerColor() const;
@@ -319,6 +325,7 @@ signals:
 
     void accountChangedAvatar();
     void accountChangedDisplayName();
+    void prettyNameChanged();
 
     /// Used in RemoteWipe
     void appPasswordRetrieved(QString);


### PR DESCRIPTION
| With fix | Without fix |
|----------|-------------|
| ![image](https://user-images.githubusercontent.com/70155116/194385379-a1e91c17-3ede-4b04-a4ea-e5970252b3ae.png) | ![Screenshot_20221006_164418](https://user-images.githubusercontent.com/70155116/194344683-c45730fb-136d-47c6-aa64-a9cb57a46caa.png) |

Signed-off-by: Claudio Cambra <claudio.cambra@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
