### PR TITLE
Fix warnings on QPROPERTY-s

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -132,6 +132,8 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     auto *networkSettings = new NetworkSettings;
     _ui->stack->addWidget(networkSettings);
 
+    connect(_ui->stack, &QStackedWidget::currentChanged, this, &SettingsDialog::currentPageChanged);
+
     _actionGroupWidgets.insert(generalAction, generalSettings);
     _actionGroupWidgets.insert(networkAction, networkSettings);
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -45,7 +45,7 @@ class ownCloudGui;
 class SettingsDialog : public QDialog
 {
     Q_OBJECT
-    Q_PROPERTY(QWidget* currentPage READ currentPage)
+    Q_PROPERTY(QWidget* currentPage READ currentPage NOTIFY currentPageChanged)
 
 public:
     explicit SettingsDialog(ownCloudGui *gui, QWidget *parent = nullptr);
@@ -63,6 +63,7 @@ public slots:
 signals:
     void styleChanged();
     void onActivate();
+    void currentPageChanged();
 
 protected:
     void reject() override;

--- a/src/gui/wizard/slideshow.cpp
+++ b/src/gui/wizard/slideshow.cpp
@@ -55,6 +55,8 @@ void SlideShow::setInterval(int interval)
 
     _interval = interval;
     maybeRestartTimer();
+
+    emit intervalChanged();
 }
 
 int SlideShow::currentSlide() const

--- a/src/gui/wizard/slideshow.h
+++ b/src/gui/wizard/slideshow.h
@@ -29,7 +29,7 @@ namespace OCC {
 class SlideShow : public QWidget
 {
     Q_OBJECT
-    Q_PROPERTY(int interval READ interval WRITE setInterval)
+    Q_PROPERTY(int interval READ interval WRITE setInterval NOTIFY intervalChanged)
     Q_PROPERTY(int currentSlide READ currentSlide WRITE setCurrentSlide NOTIFY currentSlideChanged)
 
 public:
@@ -57,6 +57,7 @@ public slots:
 signals:
     void clicked();
     void currentSlideChanged(int index);
+    void intervalChanged();
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -55,8 +55,8 @@ class OWNCLOUDSYNC_EXPORT Theme : public QObject
     Q_PROPERTY(QString version READ version CONSTANT)
     Q_PROPERTY(QString helpUrl READ helpUrl CONSTANT)
     Q_PROPERTY(QString conflictHelpUrl READ conflictHelpUrl CONSTANT)
-    Q_PROPERTY(QString overrideServerUrl READ overrideServerUrl)
-    Q_PROPERTY(bool forceOverrideServerUrl READ forceOverrideServerUrl)
+    Q_PROPERTY(QString overrideServerUrl READ overrideServerUrl CONSTANT)
+    Q_PROPERTY(bool forceOverrideServerUrl READ forceOverrideServerUrl CONSTANT)
 #ifndef TOKEN_AUTH_ONLY
     Q_PROPERTY(QColor wizardHeaderTitleColor READ wizardHeaderTitleColor CONSTANT)
     Q_PROPERTY(QColor wizardHeaderBackgroundColor READ wizardHeaderBackgroundColor CONSTANT)


### PR DESCRIPTION
Clazy runs reveal several poorly defined QPROPERTYs in the codebase which are missing a CONSTANT or NOTIFY declaration

This PR fixes these

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
