### PR TITLE
Improve macOS Sparkle updater

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -304,9 +304,11 @@ void GeneralSettings::slotUpdateInfo()
                                       ocupdater->downloadState() != OCUpdater::DownloadComplete);
     }
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    else if (auto sparkleUpdater = qobject_cast<SparkleUpdater *>(updater)) {
+    else if (const auto sparkleUpdater = qobject_cast<SparkleUpdater *>(updater)) {
+        connect(sparkleUpdater, &SparkleUpdater::statusChanged, this, &GeneralSettings::slotUpdateInfo, Qt::UniqueConnection);
         _ui->updateStateLabel->setText(sparkleUpdater->statusString());
         _ui->restartButton->setVisible(false);
+        _ui->updateButton->setEnabled(true);
     }
 #endif
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -308,7 +308,11 @@ void GeneralSettings::slotUpdateInfo()
         connect(sparkleUpdater, &SparkleUpdater::statusChanged, this, &GeneralSettings::slotUpdateInfo, Qt::UniqueConnection);
         _ui->updateStateLabel->setText(sparkleUpdater->statusString());
         _ui->restartButton->setVisible(false);
-        _ui->updateButton->setEnabled(true);
+
+        const auto updaterState = sparkleUpdater->state();
+        const auto enableUpdateButton = updaterState == SparkleUpdater::State::Idle ||
+                                        updaterState == SparkleUpdater::State::Unknown;
+        _ui->updateButton->setEnabled(enableUpdateButton);
     }
 #endif
 

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -26,7 +26,7 @@ class SparkleUpdater : public Updater
     Q_OBJECT
 public:
     SparkleUpdater(const QUrl &appCastUrl);
-    ~SparkleUpdater() override;
+    ~SparkleUpdater();
 
     void setUpdateUrl(const QUrl &url);
 
@@ -39,7 +39,7 @@ public:
 
 private:
     class Private;
-    Private *d;
+    std::unique_ptr<Private> d;
 };
 
 } // namespace OCC

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -26,6 +26,13 @@ class SparkleUpdater : public Updater
     Q_OBJECT
 
 public:
+    enum class State {
+        Unknown = 0,
+        Idle,
+        Working,
+        AwaitingUserInput
+    };
+
     SparkleUpdater(const QUrl &appCastUrl);
     ~SparkleUpdater();
 
@@ -36,7 +43,8 @@ public:
     void backgroundCheckForUpdate() override;
     bool handleStartup() override { return false; }
 
-    QString statusString();
+    QString statusString() const;
+    State state() const;
 
     class SparkleInterface;
 
@@ -46,6 +54,7 @@ signals:
 private:
     std::unique_ptr<SparkleInterface> _interface;
     QString _statusString;
+    State _state = State::Unknown;
     friend class SparkleInterface;
 };
 

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -37,9 +37,10 @@ public:
 
     QString statusString();
 
+    class SparkleInterface;
+
 private:
-    class Private;
-    std::unique_ptr<Private> d;
+    std::unique_ptr<SparkleInterface> _interface;
 };
 
 } // namespace OCC

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -24,6 +24,7 @@ namespace OCC {
 class SparkleUpdater : public Updater
 {
     Q_OBJECT
+
 public:
     SparkleUpdater(const QUrl &appCastUrl);
     ~SparkleUpdater();
@@ -38,6 +39,9 @@ public:
     QString statusString();
 
     class SparkleInterface;
+
+signals:
+    void statusChanged();
 
 private:
     std::unique_ptr<SparkleInterface> _interface;

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -45,6 +45,8 @@ signals:
 
 private:
     std::unique_ptr<SparkleInterface> _interface;
+    QString _statusString;
+    friend class SparkleInterface;
 };
 
 } // namespace OCC

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -36,6 +36,8 @@ public:
     SparkleUpdater(const QUrl &appCastUrl);
     ~SparkleUpdater();
 
