### PR TITLE
Edit locally. Fix crash on _chekTokenJob pointer deref.

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -98,16 +98,16 @@ void EditLocallyJob::startTokenRemoteCheck()
     const auto encodedToken = QString::fromUtf8(QUrl::toPercentEncoding(_token)); // Sanitise the token
     const auto encodedRelPath = QUrl::toPercentEncoding(_relPath); // Sanitise the relPath
 
-    _checkTokenJob.reset(new SimpleApiJob(_accountState->account(),
-                                          QStringLiteral("/ocs/v2.php/apps/files/api/v1/openlocaleditor/%1").arg(encodedToken)));
+    const auto checkTokenJob = new SimpleApiJob(_accountState->account(),
+                                          QStringLiteral("/ocs/v2.php/apps/files/api/v1/openlocaleditor/%1").arg(encodedToken));
 
     QUrlQuery params;
     params.addQueryItem(QStringLiteral("path"), prefixSlashToPath(encodedRelPath));
-    _checkTokenJob->addQueryParams(params);
-    _checkTokenJob->setVerb(SimpleApiJob::Verb::Post);
-    connect(_checkTokenJob.get(), &SimpleApiJob::resultReceived, this, &EditLocallyJob::remoteTokenCheckResultReceived);
+    checkTokenJob->addQueryParams(params);
+    checkTokenJob->setVerb(SimpleApiJob::Verb::Post);
+    connect(checkTokenJob, &SimpleApiJob::resultReceived, this, &EditLocallyJob::remoteTokenCheckResultReceived);
 
-    _checkTokenJob->start();
+    checkTokenJob->start();
 }
 
 void EditLocallyJob::remoteTokenCheckResultReceived(const int statusCode)

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -106,7 +106,6 @@ private:
     QString _localFilePath;
     QString _folderRelativePath;
     Folder *_folderForFile = nullptr;
-    std::unique_ptr<SimpleApiJob> _checkTokenJob;
     QMetaObject::Connection _syncTerminatedConnection = {};
     QVector<QMetaObject::Connection> _folderConnections;
 };


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
