### PR TITLE
Bugfix. Fix incorrect size of the folderbutton size and scaling.

### DIFF
--- a/src/gui/tray/TrayFoldersMenuButton.qml
+++ b/src/gui/tray/TrayFoldersMenuButton.qml
@@ -20,6 +20,8 @@ import Style 1.0
 HeaderButton {
     id: root
 
+    implicitWidth: contentItem.implicitWidth
+
     signal folderEntryTriggered(string fullFolderPath, bool isGroupFolder)
 
     required property var currentUser
@@ -55,87 +57,104 @@ HeaderButton {
         text: root.userHasGroupFolders ? qsTr("Open local or group folders") : qsTr("Open local folder")
     }
 
-    Image {
-        id: folderStateIndicator
-        visible: root.currentUser.hasLocalFolder
-        source: root.currentUser.isConnected ? Style.stateOnlineImageSource : Style.stateOfflineImageSource
-        cache: false
-
-        anchors.top: root.verticalCenter
-        anchors.left: root.horizontalCenter
-        sourceSize.width: Style.folderStateIndicatorSize
-        sourceSize.height: Style.folderStateIndicatorSize
-
-        Accessible.role: Accessible.Indicator
-        Accessible.name: root.currentUser.isConnected ? qsTr("Connected") : qsTr("Disconnected")
-        z: 1
-
-        Rectangle {
-            id: folderStateIndicatorBackground
-            width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
-            height: width
-            anchors.centerIn: parent
-            color: Style.currentUserHeaderColor
-            radius: width * Style.trayFolderStatusIndicatorRadiusFactor
-            z: -2
-        }
-
-        Rectangle {
-            id: folderStateIndicatorBackgroundMouseHover
-            width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
-            height: width
-            anchors.centerIn: parent
-            color: root.hovered ? Style.currentUserHeaderTextColor : "transparent"
-            opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
-            radius: width * Style.trayFolderStatusIndicatorRadiusFactor
-            z: -1
-        }
-    }
-
-    RowLayout {
-        id: openLocalFolderButtonRowLayout
+    contentItem: Item {
+        id: rootContent
 
         anchors.fill: parent
-        spacing: 0
 
-        Image {
-            id: openLocalFolderButtonIcon
-            cache: true
-            source: "image://svgimage-custom-color/folder.svg/" + Style.currentUserHeaderTextColor
+        Item {
+            id: contentContainer
+            anchors.centerIn: parent
 
-            sourceSize {
-                width: Style.headerButtonIconSize
-                height: Style.headerButtonIconSize
+            implicitWidth: openLocalFolderButtonCaretIconLoader.active ? openLocalFolderButtonIcon.width + openLocalFolderButtonCaretIconLoader.width : openLocalFolderButtonIcon.width
+            implicitHeight: openLocalFolderButtonIcon.height
+
+            Image {
+                id: folderStateIndicator
+                visible: root.currentUser.hasLocalFolder
+                source: root.currentUser.isConnected ? Style.stateOnlineImageSource : Style.stateOfflineImageSource
+                cache: false
+
+                anchors.bottom: openLocalFolderButtonIcon.bottom
+                anchors.bottomMargin: Style.trayFoldersMenuButtonStateIndicatorBottomOffset
+                anchors.right: openLocalFolderButtonIcon.right
+                sourceSize.width: Style.folderStateIndicatorSize
+                sourceSize.height: Style.folderStateIndicatorSize
+
+                Accessible.role: Accessible.Indicator
+                Accessible.name: root.currentUser.isConnected ? qsTr("Connected") : qsTr("Disconnected")
+                z: 1
+
+                Rectangle {
+                    id: folderStateIndicatorBackground
+                    width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
+                    height: width
+                    anchors.centerIn: parent
+                    color: Style.currentUserHeaderColor
+                    radius: width * Style.trayFolderStatusIndicatorRadiusFactor
+                    z: -2
+                }
+
+                Rectangle {
+                    id: folderStateIndicatorBackgroundMouseHover
+                    width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
+                    height: width
+                    anchors.centerIn: parent
+                    color: root.hovered ? Style.currentUserHeaderTextColor : "transparent"
+                    opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
+                    radius: width * Style.trayFolderStatusIndicatorRadiusFactor
+                    z: -1
+                }
             }
 
-            verticalAlignment: Qt.AlignCenter
+            Image {
+                id: openLocalFolderButtonIcon
 
-            Accessible.role: Accessible.Graphic
-            Accessible.name: qsTr("Group folder button")
-            Layout.leftMargin: Style.trayHorizontalMargin
-        }
+                property int imageWidth: rootContent.width * Style.trayFoldersMenuButtonMainIconSizeFraction
+                property int imageHeight: rootContent.width * Style.trayFoldersMenuButtonMainIconSizeFraction
 
-        Loader {
-            id: openLocalFolderButtonCaretIconLoader
+                cache: true
 
-            active: root.userHasGroupFolders
-            visible: active
-
-            sourceComponent: ColorOverlay {
-                width: source.width
-                height: source.height
-                cached: true
-                color: Style.currentUserHeaderTextColor
-                source: Image {
-                    source: "image://svgimage-custom-color/caret-down.svg/" + Style.currentUserHeaderTextColor
-                    sourceSize.width: Style.accountDropDownCaretSize
-                    sourceSize.height: Style.accountDropDownCaretSize
-
-                    verticalAlignment: Qt.AlignCenter
-
-                    Layout.alignment: Qt.AlignRight
-                    Layout.margins: Style.accountDropDownCaretMargin
+                source: "image://svgimage-custom-color/folder.svg/" + Style.currentUserHeaderTextColor
+                sourceSize {
+                    width: imageWidth
+                    height: imageHeight
                 }
+
+                width: imageWidth
+                height: imageHeight
+
+                anchors.verticalCenter: parent
+            }
+
+
+            Loader {
+                id: openLocalFolderButtonCaretIconLoader
+
+                active: root.userHasGroupFolders
+                visible: active
+
+                anchors.left: openLocalFolderButtonIcon.right
+                anchors.verticalCenter: openLocalFolderButtonIcon.verticalCenter
+
+                property int imageWidth: rootContent.width * Style.trayFoldersMenuButtonDropDownCaretIconSizeFraction
+                property int imageHeight: rootContent.width * Style.trayFoldersMenuButtonDropDownCaretIconSizeFraction
+
+                sourceComponent: Image {
+                    id: openLocalFolderButtonCaretIcon
+
+                    cache: true
+
+                    source: "image://svgimage-custom-color/caret-down.svg/" + Style.currentUserHeaderTextColor
+                    sourceSize: {
+                        width: openLocalFolderButtonCaretIconLoader.imageWidth
+                        height: openLocalFolderButtonCaretIconLoader.imageHeight
+                    }
+                }
+
+                width: openLocalFolderButtonCaretIconLoader.imageWidth
+                height: openLocalFolderButtonCaretIconLoader.imageHeight
+
             }
         }
     }

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -622,12 +622,18 @@ ApplicationWindow {
                     visible: currentUser.hasLocalFolder
                     currentUser: UserModel.currentUser
 
-                    Layout.preferredWidth:  Style.iconButtonWidth * Style.trayFolderListButtonWidthScaleFactor
-                    Layout.alignment: Qt.AlignHCenter
 
                     onClicked: openLocalFolderButton.userHasGroupFolders ? openLocalFolderButton.toggleMenuOpen() : UserModel.openCurrentAccountLocalFolder()
 
                     onFolderEntryTriggered: isGroupFolder ? UserModel.openCurrentAccountFolderFromTrayInfo(fullFolderPath) : UserModel.openCurrentAccountLocalFolder()
+
+                    Accessible.role: Accessible.Graphic
+                    Accessible.name: qsTr("Open local or group folders")
+                    Accessible.onPressAction: openLocalFolderButton.userHasGroupFolders ? openLocalFolderButton.toggleMenuOpen() : UserModel.openCurrentAccountLocalFolder()
+
+                    Layout.alignment: Qt.AlignRight
+                    Layout.preferredWidth:  Style.trayWindowHeaderHeight
+                    Layout.preferredHeight: Style.trayWindowHeaderHeight
                 }
 
                 HeaderButton {
@@ -641,6 +647,11 @@ ApplicationWindow {
                     Accessible.role: Accessible.Button
                     Accessible.name: qsTr("Open Nextcloud Talk in browser")
                     Accessible.onPressAction: trayWindowTalkButton.clicked()
+
+                    Layout.alignment: Qt.AlignRight
+                    Layout.preferredWidth:  Style.trayWindowHeaderHeight
+                    Layout.preferredHeight: Style.trayWindowHeaderHeight
+
                 }
 
                 HeaderButton {

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -83,6 +83,10 @@ QtObject {
     property int accountDropDownCaretSize: 20
     property int accountDropDownCaretMargin: 8
 
+    property int trayFoldersMenuButtonStateIndicatorBottomOffset: 5
+    property double trayFoldersMenuButtonDropDownCaretIconSizeFraction: 0.3
+    property double trayFoldersMenuButtonMainIconSizeFraction: 1.0 - trayFoldersMenuButtonDropDownCaretIconSizeFraction
+
     property int addAccountButtonHeight: 50
 
     property int headerButtonIconSize: 32


### PR DESCRIPTION
Fix https://github.com/nextcloud/desktop/issues/6290

### Before:
![tray_buttons_broken](https://github.com/nextcloud/desktop/assets/12224014/5a233a48-c9f1-4cc4-8b64-ba09cb9fa3fe)

### After:
![tray_buttons_fixed](https://github.com/nextcloud/desktop/assets/12224014/8e3394e8-bf54-469b-8160-414f762e9cd6)
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
