### PR TITLE
Ask before importing accounts from legacy clients

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -175,10 +175,17 @@ bool AccountManager::restoreFromLegacySettings()
                                                       legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
 
         for (const auto &configFile : legacyLocations) {
-            if (const QFileInfo configFileInfo(configFile);
-                    configFileInfo.exists() && configFileInfo.isReadable()) {
-
+            if (const QFileInfo configFileInfo(configFile); configFileInfo.exists() && configFileInfo.isReadable()) {
                 qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
+
+                const auto importQuestion = tr("An existing configuration from a legacy desktop client was detected.\n"
+                                               "Should an account import be attempted?");
+                const auto messageBoxSelection = QMessageBox::question(nullptr, tr("Legacy import"), importQuestion);
+
+                if (messageBoxSelection == QMessageBox::No) {
+                    // User said don't import, return immediately
+                    return false;
+                }
 
                 auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
                 if (oCSettings->status() != QSettings::Status::NoError) {

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -246,11 +246,17 @@ bool AccountManager::restoreFromLegacySettings()
             settings->beginGroup(accountId);
             if (const auto acc = loadAccountHelper(*settings)) {
                 addAccount(acc);
-
+                QMessageBox::information(nullptr,
+                                         tr("Legacy import"),
+                                         tr("Successfully imported account from legacy client: %1").arg(acc->prettyName()));
                 return true;
             }
         }
     }
+
+    QMessageBox::information(nullptr,
+                             tr("Legacy import"),
+                             tr("Could not import accounts from legacy client configuration."));
     return false;
 }
 

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -178,13 +178,15 @@ bool AccountManager::restoreFromLegacySettings()
             if (const QFileInfo configFileInfo(configFile); configFileInfo.exists() && configFileInfo.isReadable()) {
                 qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
 
-                const auto importQuestion = tr("An existing configuration from a legacy desktop client was detected.\n"
-                                               "Should an account import be attempted?");
-                const auto messageBoxSelection = QMessageBox::question(nullptr, tr("Legacy import"), importQuestion);
+                if (!forceLegacyImport()) {
+                    const auto importQuestion = tr("An existing configuration from a legacy desktop client was detected.\n"
+                                                   "Should an account import be attempted?");
+                    const auto messageBoxSelection = QMessageBox::question(nullptr, tr("Legacy import"), importQuestion);
 
-                if (messageBoxSelection == QMessageBox::No) {
-                    // User said don't import, return immediately
-                    return false;
+                    if (messageBoxSelection == QMessageBox::No) {
+                        // User said don't import, return immediately
+                        return false;
+                    }
                 }
 
                 auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -558,4 +558,19 @@ void AccountManager::addAccountState(AccountState *accountState)
     ptr->trySignIn();
     emit accountAdded(accountState);
 }
+
+bool AccountManager::forceLegacyImport() const
+{
+    return _forceLegacyImport;
+}
+
+void AccountManager::setForceLegacyImport(const bool forceLegacyImport)
+{
+    if (_forceLegacyImport == forceLegacyImport) {
+        return;
+    }
+
+    _forceLegacyImport = forceLegacyImport;
+    Q_EMIT forceLegacyImportChanged();
+}
 }

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -26,6 +26,9 @@ namespace OCC {
 class AccountManager : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY(bool forceLegacyImport READ forceLegacyImport WRITE setForceLegacyImport NOTIFY forceLegacyImportChanged)
+
 public:
     enum AccountsRestoreResult {
         AccountsRestoreFailure = 0,
@@ -70,6 +73,12 @@ public:
     [[nodiscard]] AccountStatePtr accountFromUserId(const QString &id) const;
 
     /**
+     * Returns whether the account setup will force an import of
+     * legacy clients' accounts (true), or ask first (false)
+     */
+    [[nodiscard]] bool forceLegacyImport() const;
+
+    /**
      * Creates an account and sets up some basic handlers.
      * Does *not* add the account to the account manager just yet.
      */
@@ -97,11 +106,14 @@ public slots:
     /// Remove all accounts
     void shutdown();
 
+    void setForceLegacyImport(const bool forceLegacyImport);
+
 signals:
     void accountAdded(OCC::AccountState *account);
     void accountRemoved(OCC::AccountState *account);
     void accountSyncConnectionRemoved(OCC::AccountState *account);
     void removeAccountFolders(OCC::AccountState *account);
+    void forceLegacyImportChanged();
 
 private:
     // saving and loading Account to settings
@@ -120,5 +132,6 @@ private:
     QList<AccountStatePtr> _accounts;
     /// Account ids from settings that weren't read
     QSet<QString> _additionalBlockedAccountIds;
+    bool _forceLegacyImport = false;
 };
 }

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -96,6 +96,19 @@ public:
      */
     static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
+public slots:
+    /// Saves account data, not including the credentials
+    void saveAccount(OCC::Account *a);
+
+    /// Saves account state data, not including the account
+    void saveAccountState(OCC::AccountState *a);
+
+signals:
+    void accountAdded(OCC::AccountState *account);
+    void accountRemoved(OCC::AccountState *account);
+    void accountSyncConnectionRemoved(OCC::AccountState *account);
+    void removeAccountFolders(OCC::AccountState *account);
+
 private:
     // saving and loading Account to settings
     void saveAccountHelper(Account *account, QSettings &settings, bool saveCredentials = true);
@@ -113,19 +126,5 @@ private:
     QList<AccountStatePtr> _accounts;
     /// Account ids from settings that weren't read
     QSet<QString> _additionalBlockedAccountIds;
-
-public slots:
-    /// Saves account data, not including the credentials
-    void saveAccount(OCC::Account *a);
-
-    /// Saves account state data, not including the account
-    void saveAccountState(OCC::AccountState *a);
-
-
-Q_SIGNALS:
-    void accountAdded(OCC::AccountState *account);
-    void accountRemoved(OCC::AccountState *account);
-    void accountSyncConnectionRemoved(OCC::AccountState *account);
-    void removeAccountFolders(OCC::AccountState *account);
 };
 }

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -39,11 +39,6 @@ public:
     ~AccountManager() override = default;
 
     /**
-     * Saves the accounts to a given settings file
-     */
-    void save(bool saveCredentials = true);
-
-    /**
      * Creates account objects from a given settings file.
      *
      * Returns false if there was an error reading the settings,
@@ -56,11 +51,6 @@ public:
      * Typically called from the wizard
      */
     AccountState *addAccount(const AccountPtr &newAccount);
