### PR TITLE
Properly handle all fatal errors during edit locally setup procedure

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -155,7 +155,6 @@ void EditLocallyJob::proceedWithSetup()
     _localFilePath = _folderForFile->path() + _relativePathToRemoteRoot;
 
     Systray::instance()->destroyEditFileLocallyLoadingDialog();
-    Q_EMIT setupFinished();
     startEditLocally();
 }
 

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -153,6 +153,7 @@ void EditLocallyJob::proceedWithSetup()
 
     Systray::instance()->destroyEditFileLocallyLoadingDialog();
     Q_EMIT setupFinished();
+    startEditLocally();
 }
 
 void EditLocallyJob::findAfolderAndConstructPaths()

--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -89,6 +89,9 @@ void EditLocallyJob::startTokenRemoteCheck()
                                         << "accountState:" << _accountState
                                         << "relPath:" << _relPath
                                         << "token:" << _token;
+
+        showError(tr("Could not start editing locally."),
+                  tr("An error occurred trying to verify the request to edit locally."));
         return;
     }
 
@@ -199,6 +202,8 @@ void EditLocallyJob::fetchRemoteFileParentInfo()
 
     if (_relPathParent == QStringLiteral("/")) {
         qCWarning(lcEditLocallyJob) << "LsColJob must only be used for nested folders.";
+        showError(tr("Could not start editing locally."),
+                  tr("An error occurred during data retrieval."));
         return;
     }
 
@@ -448,6 +453,8 @@ void EditLocallyJob::startEditLocally()
                                         << "fileName:" << _fileName
                                         << "localFilePath:" << _localFilePath
                                         << "folderForFile:" << _folderForFile;
+
+        showError(tr("Could not start editing locally."), tr("An error occurred during setup."));
         return;
     }
 
@@ -504,6 +511,8 @@ void EditLocallyJob::slotDirectoryListingIterated(const QString &name, const QMa
 
     if (_relPathParent == QStringLiteral("/")) {
         qCWarning(lcEditLocallyJob) << "LsColJob must only be used for nested folders.";
+        showError(tr("Could not start editing locally."),
+                  tr("An error occurred during data retrieval."));
         return;
     }
 
@@ -511,6 +520,8 @@ void EditLocallyJob::slotDirectoryListingIterated(const QString &name, const QMa
     Q_ASSERT(job);
     if (!job) {
         qCWarning(lcEditLocallyJob) << "Must call slotDirectoryListingIterated from a signal.";
+        showError(tr("Could not start editing locally."),
+                  tr("An error occurred during data retrieval."));
         return;
     }
 
@@ -534,8 +545,9 @@ void EditLocallyJob::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
     Q_ASSERT(item && !item->isEmpty());
     if (!item || item->isEmpty()) {
         qCWarning(lcEditLocallyJob) << "invalid item";
-    }
-    if (item->_file == _relativePathToRemoteRoot) {
+        showError(tr("Could not start editing locally."),
+                  tr("An error occurred trying to synchronise the file to edit locally."));
+    } else if (item->_file == _relativePathToRemoteRoot) {
         disconnect(&_folderForFile->syncEngine(), &SyncEngine::itemDiscovered, this, &EditLocallyJob::slotItemDiscovered);
         if (item->_instruction == CSYNC_INSTRUCTION_NONE) {
             // return early if the file is already in sync
@@ -553,6 +565,8 @@ void EditLocallyJob::openFile()
 
     if(_localFilePath.isEmpty()) {
         qCWarning(lcEditLocallyJob) << "Could not edit locally. Invalid local file path.";
+        showError(tr("Could not start editing locally."),
+                  tr("Invalid local file path."));
         return;
     }
 

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -43,10 +43,10 @@ public:
     [[nodiscard]] static QString prefixSlashToPath(const QString &path);
 
 signals:
-    void setupFinished();
     void error(const QString &message, const QString &informativeText);
     void finished();
     void callShowError(const QString &message, const QString &informativeText);
+
 public slots:
     void startSetup();
     void startEditLocally();

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -54,7 +54,6 @@ public slots:
 private slots:
     void fetchRemoteFileParentInfo();
     void startSyncBeforeOpening();
-    void eraseBlacklistRecordForItem();
 
     void startTokenRemoteCheck();
     void proceedWithSetup();
@@ -85,6 +84,7 @@ private slots:
 
 private:
     [[nodiscard]] bool checkIfFileParentSyncIsNeeded(); // returns true if sync will be needed, false otherwise
+    [[nodiscard]] bool eraseBlacklistRecordForItem();
     [[nodiscard]] const QString getRelativePathToRemoteRootForFile() const; // returns either '/' or a (relative path - Folder::remotePath()) for folders pointing to a non-root remote path e.g. '/subfolder' instead of '/'
     [[nodiscard]] const QString getRelativePathParent() const;
 

--- a/src/gui/editlocallymanager.cpp
+++ b/src/gui/editlocallymanager.cpp
@@ -79,14 +79,9 @@ void EditLocallyManager::createJob(const QString &userId,
     _jobs.insert(token, job);
 
     const auto removeJob = [this, token] { _jobs.remove(token); };
-    const auto setupJob = [job] { job->startEditLocally(); };
 
-    connect(job.data(), &EditLocallyJob::error,
-            this, removeJob);
-    connect(job.data(), &EditLocallyJob::finished,
-            this, removeJob);
-    connect(job.data(), &EditLocallyJob::setupFinished,
-            job.data(), setupJob);
+    connect(job.data(), &EditLocallyJob::error, this, removeJob);
+    connect(job.data(), &EditLocallyJob::finished, this, removeJob);
 
     job->startSetup();
 }


### PR DESCRIPTION
This should fix situations where the edit locally loading dialog is presented but never destroyed when an error is met during setup

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
