### PR TITLE
Fix full-text search results not being opened in browser

### DIFF
--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -580,11 +580,12 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
     QVector<UnifiedSearchResult> newEntries;
 
     const auto makeResourceUrl = [](const QUrl &resourceUrl, const QUrl &accountUrl) {
-        QUrl finalResourceUrl(resourceUrl);
-        if (finalResourceUrl.isRelative() && !accountUrl.isRelative()) {
-            finalResourceUrl = accountUrl;
-            finalResourceUrl.setPath(resourceUrl.toString());
+        if (!resourceUrl.isRelative()) {
+            return resourceUrl;
         }
+
+        QUrl finalResourceUrl(accountUrl);
+        finalResourceUrl.setPath(resourceUrl.toString());
         return finalResourceUrl;
     };
 

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -579,16 +579,6 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
 
     QVector<UnifiedSearchResult> newEntries;
 
-    const auto makeResourceUrl = [](const QUrl &resourceUrl, const QUrl &accountUrl) {
-        if (!resourceUrl.isRelative()) {
-            return resourceUrl;
-        }
-
-        QUrl finalResourceUrl(accountUrl);
-        finalResourceUrl.setPath(resourceUrl.toString());
-        return finalResourceUrl;
-    };
-
     for (const auto &entry : entries) {
         const auto entryMap = entry.toMap();
         if (entryMap.isEmpty()) {
@@ -605,7 +595,7 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
         const auto resourceUrl = entryMap.value(QStringLiteral("resourceUrl")).toUrl();
         const auto accountUrl = (_accountState && _accountState->account()) ? _accountState->account()->url() : QUrl();
 
-        result._resourceUrl = makeResourceUrl(resourceUrl, accountUrl);
+        result._resourceUrl = openableResourceUrl(resourceUrl, accountUrl);
         const auto darkIconsData = iconsFromThumbnailAndFallbackIcon(entryMap.value(QStringLiteral("thumbnailUrl")).toString(),
                                                                      entryMap.value(QStringLiteral("icon")).toString(), accountUrl, true);
         const auto lightIconsData = iconsFromThumbnailAndFallbackIcon(entryMap.value(QStringLiteral("thumbnailUrl")).toString(),
@@ -623,6 +613,17 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
     } else {
         appendResults(newEntries, provider);
     }
+}
+
+QUrl UnifiedSearchResultsListModel::openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl)
+{
+    if (!resourceUrl.isRelative()) {
+        return resourceUrl;
+    }
+
+    QUrl finalResourceUrl(accountUrl);
+    finalResourceUrl.setPath(resourceUrl.toString());
+    return finalResourceUrl;
 }
 
 void UnifiedSearchResultsListModel::appendResults(QVector<UnifiedSearchResult> results, const UnifiedSearchProvider &provider)

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -579,13 +579,13 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
 
     QVector<UnifiedSearchResult> newEntries;
 
-    const auto makeResourceUrl = [](const QString &resourceUrl, const QUrl &accountUrl) {
-        QUrl finalResurceUrl(resourceUrl);
-        if (finalResurceUrl.scheme().isEmpty() && accountUrl.scheme().isEmpty()) {
-            finalResurceUrl = accountUrl;
-            finalResurceUrl.setPath(resourceUrl);
+    const auto makeResourceUrl = [](const QUrl &resourceUrl, const QUrl &accountUrl) {
+        QUrl finalResourceUrl(resourceUrl);
+        if (finalResourceUrl.isRelative() && !accountUrl.isRelative()) {
+            finalResourceUrl = accountUrl;
+            finalResourceUrl.setPath(resourceUrl.toString());
         }
-        return finalResurceUrl;
+        return finalResourceUrl;
     };
 
     for (const auto &entry : entries) {
@@ -601,7 +601,7 @@ void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &d
         result._title = entryMap.value(QStringLiteral("title")).toString();
         result._subline = entryMap.value(QStringLiteral("subline")).toString();
 
-        const auto resourceUrl = entryMap.value(QStringLiteral("resourceUrl")).toString();
+        const auto resourceUrl = entryMap.value(QStringLiteral("resourceUrl")).toUrl();
         const auto accountUrl = (_accountState && _accountState->account()) ? _accountState->account()->url() : QUrl();
 
         result._resourceUrl = makeResourceUrl(resourceUrl, accountUrl);

--- a/src/gui/tray/unifiedsearchresultslistmodel.h
+++ b/src/gui/tray/unifiedsearchresultslistmodel.h
@@ -119,6 +119,8 @@ private slots:
     void slotSearchForProviderFinished(const QJsonDocument &json, int statusCode);
 
 private:
+    static QUrl openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl);
+
     QMap<QString, UnifiedSearchProvider> _providers;
     QVector<UnifiedSearchResult> _results;
 


### PR DESCRIPTION
The full-text search app provides incomplete resource URLs unlike all other search result apps, meaning our default behaviour for opening search results in the browser does not work

This PR adds a procedure to compensate for this

Closes #5113 and https://github.com/nextcloud/fulltextsearch/issues/728

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
