### PR TITLE
Store the new etag into local database when opening with auto-locking…

### DIFF
--- a/src/libsync/lockfilejobs.cpp
+++ b/src/libsync/lockfilejobs.cpp
@@ -104,6 +104,9 @@ void LockFileJob::setFileRecordLocked(SyncJournalFileRecord &record) const
     record._lockstate._lockEditorApp = _editorName;
     record._lockstate._lockTime = _lockTime;
     record._lockstate._lockTimeout = _lockTimeout;
+    if (!_etag.isEmpty()) {
+        record._etag = _etag;
+    }
 }
 
 void LockFileJob::resetState()
@@ -223,6 +226,8 @@ void LockFileJob::decodeStartElement(const QString &name,
         }
     } else if (name == QStringLiteral("lock-owner-editor")) {
         _editorName = reader.readElementText();
+    } else if (name == QStringLiteral("getetag")) {
+        _etag = reader.readElementText().toUtf8();
     }
 }
 

--- a/src/libsync/lockfilejobs.h
+++ b/src/libsync/lockfilejobs.h
@@ -54,6 +54,7 @@ private:
     QString _userDisplayName;
     QString _editorName;
     QString _userId;
+    QByteArray _etag;
     qint64 _lockTime = 0;
     qint64 _lockTimeout = 0;
     QString _remoteSyncPathWithTrailingSlash;


### PR DESCRIPTION
…/manual locking the file locally.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
