### PR TITLE
fix edit locally job not finding the user account: wrong user id

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -163,15 +163,7 @@ QString Account::displayName() const
 
 QString Account::userIdAtHostWithPort() const
 {
-    const auto credentialsUserSplit = credentials() ? credentials()->user().split(QLatin1Char('@')) : QStringList{};
-
-    if (credentialsUserSplit.isEmpty()) {
-        return {};
-    }
-
-    const auto userName = credentialsUserSplit.first();
-
-    QString dn = QStringLiteral("%1@%2").arg(userName, _url.host());
+    QString dn = QStringLiteral("%1@%2").arg(_davUser, _url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         dn.append(QLatin1Char(':'));


### PR DESCRIPTION
the only correct id for an user is Account::_davUser

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