-
-    /**
-     * remove all accounts
-     */
-    void shutdown();
 
     /**
      * Return a list of all accounts.
@@ -80,11 +70,6 @@ public:
     [[nodiscard]] AccountStatePtr accountFromUserId(const QString &id) const;
 
     /**
-     * Delete the AccountState
-     */
-    void deleteAccount(AccountState *account);
-
-    /**
      * Creates an account and sets up some basic handlers.
      * Does *not* add the account to the account manager just yet.
      */
@@ -102,6 +87,15 @@ public slots:
 
     /// Saves account state data, not including the account
     void saveAccountState(OCC::AccountState *a);
+
+    /// Saves the accounts to a given settings file
+    void save(bool saveCredentials = true);
+
+    /// Delete the AccountState
+    void deleteAccount(AccountState *account);
+
+    /// Remove all accounts
+    void shutdown();
 
 signals:
     void accountAdded(OCC::AccountState *account);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -77,28 +77,28 @@ namespace {
 
     static const char optionsC[] =
         "Options:\n"
-        "  --help, -h           : show this help screen.\n"
-        "  --version, -v        : show version information.\n"
-        "  -q --quit            : quit the running instance\n"
-        "  --logwindow, -l      : open a window to show log output.\n"
-        "  --logfile <filename> : write log output to file <filename>.\n"
-        "  --logdir <name>      : write each sync log output in a new file\n"
-        "                         in folder <name>.\n"
-        "  --logexpire <hours>  : removes logs older than <hours> hours.\n"
-        "                         (to be used with --logdir)\n"
-        "  --logflush           : flush the log file after every write.\n"
-        "  --logdebug           : also output debug-level messages in the log.\n"
-        "  --confdir <dirname>  : Use the given configuration folder.\n"
-        "  --background         : launch the application in the background.\n"
-        "  --overrideserverurl  : specify a server URL to use for the force override to be used in the account setup wizard.\n"
-        "  --overridelocaldir   : specify a local dir to be used in the account setup wizard.\n"
-        "  --userid             : userId (username as on the server) to pass when creating an account via command-line.\n"
-        "  --apppassword        : appPassword to pass when creating an account via command-line.\n"
-        "  --localdirpath       : (optional) path where to create a local sync folder when creating an account via command-line.\n"
-        "  --isvfsenabled       : whether to set a VFS or non-VFS folder (1 for 'yes' or 0 for 'no') when creating an account via command-line.\n"
-        "  --remotedirpath      : (optional) path to a remote subfolder when creating an account via command-line.\n"
-        "  --serverurl          : a server URL to use when creating an account via command-line.\n"
-        "  --forcelegacyimport  : forcefully import account configurations from legacy clients (if available).\n";
+        "  --help, -h                 : show this help screen.\n"
+        "  --version, -v              : show version information.\n"
+        "  -q --quit                  : quit the running instance\n"
+        "  --logwindow, -l            : open a window to show log output.\n"
+        "  --logfile <filename>       : write log output to file <filename>.\n"
+        "  --logdir <name>            : write each sync log output in a new file\n"
+        "                               in folder <name>.\n"
+        "  --logexpire <hours>        : removes logs older than <hours> hours.\n"
+        "                               (to be used with --logdir)\n"
+        "  --logflush                 : flush the log file after every write.\n"
+        "  --logdebug                 : also output debug-level messages in the log.\n"
+        "  --confdir <dirname>        : Use the given configuration folder.\n"
+        "  --background               : launch the application in the background.\n"
+        "  --overrideserverurl        : specify a server URL to use for the force override to be used in the account setup wizard.\n"
+        "  --overridelocaldir         : specify a local dir to be used in the account setup wizard.\n"
+        "  --userid                   : userId (username as on the server) to pass when creating an account via command-line.\n"
+        "  --apppassword              : appPassword to pass when creating an account via command-line.\n"
+        "  --localdirpath             : (optional) path where to create a local sync folder when creating an account via command-line.\n"
+        "  --isvfsenabled             : whether to set a VFS or non-VFS folder (1 for 'yes' or 0 for 'no') when creating an account via command-line.\n"
+        "  --remotedirpath            : (optional) path to a remote subfolder when creating an account via command-line.\n"
+        "  --serverurl                : a server URL to use when creating an account via command-line.\n"
+        "  --forcelegacyconfigimport  : forcefully import account configurations from legacy clients (if available).\n";
 
     QString applicationTrPath()
     {
@@ -756,7 +756,7 @@ void Application::parseOptions(const QStringList &options)
             } else {
                 showHint("Invalid URL passed to --overridelocaldir");
             }
-        } else if (option == QStringLiteral("--forcelegacyimport")) {
+        } else if (option == QStringLiteral("--forcelegacyconfigimport")) {
             AccountManager::instance()->setForceLegacyImport(true);
         } else {
             QString errorMessage;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -97,7 +97,8 @@ namespace {
         "  --localdirpath       : (optional) path where to create a local sync folder when creating an account via command-line.\n"
         "  --isvfsenabled       : whether to set a VFS or non-VFS folder (1 for 'yes' or 0 for 'no') when creating an account via command-line.\n"
         "  --remotedirpath      : (optional) path to a remote subfolder when creating an account via command-line.\n"
-        "  --serverurl          : a server URL to use when creating an account via command-line.\n";
+        "  --serverurl          : a server URL to use when creating an account via command-line.\n"
+        "  --forcelegacyimport  : forcefully import account configurations from legacy clients (if available).\n";
 
     QString applicationTrPath()
     {
@@ -755,8 +756,9 @@ void Application::parseOptions(const QStringList &options)
             } else {
                 showHint("Invalid URL passed to --overridelocaldir");
             }
-        }
-        else {
+        } else if (option == QStringLiteral("--forcelegacyimport")) {
+            AccountManager::instance()->setForceLegacyImport(true);
+        } else {
             QString errorMessage;
             if (!AccountSetupCommandLineManager::instance()->parseCommandlineOption(option, it, errorMessage)) {
                 if (!errorMessage.isEmpty()) {


### PR DESCRIPTION
Displays dialog asking user to confirm if they'd like to attempt an import of legacy accounts.

Also adds a command line argument to force imports if needed

Closes #5556 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
