### PR TITLE
Add end-to-end tests to our CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -G Ninja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DBUILD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
+    - cmake -G Ninja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DADD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
 
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-11
@@ -79,7 +79,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DBUILD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
+    - cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DADD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-11
   volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,8 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -G Ninja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
+    - cmake -G Ninja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DBUILD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
+
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-11
   volumes:
@@ -18,6 +19,7 @@ steps:
   commands:
     - cd /drone/build
     - ninja
+
 - name: test
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-11
   volumes:
@@ -28,6 +30,30 @@ steps:
     - useradd -m -s /bin/bash test
     - chown -R test:test .
     - su -c 'ASAN_OPTIONS=detect_leaks=0 xvfb-run ctest --output-on-failure' test
+
+services:
+  - name: server
+    image: ghcr.io/nextcloud/continuous-integration-server:latest # also change in updateScreenshots.sh
+    environment:
+      EVAL: true
+      SERVER_VERSION: 'stable24'
+    commands:
+      - BRANCH="$SERVER_VERSION" /usr/local/bin/initnc.sh
+      - echo 127.0.0.1 server >> /etc/hosts
+      - su www-data -c "OC_PASS=user1 php /var/www/html/occ user:add --password-from-env --display-name='User One' user1"
+      - su www-data -c "OC_PASS=user2 php /var/www/html/occ user:add --password-from-env --display-name='User Two' user2"
+      - su www-data -c "OC_PASS=user3 php /var/www/html/occ user:add --password-from-env --display-name='User Three' user3"
+      - su www-data -c "php /var/www/html/occ user:setting user2 files quota 1G"
+      - su www-data -c "php /var/www/html/occ group:add users"
+      - su www-data -c "php /var/www/html/occ group:adduser users user1"
+      - su www-data -c "php /var/www/html/occ group:adduser users user2"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/activity.git /var/www/html/apps/activity/"
+      - su www-data -c "php /var/www/html/occ app:enable activity"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/text.git /var/www/html/apps/text/"
+      - su www-data -c "php /var/www/html/occ app:enable text"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/end_to_end_encryption.git /var/www/html/apps/end_to_end_encryption/"
+      - su www-data -c "php /var/www/html/occ app:enable end_to_end_encryption"
+      - /usr/local/bin/run.sh
 
 volumes:
 - name: build
@@ -53,7 +79,7 @@ steps:
       path: /drone/build
   commands:
     - cd /drone/build
-    - cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
+    - cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Debug -DQUICK_COMPILER=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DBUILD_E2E_TESTS=ON -DECM_ENABLE_SANITIZERS=address -DCMAKE_CXX_FLAGS=-Werror -DOPENSSL_ROOT_DIR=/usr/local/lib64 ../src
 - name: compile
   image: ghcr.io/nextcloud/continuous-integration-client:client-5.15-11
   volumes:
@@ -72,6 +98,30 @@ steps:
     - useradd -m -s /bin/bash test
     - chown -R test:test .
     - su -c 'ASAN_OPTIONS=detect_leaks=0 xvfb-run ctest --output-on-failure' test
+
+services:
+  - name: server
+    image: ghcr.io/nextcloud/continuous-integration-server:latest # also change in updateScreenshots.sh
+    environment:
+      EVAL: true
+      SERVER_VERSION: 'stable24'
+    commands:
+      - BRANCH="$SERVER_VERSION" /usr/local/bin/initnc.sh
+      - echo 127.0.0.1 server >> /etc/hosts
+      - su www-data -c "OC_PASS=user1 php /var/www/html/occ user:add --password-from-env --display-name='User One' user1"
+      - su www-data -c "OC_PASS=user2 php /var/www/html/occ user:add --password-from-env --display-name='User Two' user2"
+      - su www-data -c "OC_PASS=user3 php /var/www/html/occ user:add --password-from-env --display-name='User Three' user3"
+      - su www-data -c "php /var/www/html/occ user:setting user2 files quota 1G"
+      - su www-data -c "php /var/www/html/occ group:add users"
+      - su www-data -c "php /var/www/html/occ group:adduser users user1"
+      - su www-data -c "php /var/www/html/occ group:adduser users user2"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/activity.git /var/www/html/apps/activity/"
+      - su www-data -c "php /var/www/html/occ app:enable activity"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/text.git /var/www/html/apps/text/"
+      - su www-data -c "php /var/www/html/occ app:enable text"
+      - su www-data -c "git clone --depth=1 -b $SERVER_VERSION https://github.com/nextcloud/end_to_end_encryption.git /var/www/html/apps/end_to_end_encryption/"
+      - su www-data -c "php /var/www/html/occ app:enable end_to_end_encryption"
+      - /usr/local/bin/run.sh
 
 volumes:
 - name: build

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -29,6 +29,7 @@ class TestFolderMan;
 class TestCfApiShellExtensionsIPC;
 class TestShareModel;
 class ShareTestHelper;
