### PR TITLE
Fix issues with emoji popup scrolling in user status selector

### DIFF
--- a/src/gui/EmojiPicker.qml
+++ b/src/gui/EmojiPicker.qml
@@ -33,52 +33,59 @@ ColumnLayout {
         id: metrics
     }
 
-    ListView {
-        id: headerLayout
+    ScrollView {
+        property int desiredContentHeight: metrics.height * 2
+
         Layout.fillWidth: true
+        Layout.preferredHeight: ScrollBar.horizontal.visible ?
+                                    desiredContentHeight + ScrollBar.horizontal.height :
+                                    desiredContentHeight
         Layout.margins: 1
-        implicitWidth: contentItem.childrenRect.width
-        implicitHeight: metrics.height * 2
 
-        orientation: ListView.Horizontal
+        contentHeight: availableHeight
+        ScrollBar.vertical.policy: ScrollBar.AlwaysOff
 
-        model: emojiModel.emojiCategoriesModel
+        ListView {
+            id: headerLayout
 
-        delegate: ItemDelegate {
-            id: headerDelegate
-            width: metrics.height * 2
-            height: headerLayout.height
+            orientation: ListView.Horizontal
+            model: emojiModel.emojiCategoriesModel
 
-            background: Rectangle {
-                color: Style.lightHover
-                visible: ListView.isCurrentItem || headerDelegate.highlighted || headerDelegate.checked || headerDelegate.down || headerDelegate.hovered
-                radius: Style.slightlyRoundedButtonRadius
-            }
+            delegate: ItemDelegate {
+                id: headerDelegate
+                width: metrics.height * 2
+                height: headerLayout.height
 
-            contentItem: EnforcedPlainTextLabel {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: emoji
-                color: Style.ncTextColor
-            }
+                background: Rectangle {
+                    color: Style.lightHover
+                    visible: ListView.isCurrentItem || headerDelegate.highlighted || headerDelegate.checked || headerDelegate.down || headerDelegate.hovered
+                    radius: Style.slightlyRoundedButtonRadius
+                }
 
-            Rectangle {
-                anchors.bottom: parent.bottom
+                contentItem: EnforcedPlainTextLabel {
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    text: emoji
+                    color: Style.ncTextColor
+                }
 
-                width: parent.width
-                height: Style.thickBorderWidth
+                Rectangle {
+                    anchors.bottom: parent.bottom
 
-                visible: ListView.isCurrentItem
+                    width: parent.width
+                    height: Style.thickBorderWidth
 
-                color: Style.menuBorder
-            }
+                    visible: ListView.isCurrentItem
+
+                    color: Style.menuBorder
+                }
 
 
-            onClicked: {
-                emojiModel.setCategory(label)
+                onClicked: {
+                    emojiModel.setCategory(label)
+                }
             }
         }
-
     }
 
     Rectangle {
@@ -87,59 +94,62 @@ ColumnLayout {
         color: Style.menuBorder
     }
 
-    GridView {
-        id: emojiView
+    ScrollView {
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.preferredHeight: metrics.height * 8
         Layout.margins: Style.normalBorderWidth
 
-        cellWidth: metrics.height * 2
-        cellHeight: metrics.height * 2
+        contentWidth: availableWidth
 
-        boundsBehavior: Flickable.DragOverBounds
         clip: true
 
-        model: emojiModel.model
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
-        delegate: ItemDelegate {
-            id: emojiDelegate
+        GridView {
+            id: emojiView
 
-            width: metrics.height * 2
-            height: metrics.height * 2
+            cellWidth: metrics.height * 2
+            cellHeight: metrics.height * 2
 
-            background: Rectangle {
-                color: Style.lightHover
-                visible: ListView.isCurrentItem || emojiDelegate.highlighted || emojiDelegate.checked || emojiDelegate.down || emojiDelegate.hovered
-                radius: Style.slightlyRoundedButtonRadius
+            model: emojiModel.model
+
+            delegate: ItemDelegate {
+                id: emojiDelegate
+
+                width: metrics.height * 2
+                height: metrics.height * 2
+
+                background: Rectangle {
+                    color: Style.lightHover
+                    visible: ListView.isCurrentItem || emojiDelegate.highlighted || emojiDelegate.checked || emojiDelegate.down || emojiDelegate.hovered
+                    radius: Style.slightlyRoundedButtonRadius
+                }
+
+                contentItem: EnforcedPlainTextLabel {
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    text: modelData === undefined ? "" : modelData.unicode
+                    color: Style.ncTextColor
+                }
+
+                onClicked: {
+                    chosen(modelData.unicode);
+                    emojiModel.emojiUsed(modelData);
+                }
             }
 
-            contentItem: EnforcedPlainTextLabel {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: modelData === undefined ? "" : modelData.unicode
-                color: Style.ncTextColor
-            }
-
-            onClicked: {
-                chosen(modelData.unicode);
-                emojiModel.emojiUsed(modelData);
+            EnforcedPlainTextLabel {
+                id: placeholderMessage
+                width: parent.width * 0.8
+                anchors.centerIn: parent
+                text: qsTr("No recent emojis")
+                color: Style.ncSecondaryTextColor
+                wrapMode: Text.Wrap
+                font.bold: true
+                visible: emojiView.count === 0
             }
         }
-
-        EnforcedPlainTextLabel {
-            id: placeholderMessage
-            width: parent.width * 0.8
-            anchors.centerIn: parent
-            text: qsTr("No recent emojis")
-            color: Style.ncSecondaryTextColor
-            wrapMode: Text.Wrap
-            font.bold: true
-            visible: emojiView.count === 0
-        }
-
-        ScrollBar.vertical: ScrollBar {}
-        
     }
 
 }

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -24,8 +24,11 @@ import "./tray"
 
 ColumnLayout {
     id: rootLayout
-    spacing: Style.standardSpacing * 2
+
     property NC.UserStatusSelectorModel userStatusSelectorModel
+    readonly property alias emojiPopupOpen: emojiDialog.opened
+
+    spacing: Style.standardSpacing * 2
 
     ColumnLayout {
         id: statusButtonsLayout
@@ -181,9 +184,11 @@ ColumnLayout {
 
             Popup {
                 id: emojiDialog
+
                 padding: 0
                 margins: 0
                 clip: true
+                modal: true
 
                 anchors.centerIn: Overlay.overlay
 
@@ -194,7 +199,7 @@ ColumnLayout {
                     radius: Style.slightlyRoundedButtonRadius
                 }
 
-                EmojiPicker {
+                contentItem: EmojiPicker {
                     id: emojiPicker
 
                     onChosen: {

--- a/src/gui/UserStatusSelectorPage.qml
+++ b/src/gui/UserStatusSelectorPage.qml
@@ -28,6 +28,7 @@ Page {
         userIndex: page.userIndex
         onFinished: page.finished()
     }
+    readonly property alias emojiPopupOpen: userStatusSelector.emojiPopupOpen
 
     padding: Style.standardSpacing * 2
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -106,11 +106,18 @@ ApplicationWindow {
 
     Drawer {
         id: userStatusDrawer
+
         width: parent.width
         height: parent.height - Style.trayDrawerMargin
         padding: 0
+
         edge: Qt.BottomEdge
-        modal: true
+        // Having multiple model Popup types (Drawer inherits Popup) can cause
+        // small issues -- in this case, with the emoji popup, which won't
+        // scroll. So only have this modal if the emoji popup is closed
+        modal: userStatusContents.status === Loader.Ready ?
+                   !userStatusContents.item.emojiPopupOpen : true
+
         visible: false
 
         background: Rectangle {


### PR DESCRIPTION
Scrolling on the emoji popup is broken at the moment due to issues with the user status selector being modal, preventing some input into the emoji popup

This PR fixes the issue

**This PR also contains some fixes that are visible when compiling with Qt 6**

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
