### PR TITLE
enh(debugArchive): Add reminder to redact before sharing

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -501,7 +501,7 @@ void GeneralSettings::slotCreateDebugArchive()
     }
 
     createDebugArchive(filename);
-    QMessageBox::information(this, tr("Debug Archive Created"), tr("Debug archive is created at %1").arg(filename));
+    QMessageBox::information(this, tr("Debug Archive Created"), tr("Redact information deemed sensitive before sharing! Debug archive created at %1").arg(filename));
 }
 
 void GeneralSettings::slotShowLegalNotice()


### PR DESCRIPTION
Closes #3189

Adds a reminder, when a debug archive is created, that information deemed sensitive should be redacted before sharing.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
