### PR TITLE
Exclude NavigationPaneHelper from non-Windows compile

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -109,8 +109,6 @@ set(client_SRCS
     lockwatcher.cpp
     logbrowser.h
     logbrowser.cpp
-    navigationpanehelper.h
-    navigationpanehelper.cpp
     networksettings.h
     networksettings.cpp
     ocsnavigationappsjob.h
@@ -339,13 +337,19 @@ IF( APPLE )
 ENDIF()
 
 IF( NOT WIN32 AND NOT APPLE )
-set(client_SRCS ${client_SRCS} folderwatcher_linux.cpp)
+    set(client_SRCS ${client_SRCS} folderwatcher_linux.cpp)
 ENDIF()
 IF( WIN32 )
-set(client_SRCS ${client_SRCS} folderwatcher_win.cpp shellextensionsserver.cpp ${CMAKE_SOURCE_DIR}/src/common/shellextensionutils.cpp)
+    set(client_SRCS
+        ${client_SRCS}
+        folderwatcher_win.cpp
+        navigationpanehelper.h
+        navigationpanehelper.cpp
+        shellextensionsserver.cpp
+        ${CMAKE_SOURCE_DIR}/src/common/shellextensionutils.cpp)
 ENDIF()
 IF( APPLE )
-list(APPEND client_SRCS folderwatcher_mac.cpp)
+    list(APPEND client_SRCS folderwatcher_mac.cpp)
 ENDIF()
 
 set(3rdparty_SRC

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -839,9 +839,11 @@ void AccountSettings::slotFolderWizardAccepted()
      */
     definition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();
 
+#ifdef Q_OS_WIN
     if (folderMan->navigationPaneHelper().showInExplorerNavigationPane()) {
         definition.navigationPaneClsid = QUuid::createUuid();
     }
+#endif
 
     const auto selectiveSyncBlackList = folderWizard->property("selectiveSyncBlackList").toStringList();
 
@@ -937,8 +939,10 @@ void AccountSettings::slotEnableVfsCurrentFolder()
             return;
         }
 
+#ifdef Q_OS_WIN
         // we might need to add or remove the panel entry as cfapi brings this feature out of the box
         FolderMan::instance()->navigationPaneHelper().scheduleUpdateCloudStorageRegistry();
+#endif
 
         // It is unsafe to switch on vfs while a sync is running - wait if necessary.
         const auto connection = std::make_shared<QMetaObject::Connection>();
@@ -1014,8 +1018,10 @@ void AccountSettings::slotDisableVfsCurrentFolder()
             return;
         }
 
+#ifdef Q_OS_WIN
         // we might need to add or remove the panel entry as cfapi brings this feature out of the box
         FolderMan::instance()->navigationPaneHelper().scheduleUpdateCloudStorageRegistry();
+#endif
 
         // It is unsafe to switch off vfs while a sync is running - wait if necessary.
         const auto connection = std::make_shared<QMetaObject::Connection>();

