### PR TITLE
Make use of plain text-enforcing qml labels

### DIFF
--- a/.github/workflows/qml-label-check.yml
+++ b/.github/workflows/qml-label-check.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run label component count
         run: |
-          MATCHESRESULT=$(grep -r -e "^\s*Label\s*[{]" . | wc -l | sed 's/ //g')
+          MATCHESRESULT=$(find . -iname "*.qml" | xargs grep -r -e "^\s*Label\s*[{]" | wc -l | sed "s/ //g")
           echo "MATCHES=${MATCHESRESULT}" >> $GITHUB_ENV
           echo "EXPECTED_MATCHES=1" >> $GITHUB_ENV
       - name: Check label component use count

--- a/.github/workflows/qml-label-check.yml
+++ b/.github/workflows/qml-label-check.yml
@@ -1,0 +1,24 @@
+name: QML Label component check
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run label component count
+        run: |
+          MATCHESRESULT=$(grep -r -e "^\s*Label\s*[{]" . | wc -l | sed 's/ //g')
+          echo "MATCHES=${MATCHESRESULT}" >> $GITHUB_ENV
+          echo "EXPECTED_MATCHES=1" >> $GITHUB_ENV
+      - name: Check label component use count
+        if: env.MATCHES != env.EXPECTED_MATCHES
+        uses: actions/github-script@v3
+        with:
+          script: |
+              core.setFailed('Using QML Labels! Make sure to use EnforcedPlainTextLabel instead!')

--- a/resources.qrc
+++ b/resources.qrc
@@ -46,6 +46,7 @@
         <file>src/gui/tray/EditFileLocallyLoadingDialog.qml</file>
         <file>src/gui/tray/NCBusyIndicator.qml</file>
         <file>src/gui/tray/NCToolTip.qml</file>
+        <file>src/gui/tray/EnforcedPlainTextLabel.qml</file>
         <file>theme/Style/Style.qml</file>
         <file>theme/Style/qmldir</file>
     </qresource>

