### PR TITLE
Fix SVG rendering error in SvgImageProvider

### DIFF
--- a/src/gui/iconutils.cpp
+++ b/src/gui/iconutils.cpp
@@ -23,15 +23,16 @@
 #include <QSvgRenderer>
 
 namespace {
+
 QString findSvgFilePath(const QString &fileName, const QStringList &possibleColors)
 {
-    QString result;
-    result = QString{OCC::Theme::themePrefix} + fileName;
+    auto result = QString{OCC::Theme::themePrefix + fileName};
+
     if (QFile::exists(result)) {
         return result;
     } else {
         for (const auto &color : possibleColors) {
-            result = QString{OCC::Theme::themePrefix} + color + QStringLiteral("/") + fileName;
+            result = QString{OCC::Theme::themePrefix + color + QStringLiteral("/") + fileName};
 
             if (QFile::exists(result)) {
                 return result;
@@ -42,6 +43,7 @@ QString findSvgFilePath(const QString &fileName, const QStringList &possibleColo
 
     return result;
 }
+
 }
 
 namespace OCC {

--- a/src/gui/iconutils.cpp
+++ b/src/gui/iconutils.cpp
@@ -91,7 +91,7 @@ QPixmap pixmapForBackground(const QString &fileName, const QColor &backgroundCol
     const auto pixmapColor = backgroundColor.isValid() && !Theme::isDarkColor(backgroundColor)
         ? QColorConstants::Svg::black
         : QColorConstants::Svg::white;
-    ;
+
     return createSvgPixmapWithCustomColorCached(fileName, pixmapColor);
 }
 

--- a/src/gui/iconutils.cpp
+++ b/src/gui/iconutils.cpp
@@ -44,12 +44,46 @@ QString findSvgFilePath(const QString &fileName, const QStringList &possibleColo
     return result;
 }
 
+QImage findImageWithCustomColor(const QString &fileName,
+                                const QColor &customColor,
+                                const QStringList &iconBaseColors,
+                                const QSize &requestedSize)
+{
+    // check if there is an existing image matching the custom color
+    const auto customColorName = [&customColor]() {
+        auto result = customColor.name();
+        if (result.startsWith(QStringLiteral("#"))) {
+            if (result == QStringLiteral("#000000")) {
+                result = QStringLiteral("black");
+            }
+            if (result == QStringLiteral("#ffffff")) {
+                result = QStringLiteral("white");
+            }
+        }
+        return result;
+    }();
+
+    if (const auto possiblePath = QString(OCC::Theme::themePrefix + customColorName + QStringLiteral("/") + fileName);
+            iconBaseColors.contains(customColorName) && QFile::exists(possiblePath)) {
+
+        if (requestedSize.width() > 0 && requestedSize.height() > 0) {
+            return QIcon(possiblePath).pixmap(requestedSize).toImage();
+        } else {
+            return QImage{possiblePath};
+        }
+    }
+
+    return {};
+}
+
 }
 
 namespace OCC {
 namespace Ui {
 namespace IconUtils {
+
 Q_LOGGING_CATEGORY(lcIconUtils, "nextcloud.gui.iconutils", QtInfoMsg)
+
 QPixmap pixmapForBackground(const QString &fileName, const QColor &backgroundColor)
 {
     Q_ASSERT(!fileName.isEmpty());
@@ -61,60 +95,39 @@ QPixmap pixmapForBackground(const QString &fileName, const QColor &backgroundCol
     return createSvgPixmapWithCustomColorCached(fileName, pixmapColor);
 }
 
-QImage createSvgImageWithCustomColor(const QString &fileName, const QColor &customColor, QSize *originalSize, const QSize &requestedSize)
+QImage createSvgImageWithCustomColor(const QString &fileName,
+                                     const QColor &customColor,
+                                     QSize *originalSize,
+                                     const QSize &requestedSize)
 {
     Q_ASSERT(!fileName.isEmpty());
     Q_ASSERT(customColor.isValid());
 
-    QImage result{};
-
     if (fileName.isEmpty() || !customColor.isValid()) {
-        qCWarning(lcIconUtils) << "invalid fileName or customColor";
-        return result;
+        qWarning(lcIconUtils) << "invalid fileName or customColor";
+        return {};
     }
 
     // some icons are present in white or black only, so, we need to check both when needed
     const auto iconBaseColors = QStringList{QStringLiteral("black"), QStringLiteral("white")};
+    const auto customColorImage = findImageWithCustomColor(fileName, customColor, iconBaseColors, requestedSize);
 
-    // check if there is an existing image matching the custom color
-    {
-        const auto customColorName = [&customColor]() {
-            auto result = customColor.name();
-            if (result.startsWith(QStringLiteral("#"))) {
-                if (result == QStringLiteral("#000000")) {
-                    result = QStringLiteral("black");
-                }
-                if (result == QStringLiteral("#ffffff")) {
-                    result = QStringLiteral("white");
-                }
-            }
-            return result;
-        }();
-
-        if (iconBaseColors.contains(customColorName)) {
-            if (requestedSize.width() > 0 && requestedSize.height() > 0) {
-                result = QIcon(QString{OCC::Theme::themePrefix} + customColorName + QStringLiteral("/") + fileName).pixmap(requestedSize).toImage();
-            } else {
-                result = QImage{QString{OCC::Theme::themePrefix} + customColorName + QStringLiteral("/") + fileName};
-            }
-            if (!result.isNull()) {
-                return result;
-            }
-        }
+    if (!customColorImage.isNull()) {
+        return customColorImage;
     }
     
     // find the first matching svg file
     const auto sourceSvg = findSvgFilePath(fileName, iconBaseColors);
-
     Q_ASSERT(!sourceSvg.isEmpty());
+
     if (sourceSvg.isEmpty()) {
-        qCWarning(lcIconUtils) << "Failed to find base SVG file for" << fileName;
-        return result;
+        qWarning(lcIconUtils) << "Failed to find base SVG file for" << fileName;
+        return {};
     }
 
-    result = drawSvgWithCustomFillColor(sourceSvg, customColor, originalSize, requestedSize);
-
+    const auto result = drawSvgWithCustomFillColor(sourceSvg, customColor, originalSize, requestedSize);
     Q_ASSERT(!result.isNull());
+
     if (result.isNull()) {
         qCWarning(lcIconUtils) << "Failed to load pixmap for" << fileName;
     }
@@ -147,8 +160,10 @@ QPixmap createSvgPixmapWithCustomColorCached(const QString &fileName, const QCol
     return cachedPixmap;
 }
 
-QImage drawSvgWithCustomFillColor(
-    const QString &sourceSvgPath, const QColor &fillColor, QSize *originalSize, const QSize &requestedSize)
+QImage drawSvgWithCustomFillColor(const QString &sourceSvgPath,
+                                  const QColor &fillColor,
+                                  QSize *originalSize,
+                                  const QSize &requestedSize)
 {
     QSvgRenderer svgRenderer;
 


### PR DESCRIPTION
As part of `IconUtils::createSvgImageWithCustomColor` we try to see if there is a pre-existing image with the desired colour combination string at a given path. However, we do not check if the file exists and instead try directly to create the image; this creates an unnecessary error when we could just check for the existence of the file at the path. 

`2023-05-09 14:49:16:215 [ warning qt.svg unknown:0 ]:	Cannot open file ':/client/theme/black/share.svg', because: No such file or directory`

This PR adds this file check first, avoiding the error.

Additionally, this PR includes some clean up of the relevant code.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
