### PR TITLE
Feature/filelocking keep user lock

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -650,7 +650,8 @@ void EditLocallyJob::lockFile()
                                                                 _folderForFile->remotePathTrailingSlash(),
                                                                 _folderForFile->path(),
                                                                 _folderForFile->journalDb(),
-                                                                SyncFileItem::LockStatus::LockedItem);
+                                                                SyncFileItem::LockStatus::LockedItem,
+                                                                SyncFileItem::LockOwnerType::TokenLock);
 }
 
 void EditLocallyJob::disconnectFolderSignals()

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -649,7 +649,7 @@ void Folder::slotFilesLockReleased(const QSet<QString> &files)
         }
         const auto canUnlockFile = isFileRecordValid
             && rec._lockstate._locked
-            && rec._lockstate._lockOwnerType == static_cast<qint64>(SyncFileItem::LockOwnerType::UserLock)
+            && rec._lockstate._lockOwnerType == static_cast<qint64>(SyncFileItem::LockOwnerType::TokenLock)
             && rec._lockstate._lockOwnerId == _accountState->account()->davUser();
 
         if (!canUnlockFile) {
@@ -668,11 +668,13 @@ void Folder::slotFilesLockReleased(const QSet<QString> &files)
             disconnect(_officeFileLockReleaseUnlockFailure);
             qCWarning(lcFolder) << "Failed to unlock a file:" << remoteFilePath << message;
         });
+        const auto lockOwnerType = static_cast<SyncFileItem::LockOwnerType>(rec._lockstate._lockOwnerType);
         _accountState->account()->setLockFileState(remoteFilePath,
                                                    remotePathTrailingSlash(),
                                                    path(),
                                                    journalDb(),
-                                                   SyncFileItem::LockStatus::UnlockedItem);
+                                                   SyncFileItem::LockStatus::UnlockedItem,
+                                                   lockOwnerType);
     }
 }
 
@@ -719,7 +721,8 @@ void Folder::slotLockedFilesFound(const QSet<QString> &files)
                                                    remotePathTrailingSlash(),
                                                    path(),
                                                    journalDb(),
-                                                   SyncFileItem::LockStatus::LockedItem);
+                                                   SyncFileItem::LockStatus::LockedItem,
+                                                   SyncFileItem::LockOwnerType::TokenLock);
     }
 }
 

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1091,11 +1091,18 @@ void SocketApi::setFileLock(const QString &localFile, const SyncFileItem::LockSt
         return;
     }
 
