### PR TITLE
Feature/edit file locally restart sync

### DIFF
--- a/src/gui/editlocallymanager.cpp
+++ b/src/gui/editlocallymanager.cpp
@@ -71,6 +71,9 @@ void EditLocallyManager::createJob(const QString &userId,
                                        const QString &relPath,
                                        const QString &token)
 {
+    if (_jobs.contains(token)) {
+        return;
+    }
     const EditLocallyJobPtr job(new EditLocallyJob(userId, relPath, token));
     // We need to make sure the job sticks around until it is finished
     _jobs.insert(token, job);

--- a/src/gui/editlocallymanager.h
+++ b/src/gui/editlocallymanager.h
@@ -28,8 +28,6 @@ class EditLocallyManager : public QObject
 public:
     [[nodiscard]] static EditLocallyManager *instance();
 
-    QHash<QString, QMetaObject::Connection> folderSyncFinishedConnections;
-
 public slots:
     void editLocally(const QUrl &url);
 

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -34,6 +34,7 @@ set(libsync_SRCS
     encryptfolderjob.cpp
     filesystem.h
     filesystem.cpp
+    helpers.cpp
     httplogger.h
     httplogger.cpp
     logger.h

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -64,7 +64,6 @@ constexpr int checksumRecalculateRequestServerVersionMinSupportedMajor = 24;
 }
 
 namespace OCC {
-
 Q_LOGGING_CATEGORY(lcAccount, "nextcloud.sync.account", QtInfoMsg)
 const char app_password[] = "_app-password";
 
@@ -155,6 +154,25 @@ QString Account::displayName() const
 {
     QString dn = QString("%1@%2").arg(credentials()->user(), _url.host());
     int port = url().port();
+    if (port > 0 && port != 80 && port != 443) {
+        dn.append(QLatin1Char(':'));
+        dn.append(QString::number(port));
+    }
+    return dn;
+}
+
+QString Account::userIdAtHostWithPort() const
+{
+    const auto credentialsUserSplit = credentials() ? credentials()->user().split(QLatin1Char('@')) : QStringList{};
+
+    if (credentialsUserSplit.isEmpty()) {
+        return {};
+    }
+
+    const auto userName = credentialsUserSplit.first();
+
+    QString dn = QStringLiteral("%1@%2").arg(userName, _url.host());
+    const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         dn.append(QLatin1Char(':'));
         dn.append(QString::number(port));

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -115,6 +115,9 @@ public:
     /// The name of the account as shown in the toolbar
     [[nodiscard]] QString displayName() const;
 
+    /// User id in a form 'user@example.de, optionally port is added (if it is not 80 or 443)
+    [[nodiscard]] QString userIdAtHostWithPort() const;
+
     /// The name of the account that is displayed as nicely as possible,
     /// e.g. the actual name of the user (John Doe). If this cannot be
     /// provided, defaults to davUser (e.g. johndoe)

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -49,8 +49,45 @@ class ProcessDirectoryJob : public QObject
 {
     Q_OBJECT
 
-    struct PathTuple;
 public:
+
+    /** Structure representing a path during discovery. A same path may have different value locally
+     * or on the server in case of renames.
+     *
+     * These strings never start or ends with slashes. They are all relative to the folder's root.
+     * Usually they are all the same and are even shared instance of the same QString.
+     *
+     * _server and _local paths will differ if there are renames, example:
+     *   remote renamed A/ to B/ and local renamed A/X to A/Y then
+     *     target:   B/Y/file
+     *     original: A/X/file
+     *     local:    A/Y/file
+     *     server:   B/X/file
+     */
+    struct PathTuple {
+        QString _original; // Path as in the DB (before the sync)
+        QString _target; // Path that will be the result after the sync (and will be in the DB)
+        QString _server; // Path on the server (before the sync)
+        QString _local; // Path locally (before the sync)
+        static QString pathAppend(const QString &base, const QString &name)
+        {
+            return base.isEmpty() ? name : base + QLatin1Char('/') + name;
+        }
+        [[nodiscard]] PathTuple addName(const QString &name) const
+        {
+            PathTuple result;
+            result._original = pathAppend(_original, name);
+            auto buildString = [&](const QString &other) {
+                // Optimize by trying to keep all string implicitly shared if they are the same (common case)
+                return other == _original ? result._original : pathAppend(other, name);
+            };
+            result._target = buildString(_target);
+            result._server = buildString(_server);
+            result._local = buildString(_local);
+            return result;
+        }
+    };
+
     enum QueryMode {
         NormalQuery,
         ParentDontExist, // Do not query this folder because it does not exist
@@ -70,6 +107,9 @@ public:
     explicit ProcessDirectoryJob(const PathTuple &path, const SyncFileItemPtr &dirItem,
         QueryMode queryLocal, QueryMode queryServer, qint64 lastSyncTimestamp,
         ProcessDirectoryJob *parent);
+
+    explicit ProcessDirectoryJob(DiscoveryPhase *data, PinState basePinState, const PathTuple &path, const SyncFileItemPtr &dirItem,
+        QueryMode queryLocal, qint64 lastSyncTimestamp, QObject *parent);
 
     void start();
     /** Start up to nbJobs, return the number of job started; emit finished() when done */
@@ -94,44 +134,6 @@ private:
         SyncJournalFileRecord dbEntry;
         RemoteInfo serverEntry;
         LocalInfo localEntry;
-    };
-
-    /** Structure representing a path during discovery. A same path may have different value locally
-     * or on the server in case of renames.
-     *
-     * These strings never start or ends with slashes. They are all relative to the folder's root.
-     * Usually they are all the same and are even shared instance of the same QString.
-     *
-     * _server and _local paths will differ if there are renames, example:
-     *   remote renamed A/ to B/ and local renamed A/X to A/Y then
-     *     target:   B/Y/file
-     *     original: A/X/file
-     *     local:    A/Y/file
-     *     server:   B/X/file
-     */
-    struct PathTuple
-    {
-        QString _original; // Path as in the DB (before the sync)
-        QString _target; // Path that will be the result after the sync (and will be in the DB)
-        QString _server; // Path on the server (before the sync)
-        QString _local; // Path locally (before the sync)
-        static QString pathAppend(const QString &base, const QString &name)
-        {
-            return base.isEmpty() ? name : base + QLatin1Char('/') + name;
-        }
-        [[nodiscard]] PathTuple addName(const QString &name) const
-        {
-            PathTuple result;
-            result._original = pathAppend(_original, name);
-            auto buildString = [&](const QString &other) {
-                // Optimize by trying to keep all string implicitly shared if they are the same (common case)
-                return other == _original ? result._original : pathAppend(other, name);
-            };
-            result._target = buildString(_target);
-            result._server = buildString(_server);
-            result._local = buildString(_local);
-            return result;
-        }
     };
 
     /** Iterate over entries inside the directory (non-recursively).

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -14,6 +14,7 @@
 
 #include "discoveryphase.h"
 #include "discovery.h"
+#include "helpers.h"
 
 #include "account.h"
 #include "clientsideencryptionjobs.h"

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -294,6 +294,8 @@ public:
     QHash<QString, long long> _filesNeedingScheduledSync;
     QVector<QString> _filesUnscheduleSync;
 
+    QStringList _listExclusiveFiles;
+
 signals:
     void fatalError(const QString &errorString);
     void itemDiscovered(const OCC::SyncFileItemPtr &item);

--- a/src/libsync/helpers.cpp
+++ b/src/libsync/helpers.cpp
@@ -1,0 +1,25 @@
+#include "helpers.h"
+
+namespace OCC
+{
+QByteArray parseEtag(const char *header)
+{
+    if (!header) {
+        return {};
+    }
+    QByteArray result = header;
+
+    // Weak E-Tags can appear when gzip compression is on, see #3946
+    if (result.startsWith("W/")) {
+        result = result.mid(2);
+    }
+
+    // https://github.com/owncloud/client/issues/1195
+    result.replace("-gzip", "");
+
+    if (result.length() >= 2 && result.startsWith('"') && result.endsWith('"')) {
+        result = result.mid(1, result.length() - 2);
+    }
+    return result;
+}
+} // namespace OCC

--- a/src/libsync/helpers.h
+++ b/src/libsync/helpers.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) by Oleksandr Zolotov <alex@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#pragma once
+
+#include "owncloudlib.h"
+#include <QByteArray>
+
+namespace OCC
+{
+/** Strips quotes and gzip annotations */
+OWNCLOUDSYNC_EXPORT QByteArray parseEtag(const char *header);
+
+} // namespace OCC

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -38,6 +38,7 @@
 
 #include "networkjobs.h"
 #include "account.h"
+#include "helpers.h"
 #include "owncloudpropagator.h"
 #include "clientsideencryption.h"
 
@@ -58,25 +59,6 @@ Q_LOGGING_CATEGORY(lcSimpleApiJob, "nextcloud.sync.networkjob.simpleapi", QtInfo
 Q_LOGGING_CATEGORY(lcDetermineAuthTypeJob, "nextcloud.sync.networkjob.determineauthtype", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcSimpleFileJob, "nextcloud.sync.networkjob.simplefilejob", QtInfoMsg)
 const int notModifiedStatusCode = 304;
-
-QByteArray parseEtag(const char *header)
-{
-    if (!header)
-        return QByteArray();
-    QByteArray arr = header;
-
-    // Weak E-Tags can appear when gzip compression is on, see #3946
-    if (arr.startsWith("W/"))
-        arr = arr.mid(2);
-
-    // https://github.com/owncloud/client/issues/1195
-    arr.replace("-gzip", "");
-
-    if (arr.length() >= 2 && arr.startsWith('"') && arr.endsWith('"')) {
-        arr = arr.mid(1, arr.length() - 2);
-    }
-    return arr;
-}
 
 RequestEtagJob::RequestEtagJob(AccountPtr account, const QString &path, QObject *parent)
     : AbstractNetworkJob(account, path, parent)

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -30,9 +30,6 @@ class QJsonObject;
 
 namespace OCC {
 
-/** Strips quotes and gzip annotations */
-OWNCLOUDSYNC_EXPORT QByteArray parseEtag(const char *header);
-
 struct HttpError
 {
     int code; // HTTP error code

--- a/src/libsync/owncloudpropagator_p.h
+++ b/src/libsync/owncloudpropagator_p.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "owncloudpropagator.h"
+#include "helpers.h"
 #include "syncfileitem.h"
 #include "networkjobs.h"
 #include "syncengine.h"

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -57,6 +57,12 @@ class OWNCLOUDSYNC_EXPORT SyncEngine : public QObject
 {
     Q_OBJECT
 public:
+    struct SingleItemDiscoveryOptions {
+        QString discoveryPath;
+        QString filePathRelative;
+        SyncFileItemPtr discoveryDirItem;
+    };
+
     SyncEngine(AccountPtr account,
                const QString &localPath,
                const SyncOptions &syncOptions,
@@ -143,6 +149,9 @@ public slots:
      */
     void setLocalDiscoveryOptions(OCC::LocalDiscoveryStyle style, std::set<QString> paths = {});
 
+    void setSingleItemDiscoveryOptions(const SingleItemDiscoveryOptions &singleItemDiscoveryOptions);
+    [[nodiscard]] const SyncEngine::SingleItemDiscoveryOptions &singleItemDiscoveryOptions() const;
+
     void addAcceptedInvalidFileName(const QString& filePath);
 
 signals:
@@ -156,6 +165,8 @@ signals:
     void itemCompleted(const OCC::SyncFileItemPtr &);
 
     void transmissionProgress(const OCC::ProgressInfo &progress);
+
+    void itemDiscovered(const SyncFileItemPtr &);
 
     /// We've produced a new sync error of a type.
     void syncError(const QString &message, OCC::ErrorCategory category = OCC::ErrorCategory::Normal);
@@ -375,6 +386,8 @@ private:
 
     // A vector of all the (unique) scheduled sync timers
     QVector<QSharedPointer<ScheduledSyncTimer>> _scheduledSyncTimers;
+
+    SingleItemDiscoveryOptions _singleItemDiscoveryOptions;
 };
 }
 

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -13,8 +13,10 @@
  */
 
 #include "syncfileitem.h"
+#include "common/checksums.h"
 #include "common/syncjournalfilerecord.h"
 #include "common/utility.h"
+#include "helpers.h"
 #include "filesystem.h"
 
 #include <QLoggingCategory>
@@ -95,6 +97,75 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
     item->_sharedByMe = rec._sharedByMe;
     item->_isShared = rec._isShared;
     item->_lastShareStateFetchedTimestamp = rec._lastShareStateFetchedTimestamp;
+    return item;
+}
+
+SyncFileItemPtr SyncFileItem::fromProperties(const QString &filePath, const QMap<QString, QString> &properties)
+{
+    SyncFileItemPtr item(new SyncFileItem);
+    item->_file = filePath;
+    item->_originalFile = filePath;
+
+    const auto isDirectory = properties.value(QStringLiteral("resourcetype")).contains(QStringLiteral("collection"));
+    item->_type = isDirectory ? ItemTypeDirectory : ItemTypeFile;
+
+    item->_size = isDirectory ? 0 : properties.value(QStringLiteral("size")).toInt();
+    item->_fileId = properties.value(QStringLiteral("id")).toUtf8();
+
+    if (properties.contains(QStringLiteral("permissions"))) {
+        item->_remotePerm = RemotePermissions::fromServerString(properties.value("permissions"));
+    }
+
+    if (!properties.value(QStringLiteral("share-types")).isEmpty()) {
+        item->_remotePerm.setPermission(RemotePermissions::IsShared);
+    }
+
+    item->_isShared = item->_remotePerm.hasPermission(RemotePermissions::IsShared);
+    item->_lastShareStateFetchedTimestamp = QDateTime::currentMSecsSinceEpoch();
+
+    item->_isEncrypted = properties.value(QStringLiteral("is-encrypted")) == QStringLiteral("1");
+    item->_locked =
+        properties.value(QStringLiteral("lock")) == QStringLiteral("1") ? SyncFileItem::LockStatus::LockedItem : SyncFileItem::LockStatus::UnlockedItem;
+    item->_lockOwnerDisplayName = properties.value(QStringLiteral("lock-owner-displayname"));
+    item->_lockOwnerId = properties.value(QStringLiteral("lock-owner"));
+    item->_lockEditorApp = properties.value(QStringLiteral("lock-owner-editor"));
+
+    {
+        auto ok = false;
+        const auto intConvertedValue = properties.value(QStringLiteral("lock-owner-type")).toULongLong(&ok);
+        item->_lockOwnerType = ok ? static_cast<SyncFileItem::LockOwnerType>(intConvertedValue) : SyncFileItem::LockOwnerType::UserLock;
+    }
+
+    {
+        auto ok = false;
+        const auto intConvertedValue = properties.value(QStringLiteral("lock-time")).toULongLong(&ok);
+        item->_lockTime = ok ? intConvertedValue : 0;
+    }
+
+    {
+        auto ok = false;
+        const auto intConvertedValue = properties.value(QStringLiteral("lock-timeout")).toULongLong(&ok);
+        item->_lockTimeout = ok ? intConvertedValue : 0;
+    }
+
+    const auto date = QDateTime::fromString(properties.value(QStringLiteral("getlastmodified")), Qt::RFC2822Date);
+    Q_ASSERT(date.isValid());
+    if (date.toSecsSinceEpoch() > 0) {
+        item->_modtime = date.toSecsSinceEpoch();
+    }
+
+    if (properties.contains(QStringLiteral("getetag"))) {
+        item->_etag = parseEtag(properties.value(QStringLiteral("getetag")).toUtf8());
+    }
+
+    if (properties.contains(QStringLiteral("checksums"))) {
+        item->_checksumHeader = findBestChecksum(properties.value("checksums").toUtf8());
+    }
+
+    // direction and instruction are decided later
+    item->_direction = SyncFileItem::None;
+    item->_instruction = CSYNC_INSTRUCTION_NONE;
+
     return item;
 }
 

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -124,6 +124,10 @@ public:
      */
     static SyncFileItemPtr fromSyncJournalFileRecord(const SyncJournalFileRecord &rec);
 
+    /** Creates a basic SyncFileItem from remote properties
+     */
+    [[nodiscard]] static SyncFileItemPtr fromProperties(const QString &filePath, const QMap<QString, QString> &properties);
+
 
     SyncFileItem()
         : _type(ItemTypeSkip)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
This will fix #5110

Changes:
- edit locally task is now put to the top priority and when it gets triggered, all other running syncs get aborted
- it is now possible to force sync only a specific file even if it was not yet synced but is not blacklisted