### PR TITLE
Do not create systray notification if there are no errors.

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -329,7 +329,12 @@ void ConnectionValidator::reportConnected() {
 void ConnectionValidator::reportResult(Status status)
 {
     emit connectionResult(status, _errors);
-    showSystrayErrorMessage();
+
+    // notify user of errors
+    if (!_errors.isEmpty()) {
+       showSystrayErrorMessage();
+    }
+
     deleteLater();
 }
 


### PR DESCRIPTION
I overlooked this in my PR #6405 
I was getting empty systray messages when there was no error.