### PR TITLE
Fix for network validation issues on wireless (fixes Issue #4331)

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -13,6 +13,7 @@
 #include <QLabel>
 
 #include "accessmanager.h"
+#include "accountmanager.h"
 #include "account.h"
 #include "configfile.h"
 #include "theme.h"
@@ -227,6 +228,10 @@ bool WebFlowCredentials::stillValid(QNetworkReply *reply) {
     if (reply->error() != QNetworkReply::NoError) {
         qCWarning(lcWebFlowCredentials()) << reply->error();
         qCWarning(lcWebFlowCredentials()) << reply->errorString();
+        const auto accounts = AccountManager::instance()->accounts();
+	for (auto account : accounts) {
+	    account->freshConnectionAttempt();
+	}
     }
     return (reply->error() != QNetworkReply::AuthenticationRequiredError);
 }

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -229,9 +229,9 @@ bool WebFlowCredentials::stillValid(QNetworkReply *reply) {
         qCWarning(lcWebFlowCredentials()) << reply->error();
         qCWarning(lcWebFlowCredentials()) << reply->errorString();
         const auto accounts = AccountManager::instance()->accounts();
-	for (auto account : accounts) {
-	    account->freshConnectionAttempt();
-	}
+	    for (auto account : accounts) {
+	        account->freshConnectionAttempt();
+	    }
     }
     return (reply->error() != QNetworkReply::AuthenticationRequiredError);
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

There is an issue on linux (and maybe other OSes?) where reconnecting to the wifi network leads to a network validation error (unsure why, but previous code comments suggest it stems from an issue in QNAM).  See Issue #4331 for more details and comments.

This PR uses the procedure from `gui/networksettings.cpp` to force a fresh connection attempt following a validation error.  This ultimately leads to code in `AccountState::checkConnectivity()` that appears to have added to catch very similar issues (but was never reached in this error case).