### PR TITLE
once we call done on a sync file item, return is needed

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1226,6 +1226,7 @@ void PropagateDownloadFile::downloadFinished()
             QString error;
             if (!propagator()->createConflict(_item, _associatedComposite, &error)) {
                 done(SyncFileItem::SoftError, error, ErrorCategory::GenericError);
+                return;
             } else {
                 previousFileExists = false;
             }


### PR DESCRIPTION
will avoid calling done method multiple times on a signle file item causing a crash via ENFORCE function

Close #5473 