### PR TITLE
Fix displaying of file details button for local syncfileitem activities

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -341,11 +341,11 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     case DisplayActions:
         return _displayActions;
     case ShowFileDetailsRole:
-        return !data(index, PathRole).toString().isEmpty() &&
+        return _displayActions &&
                 a._objectType == QStringLiteral("files") &&
-                _displayActions &&
                 a._fileAction != "file_deleted" &&
-                a._syncFileItemStatus != SyncFileItem::FileIgnored;
+                a._syncFileItemStatus != SyncFileItem::FileIgnored &&
+                !data(index, OpenablePathRole).toString().isEmpty();
     case DismissableRole:
         // Do not allow dismissal of things requiring user input regarding syncing
         return !a._links.isEmpty() &&

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -658,6 +658,7 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
 
     Activity activity;
     activity._type = Activity::SyncFileItemType; //client activity
+    activity._objectType = QStringLiteral("files");
     activity._syncFileItemStatus = item->_status;
     activity._dateTime = QDateTime::currentDateTime();
     activity._message = item->_originalFile;


### PR DESCRIPTION
Signed-off-by: Claudio Cambra <claudio.cambra@nextcloud.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