--- a/src/gui/BasicComboBox.qml
+++ b/src/gui/BasicComboBox.qml
@@ -37,7 +37,6 @@ ComboBox {
         rightPadding: clearComboBox.indicator.width + clearComboBox.spacing
 
         text: clearComboBox.displayText
-        textFormat: Text.PlainText
         color: Style.ncTextColor
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
@@ -89,7 +88,6 @@ ComboBox {
         width: clearComboBox.width
         contentItem: EnforcedPlainTextLabel {
             text: modelData.display
-            textFormat: Text.PlainText
             color: Style.ncTextColor
             elide: Text.ElideRight
             verticalAlignment: Text.AlignVCenter

--- a/src/gui/BasicComboBox.qml
+++ b/src/gui/BasicComboBox.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.0
 
 import Style 1.0
+import "./tray"
 
 ComboBox {
     id: clearComboBox
@@ -31,7 +32,7 @@ ComboBox {
         opacity: clearComboBox.hovered ? Style.hoverOpacity : 1.0
     }
 
-    contentItem: Label {
+    contentItem: EnforcedPlainTextLabel {
         leftPadding: 0
         rightPadding: clearComboBox.indicator.width + clearComboBox.spacing
 
@@ -86,7 +87,7 @@ ComboBox {
     delegate: ItemDelegate {
         id: clearStatusDelegate
         width: clearComboBox.width
-        contentItem: Label {
+        contentItem: EnforcedPlainTextLabel {
             text: modelData.display
             textFormat: Text.PlainText
             color: Style.ncTextColor

--- a/src/gui/EmojiPicker.qml
+++ b/src/gui/EmojiPicker.qml
@@ -18,6 +18,7 @@ import QtQuick.Layouts 1.15
 
 import Style 1.0
 import com.nextcloud.desktopclient 1.0 as NC
+import "./tray"
 
 ColumnLayout {
     NC.EmojiModel {
@@ -54,7 +55,7 @@ ColumnLayout {
                 radius: Style.slightlyRoundedButtonRadius
             }
 
-            contentItem: Label {
+            contentItem: EnforcedPlainTextLabel {
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: emoji
@@ -113,7 +114,7 @@ ColumnLayout {
                 radius: Style.slightlyRoundedButtonRadius
             }
 
-            contentItem: Label {
+            contentItem: EnforcedPlainTextLabel {
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: modelData === undefined ? "" : modelData.unicode
@@ -126,7 +127,7 @@ ColumnLayout {
             }
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: placeholderMessage
             width: parent.width * 0.8
             anchors.centerIn: parent

--- a/src/gui/ErrorBox.qml
+++ b/src/gui/ErrorBox.qml
@@ -75,7 +75,6 @@ Item {
             color: Style.ncTextColor
             wrapMode: Text.WordWrap
             text: errorBox.text
-            textFormat: Text.PlainText
         }
     }
 }

--- a/src/gui/ErrorBox.qml
+++ b/src/gui/ErrorBox.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
 import Style 1.0
+import "./tray"
 
 Item {
     id: errorBox
@@ -42,7 +43,7 @@ Item {
 
         columns: 2
 
-        Label {
+        EnforcedPlainTextLabel {
             Layout.fillWidth: true
             color: Style.ncTextColor
             font.bold: true
@@ -64,7 +65,7 @@ Item {
             onClicked: errorBox.closeButtonClicked()
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: errorMessage
 
             Layout.fillWidth: true

--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -18,6 +18,7 @@ import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 
 import Style 1.0
+import "./tray"
 
 AbstractButton {
     id: root
@@ -42,7 +43,7 @@ AbstractButton {
     contentItem: Row {
         spacing: root.internalSpacing
 
-        Label {
+        EnforcedPlainTextLabel {
             width: root.emojiWidth > 0 ? root.emojiWidth : implicitWidth
             text: emoji
             textFormat: Text.PlainText
@@ -52,7 +53,7 @@ AbstractButton {
 
         Row {
             spacing: Style.smallSpacing
-            Label {
+            EnforcedPlainTextLabel {
                 text: root.statusText
                 textFormat: Text.PlainText
                 color: Style.ncTextColor
@@ -60,13 +61,13 @@ AbstractButton {
                 font.bold: true
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 text: "-"
                 color: Style.ncTextColor
                 verticalAlignment: Text.AlignVCenter
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 text: root.clearAtText
                 textFormat: Text.PlainText
                 color: Style.ncTextColor

--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -46,7 +46,6 @@ AbstractButton {
         EnforcedPlainTextLabel {
             width: root.emojiWidth > 0 ? root.emojiWidth : implicitWidth
             text: emoji
-            textFormat: Text.PlainText
             horizontalAlignment: Image.AlignHCenter
             verticalAlignment: Image.AlignVCenter
         }
@@ -55,7 +54,6 @@ AbstractButton {
             spacing: Style.smallSpacing
             EnforcedPlainTextLabel {
                 text: root.statusText
-                textFormat: Text.PlainText
                 color: Style.ncTextColor
                 verticalAlignment: Text.AlignVCenter
                 font.bold: true
@@ -69,7 +67,6 @@ AbstractButton {
 
             EnforcedPlainTextLabel {
                 text: root.clearAtText
-                textFormat: Text.PlainText
                 color: Style.ncTextColor
                 verticalAlignment: Text.AlignVCenter
             }

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -20,6 +20,7 @@ import QtQuick.Window 2.15
 
 import com.nextcloud.desktopclient 1.0 as NC
 import Style 1.0
+import "./tray"
 
 ColumnLayout {
     id: rootLayout
@@ -32,7 +33,7 @@ ColumnLayout {
         Layout.fillWidth: true
         spacing: Style.smallSpacing
 
-        Label {
+        EnforcedPlainTextLabel {
             Layout.fillWidth: true
             Layout.bottomMargin: Style.smallSpacing
             horizontalAlignment: Text.AlignHCenter
@@ -117,7 +118,7 @@ ColumnLayout {
         Layout.fillHeight: true
         spacing: Style.smallSpacing
 
-        Label {
+        EnforcedPlainTextLabel {
             Layout.fillWidth: true
             Layout.bottomMargin: Style.smallSpacing
             horizontalAlignment: Text.AlignHCenter
@@ -273,7 +274,7 @@ ColumnLayout {
             Layout.fillWidth: true
             spacing: Style.smallSpacing
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: clearComboLabel
 
                 Layout.fillWidth: true

--- a/src/gui/UserStatusSelectorButton.qml
+++ b/src/gui/UserStatusSelectorButton.qml
@@ -71,7 +71,6 @@ AbstractButton {
             verticalAlignment: Text.AlignVCenter
 
             text: root.text
-            textFormat: Text.PlainText
             wrapMode: Text.Wrap
             color: root.colored ? Style.ncHeaderTextColor : Style.ncTextColor
             font.bold: root.primary
@@ -86,7 +85,6 @@ AbstractButton {
             verticalAlignment: Text.AlignVCenter
 
             text: root.secondaryText
-            textFormat: Text.PlainText
             wrapMode: Text.Wrap
             color: Style.ncSecondaryTextColor
             visible: root.secondaryText !== ""

--- a/src/gui/UserStatusSelectorButton.qml
+++ b/src/gui/UserStatusSelectorButton.qml
@@ -19,6 +19,8 @@ import QtQuick.Controls 2.15
 
 import Style 1.0
 
+import "./tray"
+
 AbstractButton {
     id: root
 
@@ -59,7 +61,7 @@ AbstractButton {
             visible: root.icon.source !== ""
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             Layout.column: root.icon.source === "" ? 0 : 1
             Layout.columnSpan: root.icon.source === "" ? 2 : 1
             Layout.row: 0
@@ -75,7 +77,7 @@ AbstractButton {
             font.bold: root.primary
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             Layout.column: root.icon.source === "" ? 0 : 1
             Layout.columnSpan: root.icon.source === "" ? 2 : 1
             Layout.row: 1

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -18,6 +18,7 @@ import QtQuick.Controls 2.15
 
 import com.nextcloud.desktopclient 1.0
 import Style 1.0
+import "../tray"
 
 Page {
     id: root
@@ -94,7 +95,7 @@ Page {
                 fillMode: Image.PreserveAspectFit
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: fileNameLabel
 
                 Layout.fillWidth: true
@@ -106,7 +107,7 @@ Page {
                 wrapMode: Text.Wrap
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: fileDetailsLabel
 
                 Layout.fillWidth: true
@@ -117,7 +118,7 @@ Page {
                 wrapMode: Text.Wrap
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: fileLockedLabel
 
                 Layout.fillWidth: true

--- a/src/gui/filedetails/NCTabButton.qml
+++ b/src/gui/filedetails/NCTabButton.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls 2.15
 
 import com.nextcloud.desktopclient 1.0
 import Style 1.0
+import "../tray"
 
 TabButton {
     id: tabButton
@@ -57,7 +58,7 @@ TabButton {
             }
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: tabButtonLabel
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter

--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -208,7 +208,7 @@ GridLayout {
         }
     }
 
-    Label {
+    EnforcedPlainTextLabel {
         id: shareTypeLabel
 
         Layout.fillWidth: true
@@ -222,7 +222,7 @@ GridLayout {
         elide: Text.ElideRight
     }
 
-    Label {
+    EnforcedPlainTextLabel {
         id: linkDetailLabel
 
         Layout.fillWidth: true

--- a/src/gui/filedetails/ShareView.qml
+++ b/src/gui/filedetails/ShareView.qml
@@ -280,7 +280,7 @@ ColumnLayout {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: sharingDisabledLabel
                 width: parent.width
                 text: qsTr("Sharing is disabled")
@@ -289,7 +289,7 @@ ColumnLayout {
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
             }
-            Label {
+            EnforcedPlainTextLabel {
                 width: parent.width
                 text: qsTr("This item cannot be shared.")
                 color: Style.ncSecondaryTextColor
@@ -298,7 +298,7 @@ ColumnLayout {
                 verticalAlignment: Text.AlignVCenter
                 visible: !root.shareModel.canShare
             }
-            Label {
+            EnforcedPlainTextLabel {
                 width: parent.width
                 text: qsTr("Sharing is disabled.")
                 color: Style.ncSecondaryTextColor

--- a/src/gui/tray/ActivityActionButton.qml
+++ b/src/gui/tray/ActivityActionButton.qml
@@ -40,7 +40,7 @@ AbstractButton {
         text: root.toolTipText
         delay: Qt.styleHints.mousePressAndHoldInterval
         visible: root.toolTipText !== "" && root.hovered
-        contentItem: Label {
+        contentItem: EnforcedPlainTextLabel {
             text: customTextButtonTooltip.text
             color: Style.ncTextColor
         }

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -129,7 +129,6 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
-            textFormat: Text.PlainText
             color: Style.ncTextColor
             visible: text !== ""
         }
@@ -146,7 +145,6 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
-            textFormat: Text.PlainText
             color: Style.ncTextColor
             visible: text !== ""
         }
@@ -160,7 +158,6 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.subLinePixelSize
-            textFormat: Text.PlainText
             color: Style.ncSecondaryTextColor
             visible: text !== ""
         }
@@ -174,7 +171,6 @@ RowLayout {
             wrapMode: Text.Wrap
             maximumLineCount: 2
             font.pixelSize: Style.topLinePixelSize
-            textFormat: Text.PlainText
             color: Style.ncSecondaryTextColor
             visible: text !== ""
         }

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -120,7 +120,7 @@ RowLayout {
 
         spacing: Style.activityContentSpace
 
-        Label {
+        EnforcedPlainTextLabel {
             id: activityTextTitle
             text: (root.activityData.type === "Activity" || root.activityData.type === "Notification") ? root.activityData.subject : root.activityData.message
             height: (text === "") ? 0 : implicitHeight
@@ -134,7 +134,7 @@ RowLayout {
             visible: text !== ""
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: activityTextInfo
             text: (root.activityData.type === "Sync") ? root.activityData.displayPath
                                     : (root.activityData.type === "File") ? root.activityData.subject
@@ -151,7 +151,7 @@ RowLayout {
             visible: text !== ""
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: activityTextDateTime
             text: root.activityData.dateTime
             height: (text === "") ? 0 : implicitHeight
@@ -165,7 +165,7 @@ RowLayout {
             visible: text !== ""
         }
 
-        Label {
+        EnforcedPlainTextLabel {
             id: talkReplyMessageSent
             text: root.activityData.messageSent
             height: (text === "") ? 0 : implicitHeight

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -107,7 +107,7 @@ ScrollView {
                 source: "image://svgimage-custom-color/activity.svg/" + Style.ncSecondaryTextColor
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                width: parent.width
                text: qsTr("No activities yet")
                color: Style.ncSecondaryTextColor

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -195,7 +195,6 @@ Window {
             EnforcedPlainTextLabel {
                 id: message
                 text: root.subject
-                textFormat: Text.PlainText
                 color: root.usingUserAvatar ? "white" : Style.ncTextColor
                 font.pixelSize: Style.topLinePixelSize
                 wrapMode: Text.WordWrap

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -192,7 +192,7 @@ Window {
                 }
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: message
                 text: root.subject
                 textFormat: Text.PlainText

--- a/src/gui/tray/EditFileLocallyLoadingDialog.qml
+++ b/src/gui/tray/EditFileLocallyLoadingDialog.qml
@@ -55,7 +55,7 @@ Window {
             color: Style.ncTextColor
             running: true
         }
-        Label {
+        EnforcedPlainTextLabel {
             id: labelFileName
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
@@ -67,7 +67,7 @@ Window {
             horizontalAlignment: Text.AlignHCenter
             visible: root.fileName !== ""
         }
-        Label {
+        EnforcedPlainTextLabel {
             id: labelMessage
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true

--- a/src/gui/tray/EnforcedPlainTextLabel.qml
+++ b/src/gui/tray/EnforcedPlainTextLabel.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) by Claudio Cambra <claudio.cambra@nextcloud.com>
+ * Copyright (C) 2022 by Claudio Cambra <claudio.cambra@nextcloud.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,24 +14,16 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
 
-import Style 1.0
-
-EnforcedPlainTextLabel {
-    property bool hovered: false
-    property color textColor: Style.ncTextColor
-    property color textColorHovered: Style.ncSecondaryTextColor
-    property bool bold: false
+Label {
+    function resetToPlainText() {
+        if (textFormat !== Text.PlainText) {
+            console.log("WARNING: this label was set to a non-plain text format. Resetting to plain text.")
+            textFormat = Text.PlainText;
+        }
+    }
 
     textFormat: Text.PlainText
-    font.underline: true
-    font.bold: bold
-    color: hovered ? textColorHovered : textColor
-
-    horizontalAlignment: Text.AlignLeft
-    verticalAlignment: Text.AlignVCenter
-
-    elide: Text.ElideRight
+    onTextFormatChanged: resetToPlainText()
+    Component.onCompleted: resetToPlainText()
 }
-

--- a/src/gui/tray/NCButtonContents.qml
+++ b/src/gui/tray/NCButtonContents.qml
@@ -42,7 +42,7 @@ RowLayout {
         visible: root.hovered ? root.imageSourceHover !== "" : root.imageSource !== ""
     }
 
-    Label {
+    EnforcedPlainTextLabel {
         id: buttonLabel
 
         Layout.fillWidth: true

--- a/src/gui/tray/NCButtonContents.qml
+++ b/src/gui/tray/NCButtonContents.qml
@@ -48,7 +48,6 @@ RowLayout {
         Layout.fillWidth: true
 
         text: root.text
-        textFormat: Text.PlainText
 
         visible: root.text !== ""
 

--- a/src/gui/tray/NCToolTip.qml
+++ b/src/gui/tray/NCToolTip.qml
@@ -22,7 +22,7 @@ ToolTip {
     id: toolTip
     clip: true
     delay: Qt.styleHints.mousePressAndHoldInterval
-    contentItem: Label {
+    contentItem: EnforcedPlainTextLabel {
         text: toolTip.text
         textFormat: Text.PlainText
         color: Style.ncTextColor

--- a/src/gui/tray/NCToolTip.qml
+++ b/src/gui/tray/NCToolTip.qml
@@ -24,7 +24,6 @@ ToolTip {
     delay: Qt.styleHints.mousePressAndHoldInterval
     contentItem: EnforcedPlainTextLabel {
         text: toolTip.text
-        textFormat: Text.PlainText
         color: Style.ncTextColor
         wrapMode: Text.Wrap
     }

--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -47,7 +47,7 @@ RowLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
 
-        Text {
+        EnforcedPlainTextLabel {
             id: syncProgressText
 
             Layout.fillWidth: true
@@ -87,7 +87,7 @@ RowLayout {
             }
         }
 
-        Text {
+        EnforcedPlainTextLabel {
             id: syncProgressDetailText
 
             Layout.fillWidth: true

--- a/src/gui/tray/TextButtonContents.qml
+++ b/src/gui/tray/TextButtonContents.qml
@@ -24,7 +24,6 @@ EnforcedPlainTextLabel {
     property color textColorHovered: Style.ncSecondaryTextColor
     property bool bold: false
 
-    textFormat: Text.PlainText
     font.underline: true
     font.bold: bold
     color: hovered ? textColorHovered : textColor

--- a/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
+++ b/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
@@ -18,7 +18,7 @@ ColumnLayout {
     Accessible.name: unifiedSearchResultItemFetchMoreText.text
     Accessible.onPressAction: unifiedSearchResultMouseArea.clicked()
 
-    Label {
+    EnforcedPlainTextLabel {
         id: unifiedSearchResultItemFetchMoreText
 
         Layout.fillWidth: true

--- a/src/gui/tray/UnifiedSearchResultItem.qml
+++ b/src/gui/tray/UnifiedSearchResultItem.qml
@@ -90,7 +90,6 @@ RowLayout {
             id: unifiedSearchResultTitleText
             Layout.fillWidth: true
             text: unifiedSearchResultItemDetails.title.replace(/[\r\n]+/g, " ")
-            textFormat: Text.PlainText
             elide: Text.ElideRight
             font.pixelSize: unifiedSearchResultItemDetails.titleFontSize
             color: unifiedSearchResultItemDetails.titleColor
@@ -99,7 +98,6 @@ RowLayout {
             id: unifiedSearchResultTextSubline
             Layout.fillWidth: true
             text: unifiedSearchResultItemDetails.subline.replace(/[\r\n]+/g, " ")
-            textFormat: Text.PlainText
             elide: Text.ElideRight
             font.pixelSize: unifiedSearchResultItemDetails.sublineFontSize
             color: unifiedSearchResultItemDetails.sublineColor

--- a/src/gui/tray/UnifiedSearchResultItem.qml
+++ b/src/gui/tray/UnifiedSearchResultItem.qml
@@ -86,7 +86,7 @@ RowLayout {
         Layout.rightMargin: Style.trayHorizontalMargin
         spacing: Style.standardSpacing
 
-        Label {
+        EnforcedPlainTextLabel {
             id: unifiedSearchResultTitleText
             Layout.fillWidth: true
             text: unifiedSearchResultItemDetails.title.replace(/[\r\n]+/g, " ")
@@ -95,7 +95,7 @@ RowLayout {
             font.pixelSize: unifiedSearchResultItemDetails.titleFontSize
             color: unifiedSearchResultItemDetails.titleColor
         }
-        Label {
+        EnforcedPlainTextLabel {
             id: unifiedSearchResultTextSubline
             Layout.fillWidth: true
             text: unifiedSearchResultItemDetails.subline.replace(/[\r\n]+/g, " ")

--- a/src/gui/tray/UnifiedSearchResultNothingFound.qml
+++ b/src/gui/tray/UnifiedSearchResultNothingFound.qml
@@ -21,7 +21,7 @@ ColumnLayout {
         Layout.alignment: Qt.AlignHCenter
     }
 
-    Label {
+    EnforcedPlainTextLabel {
         id: unifiedSearchResultsNoResultsLabel
         text: qsTr("No results for")
         color: Style.menuBorder
@@ -32,7 +32,7 @@ ColumnLayout {
         horizontalAlignment: Text.AlignHCenter
     }
 
-    Label {
+    EnforcedPlainTextLabel {
         id: unifiedSearchResultsNoResultsLabelDetails
         text: unifiedSearchResultNothingFoundContainer.text
         textFormat: Text.PlainText

--- a/src/gui/tray/UnifiedSearchResultNothingFound.qml
+++ b/src/gui/tray/UnifiedSearchResultNothingFound.qml
@@ -35,7 +35,6 @@ ColumnLayout {
     EnforcedPlainTextLabel {
         id: unifiedSearchResultsNoResultsLabelDetails
         text: unifiedSearchResultNothingFoundContainer.text
-        textFormat: Text.PlainText
         color: Style.ncTextColor
         font.pixelSize: Style.topLinePixelSize * 1.25
         wrapMode: Text.Wrap

--- a/src/gui/tray/UnifiedSearchResultSectionItem.qml
+++ b/src/gui/tray/UnifiedSearchResultSectionItem.qml
@@ -13,7 +13,6 @@ EnforcedPlainTextLabel {
     leftPadding: Style.unifiedSearchResultSectionItemLeftPadding
 
     text: section
-    textFormat: Text.PlainText
     font.pixelSize: Style.unifiedSearchResultTitleFontSize
     color: UserModel.currentUser.accentColor
 

--- a/src/gui/tray/UnifiedSearchResultSectionItem.qml
+++ b/src/gui/tray/UnifiedSearchResultSectionItem.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts 1.2
 import Style 1.0
 import com.nextcloud.desktopclient 1.0
 
-Label {
+EnforcedPlainTextLabel {
     required property string section
 
     topPadding: Style.unifiedSearchResultSectionItemVerticalPadding

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -77,7 +77,6 @@ AbstractButton {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
                 verticalAlignment: Text.AlignBottom
                 text: name
-                textFormat: Text.PlainText
                 elide: Text.ElideRight
                 color: Style.ncTextColor
                 font.pixelSize: Style.topLinePixelSize
@@ -96,7 +95,6 @@ AbstractButton {
                     id: emoji
                     visible: model.statusEmoji !== ""
                     text: statusEmoji
-                    textFormat: Text.PlainText
                     topPadding: -Style.accountLabelsSpacing
                 }
 
@@ -105,7 +103,6 @@ AbstractButton {
                     Layout.fillWidth: true
                     visible: model.statusMessage !== ""
                     text: statusMessage
-                    textFormat: Text.PlainText
                     elide: Text.ElideRight
                     color: Style.ncTextColor
                     font.pixelSize: Style.subLinePixelSize
@@ -119,7 +116,6 @@ AbstractButton {
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                 verticalAlignment: Text.AlignTop
                 text: server
-                textFormat: Text.PlainText
                 elide: Text.ElideRight
                 color: Style.ncTextColor
                 font.pixelSize: Style.subLinePixelSize

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -71,7 +71,7 @@ AbstractButton {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: accountUser
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
@@ -92,7 +92,7 @@ AbstractButton {
                          model.serverHasUserStatus &&
                          (model.statusEmoji !== "" || model.statusMessage !== "")
 
-                Label {
+                EnforcedPlainTextLabel {
                     id: emoji
                     visible: model.statusEmoji !== ""
                     text: statusEmoji
@@ -100,7 +100,7 @@ AbstractButton {
                     topPadding: -Style.accountLabelsSpacing
                 }
 
-                Label {
+                EnforcedPlainTextLabel {
                     id: message
                     Layout.fillWidth: true
                     visible: model.statusMessage !== ""
@@ -113,7 +113,7 @@ AbstractButton {
                 }
             }
 
-            Label {
+            EnforcedPlainTextLabel {
                 id: accountServer
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignLeft | Qt.AlignTop

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -451,7 +451,6 @@ ApplicationWindow {
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
                                 width: Style.currentAccountLabelWidth
                                 text: UserModel.currentUser.name
-                                textFormat: Text.PlainText
                                 elide: Text.ElideRight
                                 color: Style.currentUserHeaderTextColor
 
@@ -471,7 +470,6 @@ ApplicationWindow {
                                     visible: UserModel.currentUser.statusEmoji !== ""
                                     width: Style.userStatusEmojiSize
                                     text: UserModel.currentUser.statusEmoji
-                                    textFormat: Text.PlainText
                                 }
                                 EnforcedPlainTextLabel {
                                     id: message
@@ -482,7 +480,6 @@ ApplicationWindow {
                                     text: UserModel.currentUser.statusMessage !== ""
                                           ? UserModel.currentUser.statusMessage
                                           : UserModel.currentUser.server
-                                    textFormat: Text.PlainText
                                     elide: Text.ElideRight
                                     color: Style.currentUserHeaderTextColor
                                     font.pixelSize: Style.subLinePixelSize

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -277,7 +277,7 @@ ApplicationWindow {
                                     sourceSize.width: Style.headerButtonIconSize
                                     sourceSize.height: Style.headerButtonIconSize
                                 }
-                                Label {
+                                EnforcedPlainTextLabel {
                                     Layout.leftMargin: 14
                                     text: qsTr("Add account")
                                     color: Style.ncTextColor
@@ -446,7 +446,7 @@ ApplicationWindow {
                             Layout.fillWidth: true
                             Layout.maximumWidth: parent.width
 
-                            Label {
+                            EnforcedPlainTextLabel {
                                 id: currentAccountUser
                                 Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
                                 width: Style.currentAccountLabelWidth
@@ -466,14 +466,14 @@ ApplicationWindow {
                                 spacing: Style.accountLabelsSpacing
                                 width: parent.width
 
-                                Label {
+                                EnforcedPlainTextLabel {
                                     id: emoji
                                     visible: UserModel.currentUser.statusEmoji !== ""
                                     width: Style.userStatusEmojiSize
                                     text: UserModel.currentUser.statusEmoji
                                     textFormat: Text.PlainText
                                 }
-                                Label {
+                                EnforcedPlainTextLabel {
                                     id: message
                                     Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
                                     Layout.fillWidth: true


### PR DESCRIPTION
This PR:

- Replaces all use of Label and Text components in our QML code for a new EnforcedPlainTextLabel
- Adds a basic check in our CI for the use of Label components (of which there should only be one, in EnforcedPlainTextLabel)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
