### PR TITLE
Ensure 'Sync now' button doesn't have its text elided

### DIFF
--- a/src/gui/tray/ActivityActionButton.qml
+++ b/src/gui/tray/ActivityActionButton.qml
@@ -71,7 +71,7 @@ AbstractButton {
             text: root.text
             textColor: root.textColor
             textColorHovered: root.textColorHovered
-            bold: root.primaryButton
+            font.bold: root.primaryButton
         }
     }
 }

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -220,7 +220,7 @@ Window {
 
                         visible: isAnswerCallButton
                         text: modelData.label
-                        bold: true
+                        contentsFont.bold: true
                         bgColor: Style.ncBlue
                         bgNormalOpacity: 0.8
 
@@ -247,7 +247,7 @@ Window {
                 CustomButton {
                     id: declineCall
                     text: qsTr("Decline")
-                    bold: true
+                    contentsFont.bold: true
                     bgColor: Style.errorBoxBackgroundColor
                     bgNormalOpacity: 0.8
 

--- a/src/gui/tray/CustomButton.qml
+++ b/src/gui/tray/CustomButton.qml
@@ -15,10 +15,9 @@ Button {
     property color textColor: Style.ncTextColor
     property color textColorHovered: textColor
 
+    property alias contentsFont: contents.font
+
     property alias bgColor: bgRectangle.color
-
-    property bool bold: false
-
     property alias bgNormalOpacity: bgRectangle.normalOpacity
     property alias bgHoverOpacity: bgRectangle.hoverOpacity
 
@@ -37,12 +36,12 @@ Button {
     }
 
     contentItem: NCButtonContents {
+        id: contents
         hovered: root.hovered
         imageSourceHover: root.imageSourceHover
         imageSource: root.imageSource
         text: root.text
         textColor: root.textColor
         textColorHovered: root.textColorHovered
-        bold: root.bold
     }
 }

--- a/src/gui/tray/NCButtonContents.qml
+++ b/src/gui/tray/NCButtonContents.qml
@@ -28,7 +28,7 @@ RowLayout {
 
     property color textColor: Style.ncTextColor
     property color textColorHovered: textColor
-    property bool bold: false
+    property alias font: buttonLabel.font
 
     Image {
         id: icon
@@ -40,6 +40,8 @@ RowLayout {
     }
 
     Label {
+        id: buttonLabel
+
         Layout.maximumWidth: icon.width > 0 ? parent.width - icon.width - parent.spacing : parent.width
         Layout.fillWidth: icon.status !== Image.Ready
 

--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -102,18 +102,19 @@ RowLayout {
     CustomButton {
         FontMetrics {
             id: syncNowFm
-            font.bold: true
+            font: parent.contentsFont
         }
 
-        Layout.preferredWidth: syncNowFm.boundingRect(text).width + leftPadding + rightPadding
+        Layout.preferredWidth: syncNowFm.boundingRect(text).width +
+                               leftPadding +
+                               rightPadding +
+                               Style.standardSpacing * 2
         Layout.rightMargin: Style.trayHorizontalMargin
-
-        FontMetrics { font.bold: true }
 
         text: qsTr("Sync now")
         textColor: Style.adjustedCurrentUserHeaderColor
         textColorHovered: Style.currentUserHeaderTextColor
-        bold: true
+        contentsFont.bold: true
         bgColor: Style.currentUserHeaderColor
 
         visible: !syncStatus.syncing &&


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