+    const auto record = fileData.journalRecord();
+    if (static_cast<SyncFileItem::LockOwnerType>(record._lockstate._lockOwnerType) != SyncFileItem::LockOwnerType::UserLock) {
+        qCDebug(lcSocketApi) << "Only user lock state or non-locked files can be affected manually!";
+        return;
+    }
+
     shareFolder->accountState()->account()->setLockFileState(fileData.serverRelativePath,
                                                              shareFolder->remotePathTrailingSlash(),
                                                              shareFolder->path(),
                                                              shareFolder->journalDb(),
-                                                             lockState);
+                                                             lockState,
+                                                             SyncFileItem::LockOwnerType::UserLock);
 
     shareFolder->journalDb()->schedulePathForRemoteDiscovery(fileData.serverRelativePath);
     shareFolder->scheduleThisFolderSoon();

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -959,7 +959,8 @@ void Account::setLockFileState(const QString &serverRelativePath,
                                const QString &remoteSyncPathWithTrailingSlash,
                                const QString &localSyncPath,
                                SyncJournalDb * const journal,
-                               const SyncFileItem::LockStatus lockStatus)
+                               const SyncFileItem::LockStatus lockStatus,
+                               const SyncFileItem::LockOwnerType lockOwnerType)
 {
     auto& lockStatusJobInProgress = _lockStatusChangeInprogress[serverRelativePath];
     if (lockStatusJobInProgress.contains(lockStatus)) {
@@ -967,7 +968,7 @@ void Account::setLockFileState(const QString &serverRelativePath,
         return;
     }
     lockStatusJobInProgress.push_back(lockStatus);
-    auto job = std::make_unique<LockFileJob>(sharedFromThis(), journal, serverRelativePath, remoteSyncPathWithTrailingSlash, localSyncPath, lockStatus);
+    auto job = std::make_unique<LockFileJob>(sharedFromThis(), journal, serverRelativePath, remoteSyncPathWithTrailingSlash, localSyncPath, lockStatus, lockOwnerType);
     connect(job.get(), &LockFileJob::finishedWithoutError, this, [this, serverRelativePath, lockStatus]() {
         removeLockStatusChangeInprogress(serverRelativePath, lockStatus);
         Q_EMIT lockFileSuccess();

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -316,7 +316,8 @@ public:
                           const QString &remoteSyncPathWithTrailingSlash,
                           const QString &localSyncPath,
                           SyncJournalDb * const journal,
-                          const SyncFileItem::LockStatus lockStatus);
+                          const SyncFileItem::LockStatus lockStatus,
+                          const SyncFileItem::LockOwnerType lockOwnerType);
 
     SyncFileItem::LockStatus fileLockStatus(SyncJournalDb * const journal,
                                             const QString &folderRelativePath) const;

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -254,6 +254,11 @@ bool Capabilities::filesLockAvailable() const
     return _capabilities["files"].toMap()["locking"].toByteArray() >= "1.0";
 }
 
+bool Capabilities::filesLockTypeAvailable() const
+{
+    return _capabilities["files"].toMap()["api-feature-lock-type"].toByteArray() >= "1.0";
+}
+
 bool Capabilities::userStatus() const
 {
     if (!_capabilities.contains("user_status")) {

--- a/src/libsync/capabilities.h
+++ b/src/libsync/capabilities.h
@@ -66,6 +66,7 @@ public:
     [[nodiscard]] bool chunkingNg() const;
     [[nodiscard]] bool bulkUpload() const;
     [[nodiscard]] bool filesLockAvailable() const;
+    [[nodiscard]] bool filesLockTypeAvailable() const;
     [[nodiscard]] bool userStatus() const;
     [[nodiscard]] bool userStatusSupportsEmoji() const;
     [[nodiscard]] QColor serverColor() const;

--- a/src/libsync/lockfilejobs.h
+++ b/src/libsync/lockfilejobs.h
@@ -25,6 +25,7 @@ public:
                          const QString &remoteSyncPathWithTrailingSlash,
                          const QString &localSyncPath,
                          const SyncFileItem::LockStatus requestedLockState,
+                         const SyncFileItem::LockOwnerType lockOwnerType,
                          QObject *parent = nullptr);
     void start() override;
 
@@ -48,6 +49,7 @@ private:
 
     SyncJournalDb* _journal = nullptr;
     SyncFileItem::LockStatus _requestedLockState = SyncFileItem::LockStatus::LockedItem;
+    SyncFileItem::LockOwnerType _requestedLockOwnerType = SyncFileItem::LockOwnerType::UserLock;
 
     SyncFileItem::LockStatus _lockStatus = SyncFileItem::LockStatus::UnlockedItem;
     SyncFileItem::LockOwnerType _lockOwnerType = SyncFileItem::LockOwnerType::UserLock;

--- a/test/testlockfile.cpp
+++ b/test/testlockfile.cpp
@@ -40,7 +40,8 @@ private slots:
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
                                                &fakeFolder.syncJournal(),
-                                               OCC::SyncFileItem::LockStatus::LockedItem);
+                                               OCC::SyncFileItem::LockStatus::LockedItem,
+                                               OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QVERIFY(lockFileSuccessSpy.wait());
         QCOMPARE(lockFileErrorSpy.count(), 0);
@@ -85,7 +86,8 @@ private slots:
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
                                                &fakeFolder.syncJournal(),
-                                               OCC::SyncFileItem::LockStatus::LockedItem);
+                                               OCC::SyncFileItem::LockStatus::LockedItem,
+                                               OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QVERIFY(lockFileErrorSpy.wait());
         QCOMPARE(lockFileSuccessSpy.count(), 0);
