### PR TITLE
Refactor user status selector buttons

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -132,19 +132,19 @@ ColumnLayout {
             Layout.fillWidth: true
             spacing: 0
 
-            UserStatusSelectorButton {
+            AbstractButton {
                 id: fieldButton
+
+                readonly property bool showBorder: hovered || checked || emojiDialog.visible
 
                 Layout.preferredWidth: userStatusMessageTextField.height
                 Layout.preferredHeight: userStatusMessageTextField.height
 
                 text: userStatusSelectorModel.userStatusEmoji
 
-                onClicked: emojiDialog.open()
-                onHeightChanged: topButtonsLayout.maxButtonHeight = Math.max(topButtonsLayout.maxButtonHeight, height)
-
                 padding: 0
-                z: hovered ? 2 : 0 // Make sure highlight is seen on top of text field
+                z: showBorder ? 2 : 0 // Make sure highlight is seen on top of text field
+                hoverEnabled: true
 
                 property color borderColor: showBorder ? Style.ncBlue : Style.menuBorder
 
@@ -176,6 +176,15 @@ ColumnLayout {
                         color: Style.buttonBackgroundColor
                     }
                 }
+
+                contentItem: Label {
+                    text: fieldButton.text
+                    textFormat: Text.PlainText
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                onClicked: emojiDialog.open()
             }
 
             Popup {

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -143,7 +143,6 @@ ColumnLayout {
                 onClicked: emojiDialog.open()
                 onHeightChanged: topButtonsLayout.maxButtonHeight = Math.max(topButtonsLayout.maxButtonHeight, height)
 
-                primary: true
                 padding: 0
                 z: hovered ? 2 : 0 // Make sure highlight is seen on top of text field
 
@@ -314,27 +313,42 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignBottom
 
-        UserStatusSelectorButton {
+        CustomButton {
             // Prevent being squashed by the other buttons with larger text
             Layout.minimumWidth: implicitWidth
             Layout.fillHeight: true
-            primary: true
+
             text: qsTr("Cancel")
+            contentsFont.bold: true
+            bgColor: Style.buttonBackgroundColor
+            bgNormalOpacity: 1.0
+            bgHoverOpacity: Style.hoverOpacity
+
             onClicked: finished()
         }
-        UserStatusSelectorButton {
+        CustomButton {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            primary: true
+
             text: qsTr("Clear status message")
+            contentsFont.bold: true
+            bgColor: Style.buttonBackgroundColor
+            bgNormalOpacity: 1.0
+            bgHoverOpacity: Style.hoverOpacity
+
             onClicked: userStatusSelectorModel.clearUserStatus()
         }
-        UserStatusSelectorButton {
+        CustomButton {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            primary: true
-            colored: true
+
             text: qsTr("Set status message")
+            textColor: Style.ncHeaderTextColor
+            contentsFont.bold: true
+            bgColor: Style.ncBlue
+            bgNormalOpacity: 1.0
+            bgHoverOpacity: Style.hoverOpacity
+
             onClicked: userStatusSelectorModel.setUserStatus()
         }
     }

--- a/src/gui/UserStatusSelectorButton.qml
+++ b/src/gui/UserStatusSelectorButton.qml
@@ -25,69 +25,67 @@ AbstractButton {
     id: root
 
     property string secondaryText: ""
-    property bool colored: false
-    property bool primary: false
-    property bool highlighted: false
-    readonly property bool showBorder: hovered || highlighted || checked
+    readonly property bool showBorder: hovered || checked
+
+    readonly property bool hasImage: root.icon.source !== ""
+    readonly property bool hasSecondaryText: root.secondaryText !== ""
+    readonly property bool hasPrimaryText: root.text !== ""
 
     hoverEnabled: true
     padding: Style.standardSpacing
 
     background: Rectangle {
-        radius: root.primary ? Style.veryRoundedButtonRadius : Style.mediumRoundedButtonRadius
-        color: root.colored ? Style.ncBlue : Style.buttonBackgroundColor
-        opacity: root.colored && root.hovered ? Style.hoverOpacity : 1.0
-        border.color: Style.ncBlue
-        border.width: root.showBorder ? root.primary ? Style.normalBorderWidth : Style.thickBorderWidth : 0
+        radius: Style.mediumRoundedButtonRadius
+        color: Style.buttonBackgroundColor
+        border.color: root.checked ? Style.ncBlue : Style.menuBorder
+        border.width: root.showBorder ? Style.thickBorderWidth : 0
     }
 
     contentItem: GridLayout {
-        columns: 2
+        columns: root.hasImage ? 2 : 1
         rows: 2
         columnSpacing: Style.standardSpacing
         rowSpacing: Style.standardSpacing / 2
 
         Image {
             Layout.column: 0
-            Layout.columnSpan: root.text === "" && root.secondaryText == "" ? 2 : 1
+            Layout.columnSpan: !root.hasPrimaryText && !root.hasSecondaryText ? 2 : 1
             Layout.row: 0
             Layout.rowSpan: 2
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
 
-
             source: root.icon.source
-            visible: root.icon.source !== ""
+            visible: root.hasImage
         }
 
         EnforcedPlainTextLabel {
-            Layout.column: root.icon.source === "" ? 0 : 1
-            Layout.columnSpan: root.icon.source === "" ? 2 : 1
+            Layout.column: root.hasImage ? 1 : 0
+            Layout.columnSpan: root.hasImage ? 1 : 2
             Layout.row: 0
-            Layout.rowSpan: root.secondaryText === "" ? 2 : 1
+            Layout.rowSpan: root.hasSecondaryText ? 1 : 2
             Layout.fillWidth: true
-            horizontalAlignment: root.primary ? Text.AlignHCenter : Text.AlignLeft
+            horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
 
             text: root.text
             wrapMode: Text.Wrap
             color: root.colored ? Style.ncHeaderTextColor : Style.ncTextColor
-            font.bold: root.primary
         }
 
         EnforcedPlainTextLabel {
-            Layout.column: root.icon.source === "" ? 0 : 1
-            Layout.columnSpan: root.icon.source === "" ? 2 : 1
+            Layout.column: root.hasImage ? 1 : 0
+            Layout.columnSpan: root.hasImage ? 1 : 2
             Layout.row: 1
             Layout.fillWidth: true
-            horizontalAlignment: root.primary ? Text.AlignHCenter : Text.AlignLeft
+            horizontalAlignment: Text.AlignLeft
             verticalAlignment: Text.AlignVCenter
 
             text: root.secondaryText
             wrapMode: Text.Wrap
             color: Style.ncSecondaryTextColor
-            visible: root.secondaryText !== ""
+            visible: root.hasSecondaryText
         }
     }
 }


### PR DESCRIPTION
The code in the user status selector buttons is unnecessarily complex, accounting for a use-case that is already covered by CustomButton.

This PR simplifies the USSB and replaces its use in some areas with CustomButton, simplifying things.

**This PR also contains some fixes that are visible when compiling with Qt 6**

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
