### PR TITLE
Simplify window positioning compute, more flexibly handle different available geometries

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -696,33 +696,6 @@ Systray::TaskBarPosition Systray::taskbarOrientation() const
 #endif
 }
 
-// TODO: Get real taskbar dimensions Linux as well
-QRect Systray::taskbarGeometry() const
-{
-#if defined(Q_OS_WIN)
-    QRect tbRect = Utility::getTaskbarDimensions();
-    //QML side expects effective pixels, convert taskbar dimensions if necessary
-    auto pixelRatio = currentScreen()->devicePixelRatio();
-    if (pixelRatio != 1) {
-        tbRect.setHeight(tbRect.height() / pixelRatio);
-        tbRect.setWidth(tbRect.width() / pixelRatio);
-    }
-    return tbRect;
-#elif defined(Q_OS_MACOS)
-    const auto screenWidth = currentScreenRect().width();
-    const auto statusBarHeight = static_cast<int>(OCC::menuBarThickness());
-    return {0, 0, screenWidth, statusBarHeight};
-#else
-    if (taskbarOrientation() == TaskBarPosition::Bottom || taskbarOrientation() == TaskBarPosition::Top) {
-        auto screenWidth = currentScreenRect().width();
-        return {0, 0, screenWidth, 32};
-    } else {
-        auto screenHeight = currentScreenRect().height();
-        return {0, 0, 32, screenHeight};
-    }
-#endif
-}
-
 QRect Systray::currentScreenRect() const
 {
     const auto screen = currentScreen();

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -587,7 +587,7 @@ void Systray::positionWindowAtScreenCenter(QQuickWindow *window) const
     if(!useNormalWindow()) {
         window->setScreen(currentScreen());
         const QPoint windowAdjustment(window->geometry().width() / 2, window->geometry().height() / 2);
-        const auto position = currentScreen()->virtualGeometry().center() - windowAdjustment;
+        const auto position = currentScreen()->availableGeometry().center() - windowAdjustment;
         window->setPosition(position);
     }
 }
