### PR TITLE
Fix user-facing message about why encryption cannot yet be done

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -329,10 +329,18 @@ void AccountSettings::doExpand()
     }
 }
 
-bool AccountSettings::canEncryptOrDecrypt(const FolderStatusModel::SubFolderInfo* info) {
-    if (info->_folder->syncResult().status() != SyncResult::Status::Success) {
+bool AccountSettings::canEncryptOrDecrypt(const FolderStatusModel::SubFolderInfo *info)
+{
+    if (const auto folderSyncStatus = info->_folder->syncResult().status(); folderSyncStatus != SyncResult::Status::Success) {
+        auto message = tr("Please wait for the folder to sync before trying to encrypt it.");
+        if (folderSyncStatus == SyncResult::Status::Problem) {
+            message = tr("The folder has a minor sync problem. Encryption of this folder will be possible once it has synced successfully");
+        } else if (folderSyncStatus == SyncResult::Status::Error) {
+            message = tr("The folder has a sync error. Encryption of this folder will be possible once it has synced successfully");
+        }
+
         QMessageBox msgBox;
-        msgBox.setText("Please wait for the folder to sync before trying to encrypt it.");
+        msgBox.setText(message);
         msgBox.exec();
         return false;
     }


### PR DESCRIPTION
The current message always says to wait until sync is done, even if sync *is* done

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
