### PR TITLE
Log to stdout when built in Debug config

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -112,6 +112,9 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
         msgW.append(L"\n");
         OutputDebugString(msgW.c_str());
     }
+#elif defined(QT_DEBUG)
+    QTextStream cout(stdout, QIODevice::WriteOnly);
+    cout << msg << endl;
 #endif
     {
         QMutexLocker lock(&_mutex);

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -52,8 +52,8 @@ Logger::Logger(QObject *parent)
     _crashLog.resize(CrashLogSize);
 #ifndef NO_MSG_HANDLER
     qInstallMessageHandler([](QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
-            Logger::instance()->doLog(type, ctx, message);
-        });
+        Logger::instance()->doLog(type, ctx, message);
+    });
 #endif
 }
 


### PR DESCRIPTION
Having to sift through the log files can be a pain, so it makes sense to log to stdout as normal when we build in debug mode

With this we can check logging directly in Qt Creator or in the terminal

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