@@ -897,11 +897,11 @@ QPoint Systray::computeNotificationPosition(int width, int height, int spacing, 
 
 QPoint Systray::calcTrayIconCenter() const
 {
-    if(geometry().isValid()) {
+    const auto geo = geometry();
+    if(geo.isValid()) {
         // QSystemTrayIcon::geometry() is broken for ages on most Linux DEs (invalid geometry returned)
         // thus we can use this only for Windows and macOS
-        auto trayIconCenter = geometry().center();
-        return trayIconCenter;
+        return geo.center();
     }
 
     // On Linux, fall back to mouse position (assuming tray icon is activated by mouse click)

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -741,12 +741,10 @@ QPoint Systray::computeWindowReferencePoint() const
 {
     constexpr auto spacing = 4;
     const auto trayIconCenter = calcTrayIconCenter();
-    const auto taskbarRect = taskbarGeometry();
     const auto taskbarScreenEdge = taskbarOrientation();
-    const auto screenRect = currentScreenRect();
+    const auto screenRect = currentAvailableScreenRect();
 
     qCDebug(lcSystray) << "screenRect:" << screenRect;
-    qCDebug(lcSystray) << "taskbarRect:" << taskbarRect;
     qCDebug(lcSystray) << "taskbarScreenEdge:" << taskbarScreenEdge;
     qCDebug(lcSystray) << "trayIconCenter:" << trayIconCenter;
 
@@ -754,21 +752,21 @@ QPoint Systray::computeWindowReferencePoint() const
     case TaskBarPosition::Bottom:
         return {
             trayIconCenter.x(),
-            screenRect.bottom() - taskbarRect.height() - spacing
+            screenRect.bottom() - spacing
         };
     case TaskBarPosition::Left:
         return {
-            screenRect.left() + taskbarRect.width() + spacing,
+            screenRect.left() + spacing,
             trayIconCenter.y()
         };
     case TaskBarPosition::Top:
         return {
             trayIconCenter.x(),
-            screenRect.top() + taskbarRect.height() + spacing
+            screenRect.top() + spacing
         };
     case TaskBarPosition::Right:
         return {
-            screenRect.right() - taskbarRect.width() - spacing,
+            screenRect.right() - spacing,
             trayIconCenter.y()
         };
     }
@@ -779,29 +777,23 @@ QPoint Systray::computeNotificationReferencePoint(int spacing, NotificationPosit
 {
     auto trayIconCenter = calcTrayIconCenter();
     auto taskbarScreenEdge = taskbarOrientation();
-    auto taskbarRect = taskbarGeometry();
-    const auto screenRect = currentScreenRect();
+    const auto screenRect = currentAvailableScreenRect();
     
     if(position == NotificationPosition::TopLeft) {
         taskbarScreenEdge = TaskBarPosition::Top;
         trayIconCenter = QPoint(0, 0);
-        taskbarRect = QRect(0, 0, screenRect.width(), 32);
     } else if(position == NotificationPosition::TopRight) {
         taskbarScreenEdge = TaskBarPosition::Top;
         trayIconCenter = QPoint(screenRect.width(), 0);
-        taskbarRect = QRect(0, 0, screenRect.width(), 32);
     } else if(position == NotificationPosition::BottomLeft) {
         taskbarScreenEdge = TaskBarPosition::Bottom;
         trayIconCenter = QPoint(0, screenRect.height());
-        taskbarRect = QRect(0, 0, screenRect.width(), 32);
     } else if(position == NotificationPosition::BottomRight) {
         taskbarScreenEdge = TaskBarPosition::Bottom;
         trayIconCenter = QPoint(screenRect.width(), screenRect.height());
-        taskbarRect = QRect(0, 0, screenRect.width(), 32);
     }
 
     qCDebug(lcSystray) << "screenRect:" << screenRect;
-    qCDebug(lcSystray) << "taskbarRect:" << taskbarRect;
     qCDebug(lcSystray) << "taskbarScreenEdge:" << taskbarScreenEdge;
     qCDebug(lcSystray) << "trayIconCenter:" << trayIconCenter;
 
@@ -809,21 +801,21 @@ QPoint Systray::computeNotificationReferencePoint(int spacing, NotificationPosit
     case TaskBarPosition::Bottom:
         return {
             trayIconCenter.x() < screenRect.center().x() ? screenRect.left() + spacing :  screenRect.right() - spacing,
-            screenRect.bottom() - taskbarRect.height() - spacing
+            screenRect.bottom() - spacing
         };
     case TaskBarPosition::Left:
         return {
-            screenRect.left() + taskbarRect.width() + spacing,
+            screenRect.left() + spacing,
             trayIconCenter.y() < screenRect.center().y() ? screenRect.top() + spacing : screenRect.bottom() - spacing
         };
     case TaskBarPosition::Top:
         return {
             trayIconCenter.x() < screenRect.center().x() ? screenRect.left() + spacing :  screenRect.right() - spacing,
-            screenRect.top() + taskbarRect.height() + spacing
+            screenRect.top() + spacing
         };
     case TaskBarPosition::Right:
         return {
-            screenRect.right() - taskbarRect.width() - spacing,
+            screenRect.right() - spacing,
             trayIconCenter.y() < screenRect.center().y() ? screenRect.top() + spacing : screenRect.bottom() - spacing
         };
     }

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -730,6 +730,13 @@ QRect Systray::currentScreenRect() const
     return screen->geometry();
 }
 
+QRect Systray::currentAvailableScreenRect() const
+{
+    const auto screen = currentScreen();
+    Q_ASSERT(screen);
+    return screen->availableGeometry();
+}
+
 QPoint Systray::computeWindowReferencePoint() const
 {
     constexpr auto spacing = 4;

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -170,7 +170,6 @@ private:
     [[nodiscard]] QPoint computeNotificationReferencePoint(int spacing = 20, NotificationPosition position = NotificationPosition::Default) const;
     [[nodiscard]] QPoint calcTrayIconCenter() const;
     [[nodiscard]] TaskBarPosition taskbarOrientation() const;
-    [[nodiscard]] QRect taskbarGeometry() const;
     [[nodiscard]] QRect computeWindowRect(int spacing, const QPoint &topLeft, const QPoint &bottomRight) const;
     [[nodiscard]] QPoint computeWindowPosition(int width, int height) const;
     [[nodiscard]] QPoint computeNotificationPosition(int width, int height, int spacing = 20, NotificationPosition position = NotificationPosition::Default) const;

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -165,6 +165,7 @@ private:
 
     [[nodiscard]] QScreen *currentScreen() const;
     [[nodiscard]] QRect currentScreenRect() const;
+    [[nodiscard]] QRect currentAvailableScreenRect() const;
     [[nodiscard]] QPoint computeWindowReferencePoint() const;
     [[nodiscard]] QPoint computeNotificationReferencePoint(int spacing = 20, NotificationPosition position = NotificationPosition::Default) const;
     [[nodiscard]] QPoint calcTrayIconCenter() const;


### PR DESCRIPTION
This PR simplifies the calculation of safe spaces for the tray window to be positioned in by using Qt's inbuilt available screen geometries, rather than us trying to manually calculate the taskbar geometry

Requires testing on Linux and Windows

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
