### PR TITLE
fix: Nautilus integration conflicts with ownCloud 

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -28,7 +28,7 @@ import time
 
 from gi.repository import GObject, Nautilus
 
-# Note: setappname.sh will search and replace 'ownCloud' on this file to update this line and other
+# Note: setappname.sh will search and replace 'Nextcloud' on this file to update this line and other
 # occurrences of the name
 appname = 'Nextcloud'
 
@@ -175,7 +175,7 @@ class SocketConnect(GObject.GObject):
 socketConnect = SocketConnect()
 
 
-class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
+class MenuExtension_Nextcloud(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
         GObject.GObject.__init__(self)
 
@@ -270,18 +270,18 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
         if len(menu_items) == 0:
             return []
 
-        # Set up the 'ownCloud...' submenu
-        item_owncloud = Nautilus.MenuItem(
+        # Set up the 'Nextcloud...' submenu
+        item_nextcloud = Nautilus.MenuItem(
             name='IntegrationMenu', label=self.strings.get('CONTEXT_MENU_TITLE', appname))
         menu = Nautilus.Menu()
-        item_owncloud.set_submenu(menu)
+        item_nextcloud.set_submenu(menu)
 
         for action, enabled, label in menu_items:
             item = Nautilus.MenuItem(name=action, label=label, sensitive=enabled)
             item.connect("activate", self.context_menu_action, action, filesstring)
             menu.append_item(item)
 
-        return [item_owncloud]
+        return [item_nextcloud]
 
 
     def legacy_menu_items(self, files):
@@ -315,11 +315,11 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
         if not shareable:
             return []
 
-        # Set up the 'ownCloud...' submenu
-        item_owncloud = Nautilus.MenuItem(
+        # Set up the 'Nextcloud...' submenu
+        item_nextcloud = Nautilus.MenuItem(
             name='IntegrationMenu', label=self.strings.get('CONTEXT_MENU_TITLE', appname))
         menu = Nautilus.Menu()
-        item_owncloud.set_submenu(menu)
+        item_nextcloud.set_submenu(menu)
 
         # Add share menu option
         item = Nautilus.MenuItem(
@@ -342,7 +342,7 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
             item_emailprivatelink.connect("activate", self.context_menu_action, 'EMAIL_PRIVATE_LINK', filename)
             menu.append_item(item_emailprivatelink)
 
-        return [item_owncloud]
+        return [item_nextcloud]
 
 
     def context_menu_action(self, menu, action, filename):
@@ -350,7 +350,7 @@ class MenuExtension_ownCloud(GObject.GObject, Nautilus.MenuProvider):
         socketConnect.sendCommand(action + ":" + filename + "\n")
 
 
-class SyncStateExtension_ownCloud(GObject.GObject, Nautilus.InfoProvider):
+class SyncStateExtension_Nextcloud(GObject.GObject, Nautilus.InfoProvider):
     def __init__(self):
         GObject.GObject.__init__(self)
 


### PR DESCRIPTION
Hello,

today I stumbled across issue #3803.

After some testing I found out that the culprit are the two Python classes `MenuExtension_ownCloud` and `SyncStateExtension_ownCloud`. They are defined by the Nextcloud and the ownCloud integration.

If the names are changed to something else, like `MenuExtension_Nextcloud`, then both integrations are working again.

Since you are using the code from the ownCloud integration (https://github.com/owncloud/client-desktop-shell-integration-nautilus), the names of the classes should normally be changed by the `setappname.sh` script. But this name is branded to "Nextcloud" in this repository. This means the "ownCloud" strings in the integration (`syncstate.py`) won't get replaced. So I changed the branding back to "ownCloud" and now the strings are correctly replaced during the Cmake build process.