@@ -109,7 +111,8 @@ private slots:
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
                                                &fakeFolder.syncJournal(),
-                                               OCC::SyncFileItem::LockStatus::LockedItem);
+                                               OCC::SyncFileItem::LockStatus::LockedItem,
+                                               OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QVERIFY(lockFileSuccessSpy.wait());
         QCOMPARE(lockFileErrorSpy.count(), 0);
@@ -136,7 +139,8 @@ private slots:
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
                                                &fakeFolder.syncJournal(),
-                                               OCC::SyncFileItem::LockStatus::LockedItem);
+                                               OCC::SyncFileItem::LockStatus::LockedItem,
+                                               OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QVERIFY(lockFileSuccessSpy.wait());
         QCOMPARE(lockFileErrorSpy.count(), 0);
@@ -160,7 +164,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::LockedItem);
+                                        OCC::SyncFileItem::LockStatus::LockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);
@@ -198,7 +203,8 @@ private slots:
                                                 QStringLiteral("/") + testFileName,
                                                 QStringLiteral("/"),
                                                 fakeFolder.localPath(),
-                                                OCC::SyncFileItem::LockStatus::LockedItem);
+                                                OCC::SyncFileItem::LockStatus::LockedItem,
+                                                OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy lockFileJobSuccess(lockFileJob, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy lockFileJobFailure(lockFileJob, &OCC::LockFileJob::finishedWithError);
@@ -215,7 +221,8 @@ private slots:
                                                   QStringLiteral("/") + testFileName,
                                                   QStringLiteral("/"),
                                                   fakeFolder.localPath(),
-                                                  OCC::SyncFileItem::LockStatus::UnlockedItem);
+                                                  OCC::SyncFileItem::LockStatus::UnlockedItem,
+                                                  OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy unlockFileJobSuccess(unlockFileJob, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy unlockFileJobFailure(unlockFileJob, &OCC::LockFileJob::finishedWithError);
@@ -274,7 +281,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::LockedItem);
+                                        OCC::SyncFileItem::LockStatus::LockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);
@@ -327,7 +335,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::LockedItem);
+                                        OCC::SyncFileItem::LockStatus::LockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);
@@ -380,7 +389,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::UnlockedItem);
+                                        OCC::SyncFileItem::LockStatus::UnlockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);
@@ -431,7 +441,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::UnlockedItem);
+                                        OCC::SyncFileItem::LockStatus::UnlockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);
@@ -469,7 +480,8 @@ private slots:
                                                 QStringLiteral("/") + testFileName,
                                                 QStringLiteral("/"),
                                                 fakeFolder.localPath(),
-                                                OCC::SyncFileItem::LockStatus::LockedItem);
+                                                OCC::SyncFileItem::LockStatus::LockedItem,
+                                                OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy lockFileJobSuccess(lockFileJob, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy lockFileJobFailure(lockFileJob, &OCC::LockFileJob::finishedWithError);
@@ -486,7 +498,8 @@ private slots:
                                                   QStringLiteral("/") + testFileName,
                                                   QStringLiteral("/"),
                                                   fakeFolder.localPath(),
-                                                  OCC::SyncFileItem::LockStatus::UnlockedItem);
+                                                  OCC::SyncFileItem::LockStatus::UnlockedItem,
+                                                  OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy unlockFileJobSuccess(unlockFileJob, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy unlockFileJobFailure(unlockFileJob, &OCC::LockFileJob::finishedWithError);
@@ -539,7 +552,8 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
-                                        OCC::SyncFileItem::LockStatus::UnlockedItem);
+                                        OCC::SyncFileItem::LockStatus::UnlockedItem,
+                                        OCC::SyncFileItem::LockOwnerType::UserLock);
 
         QSignalSpy jobSuccess(job, &OCC::LockFileJob::finishedWithoutError);
         QSignalSpy jobFailure(job, &OCC::LockFileJob::finishedWithError);


### PR DESCRIPTION
For details, see server changes: https://github.com/nextcloud/files_lock/pull/199/files
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
