### PR TITLE
Resize WebView widget once the loginpage rendered

### DIFF
--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -111,10 +111,28 @@ WebView::WebView(QWidget *parent)
 
     connect(_webview, &QWebEngineView::loadProgress, _ui.progressBar, &QProgressBar::setValue);
     connect(_schemeHandler, &WebViewPageUrlSchemeHandler::urlCatched, this, &WebView::urlCatched);
+
+    connect(_page, &QWebEnginePage::contentsSizeChanged, this, &WebView::slotResizeToContents);
 }
 
 void WebView::setUrl(const QUrl &url) {
     _page->setUrl(url);
+}
+
+QSize WebView::minimumSizeHint() const {
+    return _size;
+}
+
+void WebView::slotResizeToContents(const QSizeF &size){
+    //this widget also holds the progressbar
+    const int newHeight = size.toSize().height() + _ui.progressBar->height();
+    const int newWidth = size.toSize().width();
+    _size = QSize(newWidth, newHeight);
+
+    this->updateGeometry();
+
+    //only resize once
+    disconnect(_page, &QWebEnginePage::contentsSizeChanged, this, &WebView::slotResizeToContents);
 }
 
 WebView::~WebView() {

--- a/src/gui/wizard/webview.h
+++ b/src/gui/wizard/webview.h
@@ -23,12 +23,18 @@ public:
     WebView(QWidget *parent = nullptr);
     ~WebView() override;
     void setUrl(const QUrl &url);
+    virtual QSize minimumSizeHint() const override;
 
 signals:
     void urlCatched(const QString user, const QString pass, const QString host);
 
+private slots:
+    void slotResizeToContents(const QSizeF &size);
+
 private:
     Ui_WebView _ui;
+
+    QSize _size;
 
     QWebEngineView *_webview;
     QWebEngineProfile *_profile;


### PR DESCRIPTION
When the login dialogue displays the login page itself the WebView widget did not resize according to
the dimensions of the login page.

Fixes #5160