### PR TITLE
Change mac OS workflow to use macos-clang-arm64

### DIFF
--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -5,9 +5,9 @@ on:
 jobs:
   build:
     name: macOS Build and Test
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     env:
-      CRAFT_TARGET: macos-64-clang
+      CRAFT_TARGET: macos-clang-arm64
       CRAFT_MASTER_LOCATION: ${{ github.workspace }}/CraftMaster
       CRAFT_MASTER_CONFIG: ${{ github.workspace }}/craftmaster.ini
     steps:


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
