### PR TITLE
FileProvider: Add missing AccountState State case for notifying account state to extension

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -148,6 +148,7 @@ void FileProviderSocketController::slotAccountStateChanged(const AccountState::S
         break;
     case AccountState::SignedOut:
     case AccountState::AskingCredentials:
+    case AccountState::RedirectDetected:
         // Notify File Provider that it should show the not authenticated message
         sendNotAuthenticated();
         break;


### PR DESCRIPTION
Fixes compile time warning

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