+    static bool autoUpdaterAllowed();
+
     void setUpdateUrl(const QUrl &url);
 
     // unused in this updater

--- a/src/gui/updater/sparkleupdater.h
+++ b/src/gui/updater/sparkleupdater.h
@@ -24,8 +24,11 @@ namespace OCC {
 class SparkleUpdater : public Updater
 {
     Q_OBJECT
+    Q_PROPERTY(QString statusString READ statusString NOTIFY statusChanged)
+    Q_PROPERTY(State state READ state NOTIFY statusChanged)
 
 public:
+    class SparkleInterface;
     enum class State {
         Unknown = 0,
         Idle,
@@ -33,22 +36,19 @@ public:
         AwaitingUserInput
     };
 
-    SparkleUpdater(const QUrl &appCastUrl);
-    ~SparkleUpdater();
+    explicit SparkleUpdater(const QUrl &appCastUrl);
+    ~SparkleUpdater() override;
 
-    static bool autoUpdaterAllowed();
+    [[nodiscard]] static bool autoUpdaterAllowed();
 
+    [[nodiscard]] bool handleStartup() override { return false; }
+    [[nodiscard]] QString statusString() const;
+    [[nodiscard]] State state() const;
+
+public slots:
     void setUpdateUrl(const QUrl &url);
-
-    // unused in this updater
     void checkForUpdate() override;
     void backgroundCheckForUpdate() override;
-    bool handleStartup() override { return false; }
-
-    QString statusString() const;
-    State state() const;
-
-    class SparkleInterface;
 
 signals:
     void statusChanged();

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -22,10 +22,10 @@
 #include "configfile.h"
 #include "updater/sparkleupdater.h"
 
-@interface DelegateObject : NSObject <SUUpdaterDelegate>
+@interface NCSparkleUpdaterDelegate : NSObject <SUUpdaterDelegate>
 - (BOOL)updaterMayCheckForUpdates:(SUUpdater *)bundle;
 @end
-@implementation DelegateObject //(SUUpdaterDelegateInformalProtocol)
+@implementation NCSparkleUpdaterDelegate //(SUUpdaterDelegateInformalProtocol)
 
 - (BOOL)updaterMayCheckForUpdates:(SUUpdater *)bundle
 {
@@ -86,7 +86,7 @@ public:
     }
 
     SUUpdater* updater;
-    DelegateObject *delegate;
+    NCSparkleUpdaterDelegate *delegate;
 };
 
 // Delete ~/Library//Preferences/com.owncloud.desktopclient.plist to re-test
@@ -94,7 +94,7 @@ SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     : Updater()
     , d(std::make_unique<Private>())
 {
-    d->delegate = [[DelegateObject alloc] init];
+    d->delegate = [[NCSparkleUpdaterDelegate alloc] init];
     [d->delegate retain];
 
     d->updater = [SUUpdater sharedUpdater];

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -76,19 +76,24 @@
 
 namespace OCC {
 
-class SparkleUpdater::Private
+class Q_DECL_HIDDEN SparkleUpdater::Private
 {
-    public:
-        SUUpdater* updater;
-        DelegateObject *delegate;
+public:
+    ~Private()
+    {
+        [updater release];
+        [delegate release];
+    }
+
+    SUUpdater* updater;
+    DelegateObject *delegate;
 };
 
 // Delete ~/Library//Preferences/com.owncloud.desktopclient.plist to re-test
 SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     : Updater()
+    , d(std::make_unique<Private>())
 {
-    d = new Private;
-
     d->delegate = [[DelegateObject alloc] init];
     [d->delegate retain];
 
@@ -107,11 +112,7 @@ SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     [d->updater setUserAgentString: userAgent];
 }
 
-SparkleUpdater::~SparkleUpdater()
-{
-    [d->updater release];
-    delete d;
-}
+SparkleUpdater::~SparkleUpdater() = default;
 
 void SparkleUpdater::setUpdateUrl(const QUrl &url)
 {

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -38,8 +38,9 @@ public:
         [delegate release];
     }
 
-    void statusChanged()
+    void statusChanged(const QString &statusString)
     {
+        q->_statusString = statusString;
         emit q->statusChanged();
     }
 
@@ -78,9 +79,10 @@ private:
     return YES;
 }
 
-- (void)notifyChange
+- (void)notifyChange:(const QString&)statusString
 {
-    _owner->statusChanged();
+    qCDebug(OCC::lcUpdater) << statusString;
+    _owner->statusChanged(statusString);
 }
 
 // Sent when a valid update is found by the update driver.
@@ -88,16 +90,14 @@ private:
 {
     Q_UNUSED(updater)
     Q_UNUSED(update)
-    qCDebug(OCC::lcUpdater) << "Found a valid update.";
-    [self notifyChange];
+    [self notifyChange:QStringLiteral("Found a valid update.")];
 }
 
 // Sent when a valid update is not found.
 - (void)updaterDidNotFindUpdate:(SUUpdater *)update
 {
     Q_UNUSED(update)
-    qCDebug(OCC::lcUpdater) << "No valid update found.";
-    [self notifyChange];
+    [self notifyChange:QStringLiteral("No valid update found.")];
 }
 
 // Sent immediately before installing the specified update.
@@ -105,24 +105,21 @@ private:
 {
     Q_UNUSED(updater)
     Q_UNUSED(update)
-    qCDebug(OCC::lcUpdater) << "About to install update.";
-    [self notifyChange];
+    [self notifyChange:QStringLiteral("About to install update.")];
 }
 
 - (void)updater:(SUUpdater *)updater didAbortWithError:(NSError *)error
 {
     Q_UNUSED(updater)
-    qCDebug(OCC::lcUpdater) << error.description;
-    [self notifyChange];
+    const QString message(QStringLiteral("Aborted with error: ") + QString::fromNSString(error.description));
+    [self notifyChange:message];
 }
 
 - (void)updater:(SUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast
 {
     Q_UNUSED(updater)
     Q_UNUSED(appcast)
-
-    qCDebug(OCC::lcUpdater) << "Finished loading appcast.";
-    [self notifyChange];
+    [self notifyChange:QStringLiteral("Finished loading appcast.")];
 }
 
 
@@ -200,8 +197,7 @@ void SparkleUpdater::backgroundCheckForUpdate()
 
 QString SparkleUpdater::statusString()
 {
-    // FIXME Show the real state depending on the callbacks
-    return QString();
+    return _statusString;
 }
 
 } // namespace OCC

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -93,6 +93,11 @@ namespace OCC {
 class Q_DECL_HIDDEN SparkleUpdater::SparkleInterface
 {
 public:
+    explicit SparkleInterface(SparkleUpdater *parent)
+        : q(parent)
+    {
+    }
+
     ~SparkleInterface()
     {
         [updater release];
@@ -101,12 +106,15 @@ public:
 
     SUUpdater* updater;
     NCSparkleUpdaterDelegate *delegate;
+
+private:
+    SparkleUpdater * const q;
 };
 
 // Delete ~/Library//Preferences/com.owncloud.desktopclient.plist to re-test
 SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     : Updater()
-    , _interface(std::make_unique<SparkleInterface>())
+    , _interface(std::make_unique<SparkleInterface>(this))
 {
     _interface->delegate = [[NCSparkleUpdaterDelegate alloc] init];
     [_interface->delegate retain];
@@ -152,7 +160,6 @@ bool autoUpdaterAllowed()
 
     return true;
 }
-
 
 void SparkleUpdater::checkForUpdate()
 {

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -247,7 +247,8 @@ SparkleUpdater::SparkleUpdater(const QUrl& appCastUrl)
     setUpdateUrl(appCastUrl);
 
     // Sparkle 1.8 required
-    NSString *userAgent = [NSString stringWithUTF8String: Utility::userAgentString().data()];
+    const auto userAgentString = QString::fromUtf8(Utility::userAgentString());
+    NSString *userAgent = userAgentString.toNSString();
     [_interface->updater setUserAgentString: userAgent];
 }
 
@@ -255,7 +256,7 @@ SparkleUpdater::~SparkleUpdater() = default;
 
 void SparkleUpdater::setUpdateUrl(const QUrl &url)
 {
-    NSURL* nsurl = [NSURL URLWithString:[NSString stringWithUTF8String:url.toString().toUtf8().data()]];
+    NSURL* nsurl = [NSURL URLWithString:url.toString().toNSString()];
     [_interface->updater setFeedURL: nsurl];
 }
 

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -260,8 +260,7 @@ void SparkleUpdater::setUpdateUrl(const QUrl &url)
     [_interface->updater setFeedURL: nsurl];
 }
 
-// FIXME: Should be changed to not instantiate the SparkleUpdater at all in this case
-bool autoUpdaterAllowed()
+bool SparkleUpdater::autoUpdaterAllowed()
 {
     // See https://github.com/owncloud/client/issues/2931
     NSString *bundlePath = [[NSBundle mainBundle] bundlePath];

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -41,7 +41,7 @@ public:
     void statusChanged(const OCC::SparkleUpdater::State state, const QString &statusString = {})
     {
         q->_state = state;
-        q->_statusString = tr(statusString.toUtf8());
+        q->_statusString = statusString;
         emit q->statusChanged();
     }
 
@@ -106,7 +106,7 @@ private:
     Q_UNUSED(update)
 
     const auto versionQstring = QString::fromNSString(update.displayVersionString);
-    const auto message = QStringLiteral("Found a valid update: version %1").arg(versionQstring);
+    const auto message = QObject::tr("Found a valid update: version %1", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::AwaitingUserInput
               displayStatus:message];
@@ -117,7 +117,7 @@ private:
 {
     Q_UNUSED(updater)
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
-              displayStatus:QStringLiteral("No valid update found.")];
+              displayStatus:QObject::tr("No valid update found.")];
 }
 
 // Sent immediately before installing the specified update.
@@ -126,7 +126,7 @@ private:
     Q_UNUSED(updater)
 
     const auto versionQstring = QString::fromNSString(update.displayVersionString);
-    const auto message = QStringLiteral("About to install version %1 update.").arg(versionQstring);
+    const auto message = QObject::tr("About to install version %1 update.", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
               displayStatus:message];
@@ -136,7 +136,8 @@ private:
 {
     Q_UNUSED(updater)
 
-    const QString message(QStringLiteral("Aborted with error: ") + QString::fromNSString(error.description));
+    const auto errorQstring = QString::fromNSString(error.localizedDescription);
+    const auto message = QObject::tr("Aborted with error: %1", "%1 is version number").arg(errorQstring);
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
               displayStatus:message];
 }
@@ -146,16 +147,16 @@ private:
     Q_UNUSED(updater)
     Q_UNUSED(appcast)
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
-              displayStatus:QStringLiteral("Finished loading appcast.")];
+              displayStatus:QObject::tr("Finished loading appcast.")];
 }
 
 - (void)updater:(SUUpdater *)updater didDismissUpdateAlertPermanently:(BOOL)permanently forItem:(nonnull SUAppcastItem *)item
 {
     Q_UNUSED(updater)
 
-    const auto permanencyString = permanently ? QStringLiteral("Permanently") : QStringLiteral("Temporarily");
+    const auto permanencyString = permanently ? QObject::tr("Permanently") : QObject::tr("Temporarily");
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("%1 dismissed %2 update").arg(permanencyString, versionQstring);
+    const auto message = QObject::tr("%1 dismissed %2 update", "%1 is permanently or temporarily, %2 is version number").arg(permanencyString, versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
               displayStatus:message];
@@ -166,7 +167,7 @@ private:
     Q_UNUSED(updater)
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("Update %1 will not be applied as it was chosen to be skipped.").arg(versionQstring);
+    const auto message = QObject::tr("Update version %1 will not be applied as it was chosen to be skipped.",  "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
               displayStatus:message];
@@ -178,7 +179,7 @@ private:
     Q_UNUSED(request)
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("Downloading version %1 update.").arg(versionQstring);
+    const auto message = QObject::tr("Downloading version %1 update.", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
               displayStatus:message];
@@ -189,7 +190,7 @@ private:
     Q_UNUSED(updater)
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("Downloaded version %1 update.").arg(versionQstring);
+    const auto message = QObject::tr("Downloaded version %1 update.", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
               displayStatus:message];
@@ -201,7 +202,7 @@ private:
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
     const auto errorQstring = QString::fromNSString(error.localizedDescription);
-    const auto message = QStringLiteral("Error downloading version %1 update: %2").arg(versionQstring);
+    const auto message = QObject::tr("Error downloading version %1 update: %2", "%1 is version number, %2 is error message").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
               displayStatus:message];
