### PR TITLE
GUI/LIBSYNC: force login flow V2 with config setting

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -41,6 +41,8 @@ Some interesting values that can be set on the configuration file are:
 | ``chunkSize``                    | ``10000000`` (10 MB)     | Specifies the chunk size of uploaded files in bytes.                                                   |
 |                                  |                          | The client will dynamically adjust this size within the maximum and minimum bounds (see below).        |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
+| ``forceLoginV2``                 | ``false``                | If the client should force the new login flow, eventhough some circumstances might need the old flow.  |
++----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``minChunkSize``                 | ``1000000`` (1 MB)       | Specifies the minimum chunk size of uploaded files in bytes.                                           |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``maxChunkSize``                 | ``1000000000`` (1000 MB) | Specifies the maximum chunk size of uploaded files in bytes.                                           |

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -213,8 +213,9 @@ int OwncloudSetupPage::nextId() const
         return WizardCommon::Page_Flow2AuthCreds;
 #ifdef WITH_WEBENGINE
     case DetermineAuthTypeJob::WebViewFlow:
-        if (this->useFlow2)
-          return WizardCommon::Page_Flow2AuthCreds;
+        if (this->useFlow2) {
+            return WizardCommon::Page_Flow2AuthCreds;
+        }
         return WizardCommon::Page_WebView;
 #endif // WITH_WEBENGINE
     case DetermineAuthTypeJob::NoAuthType:

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -213,6 +213,8 @@ int OwncloudSetupPage::nextId() const
         return WizardCommon::Page_Flow2AuthCreds;
 #ifdef WITH_WEBENGINE
     case DetermineAuthTypeJob::WebViewFlow:
+        if (this->useFlow2)
+          return WizardCommon::Page_Flow2AuthCreds;
         return WizardCommon::Page_WebView;
 #endif // WITH_WEBENGINE
     case DetermineAuthTypeJob::NoAuthType:

--- a/src/gui/wizard/owncloudsetuppage.h
+++ b/src/gui/wizard/owncloudsetuppage.h
@@ -89,6 +89,9 @@ private:
     QProgressIndicator *_progressIndi;
     OwncloudWizard *_ocWizard;
     AddCertificateDialog *addCertDial = nullptr;
+
+    // Grab the forceLoginV2-setting from the wizard
+    bool useFlow2 = _ocWizard->useFlow2();
 };
 
 } // namespace OCC

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -65,8 +65,9 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     setPage(WizardCommon::Page_Flow2AuthCreds, _flow2CredsPage);
     setPage(WizardCommon::Page_AdvancedSetup, _advancedSetupPage);
 #ifdef WITH_WEBENGINE
-    if(!useFlow2())
-      setPage(WizardCommon::Page_WebView, _webViewPage);
+    if (!useFlow2()) {
+        setPage(WizardCommon::Page_WebView, _webViewPage);
+    }
 #endif // WITH_WEBENGINE
 
     connect(this, &QDialog::finished, this, &OwncloudWizard::basicSetupFinished);
