### PR TITLE
Fix expire date field in Share settings

### DIFF
--- a/src/gui/filedetails/NCInputTextField.qml
+++ b/src/gui/filedetails/NCInputTextField.qml
@@ -25,6 +25,7 @@ TextField {
     readonly property color accentColor: Style.ncBlue
     readonly property color secondaryColor: palette.dark
     readonly property alias submitButton: submitButton
+    property bool validInput: true
 
     implicitHeight: Style.talkReplyTextFieldPreferredHeight
 
@@ -36,7 +37,7 @@ TextField {
         id: textFieldBorder
         radius: Style.slightlyRoundedButtonRadius
         border.width: Style.normalBorderWidth
-        border.color: root.activeFocus ? root.accentColor : root.secondaryColor
+        border.color: root.activeFocus ? root.validInput ? root.accentColor : Style.errorBoxBackgroundColor : root.secondaryColor
         color: palette.base
     }
 
@@ -55,7 +56,7 @@ TextField {
         icon.source: "image://svgimage-custom-color/confirm.svg" + "/" + root.secondaryColor
         icon.color: hovered && enabled ? UserModel.currentUser.accentColor : root.secondaryColor
 
-        enabled: root.text !== ""
+        enabled: root.text !== "" && root.validInput
 
         onClicked: root.accepted()
     }

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -111,7 +111,18 @@ Page {
     }
 
     function resetExpireDateField() {
-        // Expire date changing is handled by the expireDateSpinBox
+        // Expire date changing is handled through expireDateChanged listening in the expireDateSpinBox.
+        //
+        // When the user edits the expire date field they are changing the text, but the expire date
+        // value is only changed according to updates from the server.
+        //
+        // Sometimes the new expire date is the same -- say, because we were on the maximum allowed
+        // expire date already and we tried to push it beyond this, leading the server to just return
+        // the maximum allowed expire date.
+        //
+        // So to ensure that the text of the spin box is correctly updated, force an update of the
+        // contents of the expire date text field.
+        expireDateSpinBox.updateText();
         waitingForExpireDateChange = false;
     }
 
@@ -671,6 +682,10 @@ Page {
                 SpinBox {
                     id: expireDateSpinBox
 
+                    function updateText() {
+                        expireDateSpinBoxTextField.text = textFromValue(value, locale);
+                    }
+
                     // Work arounds the limitations of QML's 32 bit integer when handling msecs from epoch
                     // Instead, we handle everything as days since epoch
                     readonly property int dayInMSecs: 24 * 60 * 60 * 1000
@@ -678,7 +693,7 @@ Page {
                     // Reset the model data after binding broken on user interact
                     onExpireDateReducedChanged: {
                         value = expireDateReduced;
-                        expireDateSpinBoxTextField.text = textFromValue(value, locale);
+                        updateText();
                     }
 
                     // We can't use JS's convenient Infinity or Number.MAX_VALUE as

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -778,6 +778,11 @@ Page {
                     contentItem: NCInputTextField {
                         id: expireDateSpinBoxTextField
 
+                        validInput: {
+                            const value = expireDateSpinBox.valueFromText(text);
+                            return value >= expireDateSpinBox.from && value <= expireDateSpinBox.to;
+                        }
+
                         text: expireDateSpinBox.textFromValue(expireDateSpinBox.value, expireDateSpinBox.locale)
                         readOnly: !expireDateSpinBox.editable
                         validator: expireDateSpinBox.validator

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -131,7 +131,6 @@ Page {
     }
 
     function resetMenu() {
-        moreMenu.close();
 
         resetNoteField();
         resetPasswordField();
@@ -240,7 +239,7 @@ Page {
         clip: true
 
         ColumnLayout {
-            id: moreMenu
+            id: scrollContentsColumn
 
             readonly property int rowIconWidth: Style.smallIconSize
             readonly property int indicatorItemWidth: 20
@@ -252,12 +251,12 @@ Page {
             RowLayout {
                 Layout.fillWidth: true
                 height: visible ? implicitHeight : 0
-                spacing: moreMenu.indicatorSpacing
+                spacing: scrollContentsColumn.indicatorSpacing
 
                 visible: root.isLinkShare
 
                 Image {
-                    Layout.preferredWidth: moreMenu.indicatorItemWidth
+                    Layout.preferredWidth: scrollContentsColumn.indicatorItemWidth
                     Layout.fillHeight: true
 
                     verticalAlignment: Image.AlignVCenter
@@ -265,8 +264,8 @@ Page {
                     fillMode: Image.Pad
 
                     source: "image://svgimage-custom-color/edit.svg/" + palette.dark
-                    sourceSize.width: moreMenu.rowIconWidth
-                    sourceSize.height: moreMenu.rowIconWidth
+                    sourceSize.width: scrollContentsColumn.rowIconWidth
+                    sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
 
                 NCInputTextField {
@@ -323,10 +322,11 @@ Page {
                         toolTipBase: Style.backgroundColor
                         toolTipText: Style.ncTextColor
                     }
-                    spacing: moreMenu.indicatorSpacing
-                    padding: moreMenu.itemPadding
-                    indicator.width: moreMenu.indicatorItemWidth
-                    indicator.height: moreMenu.indicatorItemWidth
+
+                    spacing: scrollContentsColumn.indicatorSpacing
+                    padding: scrollContentsColumn.itemPadding
+                    indicator.width: scrollContentsColumn.indicatorItemWidth
+                    indicator.height: scrollContentsColumn.indicatorItemWidth
 
                     checkable: true
                     checked: root.editingAllowed
@@ -364,10 +364,10 @@ Page {
                         enabled: !root.isSharePermissionChangeInProgress
                         checked: root.currentPermissionMode === permissionMode
                         text: qsTr("View only")
-                        indicatorItemWidth: moreMenu.indicatorItemWidth
-                        indicatorItemHeight: moreMenu.indicatorItemWidth
-                        spacing: moreMenu.indicatorSpacing
-                        padding: moreMenu.itemPadding
+                        indicatorItemWidth: scrollContentsColumn.indicatorItemWidth
+                        indicatorItemHeight: scrollContentsColumn.indicatorItemWidth
+                        spacing: scrollContentsColumn.indicatorSpacing
+                        padding: scrollContentsColumn.itemPadding
                         onClicked: root.permissionModeChanged(permissionMode)
                     }
 
@@ -378,10 +378,10 @@ Page {
                         enabled: !root.isSharePermissionChangeInProgress
                         checked: root.currentPermissionMode === permissionMode
                         text: qsTr("Allow upload and editing")
-                        indicatorItemWidth: moreMenu.indicatorItemWidth
-                        indicatorItemHeight: moreMenu.indicatorItemWidth
-                        spacing: moreMenu.indicatorSpacing
-                        padding: moreMenu.itemPadding
+                        indicatorItemWidth: scrollContentsColumn.indicatorItemWidth
+                        indicatorItemHeight: scrollContentsColumn.indicatorItemWidth
+                        spacing: scrollContentsColumn.indicatorSpacing
+                        padding: scrollContentsColumn.itemPadding
                         onClicked: root.permissionModeChanged(permissionMode)
 
                         NCBusyIndicator {
@@ -399,10 +399,10 @@ Page {
                         enabled: !root.isSharePermissionChangeInProgress
                         checked: root.currentPermissionMode === permissionMode
                         text: qsTr("File drop (upload only)")
-                        indicatorItemWidth: moreMenu.indicatorItemWidth
-                        indicatorItemHeight: moreMenu.indicatorItemWidth
-                        spacing: moreMenu.indicatorSpacing
-                        padding: moreMenu.itemPadding
+                        indicatorItemWidth: scrollContentsColumn.indicatorItemWidth
+                        indicatorItemHeight: scrollContentsColumn.indicatorItemWidth
+                        spacing: scrollContentsColumn.indicatorSpacing
+                        padding: scrollContentsColumn.itemPadding
                         onClicked: root.permissionModeChanged(permissionMode)
                     }
                 }
@@ -444,10 +444,11 @@ Page {
                             toolTipText: Style.ncTextColor
                         }
 
-                        spacing: moreMenu.indicatorSpacing
-                        padding: moreMenu.itemPadding
-                        indicator.width: moreMenu.indicatorItemWidth
-                        indicator.height: moreMenu.indicatorItemWidth
+                        spacing: scrollContentsColumn.indicatorSpacing
+                        padding: scrollContentsColumn.itemPadding
+                        indicator.width: scrollContentsColumn.indicatorItemWidth
+                        indicator.height: scrollContentsColumn.indicatorItemWidth
+
                         checked: root.hideDownload
                         text: qsTr("Hide download")
                         enabled: !root.isHideDownloadInProgress
@@ -492,10 +493,10 @@ Page {
                     toolTipText: Style.ncTextColor
                 }
 
-                spacing: moreMenu.indicatorSpacing
-                padding: moreMenu.itemPadding
-                indicator.width: moreMenu.indicatorItemWidth
-                indicator.height: moreMenu.indicatorItemWidth
+                spacing: scrollContentsColumn.indicatorSpacing
+                padding: scrollContentsColumn.itemPadding
+                indicator.width: scrollContentsColumn.indicatorItemWidth
+                indicator.height: scrollContentsColumn.indicatorItemWidth
 
                 checkable: true
                 checked: root.passwordProtectEnabled
@@ -519,12 +520,12 @@ Page {
                 Layout.fillWidth: true
 
                 height: visible ? implicitHeight : 0
-                spacing: moreMenu.indicatorSpacing
+                spacing: scrollContentsColumn.indicatorSpacing
 
                 visible: root.passwordProtectEnabled
 
                 Image {
-                    Layout.preferredWidth: moreMenu.indicatorItemWidth
+                    Layout.preferredWidth: scrollContentsColumn.indicatorItemWidth
                     Layout.fillHeight: true
 
                     verticalAlignment: Image.AlignVCenter
@@ -532,8 +533,8 @@ Page {
                     fillMode: Image.Pad
 
                     source: "image://svgimage-custom-color/lock-https.svg/" + palette.dark
-                    sourceSize.width: moreMenu.rowIconWidth
-                    sourceSize.height: moreMenu.rowIconWidth
+                    sourceSize.width: scrollContentsColumn.rowIconWidth
+                    sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
 
                 NCInputTextField {
@@ -621,10 +622,10 @@ Page {
                     toolTipText: Style.ncTextColor
                 }
 
-                spacing: moreMenu.indicatorSpacing
-                padding: moreMenu.itemPadding
-                indicator.width: moreMenu.indicatorItemWidth
-                indicator.height: moreMenu.indicatorItemWidth
+                spacing: scrollContentsColumn.indicatorSpacing
+                padding: scrollContentsColumn.itemPadding
+                indicator.width: scrollContentsColumn.indicatorItemWidth
+                indicator.height: scrollContentsColumn.indicatorItemWidth
 
                 checkable: true
                 checked: root.expireDateEnabled
@@ -647,12 +648,12 @@ Page {
             RowLayout {
                 Layout.fillWidth: true
                 height: visible ? implicitHeight : 0
-                spacing: moreMenu.indicatorSpacing
+                spacing: scrollContentsColumn.indicatorSpacing
 
                 visible: root.expireDateEnabled
 
                 Image {
-                    Layout.preferredWidth: moreMenu.indicatorItemWidth
+                    Layout.preferredWidth: scrollContentsColumn.indicatorItemWidth
                     Layout.fillHeight: true
 
                     verticalAlignment: Image.AlignVCenter
@@ -660,8 +661,8 @@ Page {
                     fillMode: Image.Pad
 
                     source: "image://svgimage-custom-color/calendar.svg/" + palette.dark
-                    sourceSize.width: moreMenu.rowIconWidth
-                    sourceSize.height: moreMenu.rowIconWidth
+                    sourceSize.width: scrollContentsColumn.rowIconWidth
+                    sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
 
                 // QML dates are essentially JavaScript dates, which makes them very finicky and unreliable.
@@ -749,7 +750,6 @@ Page {
                     Layout.fillWidth: true
                     height: visible ? implicitHeight : 0
 
-
                     // We want all the internal benefits of the spinbox but don't actually want the
                     // buttons, so set an empty item as a dummy
                     up.indicator: Item {}
@@ -836,10 +836,10 @@ Page {
                     toolTipText: Style.ncTextColor
                 }
 
-                spacing: moreMenu.indicatorSpacing
-                padding: moreMenu.itemPadding
-                indicator.width: moreMenu.indicatorItemWidth
-                indicator.height: moreMenu.indicatorItemWidth
+                spacing: scrollContentsColumn.indicatorSpacing
+                padding: scrollContentsColumn.itemPadding
+                indicator.width: scrollContentsColumn.indicatorItemWidth
+                indicator.height: scrollContentsColumn.indicatorItemWidth
 
                 checkable: true
                 checked: root.noteEnabled
@@ -862,12 +862,12 @@ Page {
             RowLayout {
                 Layout.fillWidth: true
                 height: visible ? implicitHeight : 0
-                spacing: moreMenu.indicatorSpacing
+                spacing: scrollContentsColumn.indicatorSpacing
 
                 visible: root.noteEnabled
 
                 Image {
-                    Layout.preferredWidth: moreMenu.indicatorItemWidth
+                    Layout.preferredWidth: scrollContentsColumn.indicatorItemWidth
                     Layout.fillHeight: true
 
                     verticalAlignment: Image.AlignVCenter
@@ -875,8 +875,8 @@ Page {
                     fillMode: Image.Pad
 
                     source: "image://svgimage-custom-color/edit.svg/" + palette.dark
-                    sourceSize.width: moreMenu.rowIconWidth
-                    sourceSize.height: moreMenu.rowIconWidth
+                    sourceSize.width: scrollContentsColumn.rowIconWidth
+                    sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
 
                 NCInputTextEdit {

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -676,7 +676,10 @@ Page {
                     readonly property int dayInMSecs: 24 * 60 * 60 * 1000
                     readonly property int expireDateReduced: Math.floor(root.expireDate / dayInMSecs)
                     // Reset the model data after binding broken on user interact
-                    onExpireDateReducedChanged: value = expireDateReduced
+                    onExpireDateReducedChanged: {
+                        value = expireDateReduced;
+                        expireDateSpinBoxTextField.text = textFromValue(value, locale);
+                    }
 
                     // We can't use JS's convenient Infinity or Number.MAX_VALUE as
                     // JS Number type is 64 bits, whereas QML's int type is only 32 bits
@@ -758,6 +761,8 @@ Page {
                     padding: 0
                     background: null
                     contentItem: NCInputTextField {
+                        id: expireDateSpinBoxTextField
+
                         text: expireDateSpinBox.textFromValue(expireDateSpinBox.value, expireDateSpinBox.locale)
                         readOnly: !expireDateSpinBox.editable
                         validator: expireDateSpinBox.validator


### PR DESCRIPTION
This PR fix several bugs when it comes to properly resetting the expire date field after modification. It also better notifies users when the value they are providing is invalid due to, for instance, a limit of days on the expire date.

<img width="512" alt="Screenshot 2023-05-08 at 20 08 45" src="https://user-images.githubusercontent.com/70155116/236820350-3625c36b-7548-4053-a35d-103aa9d6d2d4.png">


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
