### PR TITLE
cmake: Use FindPkgConfig's pkg_get_variable instead of custom macro

### DIFF
--- a/shell_integration/libcloudproviders/CMakeLists.txt
+++ b/shell_integration/libcloudproviders/CMakeLists.txt
@@ -1,25 +1,5 @@
-include(UsePkgConfig)
-
-MACRO(PKGCONFIG_GETVAR _package _var _output_variable)
-    SET(${_output_variable})
-
-    # if pkg-config has been found
-    IF (PKGCONFIG_EXECUTABLE)
-
-        EXEC_PROGRAM(${PKGCONFIG_EXECUTABLE} ARGS ${_package} --exists RETURN_VALUE _return_VALUE OUTPUT_VARIABLE _pkgconfigDevNull)
-
-        # and if the package of interest also exists for pkg-config, then get the information
-        IF (NOT _return_VALUE)
-
-            EXEC_PROGRAM(${PKGCONFIG_EXECUTABLE} ARGS ${_package} --variable ${_var} OUTPUT_VARIABLE ${_output_variable})
-
-        ENDIF (NOT _return_VALUE)
-
-    ENDIF (PKGCONFIG_EXECUTABLE)
-ENDMACRO(PKGCONFIG_GETVAR _package _var _output_variable)
-
 macro(dbus_add_activation_service _sources)
-    PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)
+    pkg_get_variable(_install_dir dbus-1 session_bus_services_dir)
     foreach (_i ${_sources})
         get_filename_component(_service_file ${_i} ABSOLUTE)
         string(REGEX REPLACE "\\.service.*$" ".service" _output_file ${_i})


### PR DESCRIPTION
Commit b34a90183818 ("Use FindPkgConfig to find libcloudproviders and related libs") introduced the usage of cmake's FindPkgConfig module which provides `pkg_get_variable` since version 3.4 that can be used instead of the custom `PKGCONFIG_GETVAR` macro

Signed-off-by: Marvin Schmidt <marv@exherbo.org>