### PR TITLE
Use addLayout to insert the VFS option when setting account.

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -105,7 +105,7 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage(OwncloudWizard *wizard)
 
 #ifdef Q_OS_WIN
     if (bestAvailableVfsMode() == Vfs::WindowsCfApi) {
-        qobject_cast<QVBoxLayout *>(_ui.wSyncStrategy->layout())->insertItem(-1, _ui.lVirtualFileSync);
+        _ui.wSyncStrategy->addLayout(_ui.lVirtualFileSync);
         setRadioChecked(_ui.rVirtualFileSync);
     }
 #endif


### PR DESCRIPTION
- Maintains the space between the layout items when resizing the window.
- Also remove qobject_cast.

![vfs-ui-layout](https://user-images.githubusercontent.com/241266/236915828-cd112063-4279-405a-b277-4ff7d736b6aa.gif)
