### PR TITLE
Fix avatars not showing up in settings dialog account actions until clicked on

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -263,6 +263,15 @@ void SettingsDialog::accountAdded(AccountState *s)
 
     // Connect styleChanged event, to adapt (Dark-/Light-Mode switching)
     connect(this, &SettingsDialog::styleChanged, accountSettings, &AccountSettings::slotStyleChanged);
+
+    const auto userInfo = new UserInfo(s, false, true, this);
+    connect(userInfo, &UserInfo::fetchedLastInfo, this, [userInfo](const UserInfo *fetchedInfo) {
+        // UserInfo will go and update the account avatar
+        Q_UNUSED(fetchedInfo);
+        userInfo->deleteLater();
+    });
+    userInfo->setActive(true);
+    userInfo->slotFetchInfo();
 }
 
 void SettingsDialog::slotAccountAvatarChanged()

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -234,16 +234,8 @@ void SettingsDialog::accountAdded(AccountState *s)
     auto height = _toolBar->sizeHint().height();
     bool brandingSingleAccount = !Theme::instance()->multiAccount();
 
-    QAction *accountAction = nullptr;
-    QImage avatar = s->account()->avatar();
-    const QString actionText = brandingSingleAccount ? tr("Account") : s->account()->displayName();
-    if (avatar.isNull()) {
-        accountAction = createColorAwareAction(QLatin1String(":/client/theme/account.svg"),
-            actionText);
-    } else {
-        QIcon icon(QPixmap::fromImage(AvatarJob::makeCircularAvatar(avatar)));
-        accountAction = createActionWithIcon(icon, actionText);
-    }
+    const auto actionText = brandingSingleAccount ? tr("Account") : s->account()->displayName();
+    const auto accountAction = createColorAwareAction(QLatin1String(":/client/theme/account.svg"), actionText);
 
     if (!brandingSingleAccount) {
         accountAction->setToolTip(s->account()->displayName());


### PR DESCRIPTION
At creation time of the toolbar actions, the avatars are never yet available. This PR fixes this issue by dispatching a user info job that fetches the avatar at the time of creation of the toolbar action and updates the avatar image accordingly

With fix:


https://user-images.githubusercontent.com/70155116/220126929-b6e5f590-c552-42af-b7e5-af2caf4eb5b6.mov



Before fix:


https://user-images.githubusercontent.com/70155116/220127113-1d57aba0-6d2a-4a19-9710-701f7b3a20cd.mov

Closes #5447

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
