### PR TITLE
Remove unused monochrome icons setting

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -360,9 +360,6 @@ Application::Application(int &argc, char **argv)
 
     setQuitOnLastWindowClosed(false);
 
-    _theme->setSystrayUseMonoIcons(cfg.monoIcons());
-    connect(_theme, &Theme::systrayUseMonoIconsChanged, this, &Application::slotUseMonoIconsChanged);
-
     // Setting up the gui class will allow tray notifications for the
     // setup that follows, like folder setup
     _gui = new ownCloudGui(this);
@@ -569,11 +566,6 @@ void Application::setupLogging()
                           << "version:" << _theme->version()
                           << "os:" << Utility::platformName();
     qCInfo(lcApplication) << "Arguments:" << qApp->arguments();
-}
-
-void Application::slotUseMonoIconsChanged(bool)
-{
-    _gui->slotComputeOverallSyncStatus();
 }
 
 void Application::slotParseMessage(const QString &msg, QObject *)

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -100,7 +100,6 @@ signals:
 protected slots:
     void slotParseMessage(const QString &, QObject *);
     void slotCheckConnection();
-    void slotUseMonoIconsChanged(bool);
     void slotCleanup();
     void slotAccountStateAdded(OCC::AccountState *accountState);
     void slotAccountStateRemoved(OCC::AccountState *accountState);

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -182,7 +182,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     //slotUpdateInfo();
 
     // misc
-    connect(_ui->monoIconsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->crashreporterCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newFolderLimitCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::saveMiscSettings);
     connect(_ui->newFolderLimitSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &GeneralSettings::saveMiscSettings);
@@ -216,10 +215,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     _ui->horizontalLayout_3->getContentsMargins(&m0, &m1, &m2, &m3);
     _ui->horizontalLayout_3->setContentsMargins(0, m1, m2, m3);
 
-    // OEM themes are not obliged to ship mono icons, so there
-    // is no point in offering an option
-    _ui->monoIconsCheckBox->setVisible(Theme::instance()->monoIconsAvailable());
-
     connect(_ui->ignoredFilesButton, &QAbstractButton::clicked, this, &GeneralSettings::slotIgnoreFilesEditor);
     connect(_ui->debugArchiveButton, &QAbstractButton::clicked, this, &GeneralSettings::slotCreateDebugArchive);
 
@@ -246,7 +241,6 @@ void GeneralSettings::loadMiscSettings()
 {
     QScopedValueRollback<bool> scope(_currentlyLoading, true);
     ConfigFile cfgFile;
-    _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
     _ui->serverNotificationsCheckBox->setChecked(cfgFile.optionalServerNotifications());
     _ui->callNotificationsCheckBox->setEnabled(_ui->serverNotificationsCheckBox->isEnabled());
     _ui->callNotificationsCheckBox->setChecked(cfgFile.showCallNotifications());
@@ -256,7 +250,6 @@ void GeneralSettings::loadMiscSettings()
     _ui->newFolderLimitCheckBox->setChecked(newFolderLimit.first);
     _ui->newFolderLimitSpinBox->setValue(newFolderLimit.second);
     _ui->newExternalStorage->setChecked(cfgFile.confirmExternalStorage());
-    _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
 }
 
 #if defined(BUILD_UPDATER)
@@ -420,9 +413,6 @@ void GeneralSettings::saveMiscSettings()
     if (_currentlyLoading)
         return;
     ConfigFile cfgFile;
