### PR TITLE
nmc/add new unit test files

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -31,6 +31,9 @@ class TestShareModel;
 class ShareTestHelper;
 class EndToEndTestHelper;
 class TestSyncConflictsModel;
+class TestFolderWizard;
+class TestSettingsDialog;
+class TestGeneralSettings;
 
 namespace OCC {
 
@@ -396,6 +399,9 @@ private:
     friend class ::TestCfApiShellExtensionsIPC;
     friend class ::ShareTestHelper;
     friend class ::EndToEndTestHelper;
+    friend class ::TestFolderWizard;
+    friend class ::TestSettingsDialog;
+    friend class ::TestGeneralSettings;
 };
 
 } // namespace OCC

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -23,6 +23,7 @@
 #include <QPointer>
 
 class QNetworkReply;
+class TestFolderStatusModel;
 namespace OCC {
 
 Q_DECLARE_LOGGING_CATEGORY(lcFolderStatus)
@@ -153,6 +154,7 @@ private:
     bool _dirty = false; // If the selective sync checkboxes were changed
 
     bool _isSyncRunningForAwhile = false;
+    friend class:: TestFolderStatusModel;// for Unit Test
 
     /**
      * Keeps track of items that are fetching data from the server.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,24 @@ nextcloud_add_test(RemoteWipe)
 
 nextcloud_add_test(OAuth)
 
+nextcloud_add_test(UserModel)
+nextcloud_add_test(ConfigFile)
+nextcloud_add_test(FolderWizard)
+nextcloud_add_test(OwncloudWizard)
+nextcloud_add_test(SettingsDialog)
+nextcloud_add_test(Flow2AuthWidget)
+nextcloud_add_test(AccountSettings)
+nextcloud_add_test(GeneralSettings)
+nextcloud_add_test(FolderStatusModel)
+nextcloud_add_test(OwncloudSetupPage)
+nextcloud_add_test(FolderStatusDelegate)
+nextcloud_add_test(OwncloudAdvancedSetupPage)
+
+nextcloud_add_test(Window)
+nextcloud_add_test(Welcome)
+nextcloud_add_test(UserLine)
+nextcloud_add_test(HeaderButton)
+
 configure_file(test_journal.db "${PROJECT_BINARY_DIR}/bin/test_journal.db" COPYONLY)
 
 find_package(CMocka)

--- a/test/nextcloud_add_test.cmake
+++ b/test/nextcloud_add_test.cmake
@@ -1,4 +1,6 @@
 find_package(Qt5 COMPONENTS Core Test Xml Network Qml Quick REQUIRED)
+get_property(nextcloudCoreName TARGET nextcloudCore PROPERTY NAME)
+set(nextcloudCoreAutogenInclude ${CMAKE_BINARY_DIR}/src/gui/${nextcloudCoreName}_autogen/include)
 
 macro(nextcloud_build_test test_class)
     set(CMAKE_AUTOMOC TRUE)
@@ -32,6 +34,7 @@ macro(nextcloud_build_test test_class)
 
     target_include_directories(${OWNCLOUD_TEST_CLASS}Test PRIVATE
         "${CMAKE_SOURCE_DIR}/test/"
+        ${nextcloudCoreAutogenInclude}
         ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer
     )
     set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES FOLDER Tests)
@@ -81,8 +84,9 @@ macro(nextcloud_add_test test_class)
     target_include_directories(${OWNCLOUD_TEST_CLASS}Test
         PRIVATE
         "${CMAKE_SOURCE_DIR}/test/"
+        ${nextcloudCoreAutogenInclude}
         ${CMAKE_SOURCE_DIR}/src/3rdparty/qtokenizer
-        )
+    )
     set_target_properties(${OWNCLOUD_TEST_CLASS}Test PROPERTIES FOLDER Tests)
 endmacro()
 

--- a/test/testaccountsettings.cpp
+++ b/test/testaccountsettings.cpp
@@ -1,0 +1,24 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "ui_accountsettings.h"
+#include "accountsettings.h"
+
+using namespace OCC;
+
+class TestAccountSettings: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestAccountSettings)
+#include "testaccountsettings.moc"

--- a/test/testconfigfile.cpp
+++ b/test/testconfigfile.cpp
@@ -1,0 +1,22 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include "configfile.h"
+
+using namespace OCC;
+
+class TestConfigFile: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestConfigFile)
+#include "testconfigfile.moc"

--- a/test/testflow2authwidget.cpp
+++ b/test/testflow2authwidget.cpp
@@ -1,0 +1,22 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include "wizard/flow2authwidget.h"
+
+using namespace OCC;
+
+class TestFlow2AuthWidget: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestFlow2AuthWidget)
+#include "testflow2authwidget.moc"

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -5,16 +5,15 @@
  *
  */
 
-#include <qglobal.h>
+#include <QtGlobal>
 #include <QTemporaryDir>
 #include <QtTest>
 
-#include "QtTest/qtestcase.h"
 #include "common/utility.h"
 #include "folderman.h"
 #include "account.h"
 #include "accountstate.h"
-#include <accountmanager.h>
+#include "accountmanager.h"
 #include "configfile.h"
 #include "syncenginetestutils.h"
 #include "testhelper.h"

--- a/test/testfolderstatusdelegate.cpp
+++ b/test/testfolderstatusdelegate.cpp
@@ -1,0 +1,27 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include <QPainter>
+
+#include "folderstatusmodel.h"
+#define private public
+#include "folderstatusdelegate.h"
+#undef private
+
+using namespace OCC;
+
+class TestFolderStatusDelegate: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestFolderStatusDelegate)
+#include "testfolderstatusdelegate.moc"

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -1,0 +1,34 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "localdiscoverytracker.h"
+#include "folderstatusmodel.h"
+#include "syncrunfilelog.h"
+#include "syncengine.h"
+#include "account.h"
+
+#define private public
+#include "accountstate.h"
+#include "syncresult.h"
+#include "folder.h"
+#include "theme.h"
+#undef private
+
+using namespace OCC;
+
+class TestFolderStatusModel: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_GUILESS_MAIN(TestFolderStatusModel)
+#include "testfolderstatusmodel.moc"

