### PR TITLE
Remove close/dismiss button from encryption message

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -228,6 +228,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 
     // Connect E2E stuff
     initializeE2eEncryption();
+    _ui->encryptionMessage->setCloseButtonVisible(false);
 
     _ui->connectLabel->setText(tr("No account configured."));
 


### PR DESCRIPTION

![Screenshot 2022-11-10 at 17 08 06](https://user-images.githubusercontent.com/70155116/201147191-08a7fb34-8ed8-4cb2-9466-99857f43d8bc.png)

Part of #5126

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
