### PR TITLE
no longer override the pixman default version

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -49,7 +49,6 @@ dev-utils/python2.ignored = True
 dev-utils/python3.ignored = True
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
-libs/pixman.version = 0.40.0
 
 [windows-msvc2019_64-cl]
 QtSDK/Compiler = msvc2019_64


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
