### PR TITLE
Fix crash when clicking on import legacy account dialog 'Skip' button. 

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -199,7 +199,6 @@ bool AccountManager::restoreFromLegacySettings()
                     const auto importMessageBox = new QMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
                     importMessageBox->addButton(tr("Import"), QMessageBox::AcceptRole);
                     const auto skipButton = importMessageBox->addButton(tr("Skip"), QMessageBox::DestructiveRole);
-                    importMessageBox->setAttribute(Qt::WA_DeleteOnClose);
                     importMessageBox->exec();
                     if (importMessageBox->clickedButton() == skipButton) {
                         return false;


### PR DESCRIPTION
With Qt::WA_DeleteOnClose the message box was being deleted twice.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
