### PR TITLE
do not create GUI from a random thread and show error on real error

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -37,6 +37,7 @@ EditLocallyJob::EditLocallyJob(const QString &userId,
     , _relPath(relPath)
     , _token(token)
 {
+    connect(this, &EditLocallyJob::callShowError, this, &EditLocallyJob::showError, Qt::QueuedConnection);
 }
 
 void EditLocallyJob::startSetup()
@@ -546,8 +547,8 @@ void EditLocallyJob::openFile()
     // from a separate thread, or, there will be a freeze. To avoid searching for a specific folder and checking
     // if the VFS is enabled - we just always call it from a separate thread.
     QtConcurrent::run([localFilePathUrl, this]() {
-        if (QDesktopServices::openUrl(localFilePathUrl)) {
-            showError(tr("Could not open %1").arg(_fileName), tr("Please try again."));
+        if (!QDesktopServices::openUrl(localFilePathUrl)) {
+            emit callShowError(tr("Could not open %1").arg(_fileName), tr("Please try again."));
         }
 
         Systray::instance()->destroyEditFileLocallyLoadingDialog();

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -46,7 +46,7 @@ signals:
     void setupFinished();
     void error(const QString &message, const QString &informativeText);
     void finished();
-
+    void callShowError(const QString &message, const QString &informativeText);
 public slots:
     void startSetup();
     void startEditLocally();


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