-    bool isChecked = _ui->monoIconsCheckBox->isChecked();
-    cfgFile.setMonoIcons(isChecked);
-    Theme::instance()->setSystrayUseMonoIcons(isChecked);
     cfgFile.setCrashReporter(_ui->crashreporterCheckBox->isChecked());
 
     cfgFile.setNewBigFolderSizeLimit(_ui->newFolderLimitCheckBox->isChecked(),

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>556</width>
-    <height>563</height>
+    <height>573</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,16 +66,6 @@
       <string>General Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="monoIconsCheckBox">
-        <property name="toolTip">
-         <string>For System Tray</string>
-        </property>
-        <property name="text">
-         <string>Use &amp;Monochrome Icons</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="autostartCheckBox">
         <property name="text">
@@ -343,7 +333,6 @@
  <tabstops>
   <tabstop>autostartCheckBox</tabstop>
   <tabstop>serverNotificationsCheckBox</tabstop>
-  <tabstop>monoIconsCheckBox</tabstop>
   <tabstop>ignoredFilesButton</tabstop>
   <tabstop>newFolderLimitCheckBox</tabstop>
   <tabstop>newFolderLimitSpinBox</tabstop>

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -56,7 +56,6 @@ static constexpr char remotePollIntervalC[] = "remotePollInterval";
 static constexpr char forceSyncIntervalC[] = "forceSyncInterval";
 static constexpr char fullLocalDiscoveryIntervalC[] = "fullLocalDiscoveryInterval";
 static constexpr char notificationRefreshIntervalC[] = "notificationRefreshInterval";
-static constexpr char monoIconsC[] = "monoIcons";
 static constexpr char promptDeleteC[] = "promptDeleteAllFiles";
 static constexpr char crashReporterC[] = "crashReporter";
 static constexpr char optionalServerNotificationsC[] = "optionalServerNotifications";
@@ -945,23 +944,6 @@ void ConfigFile::setPromptDeleteFiles(bool promptDeleteFiles)
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(QLatin1String(promptDeleteC), promptDeleteFiles);
-}
-
-bool ConfigFile::monoIcons() const
-{
-    QSettings settings(configFile(), QSettings::IniFormat);
-    bool monoDefault = false; // On Mac we want bw by default
-#ifdef Q_OS_MAC
-    // OEM themes are not obliged to ship mono icons
-    monoDefault = QByteArrayLiteral("Nextcloud") == QByteArrayLiteral(APPLICATION_NAME);
-#endif
-    return settings.value(QLatin1String(monoIconsC), monoDefault).toBool();
-}
-
-void ConfigFile::setMonoIcons(bool useMonoIcons)
-{
-    QSettings settings(configFile(), QSettings::IniFormat);
-    settings.setValue(QLatin1String(monoIconsC), useMonoIcons);
 }
 
 bool ConfigFile::crashReporter() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -83,9 +83,6 @@ public:
      */
     [[nodiscard]] std::chrono::milliseconds fullLocalDiscoveryInterval() const;
 
-    [[nodiscard]] bool monoIcons() const;
-    void setMonoIcons(bool);
-
     [[nodiscard]] bool promptDeleteFiles() const;
     void setPromptDeleteFiles(bool promptDeleteFiles);
 

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -480,23 +480,6 @@ QString Theme::systrayIconFlavor(bool mono) const
     return flavor;
 }
 
-void Theme::setSystrayUseMonoIcons(bool mono)
-{
-    _mono = mono;
-    emit systrayUseMonoIconsChanged(mono);
-}
-
-bool Theme::systrayUseMonoIcons() const
-{
-    return _mono;
-}
-
-bool Theme::monoIconsAvailable() const
-{
-    QString themeDir = QString(Theme::themePrefix) + QString::fromLatin1("%1/").arg(Theme::instance()->systrayIconFlavor(true));
-    return QDir(themeDir).exists();
-}
-
 QString Theme::updateCheckUrl() const
 {
     return APPLICATION_UPDATE_URL;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -341,21 +341,6 @@ public:
     virtual QString aboutDetails() const;
 
     /**
-     * Define if the systray icons should be using mono design
-     */
-    void setSystrayUseMonoIcons(bool mono);
-
-    /**
-     * Retrieve wether to use mono icons for systray
-     */
-    bool systrayUseMonoIcons() const;
-
-    /**
-     * Check if mono icons are available
-     */
-    bool monoIconsAvailable() const;
-
-    /**
      * @brief Where to check for new Updates.
      */
     virtual QString updateCheckUrl() const;
@@ -612,7 +597,6 @@ protected:
     Theme();
 
 signals:
-    void systrayUseMonoIconsChanged(bool);
     void systemPaletteChanged(const QPalette &palette);
     void darkModeChanged();
     void overrideServerUrlChanged();


### PR DESCRIPTION
This legacy setting is not used anywhere so it makes sense to remove it

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
