### PR TITLE
only flush debug log files when closing them

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -89,6 +89,9 @@ Logger::Logger(QObject *parent)
 
 Logger::~Logger()
 {
+    if (_logstream) {
+        _logstream->flush();
+    }
 #ifndef NO_MSG_HANDLER
     qInstallMessageHandler(nullptr);
 #endif
@@ -144,6 +147,9 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
 
         if (linesCounter >= MaxLogLinesCount) {
             linesCounter = 0;
+            if (_logstream) {
+                _logstream->flush();
+            }
             closeNoLock();
             enterNextLogFileNoLock();
         }
@@ -153,7 +159,7 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
         _crashLog[_crashLogIndex] = msg;
 
         if (_logstream) {
-            (*_logstream) << msg << Qt::endl;
+            (*_logstream) << msg << "\n";
             if (_doFileFlush)
                 _logstream->flush();
         }


### PR DESCRIPTION
do not force a flush every time a log line is added to a file to speed up the logging process

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
