### PR TITLE
Fix fetch more unified search result item not being clickable

### DIFF
--- a/src/gui/tray/UnifiedSearchResultListItem.qml
+++ b/src/gui/tray/UnifiedSearchResultListItem.qml
@@ -19,7 +19,7 @@ MouseArea {
     property var fetchMoreTriggerClicked: function(){}
     property var resultClicked: function(){}
 
-    enabled: !isFetchMoreTrigger || !isSearchInProgress
+    enabled: !isSearchInProgress
     hoverEnabled: enabled
 
     height: Style.unifiedSearchItemHeight


### PR DESCRIPTION
For some reason, the unified search result item is disabled if it is a "Fetch More" entry, preventing user interaction

This fixes this issue

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
