### PR TITLE
avoid restore algorithm by setting the data fingerprint from sync DB

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -686,6 +686,8 @@ void SyncEngine::startSync()
     }
 
     if (singleItemDiscoveryOptions().isValid() && singleItemDiscoveryOptions().discoveryDirItem) {
+        const auto databaseFingerprint = _journal->dataFingerprint();
+        _discoveryPhase->_dataFingerprint = databaseFingerprint;
         ProcessDirectoryJob::PathTuple path = {};
         path._local = path._original = path._server = path._target = singleItemDiscoveryOptions().discoveryPath;
 


### PR DESCRIPTION
avoid single file sync to switch to data fingerprint restore sync mode if a data fingerprint has been saved in the database but missed during single file sync

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
