### PR TITLE
Allow opening a file or folder in the local sync root.

### DIFF
--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -90,6 +90,8 @@ private:
 
     [[nodiscard]] static int fileLockTimeRemainingMinutes(const qint64 lockTime, const qint64 lockTimeOut);
 
+    [[nodiscard]] bool isFileParentItemValid() const;
+
     bool _tokenVerified = false;
 
     bool _shouldScheduleFolderSyncAfterFileIsOpened = false;

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -911,8 +911,7 @@ void Folder::startSync(const QStringList &pathList)
         fullLocalDiscoveryInterval.count() >= 0 // negative means we don't require periodic full runs
         && _timeSinceLastFullLocalDiscovery.hasExpired(fullLocalDiscoveryInterval.count());
 
-    if (!singleItemDiscoveryOptions.filePathRelative.isEmpty()
-        && singleItemDiscoveryOptions.discoveryDirItem && !singleItemDiscoveryOptions.discoveryDirItem->isEmpty()) {
+    if (singleItemDiscoveryOptions.isValid() && singleItemDiscoveryOptions.discoveryPath != QStringLiteral("/")) {
         qCInfo(lcFolder) << "Going to sync just one file";
         _engine->setLocalDiscoveryOptions(LocalDiscoveryStyle::DatabaseAndFilesystem, {singleItemDiscoveryOptions.discoveryPath});
         _localDiscoveryTracker->startSyncPartialDiscovery();

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -123,6 +123,12 @@ SyncEngine::~SyncEngine()
     _excludedFiles.reset();
 }
 
+bool SyncEngine::SingleItemDiscoveryOptions::isValid() const
+{
+    return !filePathRelative.isEmpty() && !discoveryPath.isEmpty()
+        && ((discoveryDirItem && !discoveryDirItem->isEmpty()) || discoveryPath == QStringLiteral("/"));
+}
+
 /**
  * Check if the item is in the blacklist.
  * If it should not be sync'ed because of the blacklist, update the item with the error instruction
@@ -658,12 +664,12 @@ void SyncEngine::startSync()
 
     ProcessDirectoryJob *discoveryJob = nullptr;
 
-    if (!singleItemDiscoveryOptions().filePathRelative.isEmpty()) {
+    if (singleItemDiscoveryOptions().isValid()) {
         _discoveryPhase->_listExclusiveFiles.clear();
         _discoveryPhase->_listExclusiveFiles.push_back(singleItemDiscoveryOptions().filePathRelative);
     }
 
-    if (!singleItemDiscoveryOptions().discoveryPath.isEmpty() && singleItemDiscoveryOptions().discoveryDirItem) {
+    if (singleItemDiscoveryOptions().isValid() && singleItemDiscoveryOptions().discoveryDirItem) {
         ProcessDirectoryJob::PathTuple path = {};
         path._local = path._original = path._server = path._target = singleItemDiscoveryOptions().discoveryPath;
 

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -57,10 +57,12 @@ class OWNCLOUDSYNC_EXPORT SyncEngine : public QObject
 {
     Q_OBJECT
 public:
-    struct SingleItemDiscoveryOptions {
+    struct OWNCLOUDSYNC_EXPORT SingleItemDiscoveryOptions {
         QString discoveryPath;
         QString filePathRelative;
         SyncFileItemPtr discoveryDirItem;
+
+        [[nodiscard]] bool isValid() const;
     };
 
     SyncEngine(AccountPtr account,


### PR DESCRIPTION
It was impossible to open for local editing anything if it was located in the topmost (root) local sync folder.
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
