### PR TITLE
always propagate locked status to read-only or read/write for real file

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1200,16 +1200,13 @@ void PropagateDownloadFile::downloadFinished()
 
     if (_item->_locked == SyncFileItem::LockStatus::LockedItem && (_item->_lockOwnerType != SyncFileItem::LockOwnerType::UserLock || _item->_lockOwnerId != propagator()->account()->davUser())) {
         qCDebug(lcPropagateDownload()) << _tmpFile << "file is locked: making it read only";
-        FileSystem::setFileReadOnly(filename, true);
+        FileSystem::setFileReadOnly(_tmpFile.fileName(), true);
     } else {
         qCDebug(lcPropagateDownload()) << _tmpFile << "file is not locked: making it"
                                        << ((!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) ? "read only"
                                                                                                                                             : "read write");
-        FileSystem::setFileReadOnlyWeak(filename, (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
+        FileSystem::setFileReadOnlyWeak(_tmpFile.fileName(), (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
     }
-
-    // Apply the remote permissions
-    FileSystem::setFileReadOnlyWeak(_tmpFile.fileName(), !_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite));
 
     const auto isConflict = (_item->_instruction == CSYNC_INSTRUCTION_CONFLICT
                              && (QFileInfo(filename).isDir() || !FileSystem::fileEquals(filename, _tmpFile.fileName()))) ||

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1205,7 +1205,7 @@ void PropagateDownloadFile::downloadFinished()
         qCDebug(lcPropagateDownload()) << _tmpFile << "file is not locked: making it"
                                        << ((!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) ? "read only"
                                                                                                                                             : "read write");
-        FileSystem::setFileReadOnly(filename, (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
+        FileSystem::setFileReadOnlyWeak(filename, (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
     }
 
     // Apply the remote permissions
@@ -1355,7 +1355,7 @@ void PropagateDownloadFile::updateMetadata(bool isConflict)
         FileSystem::setFileReadOnly(fn, true);
     } else {
         qCDebug(lcPropagateDownload()) << fn << "file is not locked: making it" << ((!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)) ? "read only" : "read write");
-        FileSystem::setFileReadOnly(fn, (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
+        FileSystem::setFileReadOnlyWeak(fn, (!_item->_remotePerm.isNull() && !_item->_remotePerm.hasPermission(RemotePermissions::CanWrite)));
     }
 
     qint64 duration = _stopwatch.elapsed();

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -67,6 +67,10 @@ class TestPermissions : public QObject
     Q_OBJECT
 
 private slots:
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogDebug(true);
+    }
 
     void t7pl()
     {

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -85,6 +85,11 @@ class TestSyncEngine : public QObject
     Q_OBJECT
 
 private slots:
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogDebug(true);
+    }
+
     void testFileDownload() {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         ItemCompletedSpy completeSpy(fakeFolder);


### PR DESCRIPTION
make sure that a file locked that would not be modifiable by the current client is read-only on storage

also make sure we make a file read/write when modification can happen again

Close #5537 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
