### PR TITLE
Remove unused variables

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -126,7 +126,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     QFontMetrics subFm(subFont);
     QFontMetrics aliasFm(aliasFont);
-    QFontMetrics progressFm(progressFont);
 
     int aliasMargin = aliasFm.height() / 2;
     int margin = subFm.height() / 4;
@@ -156,7 +155,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     auto statusIcon = qvariant_cast<QIcon>(index.data(FolderStatusIconRole));
     auto aliasText = qvariant_cast<QString>(index.data(HeaderRole));
     auto pathText = qvariant_cast<QString>(index.data(FolderPathRole));
-    auto remotePath = qvariant_cast<QString>(index.data(FolderSecondPathRole));
     auto conflictTexts = qvariant_cast<QStringList>(index.data(FolderConflictMsg));
     auto errorTexts = qvariant_cast<QStringList>(index.data(FolderErrorMsg));
     auto infoTexts = qvariant_cast<QStringList>(index.data(FolderInfoMsg));

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -221,15 +221,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
 
     auto palette = option.palette;
 
-    if (qApp->style()->inherits("QWindowsVistaStyle")) {
-        // Hack: Windows Vista's light blue is not contrasting enough for white
-
-        // (code from QWindowsVistaStyle::drawControl for CE_ItemViewItem)
-        palette.setColor(QPalette::All, QPalette::HighlightedText, palette.color(QPalette::Active, QPalette::Text));
-        palette.setColor(QPalette::All, QPalette::Highlight, palette.base().color().darker(108));
-    }
-
-
     QPalette::ColorGroup cg = option.state & QStyle::State_Enabled
         ? QPalette::Normal
         : QPalette::Disabled;

--- a/src/gui/remotewipe.cpp
+++ b/src/gui/remotewipe.cpp
@@ -77,7 +77,6 @@ void RemoteWipe::checkJobSlot()
     //check for errors
     if (_networkReplyCheck->error() != QNetworkReply::NoError ||
             jsonParseError.error != QJsonParseError::NoError) {
-        QString errorReason;
         QString errorFromJson = json["error"].toString();
         if (!errorFromJson.isEmpty()) {
             qCWarning(lcRemoteWipe) << QString("Error returned from the server: <em>%1<em>")
@@ -153,7 +152,6 @@ void RemoteWipe::notifyServerSuccessJobSlot()
     QJsonObject json = QJsonDocument::fromJson(jsonData, &jsonParseError).object();
     if (_networkReplySuccess->error() != QNetworkReply::NoError ||
             jsonParseError.error != QJsonParseError::NoError) {
-        QString errorReason;
         QString errorFromJson = json["error"].toString();
         if (!errorFromJson.isEmpty()) {
             qCWarning(lcRemoteWipe) << QString("Error returned from the server: <em>%1</em>")

--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -256,10 +256,6 @@ void BulkPropagatorJob::checkPropagationIsDone()
 void BulkPropagatorJob::slotComputeTransmissionChecksum(SyncFileItemPtr item,
                                                         UploadFileInfo fileToUpload)
 {
-    // Reuse the content checksum as the transmission checksum if possible
-    const auto supportedTransmissionChecksums =
-        propagator()->account()->capabilities().supportedChecksumTypes();
-
     // Compute the transmission checksum.
     auto computeChecksum = std::make_unique<ComputeChecksum>(this);
     if (uploadChecksumEnabled()) {

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -82,8 +82,6 @@ void PropagateRemoteMove::start()
     QString origin = propagator()->adjustRenamedPath(_item->_file);
     qCInfo(lcPropagateRemoteMove) << origin << _item->_renameTarget;
 
-    QString targetFile(propagator()->fullLocalPath(_item->_renameTarget));
-
     if (origin == _item->_renameTarget) {
         // The parent has been renamed already so there is nothing more to do.
 


### PR DESCRIPTION
Removes unused variables and procedures throughout the desktop client

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
