### PR TITLE
Fix folder wizard warning color for local path in dark mode

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -162,9 +162,10 @@ void FolderWizardLocalPath::changeEvent(QEvent *e)
 
 void FolderWizardLocalPath::changeStyle()
 {
-    const auto warnYellow = Theme::isDarkColor(QGuiApplication::palette().base().color()) ? QColor(63, 63, 0) : QColor(255, 255, 192);
+    const auto warnYellow = Theme::instance()->darkMode() ? QColor(63, 63, 0) : QColor(255, 255, 192);
     auto modifiedPalette = _ui.warnLabel->palette();
     modifiedPalette.setColor(QPalette::Window, warnYellow);
+    modifiedPalette.setColor(QPalette::Base, warnYellow);
     _ui.warnLabel->setPalette(modifiedPalette);
 }
 

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -45,6 +45,15 @@ namespace
 {
 constexpr QColor darkWarnYellow(63, 63, 0);
 constexpr QColor lightWarnYellow(255, 255, 192);
+
+QPalette yellowWarnWidgetPalette(const QPalette &existingPalette)
+{
+    const auto warnYellow = OCC::Theme::instance()->darkMode() ? darkWarnYellow : lightWarnYellow;
+    auto modifiedPalette = existingPalette;
+    modifiedPalette.setColor(QPalette::Window, warnYellow);
+    modifiedPalette.setColor(QPalette::Base, warnYellow);
+    return modifiedPalette;
+}
 }
 
 namespace OCC {
@@ -168,11 +177,8 @@ void FolderWizardLocalPath::changeEvent(QEvent *e)
 
 void FolderWizardLocalPath::changeStyle()
 {
-    const auto warnYellow = Theme::instance()->darkMode() ? darkWarnYellow : lightWarnYellow;
-    auto modifiedPalette = _ui.warnLabel->palette();
-    modifiedPalette.setColor(QPalette::Window, warnYellow);
-    modifiedPalette.setColor(QPalette::Base, warnYellow);
-    _ui.warnLabel->setPalette(modifiedPalette);
+    const auto yellowWarnPalette = yellowWarnWidgetPalette(_ui.warnLabel->palette());
+    _ui.warnLabel->setPalette(yellowWarnPalette);
 }
 
 // =================================================================================
@@ -550,11 +556,8 @@ void FolderWizardRemotePath::changeEvent(QEvent *e)
 
 void FolderWizardRemotePath::changeStyle()
 {
-    const auto warnYellow = Theme::instance()->darkMode() ? darkWarnYellow : lightWarnYellow;
-    auto modifiedPalette = _ui.warnLabel->palette();
-    modifiedPalette.setColor(QPalette::Window, warnYellow);
-    modifiedPalette.setColor(QPalette::Base, warnYellow);
-    _ui.warnLabel->setPalette(modifiedPalette);
+    const auto yellowWarnPalette = yellowWarnWidgetPalette(_ui.warnLabel->palette());
+    _ui.warnLabel->setPalette(yellowWarnPalette);
 }
 
 // ====================================================================================

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -41,6 +41,12 @@
 
 #include <cstdlib>
 
+namespace
+{
+constexpr QColor darkWarnYellow(63, 63, 0);
+constexpr QColor lightWarnYellow(255, 255, 192);
+}
+
 namespace OCC {
 
 QString FormatWarningsWizardPage::formatWarnings(const QStringList &warnings) const
@@ -162,7 +168,7 @@ void FolderWizardLocalPath::changeEvent(QEvent *e)
 
 void FolderWizardLocalPath::changeStyle()
 {
-    const auto warnYellow = Theme::instance()->darkMode() ? QColor(63, 63, 0) : QColor(255, 255, 192);
+    const auto warnYellow = Theme::instance()->darkMode() ? darkWarnYellow : lightWarnYellow;
     auto modifiedPalette = _ui.warnLabel->palette();
     modifiedPalette.setColor(QPalette::Window, warnYellow);
     modifiedPalette.setColor(QPalette::Base, warnYellow);
@@ -544,7 +550,7 @@ void FolderWizardRemotePath::changeEvent(QEvent *e)
 
 void FolderWizardRemotePath::changeStyle()
 {
-    const auto warnYellow = Theme::instance()->darkMode() ? QColor(63, 63, 0) : QColor(255, 255, 192);
+    const auto warnYellow = Theme::instance()->darkMode() ? darkWarnYellow : lightWarnYellow;
     auto modifiedPalette = _ui.warnLabel->palette();
     modifiedPalette.setColor(QPalette::Window, warnYellow);
     modifiedPalette.setColor(QPalette::Base, warnYellow);

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -193,6 +193,8 @@ FolderWizardRemotePath::FolderWizardRemotePath(const AccountPtr &account)
     _ui.folderTreeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
     // Make sure that there will be a scrollbar when the contents is too wide
     _ui.folderTreeWidget->header()->setStretchLastSection(false);
+
+    changeStyle();
 }
 
 void FolderWizardRemotePath::slotAddRemoteFolder()
@@ -522,6 +524,31 @@ void FolderWizardRemotePath::showWarn(const QString &msg) const
         _ui.warnFrame->show();
         _ui.warnLabel->setText(msg);
     }
+}
+
+void FolderWizardRemotePath::changeEvent(QEvent *e)
+{
+    switch (e->type()) {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::ThemeChange:
+        // Notify the other widgets (Dark-/Light-Mode switching)
+        changeStyle();
+        break;
+    default:
+        break;
+    }
+
+    FormatWarningsWizardPage::changeEvent(e);
+}
+
+void FolderWizardRemotePath::changeStyle()
+{
+    const auto warnYellow = Theme::instance()->darkMode() ? QColor(63, 63, 0) : QColor(255, 255, 192);
+    auto modifiedPalette = _ui.warnLabel->palette();
+    modifiedPalette.setColor(QPalette::Window, warnYellow);
+    modifiedPalette.setColor(QPalette::Base, warnYellow);
+    _ui.warnLabel->setPalette(modifiedPalette);
 }
 
 // ====================================================================================

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -94,7 +94,6 @@ public:
     void cleanupPage() override;
 
 protected slots:
-
     void showWarn(const QString & = QString()) const;
     void slotAddRemoteFolder();
     void slotCreateRemoteFolder(const QString &);
@@ -109,6 +108,12 @@ protected slots:
     void slotFolderEntryEdited(const QString &text);
     void slotLsColFolderEntry();
     void slotTypedPathFound(const QStringList &subpaths);
+
+protected:
+    void changeEvent(QEvent *) override;
+
+private slots:
+    void changeStyle();
 
 private:
     LsColJob *runLsColJob(const QString &path);


### PR DESCRIPTION
We had originally fixed this for the remote path, but not for the local path. Without this fix the warning is unreadable

Fixes #5852 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
