### PR TITLE
Settings dialog. Nextcloud version label should be visible even if auto-updates are turned off in config.

### DIFF
--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -219,6 +219,19 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
+       <widget class="QLabel" name="infoAndUpdatesLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Desktop client x.x.x</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QFrame" name="updatesContainer">
         <layout class="QVBoxLayout" name="verticalLayout_5">
          <property name="leftMargin">
@@ -233,19 +246,6 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
-          <widget class="QLabel" name="infoAndUpdatesLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Desktop client x.x.x</string>
-           </property>
-          </widget>
-         </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>


### PR DESCRIPTION
### Before (broken):
![settings_dialog_info_broken](https://github.com/nextcloud/desktop/assets/12224014/5380fc36-4e00-4414-b030-bd18d56975a7)
### After (fixed):
![settings_dialog_info_fixed](https://github.com/nextcloud/desktop/assets/12224014/9534374a-082b-414c-9de0-8f1d2a9e999e)
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
