### PR TITLE
Change logging for sparkle update to qCInfo

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -76,7 +76,7 @@ private:
 - (BOOL)backgroundUpdateChecksAllowed
 {
     BOOL allowUpdateCheck = OCC::ConfigFile().skipUpdateCheck() ? NO : YES;
-    qCDebug(OCC::lcUpdater) << "Updater may check for updates:" << (allowUpdateCheck ? "YES" : "NO");
+    qCInfo(OCC::lcUpdater) << "Updater may check for updates:" << (allowUpdateCheck ? "YES" : "NO");
     return allowUpdateCheck;
 }
 
@@ -95,7 +95,7 @@ private:
 
 - (void)notifyStateChange:(const OCC::SparkleUpdater::State)state displayStatus:(const QString&)statusString
 {
-    qCDebug(OCC::lcUpdater) << statusString;
+    qCInfo(OCC::lcUpdater) << statusString;
     _owner->statusChanged(state, statusString);
 }
 
@@ -293,7 +293,7 @@ bool SparkleUpdater::autoUpdaterAllowed()
 
 void SparkleUpdater::checkForUpdate()
 {
-    qCDebug(OCC::lcUpdater) << "Checking for updates.";
+    qCInfo(OCC::lcUpdater) << "Checking for updates.";
     if (autoUpdaterAllowed()) {
         [_interface->updater checkForUpdates: NSApp];
     }
@@ -302,10 +302,10 @@ void SparkleUpdater::checkForUpdate()
 void SparkleUpdater::backgroundCheckForUpdate()
 {
     if (autoUpdaterAllowed() && !ConfigFile().skipUpdateCheck()) {
-        qCDebug(OCC::lcUpdater) << "launching background check";
+        qCInfo(OCC::lcUpdater) << "launching background check";
         [_interface->updater checkForUpdatesInBackground];
     } else {
-        qCDebug(OCC::lcUpdater) << "not launching background check, auto updater not allowed or update check skipped in config";
+        qCInfo(OCC::lcUpdater) << "not launching background check, auto updater not allowed or update check skipped in config";
     }
 }
 


### PR DESCRIPTION
Otherwise we can't tell why things are failing by default

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
