### PR TITLE
fix regressions on pinState management when doing renames

### DIFF
--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -251,7 +251,7 @@ void PropagateRemoteMove::finalize()
         return;
     }
     auto &vfs = propagator()->syncOptions()._vfs;
-    auto pinState = vfs->pinState(_item->_renameTarget);
+    auto pinState = vfs->pinState(_item->_originalFile);
 
     const auto targetFile = propagator()->fullLocalPath(_item->_renameTarget);
 

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -277,7 +277,7 @@ void PropagateLocalRename::start()
         return;
     }
 
-    if (pinState != OCC::PinState::Unspecified && !vfs->setPinState(_item->_renameTarget, pinState)) {
+    if (!vfs->setPinState(_item->_renameTarget, pinState)) {
         qCWarning(lcPropagateLocalRename) << "Could not set pin state of" << _item->_renameTarget << "to old value" << pinState;
         done(SyncFileItem::NormalError, tr("Error setting pin state"));
         return;

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -289,6 +289,8 @@ bool VfsCfApi::statTypeVirtualFile(csync_file_stat_t *stat, void *statData)
 
 bool VfsCfApi::setPinState(const QString &folderPath, PinState state)
 {
+    qCDebug(lcCfApi) << "setPinState" << folderPath << state;
+
     const auto localPath = QDir::toNativeSeparators(params().filesystemPath + folderPath);
 
     if (cfapi::setPinState(localPath, state, cfapi::Recurse)) {

--- a/src/libsync/vfs/suffix/vfs_suffix.cpp
+++ b/src/libsync/vfs/suffix/vfs_suffix.cpp
@@ -14,11 +14,14 @@
 
 #include "vfs_suffix.h"
 
-#include <QFile>
-
 #include "syncfileitem.h"
 #include "filesystem.h"
 #include "common/syncjournaldb.h"
+
+#include <QFile>
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcVfsSuffix, "nextcloud.sync.vfs.suffix", QtInfoMsg)
 
 namespace OCC {
 
@@ -156,6 +159,12 @@ bool VfsSuffix::statTypeVirtualFile(csync_file_stat_t *stat, void *)
         return true;
     }
     return false;
+}
+
+bool VfsSuffix::setPinState(const QString &folderPath, PinState state)
+{
+    qCDebug(lcVfsSuffix) << "setPinState" << folderPath << state;
+    return setPinStateInDb(folderPath, state);
 }
 
 Vfs::AvailabilityResult VfsSuffix::availability(const QString &folderPath)

--- a/src/libsync/vfs/suffix/vfs_suffix.h
+++ b/src/libsync/vfs/suffix/vfs_suffix.h
@@ -48,8 +48,7 @@ public:
     bool isDehydratedPlaceholder(const QString &filePath) override;
     bool statTypeVirtualFile(csync_file_stat_t *stat, void *stat_data) override;
 
-    bool setPinState(const QString &folderPath, PinState state) override
-    { return setPinStateInDb(folderPath, state); }
+    bool setPinState(const QString &folderPath, PinState state) override;
     Optional<PinState> pinState(const QString &folderPath) override
     { return pinStateInDb(folderPath); }
     AvailabilityResult availability(const QString &folderPath) override;

--- a/src/libsync/vfs/xattr/vfs_xattr.cpp
+++ b/src/libsync/vfs/xattr/vfs_xattr.cpp
@@ -14,13 +14,15 @@
 
 #include "vfs_xattr.h"
 
-#include <QFile>
-
 #include "syncfileitem.h"
 #include "filesystem.h"
 #include "common/syncjournaldb.h"
-
 #include "xattrwrapper.h"
+
+#include <QFile>
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcVfsXAttr, "nextcloud.sync.vfs.xattr", QtInfoMsg)
 
 namespace xattr {
 using namespace OCC::XAttrWrapper;
@@ -172,6 +174,7 @@ bool VfsXAttr::statTypeVirtualFile(csync_file_stat_t *stat, void *statData)
 
 bool VfsXAttr::setPinState(const QString &folderPath, PinState state)
 {
+    qCDebug(lcVfsXAttr) << "setPinState" << folderPath << state;
     return setPinStateInDb(folderPath, state);
 }
 


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
