### PR TITLE
fix compilation with clazy and fully-qualified-moc-types checks enabled

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -389,7 +389,7 @@ public:
 
 public slots:
     /// Store a new or updated record in the database
-    void setCaseConflictRecord(const ConflictRecord &record);
+    void setCaseConflictRecord(const OCC::ConflictRecord &record);
 
     /// Delete a case clash conflict record by path of the file with the conflict tag
     void deleteCaseClashConflictByPathRecord(const QString &path);

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -118,7 +118,7 @@ private slots:
 
 private slots:
     void displayMnemonic(const QString &mnemonic);
-    void disableEncryptionForAccount(const AccountPtr &account) const;
+    void disableEncryptionForAccount(const OCC::AccountPtr &account) const;
     void showConnectionLabel(const QString &message, QStringList errors = QStringList());
     void openIgnoredFilesDialog(const QString & absFolderPath);
     void customizeStyle();

--- a/src/gui/accountsetupfromcommandlinejob.h
+++ b/src/gui/accountsetupfromcommandlinejob.h
@@ -47,7 +47,7 @@ private slots:
 
     void accountSetupFromCommandLinePropfindHandleFailure();
 
-    void setupLocalSyncFolder(AccountState *accountState);
+    void setupLocalSyncFolder(OCC::AccountState *accountState);
 
     void printAccountSetupFromCommandLineStatusAndExit(const QString &status, bool isFailure);
 

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -76,7 +76,7 @@ private slots:
     void lockFile();
 
     void fileAlreadyLocked();
