### PR TITLE
Add an internal link share to the share dialog

### DIFF
--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -53,6 +53,7 @@ GridLayout {
 
     readonly property bool isLinkShare: model.shareType === ShareModel.ShareTypeLink
     readonly property bool isPlaceholderLinkShare: model.shareType === ShareModel.ShareTypePlaceholderLink
+    readonly property bool isInternalLinkShare: model.shareType === ShareModel.ShareTypeInternalLink
 
     readonly property string text: model.display ?? ""
     readonly property string detailText: model.detailText ?? ""
@@ -183,7 +184,7 @@ GridLayout {
             icon.width: 16
             icon.height: 16
 
-            visible: root.isLinkShare
+            visible: root.isLinkShare || root.isInternalLinkShare
             enabled: visible
 
             onClicked: {
@@ -210,7 +211,7 @@ GridLayout {
 
             imageSource: "image://svgimage-custom-color/more.svg/" + Style.ncTextColor
 
-            visible: !root.isPlaceholderLinkShare
+            visible: !root.isPlaceholderLinkShare && !root.isInternalLinkShare
             enabled: visible
 
             onClicked: root.rootStackView.push(shareDetailsPageComponent, {}, StackView.PushTransition)

--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -59,6 +59,7 @@ GridLayout {
     readonly property string detailText: model.detailText ?? ""
     readonly property string iconUrl: model.iconUrl ?? ""
     readonly property string avatarUrl: model.avatarUrl ?? ""
+    readonly property string link: model.link ?? ""
 
     anchors.left: parent.left
     anchors.right: parent.right

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -72,7 +72,6 @@ Page {
     readonly property bool passwordEnforced: shareModelData.passwordEnforced
 
     readonly property bool isLinkShare: shareModelData.shareType === ShareModel.ShareTypeLink
-    readonly property bool isPlaceholderLinkShare: shareModelData.shareType === ShareModel.ShareTypePlaceholderLink
 
     property bool waitingForEditingAllowedChange: false
     property bool waitingForNoteEnabledChange: false

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -130,11 +130,8 @@ QVariant ShareModel::data(const QModelIndex &index, const int role) const
             return startOfExpireDayUTC.toMSecsSinceEpoch();
         }
         }
-    } else if (share->getShareType() == Share::TypeInternalLink) {
-        switch(role) {
-        case LinkRole:
-            return _privateLinkUrl;
-        }
+    } else if (share->getShareType() == Share::TypeInternalLink && role == LinkRole) {
+        return _privateLinkUrl;
     }
 
     switch(role) {

--- a/src/gui/filedetails/sharemodel.h
+++ b/src/gui/filedetails/sharemodel.h
@@ -74,6 +74,7 @@ public:
         ShareTypeCircle = Share::TypeCircle,
         ShareTypeRoom = Share::TypeRoom,
         ShareTypePlaceholderLink = Share::TypePlaceholderLink,
+        ShareTypeInternalLink = Share::TypeInternalLink,
     };
     Q_ENUM(ShareType);
 
@@ -109,6 +110,7 @@ signals:
     void fetchOngoingChanged();
     void hasInitialShareFetchCompletedChanged();
     void shareesChanged();
+    void internalLinkReady();
 
     void serverError(const int code, const QString &message);
     void passwordSetError(const QString &shareId, const int code, const QString &message);
@@ -157,6 +159,7 @@ private slots:
     void updateData();
     void initShareManager();
     void handlePlaceholderLinkShare();
+    void setupInternalLinkShare();
 
     void slotPropfindReceived(const QVariantMap &result);
     void slotServerError(const int code, const QString &message);
@@ -183,6 +186,7 @@ private:
     bool _fetchOngoing = false;
     bool _hasInitialShareFetchCompleted = false;
     SharePtr _placeholderLinkShare;
+    SharePtr _internalLinkShare;
 
     // DO NOT USE QSHAREDPOINTERS HERE.
     // QSharedPointers MUST NOT be used with pointers already assigned to other shared pointers.

--- a/src/gui/filedetails/sortedsharemodel.cpp
+++ b/src/gui/filedetails/sortedsharemodel.cpp
@@ -73,11 +73,22 @@ bool SortedShareModel::lessThan(const QModelIndex &sourceLeft, const QModelIndex
     const auto leftShareType = leftShare->getShareType();
 
     // Placeholder link shares always go at top
-    if(leftShareType == Share::TypePlaceholderLink) {
+    if (leftShareType == Share::TypePlaceholderLink) {
         return true;
+    } else if (leftShareType == Share::TypeInternalLink) {
+        // Internal links always at bottom
+        return false;
     }
 
     const auto rightShareType = rightShare->getShareType();
+
+    // Placeholder link shares always go at top
+    if (rightShareType == Share::TypePlaceholderLink) {
+        return false;
+    } else if (rightShareType == Share::TypeInternalLink) {
+        // Internal links always at bottom
+        return true;
+    }
 
     // We want to place link shares at the top
     if (leftShareType == Share::TypeLink && rightShareType != Share::TypeLink) {

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -52,6 +52,7 @@ public:
      * Need to be in sync with Sharee::Type
      */
     enum ShareType {
+        TypeInternalLink = -2,
         TypePlaceholderLink = -1,
         TypeUser = Sharee::User,
         TypeGroup = Sharee::Group,

--- a/test/sharetestutils.cpp
+++ b/test/sharetestutils.cpp
@@ -143,7 +143,9 @@ void ShareTestHelper::setup()
 
     const auto folderMan = FolderMan::instance();
     QCOMPARE(folderMan, &fm);
-    QVERIFY(folderMan->addFolder(accountState.data(), folderDefinition(fakeFolder.localPath())));
+    auto folderDef = folderDefinition(fakeFolder.localPath());
+    folderDef.targetPath = QString();
+    QVERIFY(folderMan->addFolder(accountState.data(), folderDef));
     const auto folder = FolderMan::instance()->folder(fakeFolder.localPath());
     QVERIFY(folder);
     QVERIFY(fakeFolder.syncOnce());


### PR DESCRIPTION
Re-implements a feature that we previously had in the QWidgets version

![Screenshot 2022-11-04 at 20 00 24](https://user-images.githubusercontent.com/70155116/200054623-bb0b4b75-cb4b-48bd-b124-df5951ef608e.png)

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
