### PR TITLE
Only show mnemonic request dialog when user explicitly wants to enable E2EE

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -258,6 +258,7 @@ void AccountSettings::slotE2eEncryptionGenerateKeys()
 {
     connect(_accountState->account()->e2e(), &ClientSideEncryption::initializationFinished, this, &AccountSettings::slotE2eEncryptionInitializationFinished);
     _accountState->account()->setE2eEncryptionKeysGenerationAllowed(true);
+    _accountState->account()->setAskUserForMnemonic(true);
     _accountState->account()->e2e()->initialize(_accountState->account());
 }
 
@@ -271,6 +272,7 @@ void AccountSettings::slotE2eEncryptionInitializationFinished(bool isNewMnemonic
             displayMnemonic(_accountState->account()->e2e()->_mnemonic);
         }
     }
+    _accountState->account()->setAskUserForMnemonic(false);
 }
 
 void AccountSettings::slotEncryptFolderFinished(int status)

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -966,4 +966,14 @@ void Account::setE2eEncryptionKeysGenerationAllowed(bool allowed)
     return _e2eEncryptionKeysGenerationAllowed;
 }
 
+bool Account::askUserForMnemonic() const
+{
+    return _e2eAskUserForMnemonic;
+}
+
+void Account::setAskUserForMnemonic(const bool ask)
+{
+    _e2eAskUserForMnemonic = ask;
+}
+
 } // namespace OCC

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -974,6 +974,7 @@ bool Account::askUserForMnemonic() const
 void Account::setAskUserForMnemonic(const bool ask)
 {
     _e2eAskUserForMnemonic = ask;
+    emit askUserForMnemonicChanged();
 }
 
 } // namespace OCC

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -86,6 +86,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
     Q_PROPERTY(QString prettyName READ prettyName NOTIFY prettyNameChanged)
     Q_PROPERTY(QUrl url MEMBER _url)
     Q_PROPERTY(bool e2eEncryptionKeysGenerationAllowed MEMBER _e2eEncryptionKeysGenerationAllowed)
+    Q_PROPERTY(bool askUserForMnemonic READ askUserForMnemonic WRITE setAskUserForMnemonic NOTIFY askUserForMnemonicChanged)
 
 public:
     static AccountPtr create();
@@ -343,6 +344,7 @@ signals:
     void accountChangedAvatar();
     void accountChangedDisplayName();
     void prettyNameChanged();
+    void askUserForMnemonicChanged();
 
     /// Used in RemoteWipe
     void appPasswordRetrieved(QString);

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -314,10 +314,13 @@ public:
     void setE2eEncryptionKeysGenerationAllowed(bool allowed);
     [[nodiscard]] bool e2eEncryptionKeysGenerationAllowed() const;
 
+    [[nodiscard]] bool askUserForMnemonic() const;
+
 public slots:
     /// Used when forgetting credentials
     void clearQNAMCache();
     void slotHandleSslErrors(QNetworkReply *, QList<QSslError>);
+    void setAskUserForMnemonic(const bool ask);
 
 signals:
     /// Emitted whenever there's network activity
@@ -370,6 +373,7 @@ private:
     bool _trustCertificates = false;
 
     bool _e2eEncryptionKeysGenerationAllowed = false;
+    bool _e2eAskUserForMnemonic = false;
 
     QWeakPointer<Account> _sharedThis;
     QString _id;

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1248,6 +1248,12 @@ void ClientSideEncryption::encryptPrivateKey(const AccountPtr &account)
 }
 
 void ClientSideEncryption::decryptPrivateKey(const AccountPtr &account, const QByteArray &key) {
+    if (!account->askUserForMnemonic()) {
+        qCDebug(lcCse) << "Not allowed to ask user for mnemonic";
+        emit initializationFinished();
+        return;
+    }
+
     QString msg = tr("Please enter your end-to-end encryption passphrase:<br>"
                      "<br>"
                      "Username: %2<br>"


### PR DESCRIPTION
This stops the user getting spammed with annoying pop-ups on launch asking for the mnemonic when they have no intention of enabling encryption on their current system/account

Closes #4778 

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
