### PR TITLE
Update nextcloudcmd.rst to include dedicated install method for Debian instead of using a Ubuntu ppa.

### DIFF
--- a/doc/nextcloudcmd.rst
+++ b/doc/nextcloudcmd.rst
@@ -19,13 +19,19 @@ CentOS
     $ sudo yum -y install epel-release
     $ sudo yum -y install nextcloud-client
 
-Ubuntu/Debian
+Ubuntu
 
 ::
 
     $ sudo add-apt-repository ppa:nextcloud-devs/client
     $ sudo apt update
     $ sudo apt install nextcloud-client
+
+Debian
+
+::
+
+    $ sudo apt install nextcloud-desktop-cmd
 
 
 Refer to the link


### PR DESCRIPTION
Debian has a package in its repository for nextcloudcmd. Adding an Ubuntu ppa to Debian might work, but is not the preferable solution.

Signed-off-by: mayonezo <haselnuss87@gmail.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
