### PR TITLE
fix instances of: c++11 range-loop might detach Qt container warnings

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -92,7 +92,8 @@ bool AccountManager::restore()
         return true;
     }
 
-    for (const auto &accountId : settings->childGroups()) {
+    const auto settingsChildGroups = settings->childGroups();
+    for (const auto &accountId : settingsChildGroups) {
         settings->beginGroup(accountId);
         if (!skipSettingsKeys.contains(settings->group())) {
             if (const auto acc = loadAccountHelper(*settings)) {
@@ -121,7 +122,8 @@ void AccountManager::backwardMigrationSettingsKeys(QStringList *deleteKeys, QStr
     const auto accountsVersion = settings->value(QLatin1String(versionC)).toInt();
 
     if (accountsVersion <= maxAccountsVersion) {
-        for (const auto &accountId : settings->childGroups()) {
+        const auto settingsChildGroups = settings->childGroups();
+        for (const auto &accountId : settingsChildGroups) {
             settings->beginGroup(accountId);
             const auto accountVersion = settings->value(QLatin1String(versionC), 1).toInt();
 
@@ -263,7 +265,8 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.beginGroup(QLatin1String(generalC));
     qCInfo(lcAccountManager) << "Saving " << acc->approvedCerts().count() << " unknown certs.";
     QByteArray certs;
-    for (const auto &cert : acc->approvedCerts()) {
+    const auto approvedCerts = acc->approvedCerts();
+    for (const auto &cert : approvedCerts) {
         certs += cert.toPem() + '\n';
     }
     if (!certs.isEmpty()) {
@@ -342,7 +345,8 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));
     acc->_displayName = settings.value(QLatin1String(displayNameC), "").toString();
     QString authTypePrefix = authType + "_";
-    for (const auto &key : settings.childKeys()) {
+    const auto settingsChildKeys = settings.childKeys();
+    for (const auto &key : settingsChildKeys) {
         if (!key.startsWith(authTypePrefix))
             continue;
         acc->_settingsMap.insert(key, settings.value(key));
@@ -370,7 +374,8 @@ AccountStatePtr AccountManager::account(const QString &name)
 
 AccountStatePtr AccountManager::accountFromUserId(const QString &id) const
 {
-    for (const auto &account : accounts()) {
+    const auto accountsList = accounts();
+    for (const auto &account : accountsList) {
         const auto isUserIdWithPort = id.split(QLatin1Char(':')).size() > 1;
         const auto port = isUserIdWithPort ? account->account()->url().port() : -1;
         const auto portString = (port > 0 && port != 80 && port != 443) ? QStringLiteral(":%1").arg(port) : QStringLiteral("");

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1476,7 +1476,8 @@ void AccountSettings::removeActionFromEncryptionMessage(const QString &actionId)
 
 QAction *AccountSettings::addActionToEncryptionMessage(const QString &actionTitle, const QString &actionId)
 {
-    for (const auto &action : _ui->encryptionMessage->actions()) {
+    const auto encryptionActions = _ui->encryptionMessage->actions();
+    for (const auto &action : encryptionActions) {
         if (action->property(e2eUiActionIdKey) == actionId) {
             return action;
         }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -174,8 +174,9 @@ bool Application::configVersionMigration()
         settings->endGroup();
 
         // Wipe confusing keys from the future, ignore the others
-        for (const auto &badKey : deleteKeys)
+        for (const auto &badKey : qAsConst(deleteKeys)) {
             settings->remove(badKey);
+        }
     }
 
     configFile.setClientVersionString(MIRALL_VERSION_STRING);
@@ -370,7 +371,8 @@ Application::Application(int &argc, char **argv)
         this, &Application::slotAccountStateAdded);
     connect(AccountManager::instance(), &AccountManager::accountRemoved,
         this, &Application::slotAccountStateRemoved);
-    for (const auto &ai : AccountManager::instance()->accounts()) {
+    const auto accounts = AccountManager::instance()->accounts();
+    for (const auto &ai : accounts) {
         slotAccountStateAdded(ai.data());
     }
 

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -316,7 +316,7 @@ void ShareModel::handlePlaceholderLinkShare()
     auto linkSharePresent = false;
     auto placeholderLinkSharePresent = false;
 
-    for (const auto &share : _shares) {
+    for (const auto &share : qAsConst(_shares)) {
         const auto shareType = share->getShareType();
 
         if (!linkSharePresent && shareType == Share::TypeLink) {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -188,7 +188,8 @@ int FolderMan::setupFolders()
 
     qCInfo(lcFolderMan) << "Setup folders from settings file";
 
-    for (const auto &account : AccountManager::instance()->accounts()) {
+    const auto accounts = AccountManager::instance()->accounts();
+    for (const auto &account : accounts) {
         const auto id = account->account()->id();
         if (!accountsWithSettings.contains(id)) {
             continue;
@@ -219,7 +220,7 @@ int FolderMan::setupFolders()
 
     emit folderListChanged(_folderMap);
 
-    for (const auto folder : _folderMap) {
+    for (const auto folder : qAsConst(_folderMap)) {
         folder->processSwitchedToVirtualFiles();
     }
 
@@ -228,7 +229,8 @@ int FolderMan::setupFolders()
 
 void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account, const QStringList &ignoreKeys, bool backwardsCompatible, bool foldersWithPlaceholders)
 {
-    for (const auto &folderAlias : settings.childGroups()) {
+    const auto settingsChildGroups = settings.childGroups();
+    for (const auto &folderAlias : settingsChildGroups) {
         // Skip folders with too-new version
         settings.beginGroup(folderAlias);
         if (ignoreKeys.contains(settings.group())) {
@@ -392,7 +394,8 @@ void FolderMan::backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringLi
         settings->endGroup();
     };
 
-    for (const auto &accountId : settings->childGroups()) {
+    const auto settingsChildGroups = settings->childGroups();
+    for (const auto &accountId : settingsChildGroups) {
         settings->beginGroup(accountId);
         processSubgroup("Folders");
         processSubgroup("Multifolders");
@@ -598,7 +601,8 @@ Folder *FolderMan::folder(const QString &alias)
 
 void FolderMan::scheduleAllFolders()
 {
-    for (Folder *f : _folderMap.values()) {
+    const auto folderMapValues = _folderMap.values();
+    for (Folder *f : folderMapValues) {
         if (f && f->canSync()) {
             scheduleFolder(f);
         }
@@ -741,7 +745,8 @@ void FolderMan::slotAccountStateChanged()
     if (accountState->isConnected()) {
         qCInfo(lcFolderMan) << "Account" << accountName << "connected, scheduling its folders";
 
-        for (Folder *f : _folderMap.values()) {
+        const auto folderMapValues = _folderMap.values();
+        for (Folder *f : folderMapValues) {
             if (f
                 && f->canSync()
                 && f->accountState() == accountState) {
@@ -781,7 +786,7 @@ void FolderMan::setSyncEnabled(bool enabled)
     }
     _syncEnabled = enabled;
     // force a redraw in case the network connect status changed
-    emit(folderSyncStateChange(nullptr));
+    emit folderSyncStateChange(nullptr);
 }
 
 void FolderMan::startScheduledSyncSoon()
@@ -837,7 +842,7 @@ void FolderMan::startScheduledSyncSoon()
 void FolderMan::slotStartScheduledFolderSync()
 {
     if (isAnySyncRunning()) {
-        for (auto f : _folderMap) {
+        for (auto f : qAsConst(_folderMap)) {
             if (f->isSyncRunning())
                 qCInfo(lcFolderMan) << "Currently folder " << f->remoteUrl().toString() << " is running, wait for finish!";
         }
@@ -1223,7 +1228,8 @@ QStringList FolderMan::findFileInLocalFolders(const QString &relPath, const Acco
     if (!serverPath.startsWith('/'))
         serverPath.prepend('/');
 
-    for (Folder *folder : this->map().values()) {
+    const auto mapValues = map().values();
+    for (Folder *folder : mapValues) {
         if (acc && folder->accountState()->account() != acc) {
             continue;
         }
@@ -1421,7 +1427,8 @@ void FolderMan::slotWipeFolderForAccount(AccountState *accountState)
 
 void FolderMan::setDirtyProxy()
 {
-    for (const Folder *f : _folderMap.values()) {
+    const auto folderMapValues = _folderMap.values();
+    for (const Folder *f : folderMapValues) {
         if (f) {
             if (f->accountState() && f->accountState()->account()
                 && f->accountState()->account()->networkAccessManager()) {
@@ -1435,7 +1442,8 @@ void FolderMan::setDirtyProxy()
 
 void FolderMan::setDirtyNetworkLimits()
 {
-    for (Folder *f : _folderMap.values()) {
+    const auto folderMapValues = _folderMap.values();
+    for (Folder *f : folderMapValues) {
         // set only in busy folders. Otherwise they read the config anyway.
         if (f && f->isBusy()) {
             f->setDirtyNetworkLimits();
@@ -1784,7 +1792,7 @@ void FolderMan::slotProcessFilesPushNotification(Account *account)
 {
     qCInfo(lcFolderMan) << "Got files push notification for account" << account;
 
-    for (auto folder : _folderMap) {
+    for (auto folder : qAsConst(_folderMap)) {
         // Just run on the folders that belong to this account
         if (folder->accountState()->account() != account) {
             continue;

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1428,12 +1428,12 @@ void FolderMan::slotWipeFolderForAccount(AccountState *accountState)
 void FolderMan::setDirtyProxy()
 {
     const auto folderMapValues = _folderMap.values();
-    for (const Folder *f : folderMapValues) {
-        if (f) {
-            if (f->accountState() && f->accountState()->account()
-                && f->accountState()->account()->networkAccessManager()) {
+    for (const auto folder : folderMapValues) {
+        if (folder) {
+            if (folder->accountState() && folder->accountState()->account()
+                && folder->accountState()->account()->networkAccessManager()) {
                 // Need to do this so we do not use the old determined system proxy
-                f->accountState()->account()->networkAccessManager()->setProxy(
+                folder->accountState()->account()->networkAccessManager()->setProxy(
                     QNetworkProxy(QNetworkProxy::DefaultProxy));
             }
         }
@@ -1443,10 +1443,10 @@ void FolderMan::setDirtyProxy()
 void FolderMan::setDirtyNetworkLimits()
 {
     const auto folderMapValues = _folderMap.values();
-    for (Folder *f : folderMapValues) {
+    for (auto folder : folderMapValues) {
         // set only in busy folders. Otherwise they read the config anyway.
-        if (f && f->isBusy()) {
-            f->setDirtyNetworkLimits();
+        if (folder && folder->isBusy()) {
+            folder->setDirtyNetworkLimits();
         }
     }
 }

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -252,7 +252,8 @@ void NetworkSettings::checkAccountLocalhost()
     if (_ui->manualProxyRadioButton->isChecked()) {
         // Check if at least one account is using localhost, because Qt proxy settings have no
         // effect for localhost (#7169)
-        for (const auto &account : AccountManager::instance()->accounts()) {
+        const auto accounts = AccountManager::instance()->accounts();
+        for (const auto &account : accounts) {
             const auto host = account->account()->url().host();
             // Some typical url for localhost
             if (host == "localhost" || host.startsWith("127.") || host == "[::1]")

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -990,7 +990,8 @@ void SocketApi::setFileLock(const QString &localFile, const SyncFileItem::LockSt
 void SocketApi::command_V2_LIST_ACCOUNTS(const QSharedPointer<SocketApiJobV2> &job) const
 {
     QJsonArray out;
-    for (auto acc : AccountManager::instance()->accounts()) {
+    const auto accounts = AccountManager::instance()->accounts();
+    for (auto acc : accounts) {
         // TODO: Use uuid once https://github.com/owncloud/client/pull/8397 is merged
         out << QJsonObject({ { "name", acc->account()->displayName() }, { "id", acc->account()->id() } });
     }

--- a/src/gui/tray/asyncimageresponse.cpp
+++ b/src/gui/tray/asyncimageresponse.cpp
@@ -76,7 +76,8 @@ void AsyncImageResponse::processNextImage()
 
     OCC::AccountPtr accountInRequestedServer;
 
-    for (const auto &account : OCC::AccountManager::instance()->accounts()) {
+    const auto accountsList = OCC::AccountManager::instance()->accounts();
+    for (const auto &account : accountsList) {
         if (account && account->account() && imagePath.startsWith(account->account()->url().toString())) {
            accountInRequestedServer = account->account();
         }

--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -92,7 +92,8 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
 
         if(json.contains("subjectRichParameters")) {
             const auto richParams = json.value("subjectRichParameters").toObject();
-            for(const auto &key : richParams.keys()) {
+            const auto richParamsKeys = richParams.keys();
+            for(const auto &key : richParamsKeys) {
                 const auto parameterJsonObject = richParams.value(key).toObject();
                 a._subjectRichParameters.insert(key, Activity::RichSubjectParameter{
                                                     parameterJsonObject.value(QStringLiteral("type")).toString(),

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -504,7 +504,7 @@ void UnifiedSearchResultsListModel::startSearch()
         endResetModel();
     }
 
-    for (const auto &provider : _providers) {
+    for (const auto &provider : qAsConst(_providers)) {
         startSearchForProvider(provider._id);
     }
 }
@@ -724,7 +724,7 @@ void UnifiedSearchResultsListModel::removeFetchMoreTrigger(const QString &provid
 
 void UnifiedSearchResultsListModel::disconnectAndClearSearchJobs()
 {
-    for (const auto &connection : _searchJobConnections) {
+    for (const auto &connection : qAsConst(_searchJobConnections)) {
         if (connection) {
             QObject::disconnect(connection);
         }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -136,7 +136,7 @@ void User::slotBuildNotificationDisplay(const ActivityList &list)
         showDesktopNotification(subject, message, -static_cast<int>(qHash(subject)));
 
         // Set these activities as notified here, rather than in showDesktopNotification
-        for(const auto &activity : toNotifyList) {
+        for(const auto &activity : qAsConst(toNotifyList)) {
             _notifiedNotifications.insert(activity._id);
             _activityModel->addNotificationToActivityList(activity);
         }
@@ -144,7 +144,7 @@ void User::slotBuildNotificationDisplay(const ActivityList &list)
         return;
     }
 
-    for(const auto &activity : toNotifyList) {
+    for(const auto &activity : qAsConst(toNotifyList)) {
         const auto message = activity._objectType == QStringLiteral("chat")
             ? activity._message : AccountManager::instance()->accounts().count() == 1 ? "" : activity._accName;
 
@@ -220,7 +220,8 @@ void User::slotReceivedPushActivity(Account *account)
 
 void User::slotCheckExpiredActivities()
 {
-    for (const Activity &activity : _activityModel->errorsList()) {
+    const auto errorsList = _activityModel->errorsList();
+    for (const Activity &activity : errorsList) {
         if (activity._expireAtMsecs > 0 && QDateTime::currentDateTime().toMSecsSinceEpoch() >= activity._expireAtMsecs) {
             _activityModel->removeActivityFromActivityList(activity);
         }
@@ -1032,7 +1033,7 @@ void UserModel::setCurrentUserId(const int id)
 
     const auto isCurrentUserChanged = !_users[id]->isCurrentUser();
     if (isCurrentUserChanged) {
-        for (const auto user : _users) {
+        for (const auto user : qAsConst(_users)) {
             user->setCurrentUser(false);
         }
         _users[id]->setCurrentUser(true);

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -448,7 +448,7 @@ bool HttpCredentials::refreshAccessToken()
             persist();
         }
         _isRenewingOAuthToken = false;
-        for (const auto &job : _retryQueue) {
+        for (const auto &job : qAsConst(_retryQueue)) {
             if (job)
                 job->retry();
         }

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1611,7 +1611,7 @@ bool ProcessDirectoryJob::checkPermissions(const OCC::SyncFileItemPtr &item)
 
 bool ProcessDirectoryJob::isAnyParentBeingRestored(const QString &file) const
 {
-    for (const auto &directoryNameToRestore : _discoveryData->_directoryNamesToRestoreOnPropagation) {
+    for (const auto &directoryNameToRestore : qAsConst(_discoveryData->_directoryNamesToRestoreOnPropagation)) {
         if (file.startsWith(QString(directoryNameToRestore + QLatin1Char('/')))) {
             qCWarning(lcDisco) << "File" << file << " is within the tree that's being restored" << directoryNameToRestore;
             return true;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1182,7 +1182,7 @@ void SyncEngine::slotScheduleFilesDelayedSync()
         newTimer->callOnTimeout(this, [this, newTimer] {
             qCInfo(lcEngine) << "Rescanning now that delayed sync run is scheduled for:" << newTimer->files;
 
-            for (const auto &file : newTimer->files) {
+            for (const auto &file : qAsConst(newTimer->files)) {
                 this->_filesScheduledForLaterSync.remove(file);
             }
 
@@ -1308,7 +1308,7 @@ void SyncEngine::slotUnscheduleFilesDelayedSync()
         return;
     }
 
-    for (const auto &file : _discoveryPhase->_filesUnscheduleSync) {
+    for (const auto &file : qAsConst(_discoveryPhase->_filesUnscheduleSync)) {
         const auto fileSyncRunTimer = _filesScheduledForLaterSync.value(file);
 
         if (fileSyncRunTimer) {

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -791,7 +791,8 @@ FileInfo *FakeChunkMoveReply::perform(FileInfo &uploadsFileInfo, FileInfo &remot
     Q_ASSERT(!fileName.isEmpty());
 
     // Compute the size and content from the chunks if possible
-    for (auto chunkName : sourceFolder->children.keys()) {
+    const auto childrenKeys = sourceFolder->children.keys();
+    for (auto chunkName : childrenKeys) {
         auto &x = sourceFolder->children[chunkName];
         Q_ASSERT(!x.isDir);
         Q_ASSERT(x.size > 0); // There should not be empty chunks

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -71,8 +71,8 @@ private slots:
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
         const auto childrenKeys = fakeFolder.currentRemoteState().children.keys();
-        for (const auto &s : childrenKeys) {
-            modifier.remove(s);
+        for (const auto &key : childrenKeys) {
+            modifier.remove(key);
         }
 
         QVERIFY(!fakeFolder.syncOnce()); // Should fail because we cancel the sync
@@ -113,8 +113,8 @@ private slots:
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
         const auto childrenKeys = fakeFolder.currentRemoteState().children.keys();
-        for (const auto &s : childrenKeys) {
-            modifier.remove(s);
+        for (const auto &key : childrenKeys) {
+            modifier.remove(key);
         }
 
         QVERIFY(fakeFolder.syncOnce()); // Should succeed, and all files must then be deleted

--- a/test/testallfilesdeleted.cpp
+++ b/test/testallfilesdeleted.cpp
@@ -70,8 +70,10 @@ private slots:
             });
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
-        for (const auto &s : fakeFolder.currentRemoteState().children.keys())
+        const auto childrenKeys = fakeFolder.currentRemoteState().children.keys();
+        for (const auto &s : childrenKeys) {
             modifier.remove(s);
+        }
 
         QVERIFY(!fakeFolder.syncOnce()); // Should fail because we cancel the sync
         QCOMPARE(aboutToRemoveAllFilesCalled, 1);
@@ -110,8 +112,10 @@ private slots:
             });
 
         auto &modifier = deleteOnRemote ? fakeFolder.remoteModifier() : fakeFolder.localModifier();
-        for (const auto &s : fakeFolder.currentRemoteState().children.keys())
+        const auto childrenKeys = fakeFolder.currentRemoteState().children.keys();
+        for (const auto &s : childrenKeys) {
             modifier.remove(s);
+        }
 
         QVERIFY(fakeFolder.syncOnce()); // Should succeed, and all files must then be deleted
 
@@ -139,8 +143,10 @@ private slots:
             [&] { QVERIFY(false); });
         QVERIFY(fakeFolder.syncOnce());
 
-        for (const auto &s : fakeFolder.currentRemoteState().children.keys())
+        const auto childrenKeys = fakeFolder.currentRemoteState().children.keys();
+        for (const auto &s : childrenKeys) {
             fakeFolder.syncJournal().avoidRenamesOnNextSync(s); // clears all the fileid and inodes.
+        }
         fakeFolder.localModifier().remove("A/a1");
         auto expectedState = fakeFolder.currentLocalState();
         QVERIFY(fakeFolder.syncOnce());

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -130,7 +130,8 @@ private slots:
         // Remove the second chunk, so all further chunks will be deleted and resent
         auto firstChunk = chunkMap.first();
         auto secondChunk = *(chunkMap.begin() + 1);
-        for (const auto& name : chunkMap.keys().mid(2)) {
+        const auto chunksList = chunkMap.keys().mid(2);
+        for (const auto& name : chunksList) {
             chunksToDelete.append(name);
         }
         fakeFolder.uploadState().children.first().remove(secondChunk.name);

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -127,8 +127,10 @@ public:
     int countFolders(const QString &path)
     {
         int n = 0;
-        for (const auto &sub : QDir(path).entryList(QDir::Dirs | QDir::NoDotAndDotDot))
+        const auto entryList = QDir(path).entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for (const auto &sub : entryList) {
             n += 1 + countFolders(path + '/' + sub);
+        }
         return n;
     }
 

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -45,7 +45,7 @@ bool expectAndWipeConflict(FileModifier &local, FileInfo state, const QString pa
     auto base = state.find(pathComponents.parentDirComponents());
     if (!base)
         return false;
-    for (const auto &item : base->children) {
+    for (const auto &item : qAsConst(base->children)) {
         if (item.name.startsWith(pathComponents.fileName()) && item.name.contains("(conflicted copy")) {
             local.remove(item.path());
             return true;
@@ -79,7 +79,8 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
 
         // Verify that the conflict names don't have the user name
-        for (const auto &name : findConflicts(fakeFolder.currentLocalState().children["A"])) {
+        const auto conflicts = findConflicts(fakeFolder.currentLocalState().children["A"]);
+        for (const auto &name : conflicts) {
             QVERIFY(!name.contains(fakeFolder.syncEngine().account()->davDisplayName()));
         }
 

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -80,8 +80,8 @@ private slots:
 
         // Verify that the conflict names don't have the user name
         const auto conflicts = findConflicts(fakeFolder.currentLocalState().children["A"]);
-        for (const auto &name : conflicts) {
-            QVERIFY(!name.contains(fakeFolder.syncEngine().account()->davDisplayName()));
+        for (const auto &conflict : conflicts) {
+            QVERIFY(!conflict.contains(fakeFolder.syncEngine().account()->davDisplayName()));
         }
 
         QVERIFY(expectAndWipeConflict(fakeFolder.localModifier(), fakeFolder.currentLocalState(), "A/a1"));

--- a/test/testsyncjournaldb.cpp
+++ b/test/testsyncjournaldb.cpp
@@ -289,12 +289,13 @@ private slots:
             << "foo bla bar/file"
             << "fo_"
             << "fo_/file";
-        for (const auto& elem : elements)
+        for (const auto& elem : qAsConst(elements)) {
             makeEntry(elem);
+        }
 
         auto checkElements = [&]() {
             bool ok = true;
-            for (const auto& elem : elements) {
+            for (const auto& elem : qAsConst(elements)) {
                 SyncJournalFileRecord record;
                 if (!_db.getFileRecord(elem, &record) || !record.isValid()) {
                     qWarning() << "Missing record: " << elem;

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -70,7 +70,7 @@ bool expectAndWipeConflict(FileModifier &local, FileInfo state, const QString pa
     auto base = state.find(pathComponents.parentDirComponents());
     if (!base)
         return false;
-    for (const auto &item : base->children) {
+    for (const auto &item : qAsConst(base->children)) {
         if (item.name.startsWith(pathComponents.fileName()) && item.name.contains("(conflicted copy")) {
             local.remove(item.path());
             return true;
@@ -593,7 +593,7 @@ private slots:
         }
         conflicts = findConflicts(currentLocal.children["B4"]);
         QCOMPARE(conflicts.size(), 1);
-        for (const auto& c : conflicts) {
+        for (const auto& c : qAsConst(conflicts)) {
             QCOMPARE(currentLocal.find(c)->contentChar, 'L');
             local.remove(c);
         }


### PR DESCRIPTION
analyzed via clazy

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
