### PR TITLE
Improve config upgrade warning dialog

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -147,15 +147,11 @@ bool Application::configVersionMigration()
     const auto versionChanged = previousVersion != currentVersion;
     const auto downgrading = previousVersion > currentVersion;
 
-    // We want to message the user either for destructive changes,
-    // or if we're ignoring something and the client version changed.
-    const auto showWarning = !deleteKeys.isEmpty() || (!ignoreKeys.isEmpty() && versionChanged);
-
-    if (!versionChanged && !showWarning) {
+    if (!versionChanged && !(!deleteKeys.isEmpty() || (!ignoreKeys.isEmpty() && versionChanged))) {
         return true;
     }
 
-    // back up all old config file
+    // back up all old config files
     QStringList backupFilesList;
     QDir configDir(configFile.configPath());
     const auto anyConfigFileNameList = configDir.entryInfoList({"*.cfg"}, QDir::Files);
@@ -171,7 +167,9 @@ bool Application::configVersionMigration()
         }
     }
 
-    if (showWarning || backupFilesList.count() > 0) {
+    // We want to message the user either for destructive changes,
+    // or if we're ignoring something and the client version changed.
+    if (configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
         QMessageBox box(
             QMessageBox::Warning,
             APPLICATION_SHORTNAME,

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -51,6 +51,7 @@
 
 namespace {
 static constexpr char showMainDialogAsNormalWindowC[] = "showMainDialogAsNormalWindow";
+static constexpr char showConfigBackupWarningC[] = "showConfigBackupWarning";
 
 static constexpr char remotePollIntervalC[] = "remotePollInterval";
 static constexpr char forceSyncIntervalC[] = "forceSyncInterval";
@@ -454,6 +455,11 @@ QString ConfigFile::backup(const QString &fileName) const
     }
 
     return backupFile;
+}
+
+bool ConfigFile::showConfigBackupWarning() const
+{
+    return getValue(showConfigBackupWarningC, QString(), false).toBool();
 }
 
 QString ConfigFile::configFile() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -54,6 +54,10 @@ public:
      * Returns the path of the new backup.
      */
     [[nodiscard]] QString backup(const QString &fileName) const;
+    /**
+     * Display warning with a list of the config files that were backed up
+     */
+    [[nodiscard]] bool showConfigBackupWarning() const;
 
     bool exists();
 


### PR DESCRIPTION
- Improve the code.
- Fix the check for the file name.
- Do not always display the warning about the backup of config files of older version.