### PR TITLE
Set VFS PinState to Excluded for ignored files.

### DIFF
--- a/src/common/pinstate.h
+++ b/src/common/pinstate.h
@@ -75,6 +75,13 @@ enum class PinState {
      * dehydrated (which is an arbitrary decision).
      */
     Unspecified = 3,
+
+    /** The file will never be synced to the cloud.
+     * 
+     * Usefull for ignored files to indicate to the OS the file will never be
+     * synced
+     */
+    Excluded = 4,
 };
 Q_ENUM_NS(PinState)
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -564,15 +564,17 @@ void Folder::slotWatchedPathChanged(const QString &path, ChangeReason reason)
     if (pathIsIgnored(path)) {
         const auto pinState = _vfs->pinState(relativePath.toString());
         if (!pinState || *pinState != PinState::Excluded) {
-            if (!_vfs->setPinState(relativePath.toString(), PinState::Excluded))
+            if (!_vfs->setPinState(relativePath.toString(), PinState::Excluded)) {
                 qCWarning(lcFolder) << "Could not set pin state of" << relativePath << "to excluded";
+            }
         }
         return;
     } else {
         const auto pinState = _vfs->pinState(relativePath.toString());
         if (pinState && *pinState == PinState::Excluded) {
-            if (!_vfs->setPinState(relativePath.toString(), PinState::Inherited))
+            if (!_vfs->setPinState(relativePath.toString(), PinState::Inherited)) {
                 qCWarning(lcFolder) << "Could not switch pin state of" << relativePath << "from" << *pinState << "to inherited";
+            }
         }
     }
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -561,6 +561,21 @@ void Folder::slotWatchedPathChanged(const QString &path, ChangeReason reason)
 
     auto relativePath = path.midRef(this->path().size());
 
+    if (pathIsIgnored(path)) {
+        const auto pinState = _vfs->pinState(relativePath.toString());
+        if (!pinState || *pinState != PinState::Excluded) {
+            if (!_vfs->setPinState(relativePath.toString(), PinState::Excluded))
+                qCWarning(lcFolder) << "Could not set pin state of" << relativePath << "to excluded";
+        }
+        return;
+    } else {
+        const auto pinState = _vfs->pinState(relativePath.toString());
+        if (pinState && *pinState == PinState::Excluded) {
+            if (!_vfs->setPinState(relativePath.toString(), PinState::Inherited))
+                qCWarning(lcFolder) << "Could not switch pin state of" << relativePath << "from" << *pinState << "to inherited";
+        }
+    }
+
     // Add to list of locally modified paths
     //
     // We do this before checking for our own sync-related changes to make
@@ -804,6 +819,21 @@ void Folder::removeFromSettings() const
     settings->endGroup();
     settings->beginGroup(QLatin1String("FoldersWithPlaceholders"));
     settings->remove(FolderMan::escapeAlias(_definition.alias));
+}
+
+bool Folder::pathIsIgnored(const QString &path) const
+{
+    if (path.isEmpty()) {
+        return true;
+    }
+
+#ifndef OWNCLOUD_TEST
+    if (isFileExcludedAbsolute(path) && !Utility::isConflictFile(path)) {
+        qCDebug(lcFolder) << "* Ignoring file" << path;
+        return true;
+    }
+#endif
+    return false;
 }
 
 bool Folder::isFileExcludedAbsolute(const QString &fullPath) const

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -233,6 +233,9 @@ public:
     /// Removes the folder from the account's settings.
     void removeFromSettings() const;
 
+    /* Check if the path is ignored. */
+    [[nodiscard]] bool pathIsIgnored(const QString &path) const;
+
     /**
       * Returns whether a file inside this folder should be excluded.
       */

--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -66,20 +66,9 @@ void FolderWatcher::init(const QString &root)
     _timer.start();
 }
 
-bool FolderWatcher::pathIsIgnored(const QString &path)
+bool FolderWatcher::pathIsIgnored(const QString &path) const
 {
-    if (path.isEmpty())
-        return true;
-    if (!_folder)
-        return false;
-
-#ifndef OWNCLOUD_TEST
-    if (_folder->isFileExcludedAbsolute(path) && !Utility::isConflictFile(path)) {
-        qCDebug(lcFolderWatcher) << "* Ignoring file" << path;
-        return true;
-    }
-#endif
-    return false;
+    return path.isEmpty();
 }
 
 bool FolderWatcher::isReliable() const