@@ -79,8 +80,9 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     connect(_httpCredsPage, &OwncloudHttpCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
     connect(_flow2CredsPage, &Flow2AuthCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
 #ifdef WITH_WEBENGINE
-    if(!useFlow2())
-      connect(_webViewPage, &WebViewPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
+    if (!useFlow2()) {
+        connect(_webViewPage, &WebViewPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
+    }
 #endif // WITH_WEBENGINE
     connect(_advancedSetupPage, &OwncloudAdvancedSetupPage::createLocalAndRemoteFolders,
         this, &OwncloudWizard::createLocalAndRemoteFolders);
@@ -237,8 +239,9 @@ void OwncloudWizard::successfulStep()
 
 #ifdef WITH_WEBENGINE
     case WizardCommon::Page_WebView:
-        if(!this->useFlow2())
-          _webViewPage->setConnected();
+        if (!this->useFlow2()) {
+            _webViewPage->setConnected();
+        }
         break;
 #endif // WITH_WEBENGINE
 
@@ -280,9 +283,9 @@ void OwncloudWizard::setAuthType(DetermineAuthTypeJob::AuthType type)
 #ifdef WITH_WEBENGINE
     } else if (type == DetermineAuthTypeJob::WebViewFlow) {
         if(this->useFlow2()) {
-          _credentialsPage = _flow2CredsPage;
+            _credentialsPage = _flow2CredsPage;
         } else {
-          _credentialsPage = _webViewPage;
+            _credentialsPage = _webViewPage;
         }
 #endif // WITH_WEBENGINE
     } else { // try Basic auth even for "Unknown"

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -193,6 +193,11 @@ QStringList OwncloudWizard::selectiveSyncBlacklist() const
     return _advancedSetupPage->selectiveSyncBlacklist();
 }
 
+bool OwncloudWizard::useFlow2() const
+{
+    return _useFlow2;
+}
+
 bool OwncloudWizard::useVirtualFileSync() const
 {
     return _advancedSetupPage->useVirtualFileSync();

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -65,7 +65,8 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     setPage(WizardCommon::Page_Flow2AuthCreds, _flow2CredsPage);
     setPage(WizardCommon::Page_AdvancedSetup, _advancedSetupPage);
 #ifdef WITH_WEBENGINE
-    setPage(WizardCommon::Page_WebView, _webViewPage);
+    if(!useFlow2())
+      setPage(WizardCommon::Page_WebView, _webViewPage);
 #endif // WITH_WEBENGINE
 
     connect(this, &QDialog::finished, this, &OwncloudWizard::basicSetupFinished);
@@ -78,7 +79,8 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
     connect(_httpCredsPage, &OwncloudHttpCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
     connect(_flow2CredsPage, &Flow2AuthCredsPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
 #ifdef WITH_WEBENGINE
-    connect(_webViewPage, &WebViewPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
+    if(!useFlow2())
+      connect(_webViewPage, &WebViewPage::connectToOCUrl, this, &OwncloudWizard::connectToOCUrl);
 #endif // WITH_WEBENGINE
     connect(_advancedSetupPage, &OwncloudAdvancedSetupPage::createLocalAndRemoteFolders,
         this, &OwncloudWizard::createLocalAndRemoteFolders);
@@ -235,7 +237,8 @@ void OwncloudWizard::successfulStep()
 
 #ifdef WITH_WEBENGINE
     case WizardCommon::Page_WebView:
-        _webViewPage->setConnected();
+        if(!this->useFlow2())
+          _webViewPage->setConnected();
         break;
 #endif // WITH_WEBENGINE
 
@@ -276,7 +279,11 @@ void OwncloudWizard::setAuthType(DetermineAuthTypeJob::AuthType type)
         _credentialsPage = _flow2CredsPage;
 #ifdef WITH_WEBENGINE
     } else if (type == DetermineAuthTypeJob::WebViewFlow) {
-        _credentialsPage = _webViewPage;
+        if(this->useFlow2()) {
+          _credentialsPage = _flow2CredsPage;
+        } else {
+          _credentialsPage = _webViewPage;
+        }
 #endif // WITH_WEBENGINE
     } else { // try Basic auth even for "Unknown"
         _credentialsPage = _httpCredsPage;

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -65,6 +65,7 @@ public:
     [[nodiscard]] QString ocUrl() const;
     [[nodiscard]] QString localFolder() const;
     [[nodiscard]] QStringList selectiveSyncBlacklist() const;
+    [[nodiscard]] bool useFlow2() const;
     [[nodiscard]] bool useVirtualFileSync() const;
     [[nodiscard]] bool isConfirmBigFolderChecked() const;
 
@@ -88,7 +89,6 @@ public:
     QSslKey _clientSslKey; // key extracted from pkcs12
     QSslCertificate _clientSslCertificate; // cert extracted from pkcs12
     QList<QSslCertificate> _clientSslCaCertificates;
-    bool useFlow2() { return _useFlow2; };
 
 public slots:
     void setAuthType(OCC::DetermineAuthTypeJob::AuthType type);

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -21,6 +21,7 @@
 #include <QSslKey>
 #include <QSslCertificate>
 
+#include "libsync/configfile.h"
 #include "networkjobs.h"
 #include "wizard/owncloudwizardcommon.h"
 #include "accountfwd.h"
@@ -87,6 +88,7 @@ public:
     QSslKey _clientSslKey; // key extracted from pkcs12
     QSslCertificate _clientSslCertificate; // cert extracted from pkcs12
     QList<QSslCertificate> _clientSslCaCertificates;
+    bool useFlow2() { return _useFlow2; };
 
 public slots:
     void setAuthType(OCC::DetermineAuthTypeJob::AuthType type);
@@ -130,6 +132,8 @@ private:
     QStringList _setupLog;
 
     bool _registration = false;
+
+    bool _useFlow2 = ConfigFile().forceLoginV2();
 
     friend class OwncloudSetupWizard;
 };

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -993,10 +993,13 @@ void ConfigFile::setMoveToTrash(bool isChecked)
     setValue(moveToTrashC, isChecked);
 }
 
-bool ConfigFile::forceLoginV2() const {
+bool ConfigFile::forceLoginV2() const
+{
     return getValue(forceLoginV2C, QString(), false).toBool();
 }
-void ConfigFile::setForceLoginV2(bool isChecked) {
+
+void ConfigFile::setForceLoginV2(bool isChecked)
+{
     setValue(forceLoginV2C, isChecked);
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -104,6 +104,8 @@ static constexpr char stopSyncingExistingFoldersOverLimitC[] = "stopSyncingExist
 static constexpr char confirmExternalStorageC[] = "confirmExternalStorage";
 static constexpr char moveToTrashC[] = "moveToTrash";
 
+static constexpr char forceLoginV2C[] = "forceLoginV2";
+
 static constexpr char certPath[] = "http_certificatePath";
 static constexpr char certPasswd[] = "http_certificatePasswd";
 
@@ -989,6 +991,13 @@ bool ConfigFile::moveToTrash() const
 void ConfigFile::setMoveToTrash(bool isChecked)
 {
     setValue(moveToTrashC, isChecked);
+}
+
+bool ConfigFile::forceLoginV2() const {
+    return getValue(forceLoginV2C, QString(), false).toBool();
+}
+void ConfigFile::setForceLoginV2(bool isChecked) {
+    setValue(forceLoginV2C, isChecked);
 }
 
 bool ConfigFile::showMainDialogAsNormalWindow() const {

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -153,6 +153,10 @@ public:
     [[nodiscard]] bool moveToTrash() const;
     void setMoveToTrash(bool);
 
+    /** If we should force loginflow v2 */
+    [[nodiscard]] bool forceLoginV2() const;
+    void setForceLoginV2(bool);
+
     [[nodiscard]] bool showMainDialogAsNormalWindow() const;
 
     static bool setConfDir(const QString &value);

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -44,6 +44,7 @@
 
 #include "creds/abstractcredentials.h"
 #include "creds/httpcredentials.h"
+#include "configfile.h"
 
 namespace OCC {
 
@@ -1011,7 +1012,9 @@ bool JsonApiJob::finished()
 DetermineAuthTypeJob::DetermineAuthTypeJob(AccountPtr account, QObject *parent)
     : QObject(parent)
     , _account(account)
+
 {
+  useFlow2 = ConfigFile().forceLoginV2();
 }
 
 void DetermineAuthTypeJob::start()
@@ -1077,7 +1080,11 @@ void DetermineAuthTypeJob::start()
                 if (flow != QJsonValue::Undefined) {
                     if (flow.toInt() == 1) {
 #ifdef WITH_WEBENGINE
-                        _resultOldFlow = WebViewFlow;
+                      if(!this->useFlow2) {
+                          _resultOldFlow = WebViewFlow;
+                      } else {
+                        qCWarning(lcDetermineAuthTypeJob) << "Server only supports flow1, but this client was configured to only use flow2";
+                      }
 #else // WITH_WEBENGINE
                         qCWarning(lcDetermineAuthTypeJob) << "Server does only support flow1, but this client was compiled without support for flow1";
 #endif // WITH_WEBENGINE
@@ -1111,6 +1118,8 @@ void DetermineAuthTypeJob::checkAllDone()
     // WebViewFlow > Basic
     if (_account->serverVersionInt() >= Account::makeServerVersion(12, 0, 0)) {
         result = WebViewFlow;
+        if(useFlow2)
+          result = LoginFlowV2;
     }
 #endif // WITH_WEBENGINE
 
@@ -1123,6 +1132,8 @@ void DetermineAuthTypeJob::checkAllDone()
     // If we determined that we need the webview flow (GS for example) then we switch to that
     if (_resultOldFlow == WebViewFlow) {
         result = WebViewFlow;
+        if(useFlow2)
+          result = LoginFlowV2;
     }
 #endif // WITH_WEBENGINE
 

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -1012,9 +1012,8 @@ bool JsonApiJob::finished()
 DetermineAuthTypeJob::DetermineAuthTypeJob(AccountPtr account, QObject *parent)
     : QObject(parent)
     , _account(account)
-
 {
-  useFlow2 = ConfigFile().forceLoginV2();
+    useFlow2 = ConfigFile().forceLoginV2();
 }
 
 void DetermineAuthTypeJob::start()
@@ -1080,11 +1079,11 @@ void DetermineAuthTypeJob::start()
                 if (flow != QJsonValue::Undefined) {
                     if (flow.toInt() == 1) {
 #ifdef WITH_WEBENGINE
-                      if(!this->useFlow2) {
-                          _resultOldFlow = WebViewFlow;
-                      } else {
-                        qCWarning(lcDetermineAuthTypeJob) << "Server only supports flow1, but this client was configured to only use flow2";
-                      }
+                        if(!this->useFlow2) {
+                            _resultOldFlow = WebViewFlow;
+                        } else {
+                            qCWarning(lcDetermineAuthTypeJob) << "Server only supports flow1, but this client was configured to only use flow2";
+                        }
 #else // WITH_WEBENGINE
                         qCWarning(lcDetermineAuthTypeJob) << "Server does only support flow1, but this client was compiled without support for flow1";
 #endif // WITH_WEBENGINE
@@ -1118,8 +1117,9 @@ void DetermineAuthTypeJob::checkAllDone()
     // WebViewFlow > Basic
     if (_account->serverVersionInt() >= Account::makeServerVersion(12, 0, 0)) {
         result = WebViewFlow;
-        if(useFlow2)
-          result = LoginFlowV2;
+        if (useFlow2) {
+            result = LoginFlowV2;
+        }
     }
 #endif // WITH_WEBENGINE
 
@@ -1132,8 +1132,9 @@ void DetermineAuthTypeJob::checkAllDone()
     // If we determined that we need the webview flow (GS for example) then we switch to that
     if (_resultOldFlow == WebViewFlow) {
         result = WebViewFlow;
-        if(useFlow2)
-          result = LoginFlowV2;
+        if (useFlow2) {
+            result = LoginFlowV2;
+        }
     }
 #endif // WITH_WEBENGINE
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -549,6 +549,7 @@ private:
     bool _getDone = false;
     bool _propfindDone = false;
     bool _oldFlowDone = false;
+    bool useFlow2 = false;
 };
 
 /**


### PR DESCRIPTION
This patch allows a user to set the config variable:

forceLoginV2=true

This will make the client use the browser login flow instead of the webview. This is useful for making the user experience equal on Windows, Linux and Mac. Currently only Macs use the v2 flow and it was only possible to get this behaviour in the Windows and Linux clients at build time using a CMAKE flag.

The default behaviour is kept the same, and nothing changes for the user unless the flag is manually set in the config file. A setter is included in this patch, although it is not yet used in the GUI.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