@@ -212,7 +213,7 @@ private:
     Q_UNUSED(updater)
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("Extracting version %1 update.").arg(versionQstring);
+    const auto message = QObject::tr("Extracting version %1 update.", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
               displayStatus:message];
@@ -223,7 +224,7 @@ private:
     Q_UNUSED(updater)
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
-    const auto message = QStringLiteral("Extracted version %1 update.").arg(versionQstring);
+    const auto message = QObject::tr("Extracted version %1 update.", "%1 is version number").arg(versionQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Working
               displayStatus:message];
@@ -233,7 +234,7 @@ private:
 {
     Q_UNUSED(updater);
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
-              displayStatus:QStringLiteral("Update download cancelled.")];
+              displayStatus:QObject::tr("Update download cancelled.")];
 }
 
 @end

--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -270,8 +270,7 @@ SparkleUpdater::~SparkleUpdater() = default;
 
 void SparkleUpdater::setUpdateUrl(const QUrl &url)
 {
-    NSURL* nsurl = [NSURL URLWithString:url.toString().toNSString()];
-    [_interface->updater setFeedURL: nsurl];
+    [_interface->updater setFeedURL:url.toNSURL()];
 }
 
 bool SparkleUpdater::autoUpdaterAllowed()

--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -57,7 +57,9 @@ QUrl Updater::updateUrl()
     auto urlQuery = getQueryParams();
 
 #if defined(Q_OS_MAC) && defined(HAVE_SPARKLE)
-    urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
+    if (SparkleUpdater::autoUpdaterAllowed()) {
+        urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
+    }
 #endif
 
 #if defined(Q_OS_WIN)
@@ -142,7 +144,11 @@ Updater *Updater::create()
     }
 
 #if defined(Q_OS_MACOS) && defined(HAVE_SPARKLE) && defined(BUILD_OWNCLOUD_OSX_BUNDLE)
-    return new SparkleUpdater(url);
+    if (SparkleUpdater::autoUpdaterAllowed()) {
+        return new SparkleUpdater(url);
+    }
+
+    return new PassiveUpdateNotifier(url);
 #elif defined(Q_OS_WIN32)
     // Also for MSI
     return new NSISUpdater(url);


### PR DESCRIPTION
Our current implementation of the sparkle updater is not optimal. It does not communicate with our Qt GUI at all which leads to things like the update status QLabel in the settings window not being updated, and the "Check for updates" button being permanently disabled. Additionally, our handling of edge cases such as the application not being put in the `Applications` folder is not good

This PR addresses these issues and improves our integration with the updater; it also fixes several internal updater and UI bugs along the way

Fixes #5429

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