--- a/src/gui/folderwatcher.h
+++ b/src/gui/folderwatcher.h
@@ -60,9 +60,6 @@ public:
      */
     void init(const QString &root);
 
-    /* Check if the path is ignored. */
-    bool pathIsIgnored(const QString &path);
-
     /**
      * Returns false if the folder watcher can't be trusted to capture all
      * notifications.
@@ -134,6 +131,9 @@ private:
 
     QString possiblyAddUnlockedFilePath(const QString &path);
     QString findMatchingUnlockedFileInDir(const QString &dirPath, const QString &lockFileName);
+
+    /* Check if the path should be igored by the FolderWatcher. */
+    [[nodiscard]] bool pathIsIgnored(const QString &path) const;
 
     /** Path of the expected test notification */
     QString _testNotificationPath;

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -292,6 +292,8 @@ OCC::PinState cfPinStateToPinState(CF_PIN_STATE state)
         return OCC::PinState::OnlineOnly;
     case CF_PIN_STATE_INHERIT:
         return OCC::PinState::Inherited;
+    case CF_PIN_STATE_EXCLUDED:
+        return OCC::PinState::Excluded;
     default:
         Q_UNREACHABLE();
         return OCC::PinState::Inherited;
@@ -309,6 +311,8 @@ CF_PIN_STATE pinStateToCfPinState(OCC::PinState state)
         return CF_PIN_STATE_UNPINNED;
     case OCC::PinState::Unspecified:
         return CF_PIN_STATE_UNSPECIFIED;
+    case OCC::PinState::Excluded:
+        return CF_PIN_STATE_EXCLUDED;
     default:
         Q_UNREACHABLE();
         return CF_PIN_STATE_UNSPECIFIED;

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -320,7 +320,7 @@ Optional<PinState> VfsCfApi::pinStateLocal(const QString &localPath) const
 {
     const auto info = cfapi::findPlaceholderInfo(localPath);
     if (!info) {
-        qCWarning(lcCfApi) << "Couldn't find pin state for regular non-placeholder file" << localPath;
+        qCDebug(lcCfApi) << "Couldn't find pin state for regular non-placeholder file" << localPath;
         return {};
     }
 

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -229,8 +229,9 @@ Result<Vfs::ConvertToPlaceholderResult, QString> VfsCfApi::convertToPlaceholder(
     if (item._type != ItemTypeDirectory && OCC::FileSystem::isLnkFile(filename)) {
         qCInfo(lcCfApi) << "File \"" << filename << "\" is a Windows shortcut. Not converting it to a placeholder.";
         const auto pinState = pinStateLocal(localPath);
-        if (!pinState || *pinState != PinState::Excluded)
+        if (!pinState || *pinState != PinState::Excluded) {
             setPinStateLocal(localPath, PinState::Excluded);
+        }
         return Vfs::ConvertToPlaceholderResult::Ok;
     }
 

--- a/src/libsync/vfs/cfapi/vfs_cfapi.h
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.h
@@ -76,6 +76,9 @@ private:
     void onHydrationJobFinished(HydrationJob *job);
     HydrationJob *findHydrationJob(const QString &requestId) const;
 
+    bool setPinStateLocal(const QString &localPath, PinState state);
+    [[nodiscard]] Optional<PinState> pinStateLocal(const QString &localPath) const;
+
     struct HasHydratedDehydrated {
         bool hasHydrated = false;
         bool hasDehydrated = false;


### PR DESCRIPTION
Setting PinState to Excluded ensures the syncing icon is not shown for ignored items. 
If the PinState is not set to Excluded, also all parent directories are shown as being synced, which is very inconvenient for the end user as it seems that some folder are never fully synced by Nextcloud which isn't the case. 
As long as .lnk files are not converted to placeholder files, also set them to Excluded to hide the syncing icon.

Closes #5524
Closes #5594
Closes #5825

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
