### PR TITLE
Explicitly size and align user status selector text input to avoid bugs with alternate QtQuick styles

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -206,15 +206,19 @@ ColumnLayout {
 
             TextField {
                 id: userStatusMessageTextField
+
+                property color borderColor: activeFocus ? Style.ncBlue : Style.menuBorder
+
                 Layout.fillWidth: true
+                Layout.preferredHeight: contentHeight + (Style.smallSpacing * 2)
+
                 placeholderText: qsTr("What is your status?")
                 placeholderTextColor: Style.ncSecondaryTextColor
                 text: userStatusSelectorModel.userStatusMessage
                 color: Style.ncTextColor
+                verticalAlignment: TextInput.AlignVCenter
                 selectByMouse: true
                 onEditingFinished: userStatusSelectorModel.userStatusMessage = text
-
-                property color borderColor: activeFocus ? Style.ncBlue : Style.menuBorder
 
                 background: Rectangle {
                     radius: Style.slightlyRoundedButtonRadius


### PR DESCRIPTION
This should avoid any unpleasant or unexpected surprises

**This PR also contains some fixes that are visible when compiling with Qt 6** 

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
