### PR TITLE
Fix migration from legacy client when override server url is set

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -188,16 +188,31 @@ bool AccountManager::restoreFromLegacySettings()
                 qCInfo(lcAccountManager) << "Migrate: overrideUrl" << cleanOverrideUrl;
 
                 if (!cleanOverrideUrl.isEmpty()) {
-                    const auto oCUrl = oCSettings->value(QLatin1String(urlC)).toString();
-                    const auto cleanOCUrl = oCUrl.endsWith('/') ? oCUrl.chopped(1) : oCUrl;
+                    oCSettings->beginGroup(QLatin1String(accountsC));
+                    const auto accountsChildGroups = oCSettings->childGroups();
 
-                    // in case the urls are equal reset the settings object to read from
-                    // the ownCloud settings object
-                    qCInfo(lcAccountManager) << "Migrate oC config if " << cleanOCUrl << " == " << cleanOverrideUrl << ":"
-                                             << (cleanOCUrl == cleanOverrideUrl ? "Yes" : "No");
-                    if (cleanOCUrl == cleanOverrideUrl) {
-                        qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
-                        settings = std::move(oCSettings);
+                    for (const auto &accountId : accountsChildGroups) {
+                        oCSettings->beginGroup(accountId);
+                        const auto oCUrl = oCSettings->value(QLatin1String(urlC)).toString();
+                        const auto cleanOCUrl = oCUrl.endsWith('/') ? oCUrl.chopped(1) : oCUrl;
+
+                        // in case the urls are equal reset the settings object to read from
+                        // the ownCloud settings object
+                        qCInfo(lcAccountManager) << "Migrate oC config if " << cleanOCUrl << " == " << cleanOverrideUrl << ":"
+                                                 << (cleanOCUrl == cleanOverrideUrl ? "Yes" : "No");
+                        if (cleanOCUrl == cleanOverrideUrl) {
+                            qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
+                            oCSettings->endGroup(); // current accountID group
+                            oCSettings->endGroup(); // accounts group
+                            settings = std::move(oCSettings);
+                            break;
+                        }
+
+                        oCSettings->endGroup();
+                    }
+
+                    if (oCSettings) {
+                        oCSettings->endGroup();
                     }
                 } else {
                     qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -179,6 +179,7 @@ bool AccountManager::restoreFromLegacySettings()
                 auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
                 if (oCSettings->status() != QSettings::Status::NoError) {
                     qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
+                    break;
                 }
 
                 // Check the theme url to see if it is the same url that the oC config was for

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -182,22 +182,19 @@ bool AccountManager::restoreFromLegacySettings()
                 }
 
                 // Check the theme url to see if it is the same url that the oC config was for
-                auto overrideUrl = Theme::instance()->overrideServerUrl();
-                qCInfo(lcAccountManager) << "Migrate: overrideUrl" << overrideUrl;
-                if (!overrideUrl.isEmpty()) {
-                    if (overrideUrl.endsWith('/')) {
-                        overrideUrl.chop(1);
-                    }
-                    auto oCUrl = oCSettings->value(QLatin1String(urlC)).toString();
-                    if (oCUrl.endsWith('/')) {
-                        oCUrl.chop(1);
-                    }
+                const auto overrideUrl = Theme::instance()->overrideServerUrl();
+                const auto cleanOverrideUrl = overrideUrl.endsWith('/') ? overrideUrl.chopped(1) : overrideUrl;
+                qCInfo(lcAccountManager) << "Migrate: overrideUrl" << cleanOverrideUrl;
+
+                if (!cleanOverrideUrl.isEmpty()) {
+                    const auto oCUrl = oCSettings->value(QLatin1String(urlC)).toString();
+                    const auto cleanOCUrl = oCUrl.endsWith('/') ? oCUrl.chopped(1) : oCUrl;
 
                     // in case the urls are equal reset the settings object to read from
                     // the ownCloud settings object
-                    qCInfo(lcAccountManager) << "Migrate oC config if " << oCUrl << " == " << overrideUrl << ":"
-                                             << (oCUrl == overrideUrl ? "Yes" : "No");
-                    if (oCUrl == overrideUrl) {
+                    qCInfo(lcAccountManager) << "Migrate oC config if " << cleanOCUrl << " == " << cleanOverrideUrl << ":"
+                                             << (cleanOCUrl == cleanOverrideUrl ? "Yes" : "No");
+                    if (cleanOCUrl == cleanOverrideUrl) {
                         qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
                         settings = std::move(oCSettings);
                     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
