### PR TITLE
Add support cmake unity build

### DIFF
--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -34,6 +34,7 @@ cmake \
     -D BUILD_UPDATER=$BUILD_UPDATER \
     -D MIRALL_VERSION_BUILD=$BUILDNR \
     -D MIRALL_VERSION_SUFFIX="$VERSION_SUFFIX" \
+    -D CMAKE_UNITY_BUILD=ON \
     ${DESKTOP_CLIENT_ROOT}
 cmake --build . --target all
 DESTDIR=/app cmake --install .

--- a/src/3rdparty/qtsingleapplication/qtlocalpeer.h
+++ b/src/3rdparty/qtsingleapplication/qtlocalpeer.h
@@ -27,6 +27,8 @@
 **
 ****************************************************************************/
 
+#pragma once
+
 #include <qtlockedfile.h>
 
 #include <QLocalServer>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -317,6 +317,9 @@ set(3rdparty_SRC
     ../3rdparty/kirigami/wheelhandler.cpp
    )
 
+set_property(SOURCE ../3rdparty/kmessagewidget/kmessagewidget.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+set_property(SOURCE ../3rdparty/kirigami/wheelhandler.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+
 if(NOT WIN32)
    list(APPEND 3rdparty_SRC ../3rdparty/qtlockedfile/qtlockedfile_unix.cpp)
    set_property(SOURCE ../3rdparty/qtlockedfile/qtlockedfile_unix.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -319,8 +319,10 @@ set(3rdparty_SRC
 
 if(NOT WIN32)
    list(APPEND 3rdparty_SRC ../3rdparty/qtlockedfile/qtlockedfile_unix.cpp)
+   set_property(SOURCE ../3rdparty/qtlockedfile/qtlockedfile_unix.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
 else()
    list(APPEND 3rdparty_SRC ../3rdparty/qtlockedfile/qtlockedfile_win.cpp )
+   set_property(SOURCE ../3rdparty/qtlockedfile/qtlockedfile_win.cpp PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
 endif()
 
 find_package(Qt5LinguistTools)
@@ -514,6 +516,16 @@ target_link_libraries(nextcloudCore
   )
 
 add_subdirectory(socketapi)
+
+# skip unity inclusion for files which cause problems with a CMake unity build
+set_property(SOURCE
+    ${CMAKE_CURRENT_SOURCE_DIR}/socketapi/socketapi.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/socketapi/socketuploadjob.cpp
+    PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+
+foreach(FILE IN LISTS client_UI_SRCS)
+	set_property(SOURCE ${FILE} PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+endforeach()
 
 if(Qt5WebEngine_FOUND AND Qt5WebEngineWidgets_FOUND)
   target_link_libraries(nextcloudCore PUBLIC Qt5::WebEngineWidgets)

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -46,8 +46,12 @@
 #include <QPushButton>
 #include <QApplication>
 
-static const char versionC[] = "version";
-
+namespace {
+#ifndef VERSION_C
+#define VERSION_C
+constexpr auto versionC= "version";
+#endif
+}
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcFolder, "nextcloud.gui.folder", QtInfoMsg)

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -38,7 +38,12 @@
 #include <QSet>
 #include <QNetworkProxy>
 
-static const char versionC[] = "version";
+namespace {
+#ifndef VERSION_C
+#define VERSION_C
+constexpr auto versionC= "version";
+#endif
+}
 static const int maxFoldersVersion = 1;
 
 namespace OCC {


### PR DESCRIPTION
This PR prepares building with `CMAKE_UNITY_BUILD` enabled. This makes builds often a bit faster and the executables often a bit smaller.

I tried to keep the changes as small as possible and without renaming variables. This is why I exclude the file causing troubles from the unity build or added macros in order to avoid defining a variable multiple times. 

I timed the builds with `time ninja`

Unity build:  nextcloud 5.6M
```
real    0m42,137s
user    3m36,684s
sys     0m17,226s
```

Normal build: nextcloud 5.8M
```
real    0m46,048s
user    9m13,199s
sys     0m45,951s
```


  