### PR TITLE
Fix text labels in Sync Status component

### DIFF
--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -57,6 +57,7 @@ RowLayout {
             font.pixelSize: Style.topLinePixelSize
             font.bold: true
             color: Style.ncTextColor
+            wrapMode: Text.Wrap
         }
 
         Loader {
@@ -96,6 +97,7 @@ RowLayout {
             visible: syncStatus.syncStatusDetailString !== ""
             color: Style.ncSecondaryTextColor
             font.pixelSize: Style.subLinePixelSize
+            wrapMode: Text.Wrap
         }
     }
 


### PR DESCRIPTION
With fix:

![Screenshot 2023-02-27 at 14 54 27](https://user-images.githubusercontent.com/70155116/221583045-d37cf3b6-19db-44cf-adc9-4a16871d79ac.png)


Before fix:

![Screenshot 2023-02-27 at 14 57 11](https://user-images.githubusercontent.com/70155116/221583110-927cebef-5dfc-4297-a4fc-ec2a85017a68.png)


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
