### PR TITLE
suppress deprecated warnings from openssl

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1,3 +1,5 @@
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include "clientsideencryption.h"
 
 #include <openssl/rsa.h>


### PR DESCRIPTION
is needed to avoid failing builds due to warnings

unclear when we will tackle the work of removing the use of deprectaed APIs

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
