### PR TITLE
Remove unused remotePath in User::processCompletedSyncItem

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -617,9 +617,6 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
         }
 
         if(activity._fileAction != "file_deleted" && !item->isEmpty()) {
-            auto remotePath = folder->remotePath();
-            remotePath.append(activity._fileAction == "file_renamed" ? item->_renameTarget : activity._file);
-
             const auto localFiles = FolderMan::instance()->findFileInLocalFolders(item->_file, account());
             if (!localFiles.isEmpty()) {
                 const auto firstFilePath = localFiles.constFirst();


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
