### PR TITLE
Reduce excessive info logging

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -74,7 +74,7 @@ ProcessDirectoryJob::ProcessDirectoryJob(DiscoveryPhase *data, PinState basePinS
 
 void ProcessDirectoryJob::start()
 {
-    qCInfo(lcDisco) << "STARTING" << _currentFolder._server << _queryServer << _currentFolder._local << _queryLocal;
+    qCDebug(lcDisco) << "STARTING" << _currentFolder._server << _queryServer << _currentFolder._local << _queryLocal;
 
     if (_queryServer == NormalQuery) {
         _serverJob = startAsyncServerQuery();
@@ -461,19 +461,19 @@ void ProcessDirectoryJob::processFile(PathTuple path,
     const char *hasLocal = localEntry.isValid() ? "true" : _queryLocal == ParentNotChanged ? "db" : "false";
     const auto serverFileIsLocked = (serverEntry.isValid() ? (serverEntry.locked == SyncFileItem::LockStatus::LockedItem ? "locked" : "not locked")  : "");
     const auto localFileIsLocked = dbEntry._lockstate._locked ? "locked" : "not locked";
-    qCInfo(lcDisco).nospace() << "Processing " << path._original
-                              << " | (db/local/remote)"
-                              << " | valid: " << dbEntry.isValid() << "/" << hasLocal << "/" << hasServer
-                              << " | mtime: " << dbEntry._modtime << "/" << localEntry.modtime << "/" << serverEntry.modtime
-                              << " | size: " << dbEntry._fileSize << "/" << localEntry.size << "/" << serverEntry.size
-                              << " | etag: " << dbEntry._etag << "//" << serverEntry.etag
-                              << " | checksum: " << dbEntry._checksumHeader << "//" << serverEntry.checksumHeader
-                              << " | perm: " << dbEntry._remotePerm << "//" << serverEntry.remotePerm
-                              << " | fileid: " << dbEntry._fileId << "//" << serverEntry.fileId
-                              << " | type: " << dbEntry._type << "/" << localEntry.type << "/" << (serverEntry.isDirectory ? ItemTypeDirectory : ItemTypeFile)
-                              << " | e2ee: " << dbEntry.isE2eEncrypted() << "/" << serverEntry.isE2eEncrypted()
-                              << " | e2eeMangledName: " << dbEntry.e2eMangledName() << "/" << serverEntry.e2eMangledName
-                              << " | file lock: " << localFileIsLocked << "//" << serverFileIsLocked;
+    qCDebug(lcDisco).nospace() << "Processing " << path._original
+                               << " | (db/local/remote)"
+                               << " | valid: " << dbEntry.isValid() << "/" << hasLocal << "/" << hasServer
+                               << " | mtime: " << dbEntry._modtime << "/" << localEntry.modtime << "/" << serverEntry.modtime
+                               << " | size: " << dbEntry._fileSize << "/" << localEntry.size << "/" << serverEntry.size
+                               << " | etag: " << dbEntry._etag << "//" << serverEntry.etag
+                               << " | checksum: " << dbEntry._checksumHeader << "//" << serverEntry.checksumHeader
+                               << " | perm: " << dbEntry._remotePerm << "//" << serverEntry.remotePerm
+                               << " | fileid: " << dbEntry._fileId << "//" << serverEntry.fileId
+                               << " | type: " << dbEntry._type << "/" << localEntry.type << "/" << (serverEntry.isDirectory ? ItemTypeDirectory : ItemTypeFile)
+                               << " | e2ee: " << dbEntry.isE2eEncrypted() << "/" << serverEntry.isE2eEncrypted()
+                               << " | e2eeMangledName: " << dbEntry.e2eMangledName() << "/" << serverEntry.e2eMangledName
+                               << " | file lock: " << localFileIsLocked << "//" << serverFileIsLocked;
 
     if (localEntry.isValid()
         && !serverEntry.isValid()


### PR DESCRIPTION
This cuts back logging from the worst offenders of https://github.com/nextcloud/desktop/issues/5302 - there might be more that appear when the client runs for a longer time, I mainly checked the ones that appeared after a few minutes of running the client.
https://github.com/nextcloud/desktop/issues/5752 might be a better solution, but I decided to submit a quick fix because I was frustrated that this critical issue (it causes significant SSD wear and potentially causes data loss by filling up the volume) didn't get enough attention in months.
Even after https://github.com/nextcloud/desktop/pull/5769 the client is unusable for me without these changes.

I think it's possible that this masks a deeper issue, a lot of the log messages referred to files that Nextcloud shouldn't even care about (i.e. files that are stored outside of any synced folders).