### PR TITLE
docs(troubleshooting): Add warning about sensitive data in logs

### DIFF
--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -136,6 +136,8 @@ many relevant logs as possible. Log output can help  with tracking down
 problems and, if you report a bug, log output can help to resolve an issue more
 quickly.
 
+  .. warning:: Log files contain sensitive information. You may wish to redact sensitive details or to only share limited excerpts.
+
 Obtaining the Client Log File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Fixes #3189 (at least the documentation piece)

A follow-up may be desirable to also add a warning in the user interface when the debug archive is created.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
