### PR TITLE
Fix share dialog infinite loading

### DIFF
--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -240,12 +240,13 @@ void ShareModel::updateData()
     SyncJournalFileRecord fileRecord;
     auto resharingAllowed = true; // lets assume the good
 
-    if(_folder->journalDb()->getFileRecord(relPath, &fileRecord) && fileRecord.isValid()) {
-        if (!fileRecord._remotePerm.isNull() &&
-            !fileRecord._remotePerm.hasPermission(RemotePermissions::CanReshare)) {
+    if(_folder->journalDb()->getFileRecord(relPath, &fileRecord) &&
+       fileRecord.isValid() &&
+       !fileRecord._remotePerm.isNull() &&
+       !fileRecord._remotePerm.hasPermission(RemotePermissions::CanReshare)) {
 
-            resharingAllowed = false;
-        }
+        qCInfo(lcShareModel) << "File record says resharing not allowed";
+        resharingAllowed = false;
     }
 
     _maxSharingPermissions = resharingAllowed ? SharePermissions(_accountState->account()->capabilities().shareDefaultPermissions()) : SharePermissions({});

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -357,9 +357,17 @@ void ShareModel::slotPropfindReceived(const QVariantMap &result)
 
     const QVariant receivedPermissions = result["share-permissions"];
     if (!receivedPermissions.toString().isEmpty()) {
+        const auto oldCanShare = canShare();
+
         _maxSharingPermissions = static_cast<SharePermissions>(receivedPermissions.toInt());
         Q_EMIT sharePermissionsChanged();
         qCInfo(lcShareModel) << "Received sharing permissions for" << _sharePath << _maxSharingPermissions;
+
+        if (!oldCanShare && canShare()) {
+            qCInfo(lcShareModel) << "Received updated sharing data that says we have permission to share now."
+                                 << "Trying to init share manager again.";
+            initShareManager();
+        }
     }
 
     const auto privateLinkUrl = result["privatelink"].toString();


### PR DESCRIPTION
Restrictive file sharing defaults from the server can cause the client to assume the worst at the start, and then we don't try to reinitialise the share manager when we get more permissive sharing permissions from the server -- causing the infinite loop as sharing is allowed, but the manager is never initialised

Now we reinitialise the manager if we have received nice permissions on PROPFIND

Fixes #5411

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
