### PR TITLE
skip e2e encrypted files with empty filename in metadata

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1591,7 +1591,14 @@ void FolderMetadata::setupExistingMetadata(const QByteArray& metadata)
         auto encryptedFile = fileObj["encrypted"].toString().toLocal8Bit();
         auto decryptedFile = !key.isEmpty() ? decryptJsonObject(encryptedFile, key) : QByteArray{};
         auto decryptedFileDoc = QJsonDocument::fromJson(decryptedFile);
+
         auto decryptedFileObj = decryptedFileDoc.object();
+
+        if (decryptedFileObj["filename"].toString().isEmpty()) {
+            qCDebug(lcCse) << "decrypted metadata" << decryptedFileDoc.toJson(QJsonDocument::Indented);
+            qCWarning(lcCse) << "skipping encrypted file" << file.encryptedFilename << "metadata has an empty file name";
+            continue;
+        }
 
         file.originalFilename = decryptedFileObj["filename"].toString();
         file.encryptionKey = QByteArray::fromBase64(decryptedFileObj["key"].toString().toLocal8Bit());


### PR DESCRIPTION
we cannot decrypt a file without a name

for now we will ignore them

we should probably do much more for the user but I fail to see how to generate errors from e2ee module

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
