### PR TITLE
Declare all QRegularExpressions statically

### DIFF
--- a/src/gui/creds/oauth.cpp
+++ b/src/gui/creds/oauth.cpp
@@ -70,7 +70,7 @@ void OAuth::start()
                 QByteArray peek = socket->peek(qMin(socket->bytesAvailable(), 4000LL)); //The code should always be within the first 4K
                 if (peek.indexOf('\n') < 0)
                     return; // wait until we find a \n
-                const QRegularExpression rx("^GET /\\?code=([a-zA-Z0-9]+)[& ]"); // Match a  /?code=...  URL
+                static const QRegularExpression rx("^GET /\\?code=([a-zA-Z0-9]+)[& ]"); // Match a  /?code=...  URL
                 const auto rxMatch = rx.match(peek);
                 if (!rxMatch.hasMatch()) {
                     httpReplyAndClose(socket, "404 Not Found", "<html><head><title>404 Not Found</title></head><body><center><h1>404 Not Found</h1></center></body></html>");

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -319,7 +319,7 @@ bool EditLocallyJob::isTokenValid(const QString &token)
 
     // Token is an alphanumeric string 128 chars long.
     // Ensure that is what we received and what we are sending to the server.
-    const QRegularExpression tokenRegex("^[a-zA-Z0-9]{128}$");
+    static const QRegularExpression tokenRegex("^[a-zA-Z0-9]{128}$");
     const auto regexMatch = tokenRegex.match(token);
 
     return regexMatch.hasMatch();

--- a/src/gui/notificationconfirmjob.cpp
+++ b/src/gui/notificationconfirmjob.cpp
@@ -56,7 +56,7 @@ bool NotificationConfirmJob::finished()
     const QString replyStr = reply()->readAll();
 
     if (replyStr.contains("<?xml version=\"1.0\"?>")) {
-        const QRegularExpression rex("<statuscode>(\\d+)</statuscode>");
+        static const QRegularExpression rex("<statuscode>(\\d+)</statuscode>");
         const auto rexMatch = rex.match(replyStr);
         if (rexMatch.hasMatch()) {
             // this is a error message coming back from ocs.

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -104,7 +104,7 @@ void SyncRunFileLog::logItem(const SyncFileItem &item)
     }
     QString ts = QString::fromLatin1(item._responseTimeStamp);
     if (ts.length() > 6) {
-        const QRegularExpression rx(R"((\d\d:\d\d:\d\d))");
+        static const QRegularExpression rx(R"((\d\d:\d\d:\d\d))");
         const auto rxMatch = rx.match(ts);
         if (rxMatch.hasMatch()) {
             ts = rxMatch.captured(0);

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -306,7 +306,7 @@ void Logger::enterNextLogFile()
         // Expire old log files and deal with conflicts
         QStringList files = dir.entryList(QStringList("*owncloud.log.*"), QDir::Files, QDir::Name) +
             dir.entryList(QStringList("*nextcloud.log.*"), QDir::Files, QDir::Name);
-        const QRegularExpression rx(QRegularExpression::anchoredPattern(R"(.*(next|own)cloud\.log\.(\d+).*)"));
+        static const QRegularExpression rx(QRegularExpression::anchoredPattern(R"(.*(next|own)cloud\.log\.(\d+).*)"));
         int maxNumber = -1;
         foreach (const QString &s, files) {
             if (_logExpire > 0) {

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -840,7 +840,7 @@ bool JsonApiJob::finished()
 
     QString jsonStr = QString::fromUtf8(reply()->readAll());
     if (jsonStr.contains("<?xml version=\"1.0\"?>")) {
-        const QRegularExpression rex("<statuscode>(\\d+)</statuscode>");
+        static const QRegularExpression rex("<statuscode>(\\d+)</statuscode>");
         const auto rexMatch = rex.match(jsonStr);
         if (rexMatch.hasMatch()) {
             // this is a error message coming back from ocs.
@@ -850,7 +850,7 @@ bool JsonApiJob::finished()
         qCWarning(lcJsonApiJob) << "Nothing changed so nothing to retrieve - status code: " << httpStatusCode;
         statusCode = httpStatusCode;
     } else {
-        const QRegularExpression rex(R"("statuscode":(\d+))");
+        static const QRegularExpression rex(R"("statuscode":(\d+))");
         // example: "{"ocs":{"meta":{"status":"ok","statuscode":100,"message":null},"data":{"version":{"major":8,"minor":"... (504)
         const auto rxMatch = rex.match(jsonStr);
         if (rxMatch.hasMatch()) {

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -219,7 +219,7 @@ void GETFileJob::slotMetaDataChanged()
     qint64 start = 0;
     QByteArray ranges = reply()->rawHeader("Content-Range");
     if (!ranges.isEmpty()) {
-        const QRegularExpression rx("bytes (\\d+)-");
+        static const QRegularExpression rx("bytes (\\d+)-");
         const auto rxMatch = rx.match(ranges);
         if (rxMatch.hasMatch()) {
             start = rxMatch.captured(1).toLongLong();

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -813,7 +813,8 @@ void Theme::replaceLinkColorStringBackgroundAware(QString &linkString)
 
 void Theme::replaceLinkColorString(QString &linkString, const QColor &newColor)
 {
-    linkString.replace(QRegularExpression("(<a href|<a style='color:#([a-zA-Z0-9]{6});' href)"), QString::fromLatin1("<a style='color:%1;' href").arg(newColor.name()));
+    static const QRegularExpression linkRegularExpression("(<a href|<a style='color:#([a-zA-Z0-9]{6});' href)");
+    linkString.replace(linkRegularExpression, QString::fromLatin1("<a style='color:%1;' href").arg(newColor.name()));
 }
 
 QIcon Theme::createColorAwareIcon(const QString &name, const QPalette &palette)


### PR DESCRIPTION
QRegularExpressions are expensive to create, but they can be declared statically to not do unneeded work. Hence Clazy complains when they are not declared statically.

This PR ensures all QRegularExpressions are declared statically

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
