### PR TITLE
Enforce virtual file type when it is falsely marked as non-virtual.  Added more logs for scenarios when virtual placeholder gets marked as non-virtual.

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -498,6 +498,7 @@ void ProcessDirectoryJob::processFile(PathTuple path,
 
     if (dbEntry._modtime == localEntry.modtime && dbEntry._type == ItemTypeVirtualFile && localEntry.type == ItemTypeFile) {
         item->_type = ItemTypeFile;
+        qCInfo(lcDisco) << "Changing item type from virtual to normal file" << item->_file;
     }
 
     // The item shall only have this type if the db request for the virtual download
@@ -507,8 +508,10 @@ void ProcessDirectoryJob::processFile(PathTuple path,
         item->_type = ItemTypeVirtualFile;
     // Similarly db entries with a dehydration request denote a regular file
     // until the request is processed.
-    if (item->_type == ItemTypeVirtualFileDehydration)
+    if (item->_type == ItemTypeVirtualFileDehydration) {
         item->_type = ItemTypeFile;
+        qCInfo(lcDisco) << "Changing item type from virtual to normal file" << item->_file;
+    }
 
     // VFS suffixed files on the server are ignored
     if (isVfsWithSuffix()) {
@@ -1441,8 +1444,10 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         // but it complicates handling a lot and will happen rarely.
         if (item->_type == ItemTypeVirtualFileDownload)
             item->_type = ItemTypeVirtualFile;
-        if (item->_type == ItemTypeVirtualFileDehydration)
+        if (item->_type == ItemTypeVirtualFileDehydration) {
             item->_type = ItemTypeFile;
+            qCInfo(lcDisco) << "Changing item type from virtual to normal file" << item->_file;
+        }
 
         qCInfo(lcDisco) << "Rename detected (up) " << item->_file << " -> " << item->_renameTarget;
     };

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -81,8 +81,10 @@ SyncJournalFileRecord SyncFileItem::toSyncJournalFileRecordWithInode(const QStri
 
     // Some types should never be written to the database when propagation completes
     rec._type = _type;
-    if (rec._type == ItemTypeVirtualFileDownload)
+    if (rec._type == ItemTypeVirtualFileDownload) {
         rec._type = ItemTypeFile;
+        qCInfo(lcFileItem) << "Changing item type from ItemTypeVirtualFileDownload to normal file to avoid wrong record type in database" << rec._path;
+    }
     if (rec._type == ItemTypeVirtualFileDehydration)
         rec._type = ItemTypeVirtualFile;
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