+class EndToEndTestHelper;
 
 namespace OCC {
 
@@ -385,6 +386,7 @@ private:
     friend class ::TestFolderMan;
     friend class ::TestCfApiShellExtensionsIPC;
     friend class ::ShareTestHelper;
+    friend class ::EndToEndTestHelper;
 };
 
 } // namespace OCC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,10 @@ nextcloud_add_test(ShareModel)
 nextcloud_add_test(ShareeModel)
 nextcloud_add_test(SortedShareModel)
 
+if(BUILD_E2E_TESTS)
+    nextcloud_add_test(E2eServerSetup)
+endif()
+
 if( UNIX AND NOT APPLE )
     nextcloud_add_test(InotifyWatcher)
 endif(UNIX AND NOT APPLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(testutils
   themeutils.cpp
   testhelper.cpp
   sharetestutils.cpp
+  endtoendtestutils.cpp
 )
 
 target_link_libraries(testutils PUBLIC Nextcloud::sync Qt5::Test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,6 +72,7 @@ nextcloud_add_test(SortedShareModel)
 
 if(BUILD_E2E_TESTS)
     nextcloud_add_test(E2eServerSetup)
+    nextcloud_add_test(E2eFileTransfer)
 endif()
 
 if( UNIX AND NOT APPLE )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,9 +70,12 @@ nextcloud_add_test(ShareModel)
 nextcloud_add_test(ShareeModel)
 nextcloud_add_test(SortedShareModel)
 
-if(BUILD_E2E_TESTS)
+if(ADD_E2E_TESTS)
     nextcloud_add_test(E2eServerSetup)
     nextcloud_add_test(E2eFileTransfer)
+else()
+    nextcloud_build_test(E2eServerSetup)
+    nextcloud_build_test(E2eFileTransfer)
 endif()
 
 if( UNIX AND NOT APPLE )

--- a/test/endtoendtestutils.cpp
+++ b/test/endtoendtestutils.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "endtoendtestutils.h"
+
+#include <QNetworkProxy>
+#include <QJsonObject>
+#include <QSignalSpy>
+
+#include "cmd/simplesslerrorhandler.h"
+#include "creds/httpcredentials.h"
+#include "gui/accountmanager.h"
+#include "libsync/theme.h"
+#include "accessmanager.h"
+#include "httplogger.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+
+constexpr auto serverUrl = "https://server";
+
+Q_LOGGING_CATEGORY(lcEndToEndTestUtils, "nextcloud.gui.endtoendtestutils", QtInfoMsg)
+
+/** End to end test credentials access manager class **/
+
+class EndToEndTestCredentialsAccessManager : public OCC::AccessManager
+{
+public:
+    EndToEndTestCredentialsAccessManager(const EndToEndTestCredentials *cred, QObject *parent = nullptr)
+        : OCC::AccessManager(parent)
+        , _cred(cred)
+    {
+    }
+
+protected:
+    QNetworkReply *createRequest(Operation op, const QNetworkRequest &request, QIODevice *outgoingData) override
+    {
+        if(!_cred) {
+            qCWarning(lcEndToEndTestUtils) << "Could not create request -- null creds!";
+            return {};
+        }
+
+        QNetworkRequest req(request);
+        QByteArray credHash = QByteArray(_cred->user().toUtf8() + ":" + _cred->password().toUtf8()).toBase64();
+        req.setRawHeader("Authorization", "Basic " + credHash);
+
+        return OCC::AccessManager::createRequest(op, req, outgoingData);
+    }
+
+private:
+    // The credentials object dies along with the account, while the QNAM might
+    // outlive both.
+    QPointer<const EndToEndTestCredentials> _cred;
+};
+
+/** End to end test credentials class **/
+
+QNetworkAccessManager *EndToEndTestCredentials::createQNAM() const
+{
+    return new EndToEndTestCredentialsAccessManager(this);
+}
+
+/** End to end test helper class **/
+
+EndToEndTestHelper::~EndToEndTestHelper()
+{
+    removeConfiguredSyncFolder();
+    removeConfiguredAccount();
+
+    OCC::AccountManager::instance()->shutdown();
+}
+
+void EndToEndTestHelper::startAccountConfig()
+{
+    const auto accountManager = OCC::AccountManager::instance();
+    _account = accountManager->createAccount();
+
+    _account->setCredentials(new EndToEndTestCredentials);
+    _account->setUrl(OCC::Theme::instance()->overrideServerUrl());
+
+    const auto serverUrlString = QString(serverUrl);
+    _account->setUrl(serverUrlString);
+
+    _account->networkAccessManager()->setProxy(QNetworkProxy(QNetworkProxy::NoProxy));
+    _account->setSslConfiguration(QSslConfiguration::defaultConfiguration());
+    _account->setSslErrorHandler(new OCC::SimpleSslErrorHandler);
+    _account->setTrustCertificates(true);
+
+    slotConnectToNCUrl(serverUrlString);
+}
+
+void EndToEndTestHelper::slotConnectToNCUrl(const QString &url)
+{
+    qCDebug(lcEndToEndTestUtils) << "Connect to url: " << url;
+
+    const auto fetchUserNameJob = new OCC::JsonApiJob(_account->sharedFromThis(), QStringLiteral("/ocs/v1.php/cloud/user"));
+    connect(fetchUserNameJob, &OCC::JsonApiJob::jsonReceived, this, [this, url](const QJsonDocument &json, const int statusCode) {
+        if (statusCode != 100) {
+            qCDebug(lcEndToEndTestUtils) << "Could not fetch username.";
+        }
+
+        const auto objData = json.object().value("ocs").toObject().value("data").toObject();
+        const auto userId = objData.value("id").toString("");
+        const auto displayName = objData.value("display-name").toString("");
+        _account->setDavUser(userId);
+        _account->setDavDisplayName(displayName);
+
+        _accountState = new OCC::AccountState(_account);
+
+        emit accountReady(_account);
+    });
+    fetchUserNameJob->start();
+}
+
+void EndToEndTestHelper::removeConfiguredAccount()
+{
+    OCC::AccountManager::instance()->deleteAccount(_accountState.data());
+}
+
+OCC::Folder *EndToEndTestHelper::configureSyncFolder(const QString &targetPath)
+{
+    if(_syncFolder) {
+        removeConfiguredSyncFolder();
+    }
+
+    qCDebug(lcEndToEndTestUtils) << "Creating temp end-to-end test folder.";
+    Q_ASSERT(_tempDir.isValid());
+    OCC::FileSystem::setFolderMinimumPermissions(_tempDir.path());
+    qCDebug(lcEndToEndTestUtils) << "Created temp end-to-end test folder at:" << _tempDir.path();
+
+    setupFolderMan();
+
+    OCC::FolderDefinition definition;
+    definition.localPath = _tempDir.path();
+    definition.targetPath = targetPath;
+    _syncFolder = _folderMan->addFolder(_accountState.data(), definition);
+
+    return _syncFolder;
+}
+
+void EndToEndTestHelper::removeConfiguredSyncFolder()
+{
+    if(!_syncFolder || !_folderMan) {
+        return;
+    }
+
+    QSignalSpy folderSyncFinished(_syncFolder, &OCC::Folder::syncFinished);
+    _folderMan->forceSyncForFolder(_syncFolder);
+    Q_ASSERT(folderSyncFinished.wait(3000));
+    _folderMan->unloadAndDeleteAllFolders();
+    _syncFolder = nullptr;
+}
+
+void EndToEndTestHelper::setupFolderMan()
+{
+    if(_folderMan) {
+        return;
+    }
+
+    auto folderMan = new OCC::FolderMan;
+    Q_ASSERT(folderMan);
+    folderMan->setSyncEnabled(true);
+    _folderMan.reset(folderMan);
+}

--- a/test/endtoendtestutils.h
+++ b/test/endtoendtestutils.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QTemporaryDir>
+
+#include "gui/accountstate.h"
+#include "gui/folderman.h"
+#include "libsync/account.h"
+
+constexpr auto testUsername = "test";
+constexpr auto testPassword = "test";
+
+class QNetworkReply;
+
+namespace OCC
+{
+class Folder;
+class FolderMan;
+}
+
+class EndToEndTestCredentials : public OCC::AbstractCredentials
+{
+    Q_OBJECT
+
+public:
+    explicit EndToEndTestCredentials()
+        : OCC::AbstractCredentials()
+        , _user(testUsername)
+        , _password(testPassword)
+    {
+        _wasFetched = true;
+    };
+
+    [[nodiscard]] QString authType() const override { return QStringLiteral("http"); }
+    [[nodiscard]] QString user() const override { return _user; }
+    [[nodiscard]] QString password() const override { return _password; }
+    [[nodiscard]] bool ready() const override { return true; }
+    bool stillValid(QNetworkReply *) override { return true; }
+    void askFromUser() override {};
+    void fetchFromKeychain() override { _wasFetched = true; Q_EMIT fetched(); };
+    void persist() override {};
+    void invalidateToken() override {};
+    void forgetSensitiveData() override {};
+
+    [[nodiscard]] QNetworkAccessManager *createQNAM() const override;
+
+private:
+    QString _user;
+    QString _password;
+};
+
+class EndToEndTestHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    EndToEndTestHelper() = default;
+    ~EndToEndTestHelper() override;
+
+    [[nodiscard]] OCC::AccountPtr account() const { return _account; }
+    [[nodiscard]] OCC::AccountStatePtr accountState() const { return _accountState; }
+
+    OCC::Folder *configureSyncFolder(const QString &targetPath = QStringLiteral(""));
+
+signals:
+    void accountReady(const OCC::AccountPtr &account);
+
+public slots:
+    void startAccountConfig();
+    void removeConfiguredAccount();
+    void removeConfiguredSyncFolder();
+
+private slots:
+    void slotConnectToNCUrl(const QString &url);
+    void setupFolderMan();
+
+private:
+    OCC::AccountPtr _account;
+    OCC::AccountStatePtr _accountState;
+    QScopedPointer<OCC::FolderMan> _folderMan;
+    QTemporaryDir _tempDir;
+
+    OCC::Folder* _syncFolder = nullptr;
+};

--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -1,5 +1,42 @@
 find_package(Qt5 COMPONENTS Core Test Xml Network Qml Quick REQUIRED)
 
+macro(nextcloud_build_test test_class)
+    set(CMAKE_AUTOMOC TRUE)
+    set(OWNCLOUD_TEST_CLASS ${test_class})
+    string(TOLOWER "${OWNCLOUD_TEST_CLASS}" OWNCLOUD_TEST_CLASS_LOWERCASE)
+
+    add_executable(${OWNCLOUD_TEST_CLASS}Test test${OWNCLOUD_TEST_CLASS_LOWERCASE}.cpp)
+    set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY})
+
+    target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE
+      Nextcloud::sync
+      testutils
+      nextcloudCore
+      cmdCore
+      Qt5::Test
+      Qt5::Quick
+    )
+
+    if (WIN32)
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE nextcloudsync_vfs_cfapi)
+    elseif (LINUX)
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE nextcloudsync_vfs_xattr)
+    endif()
+
+    IF(BUILD_UPDATER)
+        target_link_libraries(${OWNCLOUD_TEST_CLASS}Test PRIVATE updater)
+    endif()
+
+    add_definitions(-DOWNCLOUD_TEST)
+    add_definitions(-DOWNCLOUD_BIN_PATH="${CMAKE_BINARY_DIR}/bin")
+
+    target_include_directories(${OWNCLOUD_TEST_CLASS}Test PRIVATE
+        "${CMAKE_SOURCE_DIR}/test/"
+        ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer
+    )
+    set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES FOLDER Tests)
+endmacro()
+
 macro(nextcloud_add_test test_class)
     set(CMAKE_AUTOMOC TRUE)
     set(OWNCLOUD_TEST_CLASS ${test_class})

