### PR TITLE
Avoid duplicate declarations with latest libcloudproviders

### DIFF
--- a/shell_integration/libcloudproviders/CMakeLists.txt
+++ b/shell_integration/libcloudproviders/CMakeLists.txt
@@ -34,5 +34,8 @@ IF (Qt5DBus_FOUND)
     set(LIBCLOUDPROVIDERS_DBUS_OBJECT_PATH "/${DBUS_PREFIX}/${DBUS_VENDOR}/${DBUS_APPLICATION_NAME}")
 
     dbus_add_activation_service(org.freedesktop.CloudProviders.service.in)
-    libcloudproviders_add_config(org.freedesktop.CloudProviders.ini.in)
+    # The .ini file has been replaced by a declaration in the .desktop file in 0.3.3+
+    if (${CLOUDPROVIDERS_VERSION} VERSION_LESS "0.3.3")
+        libcloudproviders_add_config(org.freedesktop.CloudProviders.ini.in)
+    endif ()
 ENDIF ()


### PR DESCRIPTION
Only install the .ini if the target version doen't support the .desktop file declaration.

Closes: #6218

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