-    void fileLockSuccess(const SyncFileItemPtr &item);
+    void fileLockSuccess(const OCC::SyncFileItemPtr &item);
     void fileLockError(const QString &errorMessage);
     void fileLockProcedureComplete(const QString &notificationTitle,
                                    const QString &notificationMessage,

--- a/src/gui/filedetails/shareemodel.h
+++ b/src/gui/filedetails/shareemodel.h
@@ -88,7 +88,7 @@ public slots:
 
 private slots:
     void shareesFetched(const QJsonDocument &reply);
-    void insertSearchGloballyItem(const QVector<ShareePtr> &newShareesFetched);
+    void insertSearchGloballyItem(const QVector<OCC::ShareePtr> &newShareesFetched);
     void filterSharees();
     void slotDarkModeChanged();
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1549,7 +1549,6 @@ void FolderMan::trayOverallStatus(const QList<Folder *> &folders,
         int goodSeen = 0;
         int abortOrPausedSeen = 0;
         int runSeen = 0;
-        int various = 0;
 
         for (const Folder *folder : qAsConst(folders)) {
             SyncResult folderResult = folder->syncResult();
@@ -1561,7 +1560,6 @@ void FolderMan::trayOverallStatus(const QList<Folder *> &folders,
                 switch (syncStatus) {
                 case SyncResult::Undefined:
                 case SyncResult::NotYetStarted:
-                    various++;
                     break;
                 case SyncResult::SyncPrepare:
                 case SyncResult::SyncRunning:

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -276,7 +276,7 @@ public slots:
 
     void forceSyncForFolder(OCC::Folder *folder);
 
-    void removeE2eFiles(const AccountPtr &account) const;
+    void removeE2eFiles(const OCC::AccountPtr &account) const;
 
 private slots:
     void slotFolderSyncPaused(OCC::Folder *, bool paused);

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -125,9 +125,9 @@ private:
 
     // The context menu actions
     Q_INVOKABLE void command_ACTIVITY(const QString &localFile, OCC::SocketListener *listener);
-    Q_INVOKABLE void command_ENCRYPT(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_ENCRYPT(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_SHARE(const QString &localFile, OCC::SocketListener *listener);
-    Q_INVOKABLE void command_LEAVESHARE(const QString &localFile, SocketListener *listener);
+    Q_INVOKABLE void command_LEAVESHARE(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_MANAGE_PUBLIC_LINKS(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_COPY_SECUREFILEDROP_LINK(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_COPY_PUBLIC_LINK(const QString &localFile, OCC::SocketListener *listener);

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -102,7 +102,7 @@ signals:
     void shutdown();
 
     void showFileDetailsPage(const QString &fileLocalPath, const OCC::Systray::FileDetailsPage page);
-    void showFileDetails(AccountState *accountState, const QString &localPath, const OCC::Systray::FileDetailsPage fileDetailsPage);
+    void showFileDetails(OCC::AccountState *accountState, const QString &localPath, const OCC::Systray::FileDetailsPage fileDetailsPage);
     void sendChatMessage(const QString &token, const QString &message, const QString &replyTo);
     void showErrorMessageDialog(const QString &error);
 
@@ -115,7 +115,7 @@ public slots:
 
     void showMessage(const QString &title, const QString &message, QSystemTrayIcon::MessageIcon icon = Information);
     void showUpdateMessage(const QString &title, const QString &message, const QUrl &webUrl);
-    void showTalkMessage(const QString &title, const QString &message, const QString &replyTo, const QString &token, const AccountStatePtr &accountState);
+    void showTalkMessage(const QString &title, const QString &message, const QString &replyTo, const QString &token, const OCC::AccountStatePtr &accountState);
     void setToolTip(const QString &tip);
 
     void createCallDialog(const OCC::Activity &callNotification, const OCC::AccountStatePtr accountState);

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -113,15 +113,15 @@ public slots:
 private slots:
     void slotPushNotificationsReady();
     void slotDisconnectPushNotifications();
-    void slotReceivedPushNotification(Account *account);
-    void slotReceivedPushActivity(Account *account);
+    void slotReceivedPushNotification(OCC::Account *account);
+    void slotReceivedPushActivity(OCC::Account *account);
     void slotCheckExpiredActivities();
 
     void checkNotifiedNotifications();
     void showDesktopNotification(const QString &title, const QString &message, const long notificationId);
-    void showDesktopNotification(const Activity &activity);
-    void showDesktopNotification(const ActivityList &activityList);
-    void showDesktopTalkNotification(const Activity &activity);
+    void showDesktopNotification(const OCC::Activity &activity);
+    void showDesktopNotification(const OCC::ActivityList &activityList);
+    void showDesktopTalkNotification(const OCC::Activity &activity);
 
 private:
     void connectPushNotifications() const;

--- a/src/libsync/clientsideencryption.h
+++ b/src/libsync/clientsideencryption.h
@@ -137,12 +137,12 @@ signals:
     void mnemonicDeleted();
 
 public slots:
-    void initialize(const AccountPtr &account);
-    void forgetSensitiveData(const AccountPtr &account);
+    void initialize(const OCC::AccountPtr &account);
+    void forgetSensitiveData(const OCC::AccountPtr &account);
 
 private slots:
-    void generateKeyPair(const AccountPtr &account);
-    void encryptPrivateKey(const AccountPtr &account);    
+    void generateKeyPair(const OCC::AccountPtr &account);
+    void encryptPrivateKey(const OCC::AccountPtr &account);
 
     void publicKeyFetched(QKeychain::Job *incoming);
     void privateKeyFetched(QKeychain::Job *incoming);
@@ -153,15 +153,15 @@ private slots:
     void handleMnemonicDeleted(const QKeychain::Job* const incoming);
     void checkAllSensitiveDataDeleted();
 
-    void getPrivateKeyFromServer(const AccountPtr &account);
-    void getPublicKeyFromServer(const AccountPtr &account);
-    void fetchAndValidatePublicKeyFromServer(const AccountPtr &account);
-    void decryptPrivateKey(const AccountPtr &account, const QByteArray &key);
+    void getPrivateKeyFromServer(const OCC::AccountPtr &account);
+    void getPublicKeyFromServer(const OCC::AccountPtr &account);
+    void fetchAndValidatePublicKeyFromServer(const OCC::AccountPtr &account);
+    void decryptPrivateKey(const OCC::AccountPtr &account, const QByteArray &key);
 
-    void fetchFromKeyChain(const AccountPtr &account);
-    void writePrivateKey(const AccountPtr &account);
-    void writeCertificate(const AccountPtr &account);
-    void writeMnemonic(const AccountPtr &account);
+    void fetchFromKeyChain(const OCC::AccountPtr &account);
+    void writePrivateKey(const OCC::AccountPtr &account);
+    void writeCertificate(const OCC::AccountPtr &account);
+    void writeMnemonic(const OCC::AccountPtr &account);
 
 private:
     void generateCSR(const AccountPtr &account, PKey keyPair);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -128,7 +128,7 @@ public:
     [[nodiscard]] const SyncEngine::SingleItemDiscoveryOptions &singleItemDiscoveryOptions() const;
 
 public slots:
-    void setSingleItemDiscoveryOptions(const SingleItemDiscoveryOptions &singleItemDiscoveryOptions);
+    void setSingleItemDiscoveryOptions(const OCC::SyncEngine::SingleItemDiscoveryOptions &singleItemDiscoveryOptions);
 
     void startSync();
 
@@ -165,7 +165,7 @@ signals:
 
     void transmissionProgress(const OCC::ProgressInfo &progress);
 
-    void itemDiscovered(const SyncFileItemPtr &);
+    void itemDiscovered(const OCC::SyncFileItemPtr &);
 
     /// We've produced a new sync error of a type.
     void syncError(const QString &message, OCC::ErrorCategory category = OCC::ErrorCategory::Normal);

--- a/src/libsync/updatefiledropmetadata.h
+++ b/src/libsync/updatefiledropmetadata.h
@@ -51,7 +51,7 @@ private slots:
 signals:
     void folderUnlocked(const QByteArray &folderId, int httpStatus);
 
-    void fileDropMetadataParsedAndAdjusted(const FolderMetadata *const metadata);
+    void fileDropMetadataParsedAndAdjusted(const OCC::FolderMetadata *const metadata);
 
 private:
     QString _path;


### PR DESCRIPTION
will make all signals and slots be using fully qualified data types

makes code safer

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
