### PR TITLE
Fix share delegate button icon colors in dark mode

### DIFF
--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -256,7 +256,7 @@ GridLayout {
             bgColor: Style.lightHover
             bgNormalOpacity: 0
 
-            imageSource: "qrc:///client/theme/add.svg"
+            imageSource: "image://svgimage-custom-color/add.svg/" + Style.ncTextColor
 
             visible: root.isPlaceholderLinkShare && root.canCreateLinkShares
             enabled: visible
@@ -276,7 +276,7 @@ GridLayout {
             bgColor: Style.lightHover
             bgNormalOpacity: 0
 
-            imageSource: "qrc:///client/theme/copy.svg"
+            imageSource: "image://svgimage-custom-color/copy.svg/" + Style.ncTextColor
             icon.width: 16
             icon.height: 16
 
@@ -305,7 +305,7 @@ GridLayout {
             bgColor: Style.lightHover
             bgNormalOpacity: 0
 
-            imageSource: "qrc:///client/theme/more.svg"
+            imageSource: "image://svgimage-custom-color/more.svg/" + Style.ncTextColor
 
             visible: !root.isPlaceholderLinkShare
             enabled: visible


### PR DESCRIPTION
With fix:

![Screenshot 2022-11-04 at 20 05 19](https://user-images.githubusercontent.com/70155116/200055704-4c95e51c-e007-4a1d-be64-63714a32bb9c.png)

Master:

![Screenshot 2022-11-04 at 20 06 31](https://user-images.githubusercontent.com/70155116/200055685-d29f4eef-b08e-4591-b9a7-4a84f19855c9.png)


Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
