### PR TITLE
fix bulk upload of empty files

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -30,7 +30,7 @@ ShortPath/EnableJunctions = False
 
 ; Packager/RepositoryUrl = https://files.kde.org/craft/
 Packager/PackageType = NullsoftInstallerPackager
-Packager/RepositoryUrl = http://ftp.acc.umu.se/mirror/kde.org/files/craft/master/
+Packager/RepositoryUrl = https://files.kde.org/craft/master/
 
 ContinuousIntegration/Enabled = True
 

--- a/src/common/checksumcalculator.cpp
+++ b/src/common/checksumcalculator.cpp
@@ -95,8 +95,6 @@ QByteArray ChecksumCalculator::calculate()
         return result;
     }
 
-    bool isAnyChunkAdded = false;
-
     for (;;) {
         QMutexLocker locker(&_deviceMutex);
         if (!_device->isOpen() || _device->atEnd()) {
@@ -114,7 +112,6 @@ QByteArray ChecksumCalculator::calculate()
         if (!addChunk(buf, sizeRead)) {
             break;
         }
-        isAnyChunkAdded = true;
     }
 
     {
@@ -124,14 +121,12 @@ QByteArray ChecksumCalculator::calculate()
         }
     }
 
-    if (isAnyChunkAdded) {
-        if (_algorithmType == AlgorithmType::Adler32) {
-            result = QByteArray::number(_adlerHash, 16);
-        } else {
-            Q_ASSERT(_cryptographicHash);
-            if (_cryptographicHash) {
-                result = _cryptographicHash->result().toHex();
-            }
+    if (_algorithmType == AlgorithmType::Adler32) {
+        result = QByteArray::number(_adlerHash, 16);
+    } else {
+        Q_ASSERT(_cryptographicHash);
+        if (_cryptographicHash) {
+            result = _cryptographicHash->result().toHex();
         }
     }
 
@@ -150,13 +145,6 @@ void ChecksumCalculator::initChecksumAlgorithm()
     if (_algorithmType == AlgorithmType::Undefined) {
         qCWarning(lcChecksumCalculator) << "_algorithmType is Undefined, impossible to init Checksum Algorithm";
         return;
-    }
-
-    {
-        QMutexLocker locker(&_deviceMutex);
-        if (_device->size() == 0) {
-            return;
-        }
     }
 
     if (_algorithmType == AlgorithmType::Adler32) {

--- a/src/libsync/putmultifilejob.cpp
+++ b/src/libsync/putmultifilejob.cpp
@@ -53,7 +53,11 @@ void PutMultiFileJob::start()
 
         auto onePart = QHttpPart{};
 
-        onePart.setBodyDevice(oneDevice._device.get());
+        if (oneDevice._device->size() == 0) {
+            onePart.setBody({});
+        } else {
+            onePart.setBodyDevice(oneDevice._device.get());
+        }
 
         for (auto it = oneDevice._headers.begin(); it != oneDevice._headers.end(); ++it) {
             onePart.setRawHeader(it.key(), it.value());


### PR DESCRIPTION
force an empty body when we bulk upload empty files

force a "valid" checksum to be computed for empty files as bulk upload server side expects a checksum even for empty files

Close #5824

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
