### PR TITLE
Hide password field in share settings when share type does not support passwords

### DIFF
--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -80,6 +80,8 @@ Page {
     readonly property int  currentPermissionMode: shareModelData.currentPermissionMode
 
     readonly property bool isLinkShare: shareModelData.shareType === ShareModel.ShareTypeLink
+    readonly property bool isEmailShare: shareModelData.shareType === ShareModel.ShareTypeEmail
+    readonly property bool shareSupportsPassword: isLinkShare || isEmailShare
 
     readonly property bool isFolderItem: shareModelData.sharedItemType === ShareModel.SharedItemTypeFolder
     readonly property bool isEncryptedItem: shareModelData.sharedItemType === ShareModel.SharedItemTypeEncryptedFile || shareModelData.sharedItemType === ShareModel.SharedItemTypeEncryptedFolder || shareModelData.sharedItemType === ShareModel.SharedItemTypeEncryptedTopLevelFolder
@@ -560,7 +562,10 @@ Page {
                 checkable: true
                 checked: root.passwordProtectEnabled
                 text: qsTr("Password protect")
-                enabled: !root.waitingForPasswordProtectEnabledChange && !root.passwordEnforced
+                visible: root.shareSupportsPassword
+                enabled: visible && 
+                         !root.waitingForPasswordProtectEnabledChange && 
+                         !root.passwordEnforced
 
                 onClicked: {
                     root.togglePasswordProtect(checked);
@@ -581,7 +586,7 @@ Page {
                 height: visible ? implicitHeight : 0
                 spacing: scrollContentsColumn.indicatorSpacing
 
-                visible: root.passwordProtectEnabled
+                visible: root.shareSupportsPassword && root.passwordProtectEnabled
 
                 Image {
                     Layout.preferredWidth: scrollContentsColumn.indicatorItemWidth
@@ -603,7 +608,8 @@ Page {
                     height: visible ? implicitHeight : 0
 
                     text: root.password !== "" ? root.password : root.passwordPlaceholder
-                    enabled: root.passwordProtectEnabled &&
+                    enabled: visible &&
+                             root.passwordProtectEnabled &&
                              !root.waitingForPasswordChange &&
                              !root.waitingForPasswordProtectEnabledChange
 


### PR DESCRIPTION
Fixes #5947 

<img width="497" alt="Screenshot 2023-08-02 at 18 02 25" src="https://github.com/nextcloud/desktop/assets/70155116/22646e12-1909-4d1b-a0d8-e4a1877d624e">

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