--- a/test/teste2efiletransfer.cpp
+++ b/test/teste2efiletransfer.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include <QObject>
+#include <QTest>
+#include <QSignalSpy>
+
+#include "gui/accountstate.h"
+#include "gui/folderman.h"
+#include "common/utility.h"
+
+#include "endtoendtestutils.h"
+
+class E2eFileTransferTest : public QObject
+{
+    Q_OBJECT
+
+public:
+    E2eFileTransferTest() = default;
+
+private:
+    EndToEndTestHelper _helper;
+    OCC::Folder *_testFolder;
+
+private slots:
+    void initTestCase()
+    {
+        QSignalSpy accountReady(&_helper, &EndToEndTestHelper::accountReady);
+        _helper.startAccountConfig();
+        QVERIFY(accountReady.wait(3000));
+
+        const auto accountState = _helper.accountState();
+        QSignalSpy accountConnected(accountState.data(), &OCC::AccountState::isConnectedChanged);
+        QVERIFY(accountConnected.wait(30000));
+
+        _testFolder = _helper.configureSyncFolder();
+        QVERIFY(_testFolder);
+    }
+
+    void testSyncFolder()
+    {
+        // Try the down-sync first
+        QSignalSpy folderSyncFinished(_testFolder, &OCC::Folder::syncFinished);
+        OCC::FolderMan::instance()->forceSyncForFolder(_testFolder);
+        QVERIFY(folderSyncFinished.wait(3000));
+
+        const auto testFolderPath = _testFolder->path();
+        const QString expectedFilePath(testFolderPath + QStringLiteral("welcome.txt"));
+        const QFile expectedFile(expectedFilePath);
+        qDebug() << "Checking if expected file exists at:" << expectedFilePath;
+        QVERIFY(expectedFile.exists());
+
+        // Now write a file to test the upload
+        const auto fileName = QStringLiteral("test_file.txt");
+        const QString localFilePath(_testFolder->path() + fileName);
+        QVERIFY(OCC::Utility::writeRandomFile(localFilePath));
+
+        OCC::FolderMan::instance()->forceSyncForFolder(_testFolder);
+        QVERIFY(folderSyncFinished.wait(3000));
+        qDebug() << "First folder sync complete";
+
+        const auto waitForServerToProcessTime = QTime::currentTime().addSecs(3);
+        while (QTime::currentTime() < waitForServerToProcessTime) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        }
+
+        // Do a propfind to check for this file
+        const QString remoteFilePath(_testFolder->remotePathTrailingSlash() + fileName);
+        auto checkFileExistsJob = new OCC::PropfindJob(_helper.account(), remoteFilePath, this);
+        QSignalSpy result(checkFileExistsJob, &OCC::PropfindJob::result);
+
+        checkFileExistsJob->setProperties(QList<QByteArray>() << "getlastmodified");
+        checkFileExistsJob->start();
+        QVERIFY(result.wait(10000));
+
+        // Now try to delete the file and check change is reflected
+        QFile createdFile(localFilePath);
+        QVERIFY(createdFile.exists());
+        createdFile.remove();
+
+        OCC::FolderMan::instance()->forceSyncForFolder(_testFolder);
+        QVERIFY(folderSyncFinished.wait(3000));
+
+        while (QTime::currentTime() < waitForServerToProcessTime) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        }
+
+        auto checkFileDeletedJob = new OCC::PropfindJob(_helper.account(), remoteFilePath, this);
+        QSignalSpy error(checkFileDeletedJob, &OCC::PropfindJob::finishedWithError);
+
+        checkFileDeletedJob->setProperties(QList<QByteArray>() << "getlastmodified");
+        checkFileDeletedJob->start();
+
+        QVERIFY(error.wait(10000));
+    }
+};
+
+QTEST_MAIN(E2eFileTransferTest)
+#include "teste2efiletransfer.moc"

