### PR TITLE
ensure that the file to test monitoring is hidden

### DIFF
--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -133,6 +133,7 @@ void FolderWatcher::startNotificationTestWhenReady()
         QFile f(path);
         f.open(QIODevice::WriteOnly | QIODevice::Append);
     }
+    FileSystem::setFileHidden(path, true);
 
     QTimer::singleShot(5000, this, [this]() {
         if (!_testNotificationPath.isEmpty())


### PR DESCRIPTION
we create a file inside the sync folder to test file system monitoring

ensure this file is hidden (i.e. has the proper hidden property)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
