### PR TITLE
in case server has no private key, let e2ee init fail

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1434,8 +1434,12 @@ void ClientSideEncryption::getPrivateKeyFromServer(const AccountPtr &account)
             decryptPrivateKey(account, key.toLocal8Bit());
         } else if (retCode == 404) {
             qCInfo(lcCse()) << "No private key on the server: setup is incomplete.";
+            emit initializationFinished();
+            return;
         } else {
             qCInfo(lcCse()) << "Error while requesting public key: " << retCode;
+            emit initializationFinished();
+            return;
         }
     });
     job->start();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
