### PR TITLE
Bugfix. Random crash in LsColJob after recent changes.

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -423,7 +423,8 @@ bool LsColJob::finished()
 
     this->deleteLater();
 
-    return true;
+    // fix crash on random deletion mess in the parent class, we never discard this job but always delete it inside this method
+    return false;
 }
 
 /*********************************************************************************************/


### PR DESCRIPTION
I caught a random crash caused by my changes in https://github.com/nextcloud/desktop/pull/6336. This needs to be released in RC2 too.
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
