### PR TITLE
Fix display of 2FA notification.

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -120,6 +120,12 @@ void User::showDesktopNotification(const Activity &activity)
 {
     const auto notificationId = activity._id;
     const auto message = AccountManager::instance()->accounts().count() == 1 ? "" : activity._accName;
+
+    // the user needs to interact with this notification
+    if (activity._links.size() > 0) {
+        _activityModel->addNotificationToActivityList(activity);
+    }
+
     showDesktopNotification(activity._subject, message, notificationId);
 }
 


### PR DESCRIPTION
Fix for issue #5421: add server notifications to the activities list when the user needs to act on it.

![2fa](https://user-images.githubusercontent.com/241266/221935634-f3869131-cf09-4132-bee8-8945c61f53d8.png)

It should also work for other notifications:
![sharing](https://user-images.githubusercontent.com/241266/221935625-669f3aa5-b599-4e9f-9efb-136a94227c02.png)