### PR TITLE
Fix SyncEngineTest failure when localstate is destroyed.

### DIFF
--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -1256,9 +1256,11 @@ private slots:
 
         fakeFolder.syncEngine().setLocalDiscoveryOptions(OCC::LocalDiscoveryStyle::DatabaseAndFilesystem);
         QVERIFY(fakeFolder.syncOnce());
-        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        auto localState = fakeFolder.currentLocalState();
+        QCOMPARE(localState, fakeFolder.currentRemoteState());
         QCOMPARE(printDbData(fakeFolder.dbState()), printDbData(fakeFolder.currentRemoteState()));
-        const auto fileFirstSync = fakeFolder.currentLocalState().find(testFile);
+        const auto fileFirstSync = localState.find(testFile);
+
         QVERIFY(fileFirstSync);
         QCOMPARE(fileFirstSync->lastModified.toSecsSinceEpoch(), CURRENT_MTIME - 2);
 
@@ -1266,9 +1268,10 @@ private slots:
 
         fakeFolder.syncEngine().setLocalDiscoveryOptions(OCC::LocalDiscoveryStyle::FilesystemOnly);
         QVERIFY(fakeFolder.syncOnce());
+        localState = fakeFolder.currentLocalState();
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
         QCOMPARE(printDbData(fakeFolder.dbState()), printDbData(fakeFolder.currentRemoteState()));
-        const auto fileSecondSync = fakeFolder.currentLocalState().find(testFile);
+        const auto fileSecondSync = localState.find(testFile);
         QVERIFY(fileSecondSync);
         QCOMPARE(fileSecondSync->lastModified.toSecsSinceEpoch(), CURRENT_MTIME - 1);
 
@@ -1276,9 +1279,10 @@ private slots:
 
         fakeFolder.syncEngine().setLocalDiscoveryOptions(OCC::LocalDiscoveryStyle::FilesystemOnly);
         QVERIFY(fakeFolder.syncOnce());
-        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        localState = fakeFolder.currentLocalState();
+        QCOMPARE(localState, fakeFolder.currentRemoteState());
         QCOMPARE(printDbData(fakeFolder.dbState()), printDbData(fakeFolder.currentRemoteState()));
-        const auto fileThirdSync = fakeFolder.currentLocalState().find(testFile);
+        const auto fileThirdSync = localState.find(testFile);
         QVERIFY(fileThirdSync);
         QCOMPARE(fileThirdSync->lastModified.toSecsSinceEpoch(), CURRENT_MTIME);
     }


### PR DESCRIPTION
Signed-off-by: alex-z <blackslayer4@gmail.com>
The localstate is getting destroyed on the stack, hence, later on, pointers to FileInfo inside it become invalid. This is a quick fix for this failing test.
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
