### PR TITLE
Show server name in tray main window

### DIFF
--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -523,6 +523,16 @@ ApplicationWindow {
                                 font.bold: true
                             }
 
+                            EnforcedPlainTextLabel {
+                                id: currentAccountServer
+                                Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
+                                width: Style.currentAccountLabelWidth
+                                text: UserModel.currentUser.server
+                                elide: Text.ElideRight
+                                color: Style.currentUserHeaderTextColor
+                                visible: UserModel.numUsers() > 1
+                            }
+
                             RowLayout {
                                 id: currentUserStatus
                                 visible: UserModel.currentUser.isConnected &&


### PR DESCRIPTION
Closes #5491 

This PR adds the Account server name to the tray main window, if more than 1 account exists.

Reason for change: If a user has the same user name across multiple servers, it's hard to know which account is currently selected.

Example:
![Screenshot 2023-03-10 150208](https://user-images.githubusercontent.com/34812414/224337245-1afd7ed3-1c1e-48d6-aef7-ca83f49eecbb.png)

*First time using QML, comments/improvements welcome!*