### PR TITLE
Fix tray window margins, stop cutting into window border

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -92,6 +92,7 @@ ApplicationWindow {
 
     OpacityMask {
         anchors.fill: parent
+        anchors.margins: Style.trayWindowBorderWidth
         source: ShaderEffectSource {
             sourceItem: trayWindowMainItem
             hideSource: true
@@ -147,7 +148,8 @@ ApplicationWindow {
                                              || unifiedSearchResultsErrorLabel.visible
                                              || unifiedSearchResultsListView.visible
 
-        anchors.fill:   parent
+        anchors.fill: parent
+        anchors.margins: Style.trayWindowBorderWidth
         clip: true
 
         Accessible.role: Accessible.Grouping
@@ -736,7 +738,6 @@ ApplicationWindow {
 
         ScrollView {
             id: controlRoot
-            padding: 1
             contentWidth: availableWidth
 
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff


### PR DESCRIPTION
At the moment we respect the tray window's margins in a very ad-hoc way, leading to small breakages and visual bugs (such as the header eating into the background border)

This PR properly addresses the sizing of the window contents

With fix:

![Screenshot 2022-11-24 at 13 21 52](https://user-images.githubusercontent.com/70155116/203783612-611eede3-65aa-42f2-b635-64621c4ceb40.png)

Before fix:

![Screenshot 2022-11-24 at 13 22 20](https://user-images.githubusercontent.com/70155116/203783637-6915d11a-4fd8-4182-a8e2-11a2b094485c.png)


Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
