### PR TITLE
Fix ActivityList delegate warnings

### DIFF
--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -58,8 +58,8 @@ ScrollView {
         }
 
         delegate: ActivityItem {
-            anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.left: if (parent) parent.left
+            anchors.right: if (parent) parent.right
             anchors.leftMargin: controlRoot.delegateHorizontalPadding
             anchors.rightMargin: controlRoot.delegateHorizontalPadding
 


### PR DESCRIPTION
Whether we use anchors or width to set the ActivityList delegates, we consistently get issues accessing the parent, polluting the logs

This PR addresses this by only setting the delegate anchors if parent is available

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
