### PR TITLE
Update CMake usage in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ with your computer.
 
 #### :memo: Step by step instructions
 
-##### Clone the repo and create build directory
+##### Clone the repo
 ```
 $ git clone https://github.com/nextcloud/desktop.git
 $ cd desktop
-$ mkdir build
-$ cd build
 ```
 ##### Compile and install
 
@@ -33,14 +31,14 @@ $ cd build
 ##### Linux & Mac OS
 
 ```
-$ cmake .. -DCMAKE_INSTALL_PREFIX=~/nextcloud-desktop-client -DCMAKE_BUILD_TYPE=Debug
-$ make install
+$ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=~/nextcloud-desktop-client -DCMAKE_BUILD_TYPE=Debug
+$ cmake --build build --target install
 ```
 
 ##### Windows
 
 ```
-$ cmake -G "Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=$USERPROFILE\nextcloud-desktop-client -DCMAKE_BUILD_TYPE=Debug
+$ cmake -S . -B build -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=$USERPROFILE\nextcloud-desktop-client -DCMAKE_BUILD_TYPE=Debug
 $ cmake --build . --config Debug --target install
 ```
 


### PR DESCRIPTION
CMake 3.14.0 released in March 2019 [1] added the command line config options `-S <source-dir>` and `-B <build-dir>` and the build argument `--build <build-dir>` [2]. These options are universally valid independent of the build system used (`make`, `nmake`, `ninja`, `MSBuild`,...), making the provided CMake commands more generic.

As reference Ubuntu 20.04 ships the CMake 3.16.3 [3] version.

- [1] https://gitlab.kitware.com/cmake/cmake/-/tags/v3.14.0
- [2] https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line
- [3] https://packages.ubuntu.com/focal/cmake

Signed-off-by: NeroBurner <pyro4hell@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