--- a/test/testfolderwizard.cpp
+++ b/test/testfolderwizard.cpp
@@ -1,0 +1,29 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QWizardPage>
+#include <QtTest>
+
+#include "creds/abstractcredentials.h"
+#include "folderwizard.h"
+#include "accountstate.h"
+#include "testhelper.h"
+#include "folderman.h"
+#include "account.h"
+
+using namespace OCC;
+
+class TestFolderWizard: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestFolderWizard)
+#include "testfolderwizard.moc"

--- a/test/testgeneralsettings.cpp
+++ b/test/testgeneralsettings.cpp
@@ -1,0 +1,29 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "theme.h"
+#include "folderman.h"
+#include "configfile.h"
+#define private public
+#include "generalsettings.h"
+#undef private
+#include "ui_generalsettings.h"
+
+using namespace OCC;
+
+class TestGeneralSettings: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestGeneralSettings)
+#include "testgeneralsettings.moc"

--- a/test/testheaderbutton.cpp
+++ b/test/testheaderbutton.cpp
@@ -1,0 +1,28 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickView>
+#include <QtTest>
+
+#include "theme.h"
+
+using namespace OCC;
+
+class TestHeaderButton: public QObject
+{
+    Q_OBJECT
+
+public:
+
+private slots:
+
+};
+
+QTEST_MAIN(TestHeaderButton)
+#include "testheaderbutton.moc"

--- a/test/testowncloudadvancedsetuppage.cpp
+++ b/test/testowncloudadvancedsetuppage.cpp
@@ -1,0 +1,24 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "wizard/owncloudadvancedsetuppage.h"
+#include "wizard/owncloudwizard.h"
+
+using namespace OCC;
+
+class TestOwncloudAdvancedSetupPage: public QWidget
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestOwncloudAdvancedSetupPage)
+#include "testowncloudadvancedsetuppage.moc"

--- a/test/testowncloudsetuppage.cpp
+++ b/test/testowncloudsetuppage.cpp
@@ -1,0 +1,23 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "wizard/owncloudsetuppage.h"
+
+using namespace OCC;
+
+class TestOwncloudSetupPage: public QWidget
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestOwncloudSetupPage)
+#include "testowncloudsetuppage.moc"

--- a/test/testowncloudwizard.cpp
+++ b/test/testowncloudwizard.cpp
@@ -1,0 +1,23 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "wizard/owncloudwizard.h"
+
+using namespace OCC;
+
+class TestOwncloudWizard: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestOwncloudWizard)
+#include "testowncloudwizard.moc"

--- a/test/testsettingsdialog.cpp
+++ b/test/testsettingsdialog.cpp
@@ -1,0 +1,25 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QToolBar>
+#include <QtTest>
+
+#include "ui_settingsdialog.h"
+#include "settingsdialog.h"
+
+using namespace OCC;
+
+class TestSettingsDialog: public QDialog
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestSettingsDialog)
+#include "testsettingsdialog.moc"

--- a/test/testuserline.cpp
+++ b/test/testuserline.cpp
@@ -1,0 +1,26 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickView>
+
+#include "theme.h"
+
+using namespace OCC;
+
+class TestUserLine: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestUserLine)
+#include "testuserline.moc"

--- a/test/testusermodel.cpp
+++ b/test/testusermodel.cpp
@@ -1,0 +1,31 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+
+#include "localdiscoverytracker.h"
+#include "syncrunfilelog.h"
+#include "syncengine.h"
+#include "account.h"
+#define private public
+#include "accountstate.h"
+#include "folder.h"
+#include "tray/usermodel.h"
+#undef private
+
+using namespace OCC;
+
+class TestUserModel: public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+};
+
+QTEST_MAIN(TestUserModel)
+#include "testusermodel.moc"

--- a/test/testwelcome.cpp
+++ b/test/testwelcome.cpp
@@ -1,0 +1,26 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include <QQuickView>
+#include <QQmlEngine>
+#include <QQuickItem>
+
+#include "theme.h"
+
+using namespace OCC;
+
+class TestWelcome: public QObject
+{
+    Q_OBJECT
+
+public slots:
+
+};
+
+QTEST_MAIN(TestWelcome)
+#include "testwelcome.moc"

--- a/test/testwindow.cpp
+++ b/test/testwindow.cpp
@@ -1,0 +1,29 @@
+/*
+ *    This software is in the public domain, furnished "as is", without technical
+ *    support, and with no warranty, express or implied, as to its usefulness for
+ *    any purpose.
+ *
+ */
+
+#include <QtTest>
+#include <QQmlApplicationEngine>
+#include <QQmlEngine>
+#include <QQmlContext>
+#include <QQuickItem>
+
+#include "tray/usermodel.h"
+#include "systray.h"
+#include "theme.h"
+
+using namespace OCC;
+
+class TestWindow: public QObject
+{
+    Q_OBJECT
+
+public:
+
+};
+
+QTEST_MAIN(TestWindow)
+#include "testwindow.moc"


### PR DESCRIPTION
Added new Unit Test files(which are not present in Nextcloud repo) with template, dependent header files and some member access dependency.
Later we will add testcase for NMC changes & nextcloud can also add test cases.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
