### PR TITLE
Fix Debug builds of File Provider module

### DIFF
--- a/shell_integration/MacOSX/CMakeLists.txt
+++ b/shell_integration/MacOSX/CMakeLists.txt
@@ -41,12 +41,12 @@ if(APPLE)
     endif()
 
     if (BUILD_OWNCLOUD_OSX_BUNDLE)
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Release/FinderSyncExt.appex
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${XCODE_TARGET_CONFIGURATION}/FinderSyncExt.appex
             DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
             USE_SOURCE_PERMISSIONS)
 
         if (BUILD_FILE_PROVIDER_MODULE)
-            install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Release/FileProviderExt.appex
+            install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${XCODE_TARGET_CONFIGURATION}/FileProviderExt.appex
                 DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
                 USE_SOURCE_PERMISSIONS)
         endif()

--- a/shell_integration/MacOSX/CMakeLists.txt
+++ b/shell_integration/MacOSX/CMakeLists.txt
@@ -41,13 +41,19 @@ if(APPLE)
     endif()
 
     if (BUILD_OWNCLOUD_OSX_BUNDLE)
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${XCODE_TARGET_CONFIGURATION}/FinderSyncExt.appex
-            DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
+        set(OSX_PLUGINS_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${XCODE_TARGET_CONFIGURATION})
+        set(OSX_PLUGINS_INSTALL_DIR ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns)
+
+        install(DIRECTORY ${OSX_PLUGINS_BINARY_DIR}/FinderSyncExt.appex
+            DESTINATION ${OSX_PLUGINS_INSTALL_DIR}
             USE_SOURCE_PERMISSIONS)
 
+        # HACK: Launch Services expects there to be a Library folder within the FinderSyncExt.appex.
+        install(DIRECTORY DESTINATION ${OSX_PLUGINS_INSTALL_DIR}/FinderSyncExt.appex/Contents/Library)
+
         if (BUILD_FILE_PROVIDER_MODULE)
-            install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${XCODE_TARGET_CONFIGURATION}/FileProviderExt.appex
-                DESTINATION ${OWNCLOUD_OSX_BUNDLE}/Contents/PlugIns
+            install(DIRECTORY ${OSX_PLUGINS_BINARY_DIR}/FileProviderExt.appex
+                DESTINATION ${OSX_PLUGINS_INSTALL_DIR}
                 USE_SOURCE_PERMISSIONS)
         endif()
     endif()


### PR DESCRIPTION
We were using a wrong hard-coded path when set to Debug

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
