### PR TITLE
Add interactive NC Talk notifications on macOS

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -486,6 +486,18 @@ void Systray::showUpdateMessage(const QString &title, const QString &message, co
 #endif
 }
 
+void Systray::showTalkMessage(const QString &title, const QString &message, const QString &token, const QString &replyTo, const AccountStatePtr &accountState)
+{
+#if defined(Q_OS_MACOS) && defined(BUILD_OWNCLOUD_OSX_BUNDLE)
+    sendOsXTalkNotification(title, message, token, replyTo, accountState);
+#else // TODO: Implement custom notifications (i.e. actionable) for other OSes
+    Q_UNUSED(replyTo);
+    Q_UNUSED(token);
+    Q_UNUSED(accountState);
+    showMessage(title, message);
+#endif
+}
+
 void Systray::setToolTip(const QString &tip)
 {
     QSystemTrayIcon::setToolTip(tr("%1: %2").arg(Theme::instance()->appNameGUI(), tip));

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -491,9 +491,9 @@ void Systray::showTalkMessage(const QString &title, const QString &message, cons
 #if defined(Q_OS_MACOS) && defined(BUILD_OWNCLOUD_OSX_BUNDLE)
     sendOsXTalkNotification(title, message, token, replyTo, accountState);
 #else // TODO: Implement custom notifications (i.e. actionable) for other OSes
-    Q_UNUSED(replyTo);
-    Q_UNUSED(token);
-    Q_UNUSED(accountState);
+    Q_UNUSED(replyTo)
+    Q_UNUSED(token)
+    Q_UNUSED(accountState)
     showMessage(title, message);
 #endif
 }

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -51,6 +51,7 @@ void registerNotificationCategories(const QString &localizedDownloadString);
 bool canOsXSendUserNotification();
 void sendOsXUserNotification(const QString &title, const QString &message);
 void sendOsXUpdateNotification(const QString &title, const QString &message, const QUrl &webUrl);
+void sendOsXTalkNotification(const QString &title, const QString &message, const QString &token, const QString &replyTo, const AccountStatePtr accountState);
 void setTrayWindowLevelAndVisibleOnAllSpaces(QWindow *window);
 double menuBarThickness();
 #endif
@@ -113,6 +114,7 @@ public slots:
 
     void showMessage(const QString &title, const QString &message, QSystemTrayIcon::MessageIcon icon = Information);
     void showUpdateMessage(const QString &title, const QString &message, const QUrl &webUrl);
+    void showTalkMessage(const QString &title, const QString &message, const QString &replyTo, const QString &token, const AccountStatePtr &accountState);
     void setToolTip(const QString &tip);
 
     void createCallDialog(const OCC::Activity &callNotification, const OCC::AccountStatePtr accountState);

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -110,22 +110,29 @@ public slots:
     void slotSendReplyMessage(const int activityIndex, const QString &conversationToken, const QString &message, const QString &replyTo);
     void forceSyncNow() const;
 
-private:
+private slots:
     void slotPushNotificationsReady();
     void slotDisconnectPushNotifications();
     void slotReceivedPushNotification(Account *account);
     void slotReceivedPushActivity(Account *account);
     void slotCheckExpiredActivities();
 
+    void checkNotifiedNotifications();
+    void showDesktopNotification(const QString &title, const QString &message, const long notificationId);
+    void showDesktopNotification(const Activity &activity);
+    void showDesktopNotification(const ActivityList &activityList);
+    void showDesktopTalkNotification(const Activity &activity);
+
+private:
     void connectPushNotifications() const;
     [[nodiscard]] bool checkPushNotificationsAreReady() const;
 
     bool isActivityOfCurrentAccount(const Folder *folder) const;
     [[nodiscard]] bool isUnsolvableConflict(const SyncFileItemPtr &item) const;
 
-    void showDesktopNotification(const QString &title, const QString &message, const long notificationId);
+    bool notificationAlreadyShown(const long notificationId);
+    bool canShowNotification(const long notificationId);
 
-private:
     AccountStatePtr _account;
     bool _isCurrentUser;
     ActivityListModel *_activityModel;


### PR DESCRIPTION
This PR makes the client differentiate between normal notifications and Talk notifications, emitting reply-able notifications for Talk on macOS

https://user-images.githubusercontent.com/70155116/200644355-8232b10f-7bfc-4f98-9f6c-a50b0c498d86.mov

Closes #4851

Interested parties: @jospoortvliet :)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
