### PR TITLE
sets a fixed version for pixman when buildign desktop client via Craft

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -72,7 +72,7 @@ jobs:
 
               $binFolder = "$buildFolder\bin"
 
-              & OpenCppCoverage.exe --quiet --sources ${{ github.workspace }} --modules $binFolder\*.dll* --export_type cobertura:${{ env.COBERTURA_COVERAGE_FILE }} --cover_children -- ctest --output-on-failure --timeout 300
+              & OpenCppCoverage.exe --optimized_build --quiet --sources ${{ github.workspace }} --modules $binFolder\*.dll* --export_type cobertura:${{ env.COBERTURA_COVERAGE_FILE }} --cover_children -- ctest --output-on-failure --timeout 300
           }
           
           runTestsAndCreateCoverage

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -49,6 +49,7 @@ dev-utils/python2.ignored = True
 dev-utils/python3.ignored = True
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
+libs/pixman.version = 0.40.0
 
 [windows-msvc2019_64-cl]
 QtSDK/Compiler = msvc2019_64


### PR DESCRIPTION
Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
