### PR TITLE
Fix residual typos found by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,7 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Don't set up tray context menu on macOS, even if not building app bundle by @claucambra in https://github.com/nextcloud/desktop/pull/4988
 * CI: check clang tidy in ci by @mgallien in https://github.com/nextcloud/desktop/pull/4995
 * Check our code with clang-tidy by @mgallien in https://github.com/nextcloud/desktop/pull/4999
-* Alway use constexpr for all text constants by @mgallien in https://github.com/nextcloud/desktop/pull/4996
+* Always use constexpr for all text constants by @mgallien in https://github.com/nextcloud/desktop/pull/4996
 * Switch AppImage CI to latest tag: client-appimage-6 by @mgallien in https://github.com/nextcloud/desktop/pull/5003
 * Apply modernize-use-using via clang-tidy by @mgallien in https://github.com/nextcloud/desktop/pull/4993
 * Use [[nodiscard]] by @mgallien in https://github.com/nextcloud/desktop/pull/4992

--- a/admin/win/nsi/lib/fileassoc.nsh
+++ b/admin/win/nsi/lib/fileassoc.nsh
@@ -14,7 +14,7 @@
 ;   !insertmacro APP_ASSOCIATE "txt" "myapp.textfile" "Description of txt files" \
 ;     "$INSTDIR\myapp.exe,0" "Open with myapp" "$INSTDIR\myapp.exe $\"%1$\""
 ;
-; Never insert the APP_ASSOCIATE macro multiple times, it is only ment
+; Never insert the APP_ASSOCIATE macro multiple times, it is only meant
 ; to associate an application with a single file and using the
 ; the "open" verb as default. To add more verbs (actions) to a file
 ; use the APP_ASSOCIATE_ADDVERB macro.

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Database/NextcloudItemMetadataTable.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Database/NextcloudItemMetadataTable.swift
@@ -192,7 +192,7 @@ class NextcloudItemMetadataTable: Object {
             comparingMetadata.favorite == self.favorite
     }
 
-    /// Returns false if the user is lokced out of the file. I.e. The file is locked but by somone else
+    /// Returns false if the user is lokced out of the file. I.e. The file is locked but by someone else
     func canUnlock(as user: String) -> Bool {
         return !lock || (lockOwner == user && lockOwnerType == 0)
     }

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -450,8 +450,8 @@ void ActivityListModel::ingestActivities(const QJsonArray &activities)
     QDateTime oldestDate = QDateTime::currentDateTime();
     oldestDate = oldestDate.addDays(static_cast<qint64>(_maxActivitiesDays) * -1);
 
-    for (const auto &activ : activities) {
-        const auto json = activ.toObject();
+    for (const auto &activity : activities) {
+        const auto json = activity.toObject();
 
         auto a = Activity::fromActivityJson(json, _accountState->account());
 

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -97,7 +97,7 @@ public:
      * This function reads the body of the reply and parses out the
      * error information, if possible.
      *
-     * \a body is optinally filled with the reply body.
+     * \a body is optionally filled with the reply body.
      *
      * Warning: Needs to call reply()->readAll().
      */

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -478,7 +478,7 @@ static void propertyMapToRemoteInfo(const QMap<QString, QString> &map, RemoteInf
                 // S means shared with me.
                 // But for our purpose, we want to know if the file is shared. It does not matter
                 // if we are the owner or not.
-                // Piggy back on the persmission field
+                // Piggy back on the permission field
                 result.remotePerm.setPermission(RemotePermissions::IsShared);
                 result.sharedByMe = true;
             }

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -287,7 +287,7 @@ private slots:
         QVERIFY(currentLocalState.find("readonlyDirectory_PERM_M_/subdir_PERM_CK_/subsubdir_PERM_CKDNV_/normalFile_PERM_WVND_.data" ));
         // new still exist
         QVERIFY(currentLocalState.find("readonlyDirectory_PERM_M_/newname_PERM_CK_/subsubdir_PERM_CKDNV_/normalFile_PERM_WVND_.data" ));
-        // but is not on server: so remove it locally for the future comarison
+        // but is not on server: so remove it locally for the future comparison
         fakeFolder.localModifier().remove("readonlyDirectory_PERM_M_/newname_PERM_CK_");
 
         //2.


### PR DESCRIPTION
I have changed a local variable name from:
```cpp
    for (const auto &activ : activities) {
        const auto json = activ.toObject();
```
to:

```cpp
    for (const auto &activity : activities) {
        const auto json = activity.toObject();
```

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Développer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
