### PR TITLE
Clean up methods in sync engine

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -970,11 +970,6 @@ bool SyncEngine::wasFileTouched(const QString &fn) const
     return false;
 }
 
-AccountPtr SyncEngine::account() const
-{
-    return _account;
-}
-
 void SyncEngine::setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QString> paths)
 {
     _localDiscoveryStyle = style;

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -65,31 +65,20 @@ public:
 
     ~SyncEngine() override;
 
-    Q_INVOKABLE void startSync();
-    void setNetworkLimits(int upload, int download);
-
-    /* Abort the sync.  Called from the main thread */
-    void abort();
-
     [[nodiscard]] bool isSyncRunning() const { return _syncRunning; }
 
     [[nodiscard]] SyncOptions syncOptions() const { return _syncOptions; }
-    void setSyncOptions(const SyncOptions &options) { _syncOptions = options; }
     [[nodiscard]] bool ignoreHiddenFiles() const { return _ignore_hidden_files; }
-    void setIgnoreHiddenFiles(bool ignore) { _ignore_hidden_files = ignore; }
 
-    void addAcceptedInvalidFileName(const QString& filePath);
-
-    ExcludedFiles &excludedFiles() { return *_excludedFiles; }
-    Utility::StopWatch &stopWatch() { return _stopWatch; }
-    SyncFileStatusTracker &syncFileStatusTracker() { return *_syncFileStatusTracker; }
+    [[nodiscard]] ExcludedFiles &excludedFiles() const { return *_excludedFiles; }
+    [[nodiscard]] SyncFileStatusTracker &syncFileStatusTracker() const { return *_syncFileStatusTracker; }
 
     /* Returns whether another sync is needed to complete the sync */
-    AnotherSyncNeeded isAnotherSyncNeeded() { return _anotherSyncNeeded; }
+    [[nodiscard]] AnotherSyncNeeded isAnotherSyncNeeded() const { return _anotherSyncNeeded; }
 
     [[nodiscard]] bool wasFileTouched(const QString &fn) const;
 
-    [[nodiscard]] AccountPtr account() const;
+    [[nodiscard]] AccountPtr account() const { return _account; };
     [[nodiscard]] SyncJournalDb *journal() const { return _journal; }
     [[nodiscard]] QString localPath() const { return _localPath; }
 
@@ -104,19 +93,6 @@ public:
      * current time is less than this duration are skipped.
      */
     static std::chrono::milliseconds minimumFileAgeForUpload;
-
-    /**
-     * Control whether local discovery should read from filesystem or db.
-     *
-     * If style is DatabaseAndFilesystem, paths a set of file paths relative to
-     * the synced folder. All the parent directories of these paths will not
-     * be read from the db and scanned on the filesystem.
-     *
-     * Note, the style and paths are only retained for the next sync and
-     * revert afterwards. Use _lastLocalDiscoveryStyle to discover the last
-     * sync's style.
-     */
-    void setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QString> paths = {});
 
     /**
      * Returns whether the given folder-relative path should be locally discovered
@@ -142,7 +118,32 @@ public:
 
     static void switchToVirtualFiles(const QString &localPath, SyncJournalDb &journal, Vfs &vfs);
 
-    auto getPropagator() { return _propagator; } // for the test
+    [[nodiscard]] QSharedPointer<OwncloudPropagator> getPropagator() const { return _propagator; } // for the test
+
+public slots:
+    void startSync();
+
+    /* Abort the sync.  Called from the main thread */
+    void abort();
+
+    void setNetworkLimits(int upload, int download);
+    void setSyncOptions(const SyncOptions &options) { _syncOptions = options; }
+    void setIgnoreHiddenFiles(bool ignore) { _ignore_hidden_files = ignore; }
+
+    /**
+     * Control whether local discovery should read from filesystem or db.
+     *
+     * If style is DatabaseAndFilesystem, paths a set of file paths relative to
+     * the synced folder. All the parent directories of these paths will not
+     * be read from the db and scanned on the filesystem.
+     *
+     * Note, the style and paths are only retained for the next sync and
+     * revert afterwards. Use _lastLocalDiscoveryStyle to discover the last
+     * sync's style.
+     */
+    void setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QString> paths = {});
+
+    void addAcceptedInvalidFileName(const QString& filePath);
 
 signals:
     // During update, before reconcile


### PR DESCRIPTION
Small clean up that consists of:

- Placing Q_INVOKABLE and void setters in slots
- Removing getter for stopwatch unused anywhere in the code
- Constifying methods that could be constified

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
