### PR TITLE
Lock file when editing locally

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -645,7 +645,7 @@ void EditLocallyJob::fileLockProcedureComplete(const QString &notificationTitle,
     openFile();
 }
 
-int EditLocallyJob::fileLockTimeRemainingMinutes(const int lockTime, const int lockTimeOut)
+int EditLocallyJob::fileLockTimeRemainingMinutes(const qint64 lockTime, const qint64 lockTimeOut)
 {
     const auto lockExpirationTime = lockTime + lockTimeOut;
     const auto remainingTime = QDateTime::currentDateTime().secsTo(QDateTime::fromSecsSinceEpoch(lockExpirationTime));

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -546,8 +546,7 @@ void EditLocallyJob::openFile()
     // from a separate thread, or, there will be a freeze. To avoid searching for a specific folder and checking
     // if the VFS is enabled - we just always call it from a separate thread.
     QtConcurrent::run([localFilePathUrl, this]() {
-        const auto fileOpened = QDesktopServices::openUrl(localFilePathUrl);
-        if (!fileOpened) {
+        if (QDesktopServices::openUrl(localFilePathUrl)) {
             showError(tr("Could not open %1").arg(_fileName), tr("Please try again."));
         }
 

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -546,7 +546,8 @@ void EditLocallyJob::openFile()
     // In case the VFS mode is enabled and a file is not yet hydrated, we must call QDesktopServices::openUrl
     // from a separate thread, or, there will be a freeze. To avoid searching for a specific folder and checking
     // if the VFS is enabled - we just always call it from a separate thread.
-    QtConcurrent::run([localFilePath]() {
+    QtConcurrent::run([localFilePath, this]() {
+        _accountState->account()->setLockFileState(_relPath, _folderForFile->journalDb(), SyncFileItem::LockStatus::LockedItem);
         QDesktopServices::openUrl(QUrl::fromLocalFile(localFilePath));
         Systray::instance()->destroyEditFileLocallyLoadingDialog();
     });

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -45,7 +45,7 @@ public:
 signals:
     void setupFinished();
     void error(const QString &message, const QString &informativeText);
-    void fileOpened();
+    void finished();
 
 public slots:
     void startSetup();
@@ -72,6 +72,11 @@ private slots:
     void slotDirectoryListingIterated(const QString &name, const QMap<QString, QString> &properties);
 
     void openFile();
+    void lockFile();
+
+    void fileLockSuccess(const bool existingLock = false);
+    void fileLockError(const QString &errorMessage);
+    void disconnectFolderSignals();
 
 private:
     [[nodiscard]] bool checkIfFileParentSyncIsNeeded(); // returns true if sync will be needed, false otherwise
@@ -90,9 +95,11 @@ private:
 
     QString _fileName;
     QString _localFilePath;
+    QString _folderRelativePath;
     Folder *_folderForFile = nullptr;
     std::unique_ptr<SimpleApiJob> _checkTokenJob;
     QMetaObject::Connection _syncTerminatedConnection = {};
+    QVector<QMetaObject::Connection> _folderConnections;
 };
 
 }

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -87,7 +87,7 @@ private:
     [[nodiscard]] const QString getRelativePathToRemoteRootForFile() const; // returns either '/' or a (relative path - Folder::remotePath()) for folders pointing to a non-root remote path e.g. '/subfolder' instead of '/'
     [[nodiscard]] const QString getRelativePathParent() const;
 
-    [[nodiscard]] static int fileLockTimeRemainingMinutes(const int lockTime, const int lockTimeOut);
+    [[nodiscard]] static int fileLockTimeRemainingMinutes(const qint64 lockTime, const qint64 lockTimeOut);
 
     bool _tokenVerified = false;
 

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -87,7 +87,7 @@ private:
     [[nodiscard]] const QString getRelativePathToRemoteRootForFile() const; // returns either '/' or a (relative path - Folder::remotePath()) for folders pointing to a non-root remote path e.g. '/subfolder' instead of '/'
     [[nodiscard]] const QString getRelativePathParent() const;
 
-    [[nodiscard]] int fileLockTimeRemainingMinutes(const int lockTime, const int lockTimeOut);
+    [[nodiscard]] static int fileLockTimeRemainingMinutes(const int lockTime, const int lockTimeOut);
 
     bool _tokenVerified = false;
 

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -74,14 +74,20 @@ private slots:
     void openFile();
     void lockFile();
 
-    void fileLockSuccess(const bool existingLock = false);
+    void fileAlreadyLocked();
+    void fileLockSuccess(const SyncFileItemPtr &item);
     void fileLockError(const QString &errorMessage);
+    void fileLockProcedureComplete(const QString &notificationTitle,
+                                   const QString &notificationMessage,
+                                   const bool success);
     void disconnectFolderSignals();
 
 private:
     [[nodiscard]] bool checkIfFileParentSyncIsNeeded(); // returns true if sync will be needed, false otherwise
     [[nodiscard]] const QString getRelativePathToRemoteRootForFile() const; // returns either '/' or a (relative path - Folder::remotePath()) for folders pointing to a non-root remote path e.g. '/subfolder' instead of '/'
     [[nodiscard]] const QString getRelativePathParent() const;
+
+    [[nodiscard]] int fileLockTimeRemainingMinutes(const int lockTime, const int lockTimeOut);
 
     bool _tokenVerified = false;
 

--- a/src/gui/editlocallymanager.cpp
+++ b/src/gui/editlocallymanager.cpp
@@ -83,7 +83,7 @@ void EditLocallyManager::createJob(const QString &userId,
 
     connect(job.data(), &EditLocallyJob::error,
             this, removeJob);
-    connect(job.data(), &EditLocallyJob::fileOpened,
+    connect(job.data(), &EditLocallyJob::finished,
             this, removeJob);
     connect(job.data(), &EditLocallyJob::setupFinished,
             job.data(), setupJob);


### PR DESCRIPTION

![Screenshot 2022-11-29 at 19 06 25](https://user-images.githubusercontent.com/70155116/204611465-7562f76b-8040-4550-b817-77724f2692f6.png)


Closes #5101 

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
