### PR TITLE
Fix visual bug with folder size confirmation combo box in general settings

### DIFF
--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>581</width>
+    <width>601</width>
     <height>663</height>
    </rect>
   </property>
@@ -237,6 +237,22 @@
              <bool>true</bool>
             </property>
            </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>10</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item>
            <widget class="QSpinBox" name="newFolderLimitSpinBox">


### PR DESCRIPTION
After fix

<img width="781" alt="Screenshot 2023-09-07 at 15 05 37" src="https://github.com/nextcloud/desktop/assets/70155116/d6e34889-7738-4b15-9f7a-97d4b5dc373f">

Before fix

<img width="677" alt="Screenshot 2023-09-08 at 10 30 10" src="https://github.com/nextcloud/desktop/assets/70155116/d4ac0e9a-204c-4fcb-8a0a-4d2befe00d7d">

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
