### PR TITLE
Do not modify discovered files on disk if not necessary

### DIFF
--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -114,17 +114,17 @@ void FileSystem::setFolderMinimumPermissions(const QString &filename)
 #endif
 }
 
-
-void FileSystem::setFileReadOnlyWeak(const QString &filename, bool readonly)
+bool FileSystem::setFileReadOnlyWeak(const QString &filename, bool readonly)
 {
     QFile file(filename);
     QFile::Permissions permissions = file.permissions();
 
     if (!readonly && (permissions & QFile::WriteOwner)) {
-        return; // already writable enough
+        return false; // already writable enough
     }
 
     setFileReadOnly(filename, readonly);
+    return true;
 }
 
 bool FileSystem::rename(const QString &originFileName,

--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -65,7 +65,7 @@ namespace FileSystem {
      * This means that it will preserve explicitly set rw-r--r-- permissions even
      * when the umask is 0002. (setFileReadOnly() would adjust to rw-rw-r--)
      */
-    void OCSYNC_EXPORT setFileReadOnlyWeak(const QString &filename, bool readonly);
+    bool OCSYNC_EXPORT setFileReadOnlyWeak(const QString &filename, bool readonly);
 
     /**
      * @brief Try to set permissions so that other users on the local machine can not

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -394,13 +394,11 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
                     emit itemCompleted(item, ErrorCategory::GenericError);
                     return;
                 }
-            } else {
-                if (!FileSystem::setModTime(filePath, item->_modtime)) {
-                    item->_instruction = CSYNC_INSTRUCTION_ERROR;
-                    item->_errorString = tr("Could not update file metadata: %1").arg(filePath);
-                    emit itemCompleted(item, ErrorCategory::GenericError);
-                    return;
-                }
+            } else if (!FileSystem::setModTime(filePath, item->_modtime)) {
+                item->_instruction = CSYNC_INSTRUCTION_ERROR;
+                item->_errorString = tr("Could not update file metadata: %1").arg(filePath);
+                emit itemCompleted(item, ErrorCategory::GenericError);
+                return;
             }
 
             // Updating the db happens on success

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -375,7 +375,7 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
             rec._serverHasIgnoredFiles |= prev._serverHasIgnoredFiles;
 
             // Ensure it's a placeholder file on disk
-            if (item->_type == ItemTypeFile) {
+            if (item->_type == ItemTypeFile && _syncOptions._vfs->mode() != Vfs::Off) {
                 const auto result = _syncOptions._vfs->convertToPlaceholder(filePath, *item);
                 if (!result) {
                     item->_status = SyncFileItem::Status::NormalError;

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -388,17 +388,17 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
             }
 
             // Update on-disk virtual file metadata
-            if (modificationHappened) {
-                if (item->_type == ItemTypeVirtualFile) {
-                    auto r = _syncOptions._vfs->updateMetadata(filePath, item->_modtime, item->_size, item->_fileId);
-                    if (!r) {
-                        item->_status = SyncFileItem::Status::NormalError;
-                        item->_instruction = CSYNC_INSTRUCTION_ERROR;
-                        item->_errorString = tr("Could not update virtual file metadata: %1").arg(r.error());
-                        emit itemCompleted(item, ErrorCategory::GenericError);
-                        return;
-                    }
-                } else if (!FileSystem::setModTime(filePath, item->_modtime)) {
+            if (modificationHappened && item->_type == ItemTypeVirtualFile) {
+                auto r = _syncOptions._vfs->updateMetadata(filePath, item->_modtime, item->_size, item->_fileId);
+                if (!r) {
+                    item->_status = SyncFileItem::Status::NormalError;
+                    item->_instruction = CSYNC_INSTRUCTION_ERROR;
+                    item->_errorString = tr("Could not update virtual file metadata: %1").arg(r.error());
+                    emit itemCompleted(item, ErrorCategory::GenericError);
+                    return;
+                }
+            } else if (modificationHappened || prev._modtime != item->_modtime) {
+                if (!FileSystem::setModTime(filePath, item->_modtime)) {
                     item->_instruction = CSYNC_INSTRUCTION_ERROR;
                     item->_errorString = tr("Could not update file metadata: %1").arg(filePath);
                     emit itemCompleted(item, ErrorCategory::GenericError);

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -357,7 +357,7 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
         // mini-jobs later on, we just update metadata right now.
 
         if (item->_direction == SyncFileItem::Down) {
-            auto modificationHappened = false;
+            auto modificationHappened = false; // Decides whether or not we modify file metadata
             QString filePath = _localPath + item->_file;
 
             // If the 'W' remote permission changed, update the local filesystem
@@ -368,6 +368,8 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
                 const bool isReadOnly = !item->_remotePerm.isNull() && !item->_remotePerm.hasPermission(RemotePermissions::CanWrite);
                 modificationHappened = FileSystem::setFileReadOnlyWeak(filePath, isReadOnly);
             }
+
+            modificationHappened |= item->_size != prev._fileSize;
 
             auto rec = item->toSyncJournalFileRecordWithInode(filePath);
             if (rec._checksumHeader.isEmpty())

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -113,6 +113,12 @@ void DiskFileModifier::setE2EE([[maybe_unused]] const QString &relativePath, [[m
 {
 }
 
+QFile DiskFileModifier::find(const QString &relativePath) const
+{
+    const auto path = _rootDir.filePath(relativePath);
+    return QFile(path);
+}
+
 FileInfo FileInfo::A12_B12_C12_S12()
 {
     FileInfo fi { QString {}, {

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -108,6 +108,8 @@ public:
     void setModTime(const QString &relativePath, const QDateTime &modTime) override;
     void modifyLockState(const QString &relativePath, LockState lockState, int lockType, const QString &lockOwner, const QString &lockOwnerId, const QString &lockEditorId, quint64 lockTime, quint64 lockTimeout) override;
     void setE2EE(const QString &relativepath, const bool enabled) override;
+
+    [[nodiscard]] QFile find(const QString &relativePath) const;
 };
 
 class FileInfo : public FileModifier

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -12,6 +12,7 @@
 #include "propagatorjobs.h"
 #include "syncengine.h"
 
+#include <QFile>
 #include <QtTest>
 
 using namespace OCC;
@@ -919,6 +920,29 @@ private slots:
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
 
         QCOMPARE(QFileInfo(fakeFolder.localPath() + "foo").lastModified(), datetime);
+    }
+
+    // A local file should not be modified after upload to server if nothing has changed.
+    void testLocalFileInitialMtime()
+    {
+        constexpr auto fooFolder = "foo/";
+        constexpr auto barFile = "foo/bar";
+
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.localModifier().mkdir(fooFolder);
+        fakeFolder.localModifier().insert(barFile);
+
+        const auto localDiskFileModifier = dynamic_cast<DiskFileModifier &>(fakeFolder.localModifier());
+
+        const auto localFile = localDiskFileModifier.find(barFile);
+        const auto localFileInfo = QFileInfo(localFile);
+        const auto expectedMtime = localFileInfo.metadataChangeTime();
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        const auto currentMtime = localFileInfo.metadataChangeTime();
+        QCOMPARE(currentMtime, expectedMtime);
     }
 
     /**


### PR DESCRIPTION
This prevents the file metadata changing when it doesn't have to, causing conflicts in certain user applications

Close #5842

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
