### PR TITLE
maintain lock state if unlock happens during sync

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -398,6 +398,12 @@ void BulkPropagatorJob::slotPutFinishedOneFile(const BulkUploadItem &singleFile,
     // the file id should only be empty for new files up- or downloaded
     computeFileId(singleFile._item, fileReply);
 
+    if (SyncJournalFileRecord oldRecord; propagator()->_journal->getFileRecord(singleFile._item->destination(), &oldRecord) && oldRecord.isValid()) {
+        if (oldRecord._etag != singleFile._item->_etag) {
+            singleFile._item->updateLockStateFromDbRecord(oldRecord);
+        }
+    }
+
     singleFile._item->_etag = etag;
     singleFile._item->_fileId = getHeaderFromJsonReply(fileReply, "fileid");
     singleFile._item->_remotePerm = RemotePermissions::fromServerString(getHeaderFromJsonReply(fileReply, "permissions"));

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -152,6 +152,13 @@ bool PollJob::finished()
     if (status == QLatin1String("finished")) {
         _item->_status = SyncFileItem::Success;
         _item->_fileId = json["fileId"].toString().toUtf8();
+
+        if (SyncJournalFileRecord oldRecord; _journal->getFileRecord(_item->destination(), &oldRecord) && oldRecord.isValid()) {
+            if (oldRecord._etag != _item->_etag) {
+                _item->updateLockStateFromDbRecord(oldRecord);
+            }
+        }
+
         _item->_etag = parseEtag(json["ETag"].toString().toUtf8());
     } else { // error
         _item->_status = classifyError(QNetworkReply::UnknownContentError, _item->_httpErrorCode);

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -528,8 +528,14 @@ void PropagateUploadFileNG::slotMoveJobFinished()
         _item->_fileId = fid;
     }
 
+    if (SyncJournalFileRecord oldRecord; propagator()->_journal->getFileRecord(_item->destination(), &oldRecord) && oldRecord.isValid()) {
+        if (oldRecord._etag != _item->_etag) {
+            _item->updateLockStateFromDbRecord(oldRecord);
+        }
+    }
+
     _item->_etag = getEtagFromReply(job->reply());
-    ;
+
     if (_item->_etag.isEmpty()) {
         qCWarning(lcPropagateUploadNG) << "Server did not return an ETAG" << _item->_file;
         abortWithError(SyncFileItem::NormalError, tr("Missing ETag from server"));

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -323,6 +323,12 @@ void PropagateUploadFileV1::slotPutFinished()
         _item->_fileId = fid;
     }
 
+    if (SyncJournalFileRecord oldRecord; propagator()->_journal->getFileRecord(_item->destination(), &oldRecord) && oldRecord.isValid()) {
+        if (oldRecord._etag != _item->_etag) {
+            _item->updateLockStateFromDbRecord(oldRecord);
+        }
+    }
+
     _item->_etag = etag;
 
     if (job->reply()->rawHeader("X-OC-MTime") != "accepted") {

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -218,4 +218,15 @@ SyncFileItemPtr SyncFileItem::fromProperties(const QString &filePath, const QMap
     return item;
 }
 
+void SyncFileItem::updateLockStateFromDbRecord(const SyncJournalFileRecord &dbRecord)
+{
+    _locked = dbRecord._lockstate._locked ? LockStatus::LockedItem : LockStatus::UnlockedItem;
+    _lockOwnerId = dbRecord._lockstate._lockOwnerId;
+    _lockOwnerDisplayName = dbRecord._lockstate._lockOwnerDisplayName;
+    _lockOwnerType = static_cast<LockOwnerType>(dbRecord._lockstate._lockOwnerType);
+    _lockEditorApp = dbRecord._lockstate._lockEditorApp;
+    _lockTime = dbRecord._lockstate._lockTime;
+    _lockTimeout = dbRecord._lockstate._lockTimeout;
+}
+
 }

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -236,6 +236,8 @@ public:
 
     [[nodiscard]] bool isEncrypted() const { return _e2eEncryptionStatus != EncryptionStatus::NotEncrypted; }
 
+    void updateLockStateFromDbRecord(const SyncJournalFileRecord &dbRecord);
+
     // Variables useful for everybody
 
     /** The syncfolder-relative filesystem path that the operation is about


### PR DESCRIPTION
currently unlock can happen during the sync
in that case, it may be possible that the propagator will lose the lock state changes and override them when updating teh etag after a file has been uploaded

detect that case and ensure we keep consistent state about files

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
