### PR TITLE
Streamline logger creation of next log files

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -605,7 +605,7 @@ void Application::setupLogging()
     if (_logFile.isEmpty()) {
         logger->setLogDir(_logDir.isEmpty() ? ConfigFile().logDir() : _logDir);
     }
-    logger->setLogExpire(_logExpire > 0 ? _logExpire : ConfigFile().logExpire());
+    logger->setLogExpireHours(_logExpire > 0 ? _logExpire : ConfigFile().logExpire());
     logger->setLogFlush(_logFlush || ConfigFile().logFlush());
     logger->setLogDebug(_logDebug || ConfigFile().logDebug());
     if (!logger->isLoggingToFile() && ConfigFile().automaticLogDir()) {

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -289,28 +289,20 @@ void Logger::enterNextLogFileNoLock()
 
         // Tentative new log name, will be adjusted if one like this already exists
         const auto now = QDateTime::currentDateTime();
-        QString newLogName = now.toString("yyyyMMdd_HHmm") + "_nextcloud.log";
+        const auto logExpireSecs = 60 * 60 * _logExpire;
+        QString newLogName = now.toString("yyyyMMdd_HHmm_ss") + "_nextcloud.log";
 
         // Expire old log files and deal with conflicts
-        const auto files = dir.entryList(QStringList("*nextcloud.log.*"), QDir::Files, QDir::Name);
-        static const QRegularExpression rx(QRegularExpression::anchoredPattern(R"(.*nextcloud\.log\.(\d+).*)"));
-        auto maxNumber = -1;
+        const auto files = dir.entryList(QStringList("*nextcloud.log"), QDir::Files, QDir::Name);
 
         for (const auto &fileName : files) {
             if (_logExpire > 0) {
                 QFileInfo fileInfo(dir.absoluteFilePath(fileName));
-
-                const auto logExpireSecs = 60 * 60 * _logExpire;
                 if (fileInfo.lastModified().addSecs(logExpireSecs) < now) {
                     dir.remove(fileName);
                 }
             }
-            const auto rxMatch = rx.match(fileName);
-            if (fileName.startsWith(newLogName) && rxMatch.hasMatch()) {
-                maxNumber = qMax(maxNumber, rxMatch.captured(2).toInt());
-            }
         }
-        newLogName.append("." + QString::number(maxNumber + 1));
 
         auto previousLog = _logFile.fileName();
         setLogFileNoLock(dir.filePath(newLogName));

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -280,13 +280,21 @@ void Logger::dumpCrashLog()
 
 void Logger::enterNextLogFileNoLock()
 {
-    if (_logDirPath.isEmpty() || _logDir.exists()) {
+    if (_logDirPath.isEmpty()) {
         return;
     }
 
     // Tentative new log name, will be adjusted if one like this already exists
     const auto now = QDateTime::currentDateTime();
-    QString newLogName = now.toString("yyyyMMdd_HHmm_ss") + "_nextcloud.log";
+    const QString dateString = now.toString("yyyy-MM-dd_HH-mm_ss-zzz");
+
+    auto logNum = 0;
+    QString newLogName;
+
+    do {
+        newLogName = dateString + QString("_log%1_nextcloud.log").arg(logNum);
+        ++logNum;
+    } while (QFile::exists(_logDir.absoluteFilePath(newLogName)));
 
     // Expire old log files and deal with conflicts
     const auto files = _logDir.entryList(QStringList("*nextcloud.log"), QDir::Files, QDir::Name);

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -292,9 +292,8 @@ void Logger::enterNextLogFileNoLock()
         QString newLogName = now.toString("yyyyMMdd_HHmm") + "_nextcloud.log";
 
         // Expire old log files and deal with conflicts
-        const auto files = dir.entryList(QStringList("*owncloud.log.*"), QDir::Files, QDir::Name) +
-                           dir.entryList(QStringList("*nextcloud.log.*"), QDir::Files, QDir::Name);
-        static const QRegularExpression rx(QRegularExpression::anchoredPattern(R"(.*(next|own)cloud\.log\.(\d+).*)"));
+        const auto files = dir.entryList(QStringList("*nextcloud.log.*"), QDir::Files, QDir::Name);
+        static const QRegularExpression rx(QRegularExpression::anchoredPattern(R"(.*nextcloud\.log\.(\d+).*)"));
         auto maxNumber = -1;
 
         for (const auto &fileName : files) {

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -297,8 +297,8 @@ void Logger::enterNextLogFileNoLock()
     // Expire old log files and deal with conflicts
     const auto files = dir.entryList(QStringList("*nextcloud.log"), QDir::Files, QDir::Name);
 
-    for (const auto &fileName : files) {
-        if (_logExpire > 0) {
+    if (_logExpire > 0) {
+        for (const auto &fileName : files) {
             QFileInfo fileInfo(dir.absoluteFilePath(fileName));
             if (fileInfo.lastModified().addSecs(logExpireSecs) < now) {
                 dir.remove(fileName);

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -295,7 +295,7 @@ void Logger::enterNextLogFileNoLock()
     QString newLogName;
 
     do {
-        newLogName = dateString + QString("_log%1_%2").arg(logNum).arg(fileNameSuffix);
+        newLogName = QString("%1_log%2_%3").arg(dateString, QString::number(logNum), fileNameSuffix);
         ++logNum;
     } while (QFile::exists(_logDir.absoluteFilePath(newLogName)));
 

--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -284,20 +284,23 @@ void Logger::enterNextLogFileNoLock()
         return;
     }
 
+    static constexpr auto compressedFileExt = ".gz";
+    static constexpr auto fileNameSuffix = "nextcloud.log";
+
     // Tentative new log name, will be adjusted if one like this already exists
     const auto now = QDateTime::currentDateTime();
-    const QString dateString = now.toString("yyyy-MM-dd_HH-mm_ss-zzz");
+    const auto dateString = now.toString("yyyy-MM-dd_HH-mm_ss-zzz");
 
     auto logNum = 0;
     QString newLogName;
 
     do {
-        newLogName = dateString + QString("_log%1_nextcloud.log").arg(logNum);
+        newLogName = dateString + QString("_log%1_%2").arg(logNum).arg(fileNameSuffix);
         ++logNum;
     } while (QFile::exists(_logDir.absoluteFilePath(newLogName)));
 
     // Expire old log files and deal with conflicts
-    const auto files = _logDir.entryList(QStringList("*nextcloud.log"), QDir::Files, QDir::Name);
+    const auto files = _logDir.entryList({ QString("*%1").arg(fileNameSuffix) }, QDir::Files, QDir::Name);
 
     if (_logExpireSecs > 0) {
         for (const auto &fileName : files) {
@@ -315,17 +318,17 @@ void Logger::enterNextLogFileNoLock()
     // Compress the previous log file. On a restart this can be the most recent
     // log file.
     auto logToCompress = previousLog;
-    if (logToCompress.isEmpty() && files.size() > 0 && !files.last().endsWith(".gz")) {
+    if (logToCompress.isEmpty() && files.isEmpty() && !files.last().endsWith(compressedFileExt)) {
         logToCompress = _logDir.absoluteFilePath(files.last());
     }
 
     if (!logToCompress.isEmpty()) {
-        const QString compressedName = logToCompress + ".gz";
+        const QString compressedFileName = logToCompress + compressedFileExt;
 
-        if (compressLog(logToCompress, compressedName)) {
+        if (compressLog(logToCompress, compressedFileName)) {
             QFile::remove(logToCompress);
         } else {
-            QFile::remove(compressedName);
+            QFile::remove(compressedFileName);
         }
     }
 }

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -49,7 +49,7 @@ public:
     QString logFile() const;
     void setLogFile(const QString &name);
 
-    void setLogExpire(int expire);
+    void setLogExpireHours(const int expireHours);
 
     QString logDir() const;
     void setLogDir(const QString &dir);
@@ -104,7 +104,7 @@ private:
 
     QFile _logFile;
     bool _doFileFlush = false;
-    int _logExpire = 0;
+    int _logExpireSecs = 0;
     bool _logDebug = false;
     QScopedPointer<QTextStream> _logstream;
     mutable QMutex _mutex;

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -18,6 +18,7 @@
 #include <QObject>
 #include <QList>
 #include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QTextStream>
 #include <qmutex.h>
@@ -107,7 +108,8 @@ private:
     bool _logDebug = false;
     QScopedPointer<QTextStream> _logstream;
     mutable QMutex _mutex;
-    QString _logDirectory;
+    QString _logDirPath;
+    QDir _logDir;
     bool _temporaryFolderLogDir = false;
     QSet<QString> _logRules;
     QVector<QString> _crashLog;


### PR DESCRIPTION
By eliminating certain parts of the process of creating new log files, such as redundant searching for legacy client log files and regex matching, stepping into new log files should be a bit faster

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
