### PR TITLE
Fix update request channel being set to wrong localised string

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -329,21 +329,11 @@ void GeneralSettings::slotUpdateChannelChanged(const QString &translatedChannel)
     };
 
     const auto updateChannelFromLocalized = [](const int index) {
-        auto channel = QString{};
-
-        switch (index)
-        {
-        case 0:
-            channel = QStringLiteral("stable");
-            break;
-        case 1:
-            channel = QStringLiteral("beta");
-            break;
-        default:
-            channel = QString{};
+        if (index == 1) {
+            return QStringLiteral("beta");
         }
 
-        return channel;
+        return QStringLiteral("stable");
     };
 
     const auto channel = updateChannelFromLocalized(_ui->updateChannel->currentIndex());

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -312,10 +312,8 @@ void GeneralSettings::slotUpdateInfo()
         this, &GeneralSettings::slotUpdateChannelChanged, Qt::UniqueConnection);
 }
 
-void GeneralSettings::slotUpdateChannelChanged(const QString &translatedChannel)
+void GeneralSettings::slotUpdateChannelChanged()
 {
-    Q_UNUSED(translatedChannel);
-
     const auto updateChannelToLocalized = [](const QString &channel) {
         auto decodedTranslatedChannel = QString{};
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -314,6 +314,8 @@ void GeneralSettings::slotUpdateInfo()
 
 void GeneralSettings::slotUpdateChannelChanged(const QString &translatedChannel)
 {
+    Q_UNUSED(translatedChannel);
+
     const auto updateChannelToLocalized = [](const QString &channel) {
         auto decodedTranslatedChannel = QString{};
 
@@ -345,8 +347,7 @@ void GeneralSettings::slotUpdateChannelChanged(const QString &translatedChannel)
     };
 
     const auto channel = updateChannelFromLocalized(_ui->updateChannel->currentIndex());
-
-    if (translatedChannel == ConfigFile().updateChannel()) {
+    if (channel == ConfigFile().updateChannel()) {
         return;
     }
 

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -56,7 +56,7 @@ private slots:
     void slotShowLegalNotice();
 #if defined(BUILD_UPDATER)
     void slotUpdateInfo();
-    void slotUpdateChannelChanged(const QString &translatedChannel);
+    void slotUpdateChannelChanged();
     void slotUpdateCheckNow();
     void slotToggleAutoUpdateCheck();
 #endif

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -104,6 +104,11 @@ static constexpr char moveToTrashC[] = "moveToTrash";
 
 static constexpr char certPath[] = "http_certificatePath";
 static constexpr char certPasswd[] = "http_certificatePasswd";
+
+bool validUpdateChannel(const QString &channel)
+{
+    return channel == QStringLiteral("stable") || channel == QStringLiteral("beta");
+}
 }
 
 namespace OCC {
@@ -692,12 +697,21 @@ QString ConfigFile::updateChannel() const
     }
 
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(updateChannelC), defaultUpdateChannel).toString();
+    const auto channel = settings.value(QLatin1String(updateChannelC), defaultUpdateChannel).toString();
+    if (!validUpdateChannel(channel)) {
+        qCWarning(lcConfigFile()) << "Received invalid update channel from confog:"
+                                  << channel
+                                  << "defaulting to:"
+                                  << defaultUpdateChannel;
+        return defaultUpdateChannel;
+    }
+
+    return channel;
 }
 
 void ConfigFile::setUpdateChannel(const QString &channel)
 {
-    if (channel != QStringLiteral("stable") || channel != QStringLiteral("beta")) {
+    if (!validUpdateChannel(channel)) {
         qCWarning(lcConfigFile()) << "Received invalid update channel:"
                                   << channel
                                   << "can only accept 'stable' or 'beta'. Ignoring.";

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -697,6 +697,13 @@ QString ConfigFile::updateChannel() const
 
 void ConfigFile::setUpdateChannel(const QString &channel)
 {
+    if (channel != QStringLiteral("stable") || channel != QStringLiteral("beta")) {
+        qCWarning(lcConfigFile()) << "Received invalid update channel:"
+                                  << channel
+                                  << "can only accept 'stable' or 'beta'. Ignoring.";
+        return;
+    }
+
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.setValue(QLatin1String(updateChannelC), channel);
 }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -105,10 +105,7 @@ static constexpr char moveToTrashC[] = "moveToTrash";
 static constexpr char certPath[] = "http_certificatePath";
 static constexpr char certPasswd[] = "http_certificatePasswd";
 
-bool validUpdateChannel(const QString &channel)
-{
-    return channel == QStringLiteral("stable") || channel == QStringLiteral("beta");
-}
+static const QSet validUpdateChannels { QStringLiteral("stable"), QStringLiteral("beta") };
 }
 
 namespace OCC {
@@ -698,7 +695,7 @@ QString ConfigFile::updateChannel() const
 
     QSettings settings(configFile(), QSettings::IniFormat);
     const auto channel = settings.value(QLatin1String(updateChannelC), defaultUpdateChannel).toString();
-    if (!validUpdateChannel(channel)) {
+    if (!validUpdateChannels.contains(channel)) {
         qCWarning(lcConfigFile()) << "Received invalid update channel from confog:"
                                   << channel
                                   << "defaulting to:"
@@ -711,7 +708,7 @@ QString ConfigFile::updateChannel() const
 
 void ConfigFile::setUpdateChannel(const QString &channel)
 {
-    if (!validUpdateChannel(channel)) {
+    if (!validUpdateChannels.contains(channel)) {
         qCWarning(lcConfigFile()) << "Received invalid update channel:"
                                   << channel
                                   << "can only accept 'stable' or 'beta'. Ignoring.";


### PR DESCRIPTION
This PR does two things:

1. Fix a check that would led to a bad comparison of the translated channel with the config-stored channel
2. More safely return the update channel to set in the config file from the input in the settings combo box, defaulting to stable where possible
3. Prevent setting or returning of bad update channels from the config file

Fixes #5455

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
