### PR TITLE
Fix bad custom button alignments, sizings, etc.

### DIFF
--- a/src/gui/tray/ActivityActionButton.qml
+++ b/src/gui/tray/ActivityActionButton.qml
@@ -20,6 +20,8 @@ AbstractButton {
     property string verb: ""
     property bool isTalkReplyButton: false
 
+    leftPadding: root.text === "" ? Style.smallSpacing : Style.standardSpacing
+    rightPadding: root.text === "" ? Style.smallSpacing : Style.standardSpacing
 
     background: NCButtonBackground {
         color: Style.currentUserHeaderColor

--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -80,7 +80,7 @@ ItemDelegate {
 
             Layout.fillWidth: true
             Layout.leftMargin: Style.trayListItemIconSize + activityContent.spacing
-            Layout.minimumHeight: Style.minActivityHeight
+            Layout.preferredHeight: Style.standardPrimaryButtonHeight
 
             displayActions: model.displayActions
             objectType: model.objectType

--- a/src/gui/tray/CustomButton.qml
+++ b/src/gui/tray/CustomButton.qml
@@ -26,8 +26,8 @@ Button {
         hovered: root.hovered
     }
 
-    leftPadding: root.text === "" ? 5 : 10
-    rightPadding: root.text === "" ? 5 : 10
+    leftPadding: root.text === "" ? Style.smallSpacing : Style.standardSpacing
+    rightPadding: root.text === "" ? Style.smallSpacing : Style.standardSpacing
     implicitWidth: contentItem.implicitWidth + leftPadding + rightPadding
 
     NCToolTip {

--- a/src/gui/tray/NCButtonContents.qml
+++ b/src/gui/tray/NCButtonContents.qml
@@ -33,17 +33,19 @@ RowLayout {
     Image {
         id: icon
 
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+        Layout.fillWidth: !buttonLabel.visible
 
         source: root.hovered ? root.imageSourceHover : root.imageSource
         fillMode: Image.PreserveAspectFit
+        horizontalAlignment: Image.AlignHCenter
+        verticalAlignment: Image.AlignVCenter
+        visible: root.hovered ? root.imageSourceHover !== "" : root.imageSource !== ""
     }
 
     Label {
         id: buttonLabel
 
-        Layout.maximumWidth: icon.width > 0 ? parent.width - icon.width - parent.spacing : parent.width
-        Layout.fillWidth: icon.status !== Image.Ready
+        Layout.fillWidth: true
 
         text: root.text
         textFormat: Text.PlainText
@@ -52,7 +54,7 @@ RowLayout {
 
         color: root.hovered ? root.textColorHovered : root.textColor
 
-        horizontalAlignment: Text.AlignHCenter
+        horizontalAlignment: icon.visible ? Text.AlignLeft : Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
 
         elide: Text.ElideRight

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -53,6 +53,7 @@ QtObject {
     property int smallSpacing: 5
 
     property int iconButtonWidth: 36
+    property int standardPrimaryButtonHeight: 40
 
     property int minActivityHeight: variableSize(40)
 


### PR DESCRIPTION
Our custom buttons implementation has some bugs with alignments and sizings that makes our buttons sometimes look either weird or broken. This PR fixes these issues

| With fix | Before fix |
|---------|-----------|
| ![Screenshot 2022-11-18 at 18 19 46](https://user-images.githubusercontent.com/70155116/202764930-c23ff5d7-a892-4f80-9a44-c65402c7857e.png) | ![Screenshot 2022-11-18 at 18 21 53](https://user-images.githubusercontent.com/70155116/202764989-79ca99f4-8c99-40e4-abf2-758ad780bc6d.png) |
| ![Screenshot 2022-11-18 at 18 22 59](https://user-images.githubusercontent.com/70155116/202765044-8bf5a0dd-af10-4c44-bfb1-cf40e0b6ad10.png) | ![Screenshot 2022-11-18 at 18 22 16](https://user-images.githubusercontent.com/70155116/202765085-4d080e17-233e-44d1-b4ed-68c4b393efd0.png) |


Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
