### PR TITLE
Ensure forcing a folder to be synced unpauses syncing on said folder

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -616,6 +616,8 @@ void FolderMan::forceSyncForFolder(Folder *folder)
     }
 
     folder->slotWipeErrorBlacklist(); // issue #6757
+    folder->setSyncPaused(false);
+
     // Insert the selected folder at the front of the queue
     scheduleFolderNext(folder);
 }


### PR DESCRIPTION
This fixes the behaviour of the "Sync now" button when a folder has its syncing paused



https://user-images.githubusercontent.com/70155116/200875644-e2d30871-e3dd-458e-abbe-5226e8e5340a.mov




Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
