### PR TITLE
Disable share view completely when server does not support/has disabled file sharing

### DIFF
--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -250,7 +250,7 @@ Page {
         FileActivityView {
             id: fileActivityView
 
-            property int swipeIndex: SwipeView.index
+            readonly property int swipeIndex: SwipeView.index
 
             delegateHorizontalPadding: root.intendedPadding
 
@@ -262,7 +262,7 @@ Page {
         Loader {
             id: shareViewLoader
 
-            property int swipeIndex: SwipeView.index
+            readonly property int swipeIndex: SwipeView.index
 
             width: swipeView.width
             height: swipeView.height

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -222,6 +222,7 @@ Page {
             Layout.rightMargin: root.intendedPadding
 
             padding: 0
+            background: null
 
             NCTabButton {
                 svgCustomColorSource: "image://svgimage-custom-color/activity.svg"

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -47,7 +47,11 @@ Page {
     Connections {
         target: Systray
         function onShowFileDetailsPage(fileLocalPath, page) {
-            if(fileLocalPath === root.localPath) {
+            if (!root.fileDetails.sharingAvailable && page == Systray.FileDetailsPage.Sharing) {
+                return;
+            }
+
+            if (fileLocalPath === root.localPath) {
                 switch(page) {
                 case Systray.FileDetailsPage.Activity:
                     swipeView.currentIndex = fileActivityView.swipeIndex;

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -53,7 +53,7 @@ Page {
                     swipeView.currentIndex = fileActivityView.swipeIndex;
                     break;
                 case Systray.FileDetailsPage.Sharing:
-                    swipeView.currentIndex = shareView.swipeIndex;
+                    swipeView.currentIndex = shareViewLoader.swipeIndex;
                     break;
                 }
             }
@@ -229,8 +229,9 @@ Page {
             NCTabButton {
                 svgCustomColorSource: "image://svgimage-custom-color/share.svg"
                 text: qsTr("Sharing")
-                checked: swipeView.currentIndex === shareView.swipeIndex
-                onClicked: swipeView.currentIndex = shareView.swipeIndex
+                checked: swipeView.currentIndex === shareViewLoader.swipeIndex
+                onClicked: swipeView.currentIndex = shareViewLoader.swipeIndex
+                visible: root.fileDetails.sharingAvailable
             }
         }
     }
@@ -253,18 +254,28 @@ Page {
             iconSize: root.iconSize
         }
 
-        ShareView {
-            id: shareView
+        Loader {
+            id: shareViewLoader
 
             property int swipeIndex: SwipeView.index
 
-            accountState: root.accountState
-            localPath: root.localPath
-            fileDetails: root.fileDetails
-            horizontalPadding: root.intendedPadding
-            iconSize: root.iconSize
-            rootStackView: root.rootStackView
-            backgroundsVisible: root.backgroundsVisible
+            width: swipeView.width
+            height: swipeView.height
+            active: root.fileDetails.sharingAvailable
+
+            sourceComponent: ShareView {
+                id: shareView
+
+                anchors.fill: parent
+
+                accountState: root.accountState
+                localPath: root.localPath
+                fileDetails: root.fileDetails
+                horizontalPadding: root.intendedPadding
+                iconSize: root.iconSize
+                rootStackView: root.rootStackView
+                backgroundsVisible: root.backgroundsVisible
+            }
         }
     }
 }

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -232,6 +232,8 @@ Page {
             }
 
             NCTabButton {
+                width: visible ? implicitWidth : 0
+                height: visible ? implicitHeight : 0
                 svgCustomColorSource: "image://svgimage-custom-color/share.svg"
                 text: qsTr("Sharing")
                 checked: swipeView.currentIndex === shareViewLoader.swipeIndex

--- a/src/gui/filedetails/filedetails.cpp
+++ b/src/gui/filedetails/filedetails.cpp
@@ -62,7 +62,11 @@ void FileDetails::setLocalPath(const QString &localPath)
     connect(&_fileWatcher, &QFileSystemWatcher::fileChanged, this, &FileDetails::refreshFileDetails);
 
     const auto folder = FolderMan::instance()->folderForPath(_localPath);
-    Q_ASSERT(folder);
+    if (!folder) {
+        qCWarning(lcFileDetails) << "No folder found for path:" << _localPath << "will not load file details.";
+        return;
+    }
+
     const auto file = _localPath.mid(folder->cleanPath().length() + 1);
 
     if (!folder->journalDb()->getFileRecord(file, &_fileRecord)) {

--- a/src/gui/filedetails/filedetails.cpp
+++ b/src/gui/filedetails/filedetails.cpp
@@ -172,4 +172,9 @@ void FileDetails::updateFileTagModel(const Folder * const folder)
     Q_EMIT fileTagModelChanged();
 }
 
+bool FileDetails::sharingAvailable() const
+{
+    return _sharingAvailable;
+}
+
 } // namespace OCC

--- a/src/gui/filedetails/filedetails.cpp
+++ b/src/gui/filedetails/filedetails.cpp
@@ -62,6 +62,7 @@ void FileDetails::setLocalPath(const QString &localPath)
     connect(&_fileWatcher, &QFileSystemWatcher::fileChanged, this, &FileDetails::refreshFileDetails);
 
     const auto folder = FolderMan::instance()->folderForPath(_localPath);
+    Q_ASSERT(folder);
     const auto file = _localPath.mid(folder->cleanPath().length() + 1);
 
     if (!folder->journalDb()->getFileRecord(file, &_fileRecord)) {
@@ -73,6 +74,8 @@ void FileDetails::setLocalPath(const QString &localPath)
     _filelockState = _fileRecord._lockstate;
     updateLockExpireString();
     updateFileTagModel(folder);
+
+    _sharingAvailable = folder->accountState()->account()->capabilities().shareAPI();
 
     Q_EMIT fileChanged();
 }

--- a/src/gui/filedetails/filedetails.h
+++ b/src/gui/filedetails/filedetails.h
@@ -38,6 +38,7 @@ class FileDetails : public QObject
     Q_PROPERTY(QString lockExpireString READ lockExpireString NOTIFY lockExpireStringChanged)
     Q_PROPERTY(bool isFolder READ isFolder NOTIFY isFolderChanged)
     Q_PROPERTY(FileTagModel* fileTagModel READ fileTagModel NOTIFY fileTagModelChanged)
+    Q_PROPERTY(bool sharingAvailable READ sharingAvailable NOTIFY fileChanged)
 
 public:
     explicit FileDetails(QObject *parent = nullptr);
@@ -50,6 +51,7 @@ public:
     [[nodiscard]] QString lockExpireString() const;
     [[nodiscard]] bool isFolder() const;
     [[nodiscard]] FileTagModel *fileTagModel() const;
+    [[nodiscard]] bool sharingAvailable() const;
 
 public slots:
     void setLocalPath(const QString &localPath);
@@ -80,6 +82,7 @@ private:
     QLocale _locale;
 
     std::unique_ptr<FileTagModel> _fileTagModel;
+    bool _sharingAvailable = true;
 };
 
 } // namespace OCC


### PR DESCRIPTION


Fixes #5826

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
