### PR TITLE
Update stale.yml: Unify "needs info" handling with other NC repos

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
                     days-before-stale: 28
                     days-before-close: 14
                     days-before-pr-close: -1
-                    only-labels: 'bug'
+                    only-labels: 'bug,need info'
                     exempt-issue-labels: 'approved'
                     stale-issue-message: 'This bug report did not receive an update in the last 4 weeks.
                                         Please take a look again and update the issue with new details,


### PR DESCRIPTION
This more closely unifies stale handling of issues tagged as `bugs` with other Nextcloud repos[1], by not closing issues that have merely not yet been fully reviewed while still keeping it easy for bug reports that require additional info from the reporter to auto-close if the reporter fails to provide the necessary additional information.

---

Context:

Currently issues tagged as `bugs` must also be tagged `approved` to not be auto closed within 4 weeks in this repo.

Realistically issues are not always able to be triaged for basic validity that quickly or tagging as `approved` is overlooked. Additionally, follow-up info is routinely needed/requested, so tagging as `approved` is inappropriate.

This PR limits the auto-closing of `bugs` to only those tagged as `needs info`. Otherwise it's assumed they're valid, haven't been fully reviewed yet, or validity is still to be determined. 

As an aside, `enhancements` remain left alone (existing behavior). We may want to consider enabling `needs info` auto-closure support for these too (the `server` repo does this) since enhancement ideas often need further info in order to be valid... And right now in this repo they're simply left alone rather than auto-closed if there isn't any follow-up info received (unless one of us manually notices and closes the issue).

[1] Server and Android repos:
- https://github.com/nextcloud/server/blob/master/.github/workflows/stale.yml
- https://github.com/nextcloud/android/blob/master/.github/workflows/stale.yml

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
