### PR TITLE
Use 'FindMimeFromData' from Win API instead of QMimeDatabase() functions to get the mimetype. Prevents freeze from VFS placeholders.

### DIFF
--- a/src/gui/caseclashfilenamedialog.cpp
+++ b/src/gui/caseclashfilenamedialog.cpp
@@ -88,7 +88,10 @@ CaseClashFilenameDialog::CaseClashFilenameDialog(AccountPtr account,
 
     _relativeFilePath = filePathFileInfo.path() + QStringLiteral("/");
     _relativeFilePath = _relativeFilePath.replace(folder->path(), QLatin1String());
-    _relativeFilePath = _relativeFilePath.isEmpty() ? QString() : _relativeFilePath + QStringLiteral("/");
+    _relativeFilePath = _relativeFilePath.isEmpty() ? QString() : _relativeFilePath;
+    if (!_relativeFilePath.isEmpty() && !_relativeFilePath.endsWith(QStringLiteral("/"))) {
+        _relativeFilePath += QStringLiteral("/");
+    }
 
     _originalFileName = _relativeFilePath + conflictFileName;
 
@@ -208,7 +211,7 @@ void CaseClashFilenameDialog::updateFileWidgetGroup(const QString &filePath,
     const auto fileSizeString = locale().formattedDataSize(filePathFileInfo.size());
     const auto fileUrl = QUrl::fromLocalFile(filePath).toString();
     const auto linkString = QStringLiteral("<a href='%1'>%2</a>").arg(fileUrl, linkText);
-    const auto mime = QMimeDatabase().mimeTypeForFile(_filePath);
+    const auto mime = QMimeDatabase().mimeTypeForFile(_filePath, QMimeDatabase::MatchExtension);
     QIcon fileTypeIcon;
 
     qCDebug(lcCaseClashConflictFialog) << filePath << filePathFileInfo.exists() << filename << lastModifiedString << fileSizeString << fileUrl << linkString << mime;


### PR DESCRIPTION
Similar, to how we had an issue with `.lnk` files (https://doc.qt.io/qt-6/qfileinfo.html#symbolic-links-and-shortcuts) on Windows with VFS mode on, we now have a freeze when trying to get mime-type for a non-hydrated(online-only) file in CaseClash conflict resolution dialog. This PR switches to using a Windows API-specific function to get the mime-type (same result as with QMimeDatabase() but without causing a freeze on placeholder files).

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
