### PR TITLE
Disable sync icon animation

### DIFF
--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -151,7 +151,7 @@ void SyncStatusSummary::setSyncStateForFolder(const Folder *folder)
         break;
     case SyncResult::SyncRunning:
     case SyncResult::NotYetStarted:
-        setSyncing(true);
+        setSyncing(false);  // disabled the animation because of performance problems, see issue #4918
         setSyncStatusString(tr("Syncing"));
         setSyncStatusDetailString("");
         setSyncIcon(Theme::instance()->syncStatusRunning());


### PR DESCRIPTION
During my investigation of #4918, I found that the animation of the blue sync icon in the tray causes massive slowdowns when the tray is open. I don't know exactly why this is happening, but I suspect that there's a scheduling issue between running the animation and performing network IO. Both tasks could be running on the same thread and blocking each other or something like that. Unfortunately, I don't have enough knowledge about Qt and this codebase to find the root cause and fix the problem there.

Since the performance bug is pretty severe, I'd like to propose a quick fix instead: Simply turning off the animation. With this single line change, the icon won't be spinning anymore, but file transfers will be a lot faster. IMO, performance beats aesthetics in this case.

Let me know if this would be an option for you. Thanks in advance!

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
