### PR TITLE
Bugfix. Do not treat item type change as metadata update.

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -983,19 +983,21 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     bool serverModified = item->_instruction == CSYNC_INSTRUCTION_NEW || item->_instruction == CSYNC_INSTRUCTION_SYNC
         || item->_instruction == CSYNC_INSTRUCTION_RENAME || item->_instruction == CSYNC_INSTRUCTION_TYPE_CHANGE;
 
+    const auto isTypeChange = item->_instruction == CSYNC_INSTRUCTION_TYPE_CHANGE;
+
     qCDebug(lcDisco) << "File" << item->_file << "- servermodified:" << serverModified
                      << "noServerEntry:" << noServerEntry;
 
     // Decay server modifications to UPDATE_METADATA if the local virtual exists
     bool hasLocalVirtual = localEntry.isVirtualFile || (_queryLocal == ParentNotChanged && dbEntry.isVirtualFile());
     bool virtualFileDownload = item->_type == ItemTypeVirtualFileDownload;
-    if (serverModified && !virtualFileDownload && hasLocalVirtual) {
+    if (serverModified && !isTypeChange && !virtualFileDownload && hasLocalVirtual) {
         item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
         serverModified = false;
         item->_type = ItemTypeVirtualFile;
     }
 
-    if (dbEntry.isVirtualFile() && (!localEntry.isValid() || localEntry.isVirtualFile) && !virtualFileDownload) {
+    if (dbEntry.isVirtualFile() && (!localEntry.isValid() || localEntry.isVirtualFile) && !virtualFileDownload && !isTypeChange) {
         item->_type = ItemTypeVirtualFile;
     }
 

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -1384,6 +1384,32 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
         QVERIFY(itemInstruction(completeSpy, "A", CSYNC_INSTRUCTION_NONE));
     }
+
+    void testRemoteTypeChangeExistingLocalMustGetRemoved()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        setupVfs(fakeFolder);
+
+        // test file change to directory on remote
+        fakeFolder.remoteModifier().mkdir("a");
+        fakeFolder.remoteModifier().insert("a/TESTFILE");
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("a/TESTFILE");
+        fakeFolder.remoteModifier().mkdir("a/TESTFILE");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+
+        // test directory change to file on remote
+        fakeFolder.remoteModifier().mkdir("a/TESTDIR");
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("a/TESTDIR");
+        fakeFolder.remoteModifier().insert("a/TESTDIR");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncCfApi)

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -1726,6 +1726,30 @@ private slots:
         QVERIFY(itemDidCompleteSuccessfully(completeSpy, "A/abcdęfg.txt"));
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    void testRemoteTypeChangeExistingLocalMustGetRemoved()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+
+        // test file change to directory on remote
+        fakeFolder.remoteModifier().mkdir("a");
+        fakeFolder.remoteModifier().insert("a/TESTFILE");
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("a/TESTFILE");
+        fakeFolder.remoteModifier().mkdir("a/TESTFILE");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        // test directory change to file on remote
+        fakeFolder.remoteModifier().mkdir("a/TESTDIR");
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("a/TESTDIR");
+        fakeFolder.remoteModifier().insert("a/TESTDIR");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)


### PR DESCRIPTION
Will probably fix https://github.com/nextcloud/desktop/issues/6272
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
