### PR TITLE
partial build fix when TOKEN_AUTH_ONLY is enabled at configure time

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,3 @@
-# TODO: OSX and LIB_ONLY seem to require this to go to binary dir only
-if(NOT TOKEN_AUTH_ONLY)
-endif()
-
 include(ECMEnableSanitizers)
 
 set(REQUIRED_QT_VERSION "5.15.0")

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -214,9 +214,11 @@ target_link_libraries(nextcloudsync
   KF5::Archive
 )
 
+find_package(Qt5 REQUIRED COMPONENTS Gui Widgets Svg)
+target_link_libraries(nextcloudsync PUBLIC Qt5::Gui Qt5::Widgets Qt5::Svg)
+
 if (NOT TOKEN_AUTH_ONLY)
-    find_package(Qt5 REQUIRED COMPONENTS Widgets Svg)
-    target_link_libraries(nextcloudsync PUBLIC Qt5::Widgets Qt5::Svg qt5keychain)
+    target_link_libraries(nextcloudsync PUBLIC qt5keychain)
 endif()
 
 if(Inotify_FOUND)

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -285,6 +285,8 @@ void ConfigFile::saveGeometry(QWidget *w)
     settings.beginGroup(w->objectName());
     settings.setValue(QLatin1String(geometryC), w->saveGeometry());
     settings.sync();
+#else
+    Q_UNUSED(w)
 #endif
 }
 
@@ -292,6 +294,8 @@ void ConfigFile::restoreGeometry(QWidget *w)
 {
 #ifndef TOKEN_AUTH_ONLY
     w->restoreGeometry(getValue(geometryC, w->objectName()).toByteArray());
+#else
+    Q_UNUSED(w)
 #endif
 }
 
@@ -306,6 +310,8 @@ void ConfigFile::saveGeometryHeader(QHeaderView *header)
     settings.beginGroup(header->objectName());
     settings.setValue(QLatin1String(geometryC), header->saveState());
     settings.sync();
+#else
+    Q_UNUSED(header)
 #endif
 }
 
@@ -319,6 +325,8 @@ void ConfigFile::restoreGeometryHeader(QHeaderView *header)
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.beginGroup(header->objectName());
     header->restoreState(settings.value(geometryC).toByteArray());
+#else
+    Q_UNUSED(header)
 #endif
 }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
