### PR TITLE
Convert VFS file to placeholder again if needed

### DIFF
--- a/src/csync/csync.h
+++ b/src/csync/csync.h
@@ -207,6 +207,7 @@ struct OCSYNC_EXPORT csync_file_stat_s {
   bool has_ignored_files BITFIELD(1); // Specify that a directory, or child directory contains ignored files.
   bool is_hidden BITFIELD(1); // Not saved in the DB, only used during discovery for local files.
   bool isE2eEncrypted BITFIELD(1);
+  bool is_metadata_missing BITFIELD(1); // Indicates the file has missing metadata, f.ex. the file is not a placeholder in case of vfs.
 
   QByteArray path;
   QByteArray rename_path;
@@ -233,6 +234,7 @@ struct OCSYNC_EXPORT csync_file_stat_s {
     , has_ignored_files(false)
     , is_hidden(false)
     , isE2eEncrypted(false)
+    , is_metadata_missing(false)
   { }
 };
 

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -618,7 +618,8 @@ void Folder::slotWatchedPathChanged(const QString &path, ChangeReason reason)
                     spurious = false;
                 if (*pinState == PinState::OnlineOnly && record.isFile())
                     spurious = false;
-            }
+            } else
+                spurious = false;
         }
         if (spurious) {
             qCInfo(lcFolder) << "Ignoring spurious notification for file" << relativePath;

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -618,8 +618,9 @@ void Folder::slotWatchedPathChanged(const QString &path, ChangeReason reason)
                     spurious = false;
                 if (*pinState == PinState::OnlineOnly && record.isFile())
                     spurious = false;
-            } else
+            } else {
                 spurious = false;
+            }
         }
         if (spurious) {
             qCInfo(lcFolder) << "Ignoring spurious notification for file" << relativePath;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -473,7 +473,8 @@ void ProcessDirectoryJob::processFile(PathTuple path,
                               << " | type: " << dbEntry._type << "/" << localEntry.type << "/" << (serverEntry.isDirectory ? ItemTypeDirectory : ItemTypeFile)
                               << " | e2ee: " << dbEntry.isE2eEncrypted() << "/" << serverEntry.isE2eEncrypted()
                               << " | e2eeMangledName: " << dbEntry.e2eMangledName() << "/" << serverEntry.e2eMangledName
-                              << " | file lock: " << localFileIsLocked << "//" << serverFileIsLocked;
+                              << " | file lock: " << localFileIsLocked << "//" << serverFileIsLocked
+                              << " | metadata missing: /" << localEntry.isMetadataMissing << '/';
 
     if (localEntry.isValid()
         && !serverEntry.isValid()
@@ -1073,6 +1074,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                 item->_type = ItemTypeVirtualFileDehydration;
             } else if (!serverModified
                 && (dbEntry._inode != localEntry.inode
+                    || localEntry.isMetadataMissing
                     || _discoveryData->_syncOptions._vfs->needsMetadataUpdate(*item))) {
                 item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
                 item->_direction = SyncFileItem::Down;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -324,6 +324,7 @@ void DiscoverySingleLocalDirectoryJob::run() {
         i.isHidden = dirent->is_hidden;
         i.isSymLink = dirent->type == ItemTypeSoftLink;
         i.isVirtualFile = dirent->type == ItemTypeVirtualFile || dirent->type == ItemTypeVirtualFileDownload;
+        i.isMetadataMissing = dirent->is_metadata_missing;
         i.type = dirent->type;
         results.push_back(i);
     }

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -101,6 +101,7 @@ struct LocalInfo
     bool isHidden = false;
     bool isVirtualFile = false;
     bool isSymLink = false;
+    bool isMetadataMissing = false;
     [[nodiscard]] bool isValid() const { return !name.isNull(); }
 };
 

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -865,7 +865,7 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::co
 
 OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::revertPlaceholder(const QString &path)
 {
-    const qint64 result = CfRevertPlaceholder(handleForPath(path).get(), CF_REVERT_FLAG_NONE, nullptr);
+    const auto result = CfRevertPlaceholder(handleForPath(path).get(), CF_REVERT_FLAG_NONE, nullptr);
     if (result != S_OK) {
         qCWarning(lcCfApiWrapper) << "Couldn't revert placeholder for" << path << ":" << QString::fromWCharArray(_com_error(result).ErrorMessage());
         return {"Couldn't revert placeholder"};

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -862,3 +862,14 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::co
         return stateResult;
     }
 }
+
+OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> OCC::CfApiWrapper::revertPlaceholder(const QString &path)
+{
+    const qint64 result = CfRevertPlaceholder(handleForPath(path).get(), CF_REVERT_FLAG_NONE, nullptr);
+    if (result != S_OK) {
+        qCWarning(lcCfApiWrapper) << "Couldn't revert placeholder for" << path << ":" << QString::fromWCharArray(_com_error(result).ErrorMessage());
+        return {"Couldn't revert placeholder"};
+    }
+
+    return OCC::Vfs::ConvertToPlaceholderResult::Ok;
+}

--- a/src/libsync/vfs/cfapi/cfapiwrapper.h
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.h
@@ -97,6 +97,7 @@ NEXTCLOUD_CFAPI_EXPORT Result<void, QString> createPlaceholderInfo(const QString
 NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> updatePlaceholderInfo(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath = QString());
 NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> convertToPlaceholder(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId, const QString &replacesPath);
 NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> dehydratePlaceholder(const QString &path, time_t modtime, qint64 size, const QByteArray &fileId);
+NEXTCLOUD_CFAPI_EXPORT Result<OCC::Vfs::ConvertToPlaceholderResult, QString> revertPlaceholder(const QString &path);
 
 }
 


### PR DESCRIPTION
Note that Windows may convert a placeholder file to a regular file when it is replaced by another file, even if the old and new file (inode, modified time, file size) are identical.

Steps to reproduce the the issue:
 - Create file "a"
 - Create folder "A"
 - Copy file "a" to "A"
 - Let the client sync the local changes to the server.
 - Copy file "a" again to "A" (and let Windows replace the file)
 - "A/a" will indefinitely show the syncing icon. 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
