### PR TITLE
Dismiss notifications

### DIFF
--- a/src/gui/tray/ActivityItem.qml
+++ b/src/gui/tray/ActivityItem.qml
@@ -74,7 +74,7 @@ ItemDelegate {
         ActivityItemActions {
             id: activityActions
 
-            visible: !root.isFileActivityList && model.linksForActionButtons.length > 0 && !isTalkReplyOptionVisible
+            visible: !root.isFileActivityList && model.linksForActionButtons.length > 1 && !isTalkReplyOptionVisible
 
             Layout.fillWidth: true
             Layout.leftMargin: Style.trayListItemIconSize + activityContent.spacing

--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -82,7 +82,6 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
     ActivityList list;
     ActivityList callList;
 
-
     foreach (auto element, notifies) {
         auto json = element.toObject();
         auto a = Activity::fromActivityJson(json, ai->account());
@@ -145,7 +144,15 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
             }
 
             a._links.insert(al._primary? 0 : a._links.size(), al);
-        } 
+        }
+
+        if (a._links.isEmpty()) {
+            ActivityLink dismissLink;
+            dismissLink._label = tr("Dismiss");
+            dismissLink._verb = "DELETE";
+            dismissLink._primary = false;
+            a._links.insert(0, dismissLink);
+        }
 
         QUrl link(json.value("link").toString());
         if (!link.isEmpty()) {

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -234,7 +234,7 @@ public:
             activity.insert(QStringLiteral("activity_id"), _startingId);
             activity.insert(QStringLiteral("object_type"), "2fa_id");
             activity.insert(QStringLiteral("subject"), QStringLiteral("Login attempt from 127.0.0.1"));
-            activity.insert(QStringLiteral("message"), QStringLiteral("Please apporve or deny the login attempt."));
+            activity.insert(QStringLiteral("message"), QStringLiteral("Please approve or deny the login attempt."));
             activity.insert(QStringLiteral("object_name"), QStringLiteral(""));
             activity.insert(QStringLiteral("datetime"), QDateTime::currentDateTime().toString(Qt::ISODate));
             activity.insert(QStringLiteral("icon"), QStringLiteral("http://example.de/core/img/places/password.svg"));
@@ -252,6 +252,34 @@ public:
             secondaryAction.insert(QStringLiteral("label"), QStringLiteral("Cancel"));
             secondaryAction.insert(QStringLiteral("link"),
                 QString(QStringLiteral("/ocs/v2.php/apps/twofactor_nextcloud_notification/api/v1/attempt/39")));
+            secondaryAction.insert(QStringLiteral("type"), QStringLiteral("DELETE"));
+            secondaryAction.insert(QStringLiteral("primary"), false);
+            actionsArray.push_back(secondaryAction);
+
+            activity.insert(QStringLiteral("actions"), actionsArray);
+
+            _activityData.push_back(activity);
+
+            _startingId++;
+        }
+
+        // Insert notification data
+        for (quint32 i = 0; i < _numItemsToInsert; i++) {
+            QJsonObject activity;
+            activity.insert(QStringLiteral("activity_id"), _startingId);
+            activity.insert(QStringLiteral("object_type"), "create");
+            activity.insert(QStringLiteral("subject"), QStringLiteral("Generate backup codes"));
+            activity.insert(QStringLiteral("message"), QStringLiteral("You enabled two-factor authentication but did not generate backup codes yet. They are needed to restore access to your account in case you lose your second factor."));
+            activity.insert(QStringLiteral("object_name"), QStringLiteral(""));
+            activity.insert(QStringLiteral("datetime"), QDateTime::currentDateTime().toString(Qt::ISODate));
+            activity.insert(QStringLiteral("icon"), QStringLiteral("http://example.de/core/img/places/password.svg"));
+
+            QJsonArray actionsArray;
+
+            QJsonObject secondaryAction;
+            secondaryAction.insert(QStringLiteral("label"), QStringLiteral("Dismiss"));
+            secondaryAction.insert(QStringLiteral("link"),
+                                   QString(QStringLiteral("ocs/v2.php/apps/notifications/api/v2/notifications/19867")));
             secondaryAction.insert(QStringLiteral("type"), QStringLiteral("DELETE"));
             secondaryAction.insert(QStringLiteral("primary"), false);
             actionsArray.push_back(secondaryAction);
@@ -619,6 +647,9 @@ private slots:
             QVERIFY(index.data(OCC::ActivityListModel::ActionTextRole).canConvert<QString>());
             QVERIFY(index.data(OCC::ActivityListModel::MessageRole).canConvert<QString>());
             QVERIFY(index.data(OCC::ActivityListModel::LinkRole).canConvert<QUrl>());
+
+            QVERIFY(index.data(OCC::ActivityListModel::ActionsLinksForActionButtonsRole).canConvert<QList<QVariant>>());
+
             QVERIFY(index.data(OCC::ActivityListModel::AccountConnectedRole).canConvert<bool>());
             QVERIFY(index.data(OCC::ActivityListModel::DisplayActions).canConvert<bool>());
 
@@ -674,6 +705,13 @@ private slots:
                         QVERIFY(actionsLinks.size() == 2);
                         QVERIFY(actionsLinks[0].value<OCC::ActivityLink>()._primary);
                         QVERIFY(!actionsLinks[1].value<OCC::ActivityLink>()._primary);
+                        QVERIFY(actionsLinksContextMenu.isEmpty());
+                    }
+
+                    // Generate 2FA backup codes notification
+                    if (objectType == QStringLiteral("create")) {
+                        QVERIFY(actionsLinks.size() == 1);
+                        QVERIFY(!actionsLinks[0].value<OCC::ActivityLink>()._primary);
                         QVERIFY(actionsLinksContextMenu.isEmpty());
                     }
 


### PR DESCRIPTION
- Fix for #5606 and #5585.
 
Any notification missing a dismiss link will get one like in the server:

![2fa-and-dismiss](https://github.com/nextcloud/desktop/assets/241266/b809d272-3224-4c3f-97d9-4414ab9ec43b)