--- a/test/teste2eserversetup.cpp
+++ b/test/teste2eserversetup.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include <QObject>
+#include <QTest>
+#include <QSignalSpy>
+
+#include "gui/accountstate.h"
+
+#include "endtoendtestutils.h"
+
+class E2eServerSetupTest : public QObject
+{
+    Q_OBJECT
+
+public:
+    E2eServerSetupTest() = default;
+
+private:
+    EndToEndTestHelper _helper;
+
+private slots:
+    void initTestCase()
+    {
+        QSignalSpy accountReady(&_helper, &EndToEndTestHelper::accountReady);
+        _helper.startAccountConfig();
+        QVERIFY(accountReady.wait(3000));
+
+        const auto accountState = _helper.accountState();
+        QSignalSpy accountConnected(accountState.data(), &OCC::AccountState::isConnectedChanged);
+        QVERIFY(accountConnected.wait(30000));
+    }
+
+    void testBasicPropfind()
+    {
+        const auto account = _helper.account();
+        auto job = new OCC::PropfindJob(account, "/", this);
+        QSignalSpy result(job, &OCC::PropfindJob::result);
+
+        job->setProperties(QList<QByteArray>() << "getlastmodified");
+        job->start();
+
+        QVERIFY(result.wait(10000));
+    }
+};
+
+QTEST_MAIN(E2eServerSetupTest)
+#include "teste2eserversetup.moc"


### PR DESCRIPTION
Fix #4234

This PR adds end-to-end testing to our CI.

Specifically, it:

1. Adds and sets up a real server to our Drone pipeline
2. Adds a end to end testing utilities class that makes it easier to test with the server set up in the CI
3. Adds a test checking the correct set-up of an account
4. Adds a test checking file transfer (down-syncing an existing file, creating and uploading a new file, and deleting said created file)

Addresses #4234

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
