### PR TITLE
Only show Sync Now button if account is connected

### DIFF
--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -116,7 +116,9 @@ RowLayout {
         bold: true
         bgColor: Style.currentUserHeaderColor
 
-        visible: !syncStatus.syncing && NC.UserModel.currentUser.hasLocalFolder
+        visible: !syncStatus.syncing &&
+                 NC.UserModel.currentUser.hasLocalFolder &&
+                 NC.UserModel.currentUser.isConnected
         enabled: visible
         onClicked: {
             if(!syncStatus.syncing) {


### PR DESCRIPTION
FIX: https://github.com/nextcloud/desktop/issues/5096

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
