### PR TITLE
Edit locally. Restart current folder sync immediately after file opened.

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -452,6 +452,7 @@ void EditLocallyJob::startEditLocally()
         });
         _folderForFile->setSilenceErrorsUntilNextSync(true);
         _folderForFile->slotTerminateSync();
+        _shouldScheduleFolderSyncAfterFileIsOpened = true;
 
         return;
     }
@@ -538,6 +539,8 @@ void EditLocallyJob::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
 
 void EditLocallyJob::openFile()
 {
+    Q_ASSERT(_folderForFile);
+
     if(_localFilePath.isEmpty()) {
         qCWarning(lcEditLocallyJob) << "Could not edit locally. Invalid local file path.";
         return;
@@ -553,6 +556,11 @@ void EditLocallyJob::openFile()
         }
 
         Systray::instance()->destroyEditFileLocallyLoadingDialog();
+
+        if (_shouldScheduleFolderSyncAfterFileIsOpened) {
+            _folderForFile->startSync();
+        }
+
         emit finished();
     });
 }

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -92,6 +92,8 @@ private:
 
     bool _tokenVerified = false;
 
+    bool _shouldScheduleFolderSyncAfterFileIsOpened = false;
+
     AccountStatePtr _accountState;
     QString _userId;
     QString _relPath; // full remote path for a file (as on the server)


### PR DESCRIPTION
Make sure a folder sync gets restarted immediately after file opening is finished. A folder sync is restarted only if it was syncing before EditLocally got triggered.
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
