### PR TITLE
Fix colouring of NCRadioButton

### DIFF
--- a/src/gui/filedetails/NCRadioButton.qml
+++ b/src/gui/filedetails/NCRadioButton.qml
@@ -30,6 +30,7 @@ RadioButton {
         anchors.left: parent.left
         anchors.leftMargin: Style.radioButtonCustomMarginLeftOuter
         radius: root.radius
+        color: palette.base
         border.color: palette.dark
         border.width: Style.normalBorderWidth
 


### PR DESCRIPTION

![Screenshot 2023-06-08 at 15 38 03](https://github.com/nextcloud/desktop/assets/70155116/5bbda446-ffa9-44c8-8d46-5132e7eb598c)

![Screenshot 2023-06-08 at 15 38 00](https://github.com/nextcloud/desktop/assets/70155116/39afcb9c-a8c0-474b-b3fa-33d4a6588208)

Fixes #5781

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
