### PR TITLE
Bugfix/legacy migration

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -179,7 +179,7 @@ bool AccountManager::restoreFromLegacySettings()
                                                       legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
 
         for (const auto &configFile : legacyLocations) {
-            auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
+            const auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
             if (oCSettings->status() != QSettings::Status::NoError) {
                 qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
                 break;
@@ -192,9 +192,9 @@ bool AccountManager::restoreFromLegacySettings()
                 qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
                 if (!forceLegacyImport() && accountsListSize > 0) {
                     const auto importQuestion = accountsListSize > 1
-                        ? tr("%1 accounts were detected on a legacy desktop client.\n"
+                        ? tr("%1 accounts were detected from a legacy desktop client.\n"
                              "Should the accounts be imported?").arg(QString::number(accountsListSize))
-                        : tr("1 account was detected on a legacy desktop client.\n"
+                        : tr("1 account was detected from a legacy desktop client.\n"
                              "Should the account be imported?");
                     const auto importMessageBox = new QMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
                     importMessageBox->addButton(tr("Import"), QMessageBox::AcceptRole);

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -28,6 +28,7 @@
 #include <QDir>
 #include <QNetworkAccessManager>
 #include <QMessageBox>
+#include <QPushButton>
 
 namespace {
 constexpr auto urlC = "url";
@@ -195,13 +196,12 @@ bool AccountManager::restoreFromLegacySettings()
                              "Should the accounts be imported?").arg(QString::number(accountsListSize))
                         : tr("One account was detected on a legacy desktop client.\n"
                              "Should the account be imported?");
-                    auto importMessageBox = new QMessageBox (QMessageBox::Question, tr("Legacy import"), importQuestion);
+                    const auto importMessageBox = new QMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
                     importMessageBox->addButton(tr("Import"), QMessageBox::AcceptRole);
-                    importMessageBox->addButton(tr("Skip"), QMessageBox::DestructiveRole);
+                    const auto skipButton = importMessageBox->addButton(tr("Skip"), QMessageBox::DestructiveRole);
                     importMessageBox->setAttribute(Qt::WA_DeleteOnClose);
-                    const auto selection = importMessageBox->exec();
-                    if (selection == QMessageBox::DestructiveRole) {
-                        // User said don't import, return immediately
+                    importMessageBox->exec();
+                    if (importMessageBox->clickedButton() == skipButton) {
                         return false;
                     }
                 }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -250,10 +250,7 @@ bool AccountManager::restoreFromLegacySettings()
         for (const auto &accountId : childGroups) {
             settings->beginGroup(accountId);
             if (const auto acc = loadAccountHelper(*settings)) {
-                addAccount(acc);
-                QMessageBox::information(nullptr,
-                                         tr("Legacy import"),
-                                         tr("Successfully imported account from legacy client: %1").arg(acc->prettyName()));                
+                addAccount(acc);              
             }
             settings->endGroup();
         }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -179,7 +179,7 @@ bool AccountManager::restoreFromLegacySettings()
                                                       legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
 
         for (const auto &configFile : legacyLocations) {
-            const auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
+            auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
             if (oCSettings->status() != QSettings::Status::NoError) {
                 qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
                 break;

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -194,7 +194,7 @@ bool AccountManager::restoreFromLegacySettings()
                     const auto importQuestion = accountsListSize > 1
                         ? tr("%1 accounts were detected on a legacy desktop client.\n"
                              "Should the accounts be imported?").arg(QString::number(accountsListSize))
-                        : tr("One account was detected on a legacy desktop client.\n"
+                        : tr("1 account was detected on a legacy desktop client.\n"
                              "Should the account be imported?");
                     const auto importMessageBox = new QMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
                     importMessageBox->addButton(tr("Import"), QMessageBox::AcceptRole);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -124,6 +124,7 @@ private:
 
     AccountManager::AccountsRestoreResult  restoreLegacyAccount();
     void createConfigFile();
+
     /**
      * Maybe a newer version of the client was used with this config file:
      * if so, backup, confirm with user and remove the config that can't be read.

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -118,6 +118,8 @@ private:
 
     void handleEditLocallyFromOptions();
 
+    bool restoreLegacyAccount();
+    void createConfigFile();
     /**
      * Maybe a newer version of the client was used with this config file:
      * if so, backup, confirm with user and remove the config that can't be read.

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -98,6 +98,10 @@ protected:
     void setupTranslations();
     void setupLogging();
 
+    // Attempt to setup new settings or restore legacy settings
+    // The settings include the accounts and folders saved in the config file
+    void setupOrRestoreSettings();
+
 signals:
     void folderRemoved();
     void folderStateChanged(OCC::Folder *);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -122,7 +122,7 @@ private:
 
     void handleEditLocallyFromOptions();
 
-    bool restoreLegacyAccount();
+    AccountManager::AccountsRestoreResult  restoreLegacyAccount();
     void createConfigFile();
     /**
      * Maybe a newer version of the client was used with this config file:

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -98,10 +98,6 @@ protected:
     void setupTranslations();
     void setupLogging();
 
-    // Attempt to setup new settings or restore legacy settings
-    // The settings include the accounts and folders saved in the config file
-    void setupOrRestoreSettings();
-
 signals:
     void folderRemoved();
     void folderStateChanged(OCC::Folder *);
@@ -122,8 +118,9 @@ private:
 
     void handleEditLocallyFromOptions();
 
-    AccountManager::AccountsRestoreResult  restoreLegacyAccount();
-    void createConfigFile();
+    AccountManager::AccountsRestoreResult restoreLegacyAccount();
+    void setupConfigFile();
+    void setupAccountsAndFolders();
 
     /**
      * Maybe a newer version of the client was used with this config file:

--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -82,8 +82,9 @@ public:
      * Version 2: introduction of metadata_parent hash in 2.6.0
      *            (version remains readable by 2.5.1)
      * Version 3: introduction of new windows vfs mode in 2.6.0
+     * Version 5: available in oC client 4.0.0 and 4.2.0
      */
-    static int maxSettingsVersion() { return 3; }
+    static int maxSettingsVersion() { return 5; }
 
     /// Ensure / as separator and trailing /.
     static QString prepareLocalPath(const QString &path);

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -364,7 +364,7 @@ int FolderMan::setupFoldersMigration()
     for (const auto &fileName : dirFiles) {
         for (const auto &accountState : legacyAccounts) {
             const auto fullFilePath = dir.filePath(fileName);
-            setupFolderFromOldConfigFile(fullFilePath, accountState.data());
+            setupLegacyFolder(fullFilePath, accountState.data());
         }
     }
 
@@ -481,7 +481,7 @@ QString FolderMan::unescapeAlias(const QString &alias)
     return a;
 }
 
-void FolderMan::setupFolderFromOldConfigFile(const QString &fileNamePath, AccountState *accountState)
+void FolderMan::setupLegacyFolder(const QString &fileNamePath, AccountState *accountState)
 {
     qCInfo(lcFolderMan) << "  ` -> setting up:" << fileNamePath;
     QString escapedFileNamePath(fileNamePath);

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -122,7 +122,7 @@ public:
      * Migrate accounts from owncloud
      * Creates a folder for a specific configuration, identified by alias.
      */
-    void setupFolderFromOldConfigFile(const QString &, AccountState *account);
+    void setupLegacyFolder(const QString &, AccountState *account);
 
     /**
      * Ensures that a given directory does not contain a sync journal file.


### PR DESCRIPTION
- cleans up a bit the Application constructor
- delays the display of the dialog notifying the user that the migration worked

TODO
- [x] test on Mac OS
- [x] test on Windows
- [x] get feedback from @nextcloud/designers


dialog 1:
![step-1](https://github.com/nextcloud/desktop/assets/241266/5ba1568b-41af-4476-b86c-1300c9be169e)

dialog 2:
![step-2](https://github.com/nextcloud/desktop/assets/241266/9d598b2d-2cd9-41d5-8bd6-22dc30616480)

dialog when nothing was imported:
![step-no-import](https://github.com/nextcloud/desktop/assets/241266/c6e9d63e-aa3d-4e4f-b07c-765958cb4bec)
