### PR TITLE
Fix: remove failure to import legacy account notification.

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -154,6 +154,8 @@ bool AccountManager::restoreFromLegacySettings()
     // try to open the correctly themed settings
     auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
 
+    auto displayMessageBoxWarning = false;
+
     // if the settings file could not be opened, the childKeys list is empty
     // then try to load settings from a very old place
     if (settings->childKeys().isEmpty()) {
@@ -189,6 +191,7 @@ bool AccountManager::restoreFromLegacySettings()
             const auto accountsListSize = oCSettings->childGroups().size();
             oCSettings->endGroup();
             if (const QFileInfo configFileInfo(configFile); configFileInfo.exists() && configFileInfo.isReadable()) {
+                displayMessageBoxWarning = true;
                 qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
                 if (!forceLegacyImport() && accountsListSize > 0) {
                     const auto importQuestion = accountsListSize > 1
@@ -256,16 +259,19 @@ bool AccountManager::restoreFromLegacySettings()
         for (const auto &accountId : childGroups) {
             settings->beginGroup(accountId);
             if (const auto acc = loadAccountHelper(*settings)) {
-                addAccount(acc);              
+                addAccount(acc);
             }
             settings->endGroup();
         }
         return true;
     }
 
-    QMessageBox::information(nullptr,
-                             tr("Legacy import"),
-                             tr("Could not import accounts from legacy client configuration."));
+    if (displayMessageBoxWarning) {
+        QMessageBox::information(nullptr,
+                                 tr("Legacy import"),
+                                 tr("Could not import accounts from legacy client configuration."));
+    }
+
     return false;
 }
 


### PR DESCRIPTION
- It was being displayed even on a fresh install:

![could-not-import](https://github.com/nextcloud/desktop/assets/241266/0203f124-63a2-4d2a-9518-e861fe9747e2)


- We are already displaying a notification when there are accounts to be imported and we ask the user on what to do.

![import](https://github.com/nextcloud/desktop/assets/241266/5c67df76-77a7-4d58-b1be-142c657f73a9)

fixes #6380 