### PR TITLE
prevent crash by resetting common pointer after deleting gobject menu

### DIFF
--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -66,6 +66,7 @@ CloudProviderWrapper::~CloudProviderWrapper()
     g_object_unref(_cloudProviderAccount);
     g_object_unref(_mainMenu);
     g_object_unref(actionGroup);
+    actionGroup = nullptr;
     g_object_unref(_recentMenu);
 }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
