### PR TITLE
Remove Ubuntu Lunar, add Noble

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -18,7 +18,7 @@ if test "${DRONE_TARGET_BRANCH}" = "stable-2.6"; then
     UBUNTU_DISTRIBUTIONS="bionic focal jammy kinetic"
     DEBIAN_DISTRIBUTIONS="buster stretch testing"
 else
-    UBUNTU_DISTRIBUTIONS="jammy lunar mantic"
+    UBUNTU_DISTRIBUTIONS="jammy mantic noble"
     DEBIAN_DISTRIBUTIONS="bullseye bookworm testing"
 fi
 


### PR DESCRIPTION
This patch removes support for Ubuntu Lunar, which is not supported anymore, and adds Noble, the next release.