### PR TITLE
Bugfix/conflict dialog

### DIFF
--- a/src/gui/invalidfilenamedialog.cpp
+++ b/src/gui/invalidfilenamedialog.cpp
@@ -110,13 +110,11 @@ InvalidFilenameDialog::~InvalidFilenameDialog() = default;
 
 void InvalidFilenameDialog::checkIfAllowedToRename()
 {
-    qCInfo(lcFileSystem) << "== InvalidFilenameDialog::checkIfAllowedToRename";
     qCInfo(lcFileSystem) <<  "RP:" << _folder->remotePath();
     qCInfo(lcFileSystem) <<  "RP + trailing:" << QDir::cleanPath(_folder->remotePath());
     qCInfo(lcFileSystem) << "Trailing:" << _folder->remotePathTrailingSlash();
     qCInfo(lcFileSystem) << "CP + Trailing:" << QDir::cleanPath(_folder->remotePathTrailingSlash());
     qCInfo(lcFileSystem) << QDir::cleanPath(_folder->remotePathTrailingSlash()) + _originalFileName;
-    qCInfo(lcFileSystem) << "== InvalidFilenameDialog::checkIfAllowedToRename";
     const auto propfindJob = new PropfindJob(_account, QDir::cleanPath(_folder->remotePath() + _originalFileName));
     propfindJob->setProperties({ "http://owncloud.org/ns:permissions" });
     connect(propfindJob, &PropfindJob::result, this, &InvalidFilenameDialog::onPropfindPermissionSuccess);

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -717,13 +717,11 @@ void ActivityListModel::triggerCaseClashAction(Activity activity)
     const auto conflictedPath = dir.filePath(conflictedRelativePath);
     const auto conflictTaggedPath = dir.filePath(conflictRecord.path);
 
-    qCInfo(lcActivity) << "== ActivityListModel::triggerCaseClashAction";
     qCInfo(lcActivity) << "dir" << QDir(folder->path());
     qCInfo(lcActivity) << "conflictedPath" << conflictedPath;
     qCInfo(lcActivity) << "conflictedRelativePath" << conflictedRelativePath;
     qCInfo(lcActivity) << "conflictRecord.path" << conflictRecord.path;
     qCInfo(lcActivity) << "conflictTaggedPath" << dir.filePath(conflictRecord.path);
-    qCInfo(lcActivity) << "== ActivityListModel::triggerCaseClashAction";
     _currentCaseClashFilenameDialog = new CaseClashFilenameDialog(_accountState->account(),
                                                                   folder,
                                                                   conflictedPath,


### PR DESCRIPTION
Bogus stuff.

The conflict dialog freezes when user tries to rename file on Windows 10 using VFS. 
The issue seems to be that somewhere instead of getting that the file to be renamed is in the e.g. Issues folder: "/Issues/test.md", it gets a path like "Issuestest.md", the response says the file does not exist/could not be renamed.