### PR TITLE
Swap unhelpful trailing slash asserts in syncfilestatustracker for useful sanitised paths instead

### DIFF
--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -187,12 +187,13 @@ void SyncFileStatusTracker::incSyncCountAndEmitStatusChanged(const QString &rela
 
         // We passed from OK to SYNC, increment the parent to keep it marked as
         // SYNC while we propagate ourselves and our own children.
-        ASSERT(!relativePath.endsWith('/'));
-        int lastSlashIndex = relativePath.lastIndexOf('/');
-        if (lastSlashIndex != -1)
+        const auto choppedPath = relativePath.endsWith('/') ? relativePath.chopped(1) : relativePath;
+        int lastSlashIndex = choppedPath.lastIndexOf('/');
+        if (lastSlashIndex != -1) {
             incSyncCountAndEmitStatusChanged(relativePath.left(lastSlashIndex), UnknownShared);
-        else if (!relativePath.isEmpty())
+        } else if (!choppedPath.isEmpty()) {
             incSyncCountAndEmitStatusChanged(QString(), UnknownShared);
+        }
     }
 }
 
@@ -209,12 +210,13 @@ void SyncFileStatusTracker::decSyncCountAndEmitStatusChanged(const QString &rela
         emit fileStatusChanged(getSystemDestination(relativePath), status);
 
         // We passed from SYNC to OK, decrement our parent.
-        ASSERT(!relativePath.endsWith('/'));
-        int lastSlashIndex = relativePath.lastIndexOf('/');
-        if (lastSlashIndex != -1)
-            decSyncCountAndEmitStatusChanged(relativePath.left(lastSlashIndex), UnknownShared);
-        else if (!relativePath.isEmpty())
+        const auto choppedPath = relativePath.endsWith('/') ? relativePath.chopped(1) : relativePath;
+        int lastSlashIndex = choppedPath.lastIndexOf('/');
+        if (lastSlashIndex != -1) {
+            decSyncCountAndEmitStatusChanged(choppedPath.left(lastSlashIndex), UnknownShared);
+        } else if (!choppedPath.isEmpty()) {
             decSyncCountAndEmitStatusChanged(QString(), UnknownShared);
+        }
     }
 }
 


### PR DESCRIPTION
This actually helps the SyncFileStatusTracker do its job rather than just throw an error

Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
