### PR TITLE
Make correct use of Qt signal 'emit' keyword

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -114,7 +114,7 @@ void ConnectionValidator::slotStatusFound(const QUrl &url, const QJsonObject &in
     if (_account->url() != url) {
         qCInfo(lcConnectionValidator()) << "status.php was redirected to" << url.toString();
         _account->setUrl(url);
-        _account->wantsAccountSaved(_account.data());
+        emit _account->wantsAccountSaved(_account.data());
     }
 
     if (!serverVersion.isEmpty() && !setAndCheckServerVersion(serverVersion)) {

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -238,7 +238,7 @@ void WebFlowCredentials::persist() {
     }
 
     _account->setCredentialSetting(userC, _user);
-    _account->wantsAccountSaved(_account);
+    emit _account->wantsAccountSaved(_account);
 
     // write cert if there is one
     if (!_clientSslCertificate.isNull()) {

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -414,7 +414,7 @@ void EditLocallyJob::showErrorNotification(const QString &message, const QString
     });
 
     if (foundFolder != folderMap.cend()) {
-        (*foundFolder)->syncEngine().addErrorToGui(SyncFileItem::SoftError, message, informativeText);
+        emit (*foundFolder)->syncEngine().addErrorToGui(SyncFileItem::SoftError, message, informativeText);
     }
 }
 

--- a/src/gui/filedetails/shareemodel.cpp
+++ b/src/gui/filedetails/shareemodel.cpp
@@ -231,9 +231,9 @@ void ShareeModel::shareesFetched(const QJsonDocument &reply)
     appendSharees(replyDataObject);
     appendSharees(replyDataExactMatchObject);
 
-    Q_EMIT beginResetModel();
+    beginResetModel();
     _sharees = newSharees;
-    Q_EMIT endResetModel();
+    endResetModel();
 
     Q_EMIT shareesReady();
 }

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -314,7 +314,7 @@ void ShareModel::initShareManager()
         connect(_manager.data(), &ShareManager::serverError, this, [this](const int code, const QString &message){
             _hasInitialShareFetchCompleted = true;
             Q_EMIT hasInitialShareFetchCompletedChanged();
-            serverError(code, message);
+            emit serverError(code, message);
         });
 
         _manager->fetchShares(_sharePath);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -821,7 +821,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     }
 
     for (int undecidedIndex : qAsConst(undecidedIndexes)) {
-        suggestExpand(index(undecidedIndex, 0, idx));
+        emit suggestExpand(index(undecidedIndex, 0, idx));
     }
     /* Try to remove the the undecided lists the items that are not on the server. */
     auto it = std::remove_if(selectiveSyncUndecidedList.begin(), selectiveSyncUndecidedList.end(),

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -224,7 +224,7 @@ void SettingsDialog::showIssuesList(AccountState *account)
     const auto userModel = UserModel::instance();
     const auto id = userModel->findUserIdForAccount(account);
     UserModel::instance()->setCurrentUserId(id);
-    emit Systray::instance()->showWindow();
+    Systray::instance()->showWindow();
 }
 
 void SettingsDialog::accountAdded(AccountState *s)

--- a/src/libsync/creds/dummycredentials.cpp
+++ b/src/libsync/creds/dummycredentials.cpp
@@ -52,12 +52,12 @@ bool DummyCredentials::stillValid(QNetworkReply *reply)
 void DummyCredentials::fetchFromKeychain()
 {
     _wasFetched = true;
-    Q_EMIT(fetched());
+    emit fetched();
 }
 
 void DummyCredentials::askFromUser()
 {
-    Q_EMIT(asked());
+    emit asked();
 }
 
 void DummyCredentials::persist()

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -523,7 +523,7 @@ void HttpCredentials::persist()
         // it's just written if it gets passed into the constructor.
         _account->setCredentialSetting(QLatin1String(clientCertBundleC), _clientCertBundle);
     }
-    _account->wantsAccountSaved(_account);
+    emit _account->wantsAccountSaved(_account);
 
     // write secrets to the keychain
     if (!_clientCertBundle.isEmpty()) {

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -955,7 +955,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             // Not locally, not on the server. The entry is stale!
             qCInfo(lcDisco) << "Stale DB entry";
             if (!_discoveryData->_statedb->deleteFileRecord(path._original, true)) {
-                _discoveryData->fatalError(tr("Error while deleting file record %1 from the database").arg(path._original));
+                emit _discoveryData->fatalError(tr("Error while deleting file record %1 from the database").arg(path._original));
                 qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
             }
             return;
@@ -1788,7 +1788,7 @@ int ProcessDirectoryJob::processSubJobs(int nbJobs)
 
 void ProcessDirectoryJob::dbError()
 {
-    _discoveryData->fatalError(tr("Error while reading the database"));
+    emit _discoveryData->fatalError(tr("Error while reading the database"));
 }
 
 void ProcessDirectoryJob::addVirtualFileSuffix(QString &str) const

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -187,7 +187,7 @@ QPair<bool, QByteArray> DiscoveryPhase::findAndCancelDeletedJob(const QString &o
                 qCWarning(lcDiscovery) << "(*it)->_type" << (*it)->_type;
                 qCWarning(lcDiscovery) << "(*it)->_isRestoration " << (*it)->_isRestoration;
                 Q_ASSERT(false);
-                addErrorToGui(SyncFileItem::Status::FatalError, tr("Error while canceling deletion of a file"), originalPath);
+                emit addErrorToGui(SyncFileItem::Status::FatalError, tr("Error while canceling deletion of a file"), originalPath);
                 emit fatalError(tr("Error while canceling deletion of %1").arg(originalPath));
             }
             (*it)->_instruction = CSYNC_INSTRUCTION_NONE;


### PR DESCRIPTION
Fixes several instances of bad/incorrect/missing use of `emit`

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
