### PR TITLE
nmc/runwizard_introduction

### DIFF
--- a/src/gui/wizard/flow2authwidget.cpp
+++ b/src/gui/wizard/flow2authwidget.cpp
@@ -42,8 +42,8 @@ Flow2AuthWidget::Flow2AuthWidget(QWidget *parent)
     WizardCommon::initErrorLabel(_ui.errorLabel);
     _ui.errorLabel->setTextFormat(Qt::RichText);
 
-    connect(_ui.openLinkLabel, &LinkLabel::clicked, this, &Flow2AuthWidget::slotOpenBrowser);
-    connect(_ui.copyLinkLabel, &LinkLabel::clicked, this, &Flow2AuthWidget::slotCopyLinkToClipboard);
+    connect(_ui.openLinkLabel, &QPushButton::clicked, this, &Flow2AuthWidget::slotOpenBrowser);
+    connect(_ui.copyLinkLabel, &QPushButton::clicked, this, &Flow2AuthWidget::slotCopyLinkToClipboard);
 
     auto sizePolicy = _progressIndi->sizePolicy();
     sizePolicy.setRetainSizeWhenHidden(true);
@@ -218,11 +218,9 @@ void Flow2AuthWidget::customizeStyle()
         }
     }
 
-    _ui.openLinkLabel->setText(tr("Reopen Browser"));
-    _ui.openLinkLabel->setAlignment(Qt::AlignCenter);
+    _ui.openLinkLabel->setText(tr("Open Browser"));
 
     _ui.copyLinkLabel->setText(tr("Copy Link"));
-    _ui.copyLinkLabel->setAlignment(Qt::AlignCenter);
 
     WizardCommon::customizeHintLabel(_ui.statusLabel);
 }

--- a/src/gui/wizard/flow2authwidget.ui
+++ b/src/gui/wizard/flow2authwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>580</width>
-    <height>330</height>
+    <width>597</width>
+    <height>387</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,31 +25,22 @@
   <property name="windowTitle">
    <string>Browser Authentication</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <spacer name="verticalSpacer_3">
+    <spacer name="verticalSpacer_6">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>80</height>
+       <height>40</height>
       </size>
      </property>
     </spacer>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QLabel" name="logoLabel">
        <property name="text">
@@ -61,13 +52,29 @@
       </widget>
      </item>
      <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>32</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <widget class="QLabel" name="label">
        <property name="font">
         <font>
+         <family>Segoe UI</family>
          <pointsize>12</pointsize>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color:&quot;#191919&quot;</string>
        </property>
        <property name="text">
         <string>Switch to your browser to connect your account</string>
@@ -79,6 +86,22 @@
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>8</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <widget class="QLabel" name="statusLabel">
@@ -94,13 +117,36 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="leftMargin">
-        <number>0</number>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
        </property>
-       <property name="topMargin">
-        <number>0</number>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>32</height>
+        </size>
        </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="progressLayout"/>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>64</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
@@ -115,15 +161,56 @@
         </spacer>
        </item>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="OCC::LinkLabel" name="copyLinkLabel" native="true"/>
+          <widget class="QPushButton" name="copyLinkLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <family>Segoe UI</family>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string notr="true">pbSelectLocalFolder</string>
+           </property>
+           <property name="autoDefault">
+            <bool>true</bool>
+           </property>
+           <property name="default">
+            <bool>false</bool>
+           </property>
+          </widget>
          </item>
          <item>
-          <widget class="OCC::LinkLabel" name="openLinkLabel" native="true"/>
+          <widget class="QPushButton" name="openLinkLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <family>Segoe UI</family>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string notr="true">pbSelectLocalFolder</string>
+           </property>
+           <property name="autoDefault">
+            <bool>true</bool>
+           </property>
+           <property name="default">
+            <bool>false</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -155,47 +242,26 @@
        </property>
       </widget>
      </item>
-     <item>
-      <layout class="QHBoxLayout" name="progressLayout"/>
-     </item>
     </layout>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
+    <spacer name="verticalSpacer_3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>80</height>
+       <height>60</height>
       </size>
      </property>
     </spacer>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>OCC::LinkLabel</class>
-   <extends>QWidget</extends>
-   <header>wizard/linklabel.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Update run wizard introduction screen UI.
Modified "Copy Link" & "Reopen Browser" with QPushButton to apply stylesheet.
Attached screen shots of UI change & final output[before & After], also attached screenshots of MagentCloud output screen for stylesheet reference.

--NC_Run_Wizard_Intro_After--
![NC_Run_Wizard_Intro_After](https://github.com/nextcloud/desktop/assets/103042752/4fbd66cd-dffc-475c-a32f-654b5b4f216f)

--NC_Run_Wizard_Intro_Before--
![NC_Run_Wizard_Intro_Before](https://github.com/nextcloud/desktop/assets/103042752/1fb00a75-5a16-4ca2-a9da-0bb1347b69fc)

--NC_UI_Design_After--
![NC_UI_Design_After](https://github.com/nextcloud/desktop/assets/103042752/cd688e9c-7bb7-4709-a7aa-c03a4a090457)

--NC_UI_Design_Before--
![NC_UI_Design_Before](https://github.com/nextcloud/desktop/assets/103042752/284faf9d-d9fe-44d8-a5a1-1a492cd5b642)

 --MagentCloud reference screen--
![MagentaCloud_Reference](https://github.com/nextcloud/desktop/assets/103042752/ade1634b-f86f-4a3e-b2ce-6618538c5773)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
