### PR TITLE
improve logs when adding sync errors in activity list of main dialog

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -547,7 +547,7 @@ void ActivityListModel::addEntriesToActivityList(const ActivityList &activityLis
 
 void ActivityListModel::addErrorToActivityList(const Activity &activity)
 {
-    qCInfo(lcActivity) << "Error successfully added to the notification list: " << activity._subject;
+    qCInfo(lcActivity) << "Error successfully added to the notification list: " << activity._message << activity._subject;
     addEntriesToActivityList({activity});
     _notificationErrorsLists.prepend(activity);
 }


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
