### PR TITLE
[stable-3.11] Moved items to protected area and changed some functions to be virtua…

### DIFF
--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -128,6 +128,9 @@ private slots:
     void checkClientSideEncryptionState();
     void removeActionFromEncryptionMessage(const QString &actionId);
 
+protected:
+    Ui::AccountSettings *_ui;
+
 private:
     bool event(QEvent *) override;
     QAction *addActionToEncryptionMessage(const QString &actionTitle, const QString &actionId);
@@ -136,8 +139,6 @@ private:
 
     /// Returns the alias of the selected folder, empty string if none
     [[nodiscard]] QString selectedFolderAlias() const;
-
-    Ui::AccountSettings *_ui;
 
     FolderStatusModel *_model;
     QUrl _OCUrl;

--- a/src/gui/folderwizard.h
+++ b/src/gui/folderwizard.h
@@ -170,7 +170,7 @@ public:
     bool eventFilter(QObject *watched, QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
 
-private:
+protected:
     FolderWizardLocalPath *_folderWizardSourcePage;
     FolderWizardRemotePath *_folderWizardTargetPage = nullptr;
     FolderWizardSelectiveSync *_folderWizardSelectiveSyncPage;

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -61,10 +61,12 @@ private slots:
     void slotToggleAutoUpdateCheck();
 #endif
 
+protected:
+    Ui::GeneralSettings *_ui;
+
 private:
     void customizeStyle();
 
-    Ui::GeneralSettings *_ui;
     QPointer<IgnoreListEditor> _ignoreEditor;
     bool _currentlyLoading = false;
 };

--- a/src/gui/networksettings.h
+++ b/src/gui/networksettings.h
@@ -48,12 +48,11 @@ private slots:
 
 protected:
     void showEvent(QShowEvent *event) override;
+    Ui::NetworkSettings *_ui;
 
 private:
     void loadProxySettings();
     void loadBWLimitSettings();
-
-    Ui::NetworkSettings *_ui;
 };
 
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -56,8 +56,8 @@ public:
 public slots:
     void showFirstPage();
     void showIssuesList(OCC::AccountState *account);
-    void slotSwitchPage(QAction *action);
-    void slotAccountAvatarChanged();
+    virtual void slotSwitchPage(QAction *action);
+    virtual void slotAccountAvatarChanged();
     void slotAccountDisplayNameChanged();
 
 signals:
@@ -74,13 +74,14 @@ private slots:
     void accountAdded(OCC::AccountState *);
     void accountRemoved(OCC::AccountState *);
 
-private:
+protected:
+    Ui::SettingsDialog *const _ui;
+    QToolBar *_toolBar;
     void customizeStyle();
 
+private:
     QAction *createColorAwareAction(const QString &iconName, const QString &fileName);
     QAction *createActionWithIcon(const QIcon &icon, const QString &text, const QString &iconPath = QString());
-
-    Ui::SettingsDialog *const _ui;
 
     QActionGroup *_actionGroup;
     // Maps the actions from the action group to the corresponding widgets
@@ -89,8 +90,6 @@ private:
     // Maps the action in the dialog to their according account. Needed in
     // case the account avatar changes
     QHash<Account *, QAction *> _actionForAccount;
-
-    QToolBar *_toolBar;
 
     ownCloudGui *_gui;
 };

--- a/src/gui/wizard/flow2authwidget.h
+++ b/src/gui/wizard/flow2authwidget.h
@@ -47,10 +47,12 @@ signals:
     void authResult(Flow2Auth::Result, const QString &errorString, const QString &user, const QString &appPassword);
     void pollNow();
 
+protected:
+    Ui_Flow2AuthWidget _ui{};
+
 private:
     Account *_account = nullptr;
     QScopedPointer<Flow2Auth> _asyncAuth;
-    Ui_Flow2AuthWidget _ui{};
 
 protected slots:
     void slotOpenBrowser();

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -64,6 +64,9 @@ private slots:
     void slotVirtualFileSyncClicked();
     void slotQuotaRetrieved(const QVariantMap &result);
 
+protected:
+    Ui_OwncloudAdvancedSetupPage _ui{};
+
 private:
     void setRadioChecked(QRadioButton *radio);
 
@@ -87,7 +90,6 @@ private:
     // TODO: remove when UX decision is made
     void refreshVirtualFilesAvailibility(const QString &path);
 
-    Ui_OwncloudAdvancedSetupPage _ui{};
     bool _checking = false;
     bool _created = false;
     bool _localFolderValid = false;

--- a/src/gui/wizard/welcomepage.h
+++ b/src/gui/wizard/welcomepage.h
@@ -35,18 +35,19 @@ public:
     ~WelcomePage() override;
     [[nodiscard]] int nextId() const override;
     void initializePage() override;
-    void setLoginButtonDefault();
+    virtual void setLoginButtonDefault();
+
+protected:
+    virtual void styleSlideShow();
+    QScopedPointer<Ui::WelcomePage> _ui;
 
 private:
     void setupUi();
     void customizeStyle();
-    void styleSlideShow();
     void setupSlideShow();
     void setupLoginButton();
     void setupCreateAccountButton();
     void setupHostYourOwnServerLabel();
-
-    QScopedPointer<Ui::WelcomePage> _ui;
 
     OwncloudWizard *_ocWizard;
     WizardCommon::Pages _nextPage = WizardCommon::Page_ServerSetup;

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -236,12 +236,11 @@ protected:
     [[nodiscard]] QVariant retrieveData(const QString &group, const QString &key) const;
     void removeData(const QString &group, const QString &key);
     [[nodiscard]] bool dataExists(const QString &group, const QString &key) const;
-
-private:
     [[nodiscard]] QVariant getValue(const QString &param, const QString &group = QString(),
-        const QVariant &defaultValue = QVariant()) const;
+    const QVariant &defaultValue = QVariant()) const;
     void setValue(const QString &key, const QVariant &value);
 
+private:
     [[nodiscard]] QString keychainProxyPasswordKey() const;
 
     using SharedCreds = QSharedPointer<AbstractCredentials>;


### PR DESCRIPTION
…l, 

signed-off-by: Eugen Fischer <e.fischer@external.t-systems.com>

We moved some class members to protected area, so we have a better access to them. I think its not good to use any getter functions, since we would expose the class members to public. We always derive from the class, thats why we need protected members and not private.  Some functions were made virtual so we can override them. It would be good to have these changes in upstream so we reduce the chances for merge conflicts. 