### PR TITLE
Don't fail download if check for file encrypted metadata fails

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -476,9 +476,13 @@ void PropagateDownloadFile::start()
           _isEncrypted = true;
           startAfterIsEncryptedIsChecked();
         });
+        connect(_downloadEncryptedHelper, &PropagateDownloadEncrypted::fileMetadataNotFound, [this, path] {
+            qCWarning(lcPropagateDownload) << "File encryption metadata not found for" << path;
+            startAfterIsEncryptedIsChecked();
+        });
         connect(_downloadEncryptedHelper, &PropagateDownloadEncrypted::failed, [this] {
-          done(SyncFileItem::NormalError,
-               tr("File %1 cannot be downloaded because encryption information is missing.").arg(QDir::toNativeSeparators(_item->_file)));
+                   done(SyncFileItem::NormalError,
+                        tr("File %1 cannot be downloaded because encryption information is missing.").arg(QDir::toNativeSeparators(_item->_file)));
         });
         _downloadEncryptedHelper->start();
     }

--- a/src/libsync/propagatedownloadencrypted.cpp
+++ b/src/libsync/propagatedownloadencrypted.cpp
@@ -62,33 +62,44 @@ void PropagateDownloadEncrypted::checkFolderId(const QStringList &list)
   metadataJob->start();
 }
 
-void PropagateDownloadEncrypted::folderEncryptedMetadataError(const QByteArray & /*fileId*/, int /*httpReturnCode*/)
+void PropagateDownloadEncrypted::folderEncryptedMetadataError(const QByteArray &fileId, const int httpReturnCode)
 {
-    qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << _info.fileName();
+    Q_UNUSED(fileId)
+
+    if (httpReturnCode == 404) {
+        qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file"
+                                                 << _info.fileName();
+        emit fileMetadataNotFound();
+        return;
+    }
+
+    qCCritical(lcPropagateDownloadEncrypted) << "Unknown error occurred fetching metadata information of remote file"
+                                             << _info.fileName()
+                                             << httpReturnCode;
     emit failed();
 }
 
 void PropagateDownloadEncrypted::checkFolderEncryptedMetadata(const QJsonDocument &json)
 {
-  qCDebug(lcPropagateDownloadEncrypted) << "Metadata Received reading"
-                                        << _item->_instruction << _item->_file << _item->_encryptedFileName;
-  const QString filename = _info.fileName();
-  auto meta = new FolderMetadata(_propagator->account(), json.toJson(QJsonDocument::Compact));
-  const QVector<EncryptedFile> files = meta->files();
+    qCDebug(lcPropagateDownloadEncrypted) << "Metadata Received reading"
+                                          << _item->_instruction << _item->_file << _item->_encryptedFileName;
+    const QString filename = _info.fileName();
+    auto meta = new FolderMetadata(_propagator->account(), json.toJson(QJsonDocument::Compact));
+    const QVector<EncryptedFile> files = meta->files();
 
-  const QString encryptedFilename = _item->_encryptedFileName.section(QLatin1Char('/'), -1);
-  for (const EncryptedFile &file : files) {
-    if (encryptedFilename == file.encryptedFilename) {
-      _encryptedInfo = file;
+    const QString encryptedFilename = _item->_encryptedFileName.section(QLatin1Char('/'), -1);
+    for (const EncryptedFile &file : files) {
+        if (encryptedFilename == file.encryptedFilename) {
+            _encryptedInfo = file;
 
-      qCDebug(lcPropagateDownloadEncrypted) << "Found matching encrypted metadata for file, starting download";
-      emit fileMetadataFound();
-      return;
+            qCDebug(lcPropagateDownloadEncrypted) << "Found matching encrypted metadata for file, starting download";
+            emit fileMetadataFound();
+            return;
+        }
     }
-  }
 
-  emit failed();
-  qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << filename;
+    qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << filename;
+    emit fileMetadataNotFound();
 }
 
 // TODO: Fix this. Exported in the wrong place.

--- a/src/libsync/propagatedownloadencrypted.h
+++ b/src/libsync/propagatedownloadencrypted.h
@@ -24,10 +24,11 @@ public slots:
   void checkFolderId(const QStringList &list);
   void checkFolderEncryptedMetadata(const QJsonDocument &json);
   void folderIdError();
-  void folderEncryptedMetadataError(const QByteArray &fileId, int httpReturnCode);
+  void folderEncryptedMetadataError(const QByteArray &fileId, const int httpReturnCode);
 
 signals:
   void fileMetadataFound();
+  void fileMetadataNotFound();
   void failed();
 
   void decryptionFinished();


### PR DESCRIPTION
It is unclear if this is intended behaviour or a bug in the server, but technically the server allows for unencrypted files to live inside E2EE folders. Forcing a fail of the sync in this situation is unnecessary as the server accepts this as normal and working fine, causing the sync to stop when nothing is (technically) wrong

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
