### PR TITLE
Make file details tray follow current account accent colour

### DIFF
--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -285,6 +285,7 @@ Page {
                 iconSize: root.iconSize
                 rootStackView: root.rootStackView
                 backgroundsVisible: root.backgroundsVisible
+                accentColor: root.accentColor
             }
         }
     }

--- a/src/gui/filedetails/FileDetailsPage.qml
+++ b/src/gui/filedetails/FileDetailsPage.qml
@@ -38,6 +38,7 @@ Page {
     property StackView rootStackView: StackView {}
     property bool showCloseButton: false
     property bool backgroundsVisible: true
+    property color accentColor: Style.ncBlue
 
     property FileDetails fileDetails: FileDetails {
         id: fileDetails
@@ -227,6 +228,7 @@ Page {
             NCTabButton {
                 svgCustomColorSource: "image://svgimage-custom-color/activity.svg"
                 text: qsTr("Activity")
+                accentColor: root.accentColor
                 checked: swipeView.currentIndex === fileActivityView.swipeIndex
                 onClicked: swipeView.currentIndex = fileActivityView.swipeIndex
             }
@@ -236,6 +238,7 @@ Page {
                 height: visible ? implicitHeight : 0
                 svgCustomColorSource: "image://svgimage-custom-color/share.svg"
                 text: qsTr("Sharing")
+                accentColor: root.accentColor
                 checked: swipeView.currentIndex === shareViewLoader.swipeIndex
                 onClicked: swipeView.currentIndex = shareViewLoader.swipeIndex
                 visible: root.fileDetails.sharingAvailable

--- a/src/gui/filedetails/FileDetailsView.qml
+++ b/src/gui/filedetails/FileDetailsView.qml
@@ -27,6 +27,7 @@ StackView {
     property alias accountState: fileDetailsPage.accountState
     property alias localPath: fileDetailsPage.localPath
     property alias showCloseButton: fileDetailsPage.showCloseButton
+    property alias accentColor: fileDetailsPage.accentColor
     property bool backgroundsVisible: true
 
     background: Rectangle {

--- a/src/gui/filedetails/NCTabButton.qml
+++ b/src/gui/filedetails/NCTabButton.qml
@@ -25,6 +25,7 @@ TabButton {
     id: tabButton
 
     property string svgCustomColorSource: ""
+    property color accentColor: Style.ncBlue
 
     padding: Style.smallSpacing
     background: Rectangle {
@@ -82,7 +83,7 @@ TabButton {
             implicitWidth: textWidth + Style.standardSpacing * 2
             implicitHeight: 2
 
-            color: tabButton.checked ? Style.ncBlue : tabButton.hovered ? palette.highlight : "transparent"
+            color: tabButton.checked ? tabButton.accentColor : tabButton.hovered ? palette.highlight : "transparent"
         }
     }
 }

--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -50,6 +50,7 @@ GridLayout {
     property FileDetails fileDetails: FileDetails {}
     property StackView rootStackView: StackView {}
     property bool backgroundsVisible: true
+    property color accentColor: Style.ncBlue
 
     property bool canCreateLinkShares: true
     property bool serverAllowsResharing: true
@@ -89,7 +90,7 @@ GridLayout {
             id: backgroundOrMask
             anchors.fill: parent
             radius: width / 2
-            color: Style.ncBlue
+            color: root.accentColor
             visible: !imageItem.isAvatar
         }
 

--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -265,6 +265,7 @@ GridLayout {
                     width: parent.width
                     height: parent.height
                     backgroundsVisible: root.backgroundsVisible
+                    accentColor: root.accentColor
 
                     fileDetails: root.fileDetails
                     shareModelData: model

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -44,6 +44,7 @@ Page {
     signal setNote(string note)
 
     property bool backgroundsVisible: true
+    property color accentColor: Style.ncBlue
 
     property FileDetails fileDetails: FileDetails {}
     property var shareModelData: ({})
@@ -1005,14 +1006,14 @@ Page {
             CustomButton {
                 height: Style.standardPrimaryButtonHeight
 
-                icon.source: "image://svgimage-custom-color/add.svg/" + Style.ncBlue
+                icon.source: "image://svgimage-custom-color/add.svg/" + root.accentColor
                 imageSourceHover: "image://svgimage-custom-color/add.svg/" + palette.brightText
                 text: qsTr("Add another link")
-                textColor: Style.ncBlue
+                textColor: root.accentColor
                 textColorHovered: palette.brightText
                 contentsFont.bold: true
                 bgNormalColor: palette.button
-                bgHoverColor: Style.ncBlue
+                bgHoverColor: root.accentColor
                 bgNormalOpacity: 1.0
                 bgHoverOpacity: 1.0
 
@@ -1054,7 +1055,7 @@ Page {
             text: shareLinkCopied ? qsTr("Share link copied!") : qsTr("Copy share link")
             textColor: palette.brightText
             contentsFont.bold: true
-            bgColor: shareLinkCopied ? Style.positiveColor : Style.ncBlue
+            bgColor: shareLinkCopied ? Style.positiveColor : root.accentColor
             bgNormalOpacity: 1.0
             bgHoverOpacity: shareLinkCopied ? 1.0 : Style.hoverOpacity
 

--- a/src/gui/filedetails/ShareView.qml
+++ b/src/gui/filedetails/ShareView.qml
@@ -31,6 +31,7 @@ ColumnLayout {
     property int horizontalPadding: 0
     property int iconSize: 32
     property bool backgroundsVisible: true
+    property color accentColor: Style.ncBlue
 
     readonly property bool sharingPossible: shareModel && shareModel.canShare && shareModel.sharingEnabled
     readonly property bool userGroupSharingPossible: sharingPossible && shareModel.userGroupSharingEnabled
@@ -216,6 +217,7 @@ ColumnLayout {
                     fileDetails: root.fileDetails
                     rootStackView: root.rootStackView
                     backgroundsVisible: root.backgroundsVisible
+                    accentColor: root.accentColor
                     canCreateLinkShares: root.publicLinkSharingPossible
                     serverAllowsResharing: root.serverAllowsResharing
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -231,6 +231,7 @@ ApplicationWindow {
                 height: parent.height
 
                 backgroundsVisible: false
+                accentColor: Style.currentUserHeaderColor
                 accountState: fileDetailsDrawer.folderAccountState
                 localPath: fileDetailsDrawer.fileLocalPath
                 showCloseButton: true


### PR DESCRIPTION
Fixes #5970

![Screenshot 2023-08-15 at 15 43 24](https://github.com/nextcloud/desktop/assets/70155116/4058bf02-5cb4-451b-8dd8-617cd0a73d0b)


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
