### PR TITLE
Fix reply button visibility after reply field opened and reply text sent

### DIFF
--- a/src/gui/tray/ActivityItemActions.qml
+++ b/src/gui/tray/ActivityItemActions.qml
@@ -19,6 +19,8 @@ Repeater {
 
     property Flickable flickable
 
+    property bool talkReplyButtonVisible: true
+
     signal triggerAction(int actionIndex)
     signal showReplyField()
 
@@ -46,5 +48,7 @@ Repeater {
         textColorHovered: Style.currentUserHeaderTextColor
         contentsFont.bold: true
         bgColor: Style.currentUserHeaderColor
+
+        visible: verb !== "REPLY" || (verb === "REPLY" && root.talkReplyButtonVisible)
     }
 }

--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -256,7 +256,7 @@ RowLayout {
             ActivityItemActions {
                 id: activityActions
 
-                visible: !isFileActivityList && activityData.linksForActionButtons.length > 0 && !isTalkReplyOptionVisible
+                visible: !isFileActivityList && activityData.linksForActionButtons.length > 0
 
                 Layout.fillWidth: true
                 Layout.leftMargin: Style.trayListItemIconSize + Style.trayHorizontalMargin
@@ -273,6 +273,7 @@ RowLayout {
                 onTriggerAction: activityModel.slotTriggerAction(activityData.activityIndex, actionIndex)
 
                 onShowReplyField: isTalkReplyOptionVisible = true
+                talkReplyButtonVisible: root.activityData.messageSent === "" && !isTalkReplyOptionVisible
             }
         }
     }


### PR DESCRIPTION


https://github.com/nextcloud/desktop/assets/70155116/d061b3a4-cb1c-4638-847a-b991bc6975bd



<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
