### PR TITLE
Display correct server colour prior to acquiring server capabilities

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -42,6 +42,8 @@ constexpr auto caCertsKeyC = "CaCertificates";
 constexpr auto accountsC = "Accounts";
 constexpr auto versionC = "version";
 constexpr auto serverVersionC = "serverVersion";
+constexpr auto serverColorC = "serverColor";
+constexpr auto serverTextColorC = "serverTextColor";
 constexpr auto skipE2eeMetadataChecksumValidationC = "skipE2eeMetadataChecksumValidation";
 constexpr auto generalC = "General";
 
@@ -306,6 +308,8 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.setValue(QLatin1String(davUserC), acc->_davUser);
     settings.setValue(QLatin1String(displayNameC), acc->_displayName);
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
+    settings.setValue(QLatin1String(serverColorC), acc->_serverColor);
+    settings.setValue(QLatin1String(serverTextColorC), acc->_serverTextColor);
     if (!acc->_skipE2eeMetadataChecksumValidation) {
         settings.remove(QLatin1String(skipE2eeMetadataChecksumValidationC));
     } else {
@@ -412,6 +416,8 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     qCInfo(lcAccountManager) << "Account for" << acc->url() << "using auth type" << authType;
 
     acc->_serverVersion = settings.value(QLatin1String(serverVersionC)).toString();
+    acc->_serverColor = settings.value(QLatin1String(serverColorC)).value<QColor>();
+    acc->_serverTextColor = settings.value(QLatin1String(serverTextColorC)).value<QColor>();
     acc->_skipE2eeMetadataChecksumValidation = settings.value(QLatin1String(skipE2eeMetadataChecksumValidationC), {}).toBool();
     acc->_davUser = settings.value(QLatin1String(davUserC), "").toString();
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -22,6 +22,7 @@
 #include "creds/abstractcredentials.h"
 #include "networkjobs.h"
 #include "pushnotifications.h"
+#include "theme.h"
 #include "version.h"
 
 #include "deletejob.h"
@@ -70,6 +71,7 @@ const char app_password[] = "_app-password";
 Account::Account(QObject *parent)
     : QObject(parent)
     , _capabilities(QVariantMap())
+    , _serverColor(Theme::defaultColor())
 {
     qRegisterMetaType<AccountPtr>("AccountPtr");
     qRegisterMetaType<Account *>("Account*");

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -646,11 +646,22 @@ const Capabilities &Account::capabilities() const
     return _capabilities;
 }
 
+void Account::updateServerColors()
+{
+    if (const auto capServerColor = _capabilities.serverColor(); capServerColor.isValid()) {
+        _serverColor = capServerColor;
+    }
+
+    if (const auto capServerTextColor = _capabilities.serverTextColor(); capServerTextColor.isValid()) {
+        _serverTextColor = capServerTextColor;
+    }
+}
+
 void Account::setCapabilities(const QVariantMap &caps)
 {
     _capabilities = Capabilities(caps);
-    _serverColor = _capabilities.serverColor();
-    _serverTextColor = _capabilities.serverTextColor();
+
+    updateServerColors();
 
     emit capabilitiesChanged();
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -13,15 +13,14 @@
  */
 
 #include "account.h"
-#include "accountfwd.h"
-#include "clientsideencryptionjobs.h"
-#include "cookiejar.h"
-#include "networkjobs.h"
-#include "configfile.h"
 #include "accessmanager.h"
-#include "creds/abstractcredentials.h"
+#include "accountfwd.h"
 #include "capabilities.h"
-#include "theme.h"
+#include "clientsideencryptionjobs.h"
+#include "configfile.h"
+#include "cookiejar.h"
+#include "creds/abstractcredentials.h"
+#include "networkjobs.h"
 #include "pushnotifications.h"
 #include "version.h"
 
@@ -197,32 +196,30 @@ QString Account::prettyName() const
     return name;
 }
 
+QColor Account::serverColor() const
+{
+    return _serverColor;
+}
+
 QColor Account::headerColor() const
 {
-    const auto serverColor = capabilities().serverColor();
-    return serverColor.isValid() ? serverColor : Theme::defaultColor();
+    return serverColor();
 }
 
 QColor Account::headerTextColor() const
 {
-    const auto headerTextColor = capabilities().serverTextColor();
-    return headerTextColor.isValid() ? headerTextColor : QColor(255,255,255);
+    return _serverTextColor;
 }
 
 QColor Account::accentColor() const
 {
-    // This will need adjusting when dark theme is a thing
-    auto serverColor = capabilities().serverColor();
+    const auto accentColor = serverColor();
+    constexpr auto effectMultiplier = 8;
 
-    if(!serverColor.isValid()) {
-        serverColor = Theme::defaultColor();
-    }
-
-    const auto effectMultiplier = 8;
-    auto darknessAdjustment = static_cast<int>((1 - Theme::getColorDarkness(serverColor)) * effectMultiplier);
+    auto darknessAdjustment = static_cast<int>((1 - Theme::getColorDarkness(accentColor)) * effectMultiplier);
     darknessAdjustment *= darknessAdjustment; // Square the value to pronounce the darkness more in lighter colours
     const auto baseAdjustment = 125;
-    const auto adjusted = Theme::isDarkColor(serverColor) ? serverColor : serverColor.darker(baseAdjustment + darknessAdjustment);
+    const auto adjusted = Theme::isDarkColor(accentColor) ? accentColor : accentColor.darker(baseAdjustment + darknessAdjustment);
     return adjusted;
 }
 
@@ -652,6 +649,8 @@ const Capabilities &Account::capabilities() const
 void Account::setCapabilities(const QVariantMap &caps)
 {
     _capabilities = Capabilities(caps);
+    _serverColor = _capabilities.serverColor();
+    _serverTextColor = _capabilities.serverTextColor();
 
     emit capabilitiesChanged();
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -376,6 +376,7 @@ protected Q_SLOTS:
 private:
     Account(QObject *parent = nullptr);
     void setSharedThis(AccountPtr sharedThis);
+    void updateServerColors();
 
     [[nodiscard]] static QString davPathBase();
     [[nodiscard]] QColor serverColor() const;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -410,7 +410,7 @@ private:
     Capabilities _capabilities;
     QString _serverVersion;
     QColor _serverColor = Theme::defaultColor();
-    QColor _serverTextColor = QColor(255, 255, 255);
+    QColor _serverTextColor = QColorConstants::White;
     bool _skipE2eeMetadataChecksumValidation = false;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
     QSharedPointer<QNetworkAccessManager> _am;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -35,7 +35,7 @@
 #include "clientsideencryption.h"
 #include "common/utility.h"
 #include "syncfileitem.h"
-#include "theme.h"
+
 #include <memory>
 
 class QSettings;
@@ -409,7 +409,7 @@ private:
     QSslConfiguration _sslConfiguration;
     Capabilities _capabilities;
     QString _serverVersion;
-    QColor _serverColor = Theme::defaultColor();
+    QColor _serverColor;
     QColor _serverTextColor = QColorConstants::White;
     bool _skipE2eeMetadataChecksumValidation = false;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -31,11 +31,12 @@
 #include <QPixmap>
 #endif
 
-#include "common/utility.h"
-#include <memory>
 #include "capabilities.h"
 #include "clientsideencryption.h"
+#include "common/utility.h"
 #include "syncfileitem.h"
+#include "theme.h"
+#include <memory>
 
 class QSettings;
 class QNetworkReply;
@@ -376,7 +377,8 @@ private:
     Account(QObject *parent = nullptr);
     void setSharedThis(AccountPtr sharedThis);
 
-    static QString davPathBase();
+    [[nodiscard]] static QString davPathBase();
+    [[nodiscard]] QColor serverColor() const;
 
     bool _trustCertificates = false;
 
@@ -406,6 +408,8 @@ private:
     QSslConfiguration _sslConfiguration;
     Capabilities _capabilities;
     QString _serverVersion;
+    QColor _serverColor = Theme::defaultColor();
+    QColor _serverTextColor = QColor(255, 255, 255);
     bool _skipE2eeMetadataChecksumValidation = false;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
     QSharedPointer<QNetworkAccessManager> _am;


### PR DESCRIPTION
Fixes #5930

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
