### PR TITLE
Differentiate between E2EE not being enabled at all vs. E2EE being enabled already through another device in account settings message

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1486,6 +1486,16 @@ void AccountSettings::initializeE2eEncryption()
 
         auto *const actionEnableE2e = addActionToEncryptionMessage(tr("Set up encryption"), e2EeUiActionEnableEncryptionId);
         connect(actionEnableE2e, &QAction::triggered, this, &AccountSettings::slotE2eEncryptionGenerateKeys);
+
+        connect(_accountState->account()->e2e(), &ClientSideEncryption::initializationFinished, this, [this] {
+            if (!_accountState->account()->e2e()->_publicKey.isNull()) {
+                _ui->encryptionMessage->setText(tr("End-to-End encryption has been enabled on this account with another device."
+                                                   "<br>"
+                                                   "It can be enabled on this device by entering your mnemonic."));
+            }
+        });
+        _accountState->account()->setE2eEncryptionKeysGenerationAllowed(false);
+        _accountState->account()->e2e()->initialize(_accountState->account());
     }
 }
 

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1489,7 +1489,7 @@ void AccountSettings::initializeE2eEncryption()
 
         connect(_accountState->account()->e2e(), &ClientSideEncryption::initializationFinished, this, [this] {
             if (!_accountState->account()->e2e()->_publicKey.isNull()) {
-                _ui->encryptionMessage->setText(tr("End-to-End encryption has been enabled on this account with another device."
+                _ui->encryptionMessage->setText(tr("End-to-end encryption has been enabled on this account with another device."
                                                    "<br>"
                                                    "It can be enabled on this device by entering your mnemonic."));
             }


### PR DESCRIPTION
Should clarify situation for users

![Screenshot 2022-11-15 at 15 30 33](https://user-images.githubusercontent.com/70155116/201945695-94f0345b-8201-4ede-b52a-410d120dca1c.png)

Part of #5126 

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
