### PR TITLE
Drop dependency on Qt Quick Controls 1

### DIFF
--- a/src/gui/BasicComboBox.qml
+++ b/src/gui/BasicComboBox.qml
@@ -13,7 +13,6 @@
  */
 
 import QtQuick 2.15
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.0

--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -13,7 +13,6 @@
  */
 
 import QtQuick 2.15
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 

--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -13,7 +13,6 @@
  */
 
 import QtQuick 2.6
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 import QtQuick.Window 2.15

--- a/src/gui/UserStatusSelectorButton.qml
+++ b/src/gui/UserStatusSelectorButton.qml
@@ -13,7 +13,6 @@
  */
 
 import QtQuick 2.6
-import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15
 


### PR DESCRIPTION
Qt Quick Controls 1 where deprecated with Qt 5.11 [1]. Nextcloud still depends on Quick Controls 1 by importing QtQuick.Dialogs. Removing those imports will cause the QMl script to use the according API from Quick Controls 2, which are, fortunately largely API-comptible.

This helps distribution to deprecate and remove Quick Controls 1 [2].

1: https://doc.qt.io/qt-6/qtquickcontrols-changes-qt6.html#migrating-from-qt-quick-controls-1
2: https://bugs.gentoo.org/889772
