### PR TITLE
Migrate old configs

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -143,6 +143,17 @@ bool Application::configVersionMigration()
     // (The client version is adjusted further down)
     bool versionChanged = configFile.clientVersionString() != MIRALL_VERSION_STRING;
 
+    if (versionChanged) {
+        QDir directory(configFile.configPath());
+        const auto anyConfigFileList = directory.entryInfoList({"*.cfg"}, QDir::Files);
+        for (const auto &file : anyConfigFileList) {
+            if (file.baseName() != APPLICATION_CONFIG_NAME) {
+                QFile::rename(file.canonicalFilePath(), configFile.configFile());
+                break;
+            }
+        }
+    }
+
     // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
     bool warningMessage = !deleteKeys.isEmpty() || (!ignoreKeys.isEmpty() && versionChanged);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -247,9 +247,7 @@ Application::Application(int &argc, char **argv)
 #endif
         QT_WARNING_PUSH
         QT_WARNING_DISABLE_DEPRECATED
-        // We need to use the deprecated QDesktopServices::storageLocation because of its Qt4
-        // behavior of adding "data" to the path
-        QString oldDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+        QString oldDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
         if (oldDir.endsWith('/')) oldDir.chop(1); // macOS 10.11.x does not like trailing slash for rename/move.
         QT_WARNING_POP
         setApplicationName(_theme->appName());

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -159,8 +159,10 @@ bool Application::configVersionMigration()
         const auto fileName = file.fileName();
         backupFilesList.append(configFile.backup(fileName));
         if (file.baseName() != APPLICATION_CONFIG_NAME) {
-            if (!QFile::rename(fileName, configFile.configFile())) {
-                qCWarning(lcApplication) << "Failed to rename configuration file from" << file.baseName() << "to" << configFile.configFile();
+            const auto newConfig = configFile.configFile();
+            const auto oldConfig = file.filePath();
+            if (!QFile::rename(oldConfig, newConfig)) {
+                qCWarning(lcApplication) << "Failed to rename configuration file from" << oldConfig << "to" << newConfig;
             }
         }
     }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -248,12 +248,22 @@ Application::Application(int &argc, char **argv)
         QT_WARNING_PUSH
         QT_WARNING_DISABLE_DEPRECATED
         QString oldDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-        if (oldDir.endsWith('/')) oldDir.chop(1); // macOS 10.11.x does not like trailing slash for rename/move.
+
+        // macOS 10.11.x does not like trailing slash for rename/move.
+        if (oldDir.endsWith('/')) {
+            oldDir.chop(1);
+        }
+
         QT_WARNING_POP
         setApplicationName(_theme->appName());
         if (QFileInfo(oldDir).isDir()) {
             auto confDir = ConfigFile().configPath();
-            if (confDir.endsWith('/')) confDir.chop(1);  // macOS 10.11.x does not like trailing slash for rename/move.
+
+            // macOS 10.11.x does not like trailing slash for rename/move.
+            if (confDir.endsWith('/')) {
+                confDir.chop(1);
+            }
+
             qCInfo(lcApplication) << "Migrating old config from" << oldDir << "to" << confDir;
 
             if (!QFile::rename(oldDir, confDir)) {

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -430,12 +430,15 @@ QString ConfigFile::excludeFileFromSystem()
     return fi.absoluteFilePath();
 }
 
-QString ConfigFile::backup() const
+QString ConfigFile::backup(const QString fileName) const
 {
-    QString baseFile = configFile();
+    QString baseFile = configPath() + fileName;
     auto versionString = clientVersionString();
-    if (!versionString.isEmpty())
+
+    if (!versionString.isEmpty()) {
         versionString.prepend('_');
+    }
+
     QString backupFile =
         QString("%1.backup_%2%3")
             .arg(baseFile)
@@ -445,10 +448,13 @@ QString ConfigFile::backup() const
     // If this exact file already exists it's most likely that a backup was
     // already done. (two backup calls directly after each other, potentially
     // even with source alterations in between!)
-    if (!QFile::exists(backupFile)) {
-        QFile f(baseFile);
-        f.copy(backupFile);
+    QFile f(baseFile);
+
+    // QFile does not overwrite it
+    if(!f.copy(backupFile)) {
+        qCWarning(lcConfigFile) << "Failed to create a backup of the config file" << baseFile;
     }
+
     return backupFile;
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -430,9 +430,9 @@ QString ConfigFile::excludeFileFromSystem()
     return fi.absoluteFilePath();
 }
 
-QString ConfigFile::backup(const QString fileName) const
+QString ConfigFile::backup(const QString &fileName) const
 {
-    QString baseFile = configPath() + fileName;
+    const QString baseFilePath = configPath() + fileName;
     auto versionString = clientVersionString();
 
     if (!versionString.isEmpty()) {
@@ -441,18 +441,16 @@ QString ConfigFile::backup(const QString fileName) const
 
     QString backupFile =
         QString("%1.backup_%2%3")
-            .arg(baseFile)
+            .arg(baseFilePath)
             .arg(QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss"))
             .arg(versionString);
 
     // If this exact file already exists it's most likely that a backup was
     // already done. (two backup calls directly after each other, potentially
     // even with source alterations in between!)
-    QFile f(baseFile);
-
-    // QFile does not overwrite it
-    if(!f.copy(backupFile)) {
-        qCWarning(lcConfigFile) << "Failed to create a backup of the config file" << baseFile;
+    // QFile does not overwrite backupFile
+    if(!QFile::copy(baseFilePath, backupFile)) {
+        qCWarning(lcConfigFile) << "Failed to create a backup of the config file" << baseFilePath;
     }
 
     return backupFile;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -53,7 +53,7 @@ public:
      *
      * Returns the path of the new backup.
      */
-    [[nodiscard]] QString backup(const QString fileName) const;
+    [[nodiscard]] QString backup(const QString &fileName) const;
 
     bool exists();
 

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -49,11 +49,11 @@ public:
     static QString excludeFileFromSystem(); // doesn't access config dir
 
     /**
-     * Creates a backup of the file
+     * Creates a backup of any given fileName in the config folder
      *
      * Returns the path of the new backup.
      */
-    [[nodiscard]] QString backup() const;
+    [[nodiscard]] QString backup(const QString fileName) const;
 
     bool exists();
 


### PR DESCRIPTION
Due to changes in the config file name, there has been issues when the desktop client.

We already had code that did migrate configs from different folders, now this change would check for previous config files independent of the name. It will back up the previous config and rename the file to the new application name when there is an update of the client version.

1. I am sure there might be drawbacks to this. wdyt?

2. There is already a notification in place to tell the user there is a previous config. 

Previous config:
![previous config](https://user-images.githubusercontent.com/241266/214074347-02257589-2807-46c1-8878-d34ef45c2461.png)

Notification:
![notification](https://user-images.githubusercontent.com/241266/214086528-47ceece0-f917-4551-b35f-1be1c7ec4042.png)

New config:
![new-config](https://user-images.githubusercontent.com/241266/214086625-35fc32ab-9265-4368-ab0e-a1215f0ec343.png)

After another upgrade, it should proceed to doing backups:
![another-upgrade](https://user-images.githubusercontent.com/241266/214086770-8185c5e5-2e70-4d90-95a9-9a1519f0dad0.png)



