### PR TITLE
Fix infinite loading in the share dialog when public link shares are disabled on the server

### DIFF
--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -345,6 +345,8 @@ void ShareModel::handlePlaceholderLinkShare()
     } else if (!linkSharePresent && !placeholderLinkSharePresent && publicLinkSharesEnabled()) {
         slotAddShare(_placeholderLinkShare);
     }
+
+    Q_EMIT sharesChanged();
 }
 
 void ShareModel::slotPropfindReceived(const QVariantMap &result)
@@ -402,7 +404,6 @@ void ShareModel::slotSharesFetched(const QList<SharePtr> &shares)
     }
 
     handlePlaceholderLinkShare();
-    Q_EMIT sharesChanged();
 }
 
 void ShareModel::setupInternalLinkShare()
@@ -479,7 +480,6 @@ void ShareModel::slotAddShare(const SharePtr &share)
     }
 
     handlePlaceholderLinkShare();
-    Q_EMIT sharesChanged();
 }
 
 void ShareModel::slotRemoveShareWithId(const QString &shareId)
@@ -506,8 +506,6 @@ void ShareModel::slotRemoveShareWithId(const QString &shareId)
     endRemoveRows();
 
     handlePlaceholderLinkShare();
-
-    Q_EMIT sharesChanged();
 }
 
 void ShareModel::slotServerError(const int code, const QString &message)

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -298,10 +298,7 @@ void ShareModel::initShareManager()
     }
 
     bool sharingPossible = true;
-    if (!publicLinkSharesEnabled()) {
-        qCWarning(lcSharing) << "Link shares have been disabled";
-        sharingPossible = false;
-    } else if (!canShare()) {
+    if (!canShare()) {
         qCWarning(lcSharing) << "The file cannot be shared because it does not have sharing permission.";
         sharingPossible = false;
     }

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -342,7 +342,7 @@ void ShareModel::handlePlaceholderLinkShare()
 
     if (linkSharePresent && placeholderLinkSharePresent) {
         slotRemoveShareWithId(placeholderLinkShareId);
-    } else if (!linkSharePresent && !placeholderLinkSharePresent) {
+    } else if (!linkSharePresent && !placeholderLinkSharePresent && publicLinkSharesEnabled()) {
         slotAddShare(_placeholderLinkShare);
     }
 }
@@ -402,6 +402,7 @@ void ShareModel::slotSharesFetched(const QList<SharePtr> &shares)
     }
 
     handlePlaceholderLinkShare();
+    Q_EMIT sharesChanged();
 }
 
 void ShareModel::setupInternalLinkShare()


### PR DESCRIPTION
We erroneously prevent the share manager from being initialised if public link shares are disabled on the server. Since we can have situations where link shares are disabled but user shares are enabled, this is wrong.

This PR fixes this bug and prevents the placeholder link share from being presented if public link shares are disabled

Fixes #5470 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
