### PR TITLE
docs(conffile) Update chunk sizes to match v2 chunking PR defaults

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -43,9 +43,9 @@ Some interesting values that can be set on the configuration file are:
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``forceLoginV2``                 | ``false``                | If the client should force the new login flow, eventhough some circumstances might need the old flow.  |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
-| ``minChunkSize``                 | ``1000000`` (1 MB)       | Specifies the minimum chunk size of uploaded files in bytes.                                           |
+| ``minChunkSize``                 | ``5000000`` (5 MB)       | Specifies the minimum chunk size of uploaded files in bytes.                                           |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
-| ``maxChunkSize``                 | ``1000000000`` (1000 MB) | Specifies the maximum chunk size of uploaded files in bytes.                                           |
+| ``maxChunkSize``                 | ``5000000000`` (5000 MB) | Specifies the maximum chunk size of uploaded files in bytes.                                           |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``targetChunkUploadDuration``    | ``60000`` (1 minute)     | Target duration in milliseconds for chunk uploads.                                                     |
 |                                  |                          | The client adjusts the chunk size until each chunk upload takes approximately this long.               |


### PR DESCRIPTION
Came up while working on #6222 and nextcloud/documentation#11295.

Updates the documented defaults to match the latest code.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
