### PR TITLE
on windows file names can always be encoded: fix wrong test

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -291,10 +291,10 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const Entries &ent
     }
 
     auto localCodec = QTextCodec::codecForLocale();
-    if (localCodec->mibEnum() != 106) {
+    if (!OCC::Utility::isWindows() && localCodec->mibEnum() != 106) {
         // If the locale codec is not UTF-8, we must check that the filename from the server can
         // be encoded in the local file system.
-        //
+        // (Note: on windows, the FS is always UTF-16, so we don't need to check)        //
         // We cannot use QTextCodec::canEncode() since that can incorrectly return true, see
         // https://bugreports.qt.io/browse/QTBUG-6925.
         QTextEncoder encoder(localCodec, QTextCodec::ConvertInvalidToNull);

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -1717,6 +1717,15 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(spy.count(), 1);
     }
+
+    void testFileDownloadWithUnicodeCharacterInName() {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        ItemCompletedSpy completeSpy(fakeFolder);
+        fakeFolder.remoteModifier().insert("A/abcdęfg.txt");
+        fakeFolder.syncOnce();
+        QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/abcdęfg.txt"));
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)


### PR DESCRIPTION
inspired by https://github.com/owncloud/client/pull/6820

Close #5935 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
