### PR TITLE
emit missing signal to update folder sync status icon

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -369,6 +369,7 @@ void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status sta
                                << _connectionStatus << "->"
                                << status;
         _connectionStatus = status;
+        emit stateChanged(_state);
     }
     _connectionErrors = errors;
 


### PR DESCRIPTION
FIX: https://github.com/nextcloud/desktop/issues/4807

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
