### PR TITLE
Fix call notification dialog buttons

### DIFF
--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -222,7 +222,7 @@ Window {
                         text: modelData.label
                         bold: true
                         bgColor: Style.ncBlue
-                        bgOpacity: 0.8
+                        bgNormalOpacity: 0.8
 
                         textColor: Style.ncHeaderTextColor
 
@@ -249,7 +249,7 @@ Window {
                     text: qsTr("Decline")
                     bold: true
                     bgColor: Style.errorBoxBackgroundColor
-                    bgOpacity: 0.8
+                    bgNormalOpacity: 0.8
 
                     textColor: Style.ncHeaderTextColor
 

--- a/src/gui/tray/CustomButton.qml
+++ b/src/gui/tray/CustomButton.qml
@@ -18,7 +18,8 @@ Button {
 
     property bool bold: false
 
-    property real bgOpacity: 0.3
+    property alias bgNormalOpacity: bgRectangle.normalOpacity
+    property alias bgHoverOpacity: bgRectangle.hoverOpacity
 
     background: NCButtonBackground {
         id: bgRectangle


### PR DESCRIPTION
The `CallNotificationDialog` component sets the `bgOpacity` property of its `CustomButton`s but this prop is not hooked up to anything, resulting in these borked-looking buttons:

![Screenshot_20221020_135632](https://user-images.githubusercontent.com/70155116/196946543-33795999-0255-44e2-8f2e-30e360d91918.png)

This PR fixes this:

![Screenshot_20221020_140952](https://user-images.githubusercontent.com/70155116/196946581-90432c2e-e7d4-4040-84dc-62904aa89468.png)


Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