--- a/src/gui/accountsetupfromcommandlinejob.cpp
+++ b/src/gui/accountsetupfromcommandlinejob.cpp
@@ -176,9 +176,11 @@ void AccountSetupFromCommandLineJob::setupLocalSyncFolder(AccountState *accountS
     definition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();
     definition.alias = folderMan->map().size() > 0 ? QString::number(folderMan->map().size()) : QString::number(0);
 
+#ifdef Q_OS_WIN
     if (folderMan->navigationPaneHelper().showInExplorerNavigationPane()) {
         definition.navigationPaneClsid = QUuid::createUuid();
     }
+#endif
 
     folderMan->setSyncEnabled(false);
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -62,7 +62,9 @@ FolderMan *FolderMan::_instance = nullptr;
 FolderMan::FolderMan(QObject *parent)
     : QObject(parent)
     , _lockWatcher(new LockWatcher)
+#ifdef Q_OS_WIN
     , _navigationPaneHelper(this)
+#endif
 {
     ASSERT(!_instance);
     _instance = this;
@@ -1257,7 +1259,9 @@ Folder *FolderMan::addFolder(AccountState *accountState, const FolderDefinition 
         emit folderListChanged(_folderMap);
     }
 
+#ifdef Q_OS_WIN
     _navigationPaneHelper.scheduleUpdateCloudStorageRegistry();
+#endif
     return folder;
 }
 
@@ -1277,10 +1281,12 @@ Folder *FolderMan::addFolderInternal(
 
     auto folder = new Folder(folderDefinition, accountState, std::move(vfs), this);
 
+#ifdef Q_OS_WIN
     if (_navigationPaneHelper.showInExplorerNavigationPane() && folderDefinition.navigationPaneClsid.isNull()) {
         folder->setNavigationPaneClsid(QUuid::createUuid());
         folder->saveToSettings();
     }
+#endif
 
     qCInfo(lcFolderMan) << "Adding folder to Folder Map " << folder << folder->alias();
     _folderMap[folder->alias()] = folder;
@@ -1414,7 +1420,9 @@ void FolderMan::removeFolder(Folder *folderToRemove)
         delete folderToRemove;
     }
 
+#ifdef Q_OS_WIN
     _navigationPaneHelper.scheduleUpdateCloudStorageRegistry();
+#endif
 
     emit folderListChanged(_folderMap);
 }
@@ -1551,7 +1559,9 @@ void FolderMan::slotWipeFolderForAccount(AccountState *accountState)
             delete f;
         }
 
+#ifdef Q_OS_WIN
         _navigationPaneHelper.scheduleUpdateCloudStorageRegistry();
+#endif
     }
 
     emit folderListChanged(_folderMap);

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -23,7 +23,9 @@
 
 #include "folder.h"
 #include "folderwatcher.h"
+#ifdef Q_OS_WIN
 #include "navigationpanehelper.h"
+#endif
 #include "syncfileitem.h"
 
 class TestFolderMan;
@@ -403,7 +405,9 @@ private:
     bool _nextSyncShouldStartImmediately = false;
 
     QScopedPointer<SocketApi> _socketApi;
+#ifdef Q_OS_WIN
     NavigationPaneHelper _navigationPaneHelper;
+#endif
 
     QPointer<UpdateE2eeFolderUsersMetadataJob> _removeE2eeShareJob;
 

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -149,7 +149,10 @@ public:
     static QString unescapeAlias(const QString &);
 
     SocketApi *socketApi();
+
+#ifdef Q_OS_WIN
     NavigationPaneHelper &navigationPaneHelper() { return _navigationPaneHelper; }
+#endif
 
     /**
      * Check if @a path is a valid path for a new folder considering the already sync'ed items.

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -580,8 +580,11 @@ void GeneralSettings::slotShowInExplorerNavigationPane(bool checked)
 {
     ConfigFile cfgFile;
     cfgFile.setShowInExplorerNavigationPane(checked);
+
+#ifdef Q_OS_WIN
     // Now update the registry with the change.
     FolderMan::instance()->navigationPaneHelper().setShowInExplorerNavigationPane(checked);
+#endif
 }
 
 void GeneralSettings::slotIgnoreFilesEditor()

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -722,8 +722,12 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
                 folderDefinition.virtualFilesMode = bestAvailableVfsMode();
             }
 #endif
-            if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
+
+#ifdef Q_OS_WIN
+            if (folderMan->navigationPaneHelper().showInExplorerNavigationPane()) {
                 folderDefinition.navigationPaneClsid = QUuid::createUuid();
+            }
+#endif
 
             auto f = folderMan->addFolder(account, folderDefinition);
             if (f) {


### PR DESCRIPTION
Since NavigationPaneHelper only includes functionality relevant to Windows and its introduction causes compile warnings on other platforms, this PR excludes the NPH from non-Windows builds

The ifdefs that cause warnings on other platforms have been modified to fix them if in the future NavigationPaneHelper is used on other platforms too

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
