### PR TITLE
Remove reference to inexistent property in NCCustomButton

### DIFF
--- a/src/gui/tray/NCButtonContents.qml
+++ b/src/gui/tray/NCButtonContents.qml
@@ -47,7 +47,6 @@ RowLayout {
 
         text: root.text
         textFormat: Text.PlainText
-        font.bold: root.bold
 
         visible: root.text !== ""
 


### PR DESCRIPTION
Fixes a number of warnings in logs

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
