### PR TITLE
[stable-3.10] Prevent empty password being passed into share creation

### DIFF
--- a/src/gui/filedetails/ShareView.qml
+++ b/src/gui/filedetails/ShareView.qml
@@ -97,7 +97,6 @@ ColumnLayout {
 
         visible: false
         onAboutToShow: dialogPasswordField.text = shareModel.generatePassword()
-        onClosed: dialogPasswordField.text = ""
 
         onAccepted: {
             if(sharee) {


### PR DESCRIPTION
We already generate a new password when the share password dialog is created, so there is really no need to clear the field when it closes. This prevents the field being cleared before the password is sent into the C++ code, leading to no password actually being sent to the server

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
