### PR TITLE
Do not display error status and messages when aborting a sync during hydration request in VFS mode

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1101,6 +1101,12 @@ void Folder::slotItemCompleted(const SyncFileItemPtr &item)
         return;
     }
 
+    if (_silenceErrorsUntilNextSync
+        && (item->_status != SyncFileItem::Status::Success && item->_status != SyncFileItem::Status::NoStatus)) {
+        item->_errorString.clear();
+        item->_status = SyncFileItem::Status::SoftError;
+    }
+
     _syncResult.processCompletedItem(item);
 
     _fileLog->logItem(*item);
@@ -1230,6 +1236,7 @@ void Folder::slotHydrationStarts()
 {
     // Abort any running full sync run and reschedule
     if (_engine->isSyncRunning()) {
+        setSilenceErrorsUntilNextSync(true);
         slotTerminateSync();
         scheduleThisFolderSoon();
         // TODO: This sets the sync state to AbortRequested on done, we don't want that


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
