### PR TITLE
Enable eviction of materialised copies of virtual files in File Provider (macOS)

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderItem.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderItem.swift
@@ -32,13 +32,25 @@ class FileProviderItem: NSObject, NSFileProviderItem {
 
     var capabilities: NSFileProviderItemCapabilities {
         guard !metadata.directory else {
-            return [
-                .allowsAddingSubItems,
-                .allowsContentEnumerating,
-                .allowsReading,
-                .allowsDeleting,
-                .allowsRenaming,
-            ]
+            if #available(macOS 13.0, *) {
+                // .allowsEvicting deprecated on macOS 13.0+, use contentPolicy instead
+                return [
+                    .allowsAddingSubItems,
+                    .allowsContentEnumerating,
+                    .allowsReading,
+                    .allowsDeleting,
+                    .allowsRenaming
+                ]
+            } else {
+                return [
+                    .allowsAddingSubItems,
+                    .allowsContentEnumerating,
+                    .allowsReading,
+                    .allowsDeleting,
+                    .allowsRenaming,
+                    .allowsEvicting
+                ]
+            }
         }
         guard !metadata.lock else {
             return [.allowsReading]
@@ -49,6 +61,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
             .allowsDeleting,
             .allowsRenaming,
             .allowsReparenting,
+            .allowsEvicting
         ]
     }
 
@@ -131,6 +144,11 @@ class FileProviderItem: NSObject, NSFileProviderItem {
         } else {
             nil
         }
+    }
+
+    @available(macOSApplicationExtension 13.0, *)
+    var contentPolicy: NSFileProviderContentPolicy {
+        .downloadLazily
     }
 
     required init(

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -55,6 +55,7 @@ public slots:
     void setFastEnumerationEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
 
     void createEvictionWindowForAccount(const QString &userIdAtHost);
+    void refreshMaterialisedItemsForAccount(const QString &userIdAtHost);
     void signalFileProviderDomain(const QString &userIdAtHost);
     void createDebugArchive(const QString &userIdAtHost);
 

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -468,6 +468,12 @@ void FileProviderSettingsController::createEvictionWindowForAccount(const QStrin
     dialog->show();
 }
 
+void FileProviderSettingsController::refreshMaterialisedItemsForAccount(const QString &userIdAtHost)
+{
+    d->enumerateMaterialisedFilesForDomainManager(FileProviderUtils::managerForDomainIdentifier(userIdAtHost),
+                                                  FileProviderUtils::domainForIdentifier(userIdAtHost));
+}
+
 void FileProviderSettingsController::signalFileProviderDomain(const QString &userIdAtHost)
 {
     d->signalFileProviderDomain(userIdAtHost);

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -442,7 +442,8 @@ QAbstractListModel *FileProviderSettingsController::materialisedItemsModelForAcc
     const auto model = new FileProviderMaterialisedItemsModel(this);
     model->setItems(items);
 
-    connect(this, &FileProviderSettingsController::materialisedItemsForAccountChanged, model, [this, model, userIdAtHost](const QString &accountUserIdAtHost) {
+    connect(this, &FileProviderSettingsController::materialisedItemsForAccountChanged,
+            model, [this, model, userIdAtHost](const QString &accountUserIdAtHost) {
         if (accountUserIdAtHost != userIdAtHost) {
             return;
         }
@@ -464,6 +465,8 @@ void FileProviderSettingsController::createEvictionWindowForAccount(const QStrin
             {fpMaterialisedItemsModelProp, QVariant::fromValue(model)},
     });
     const auto dialog = qobject_cast<QQuickWindow *>(genericDialog);
+    QObject::connect(dialog, SIGNAL(reloadMaterialisedItems(QString)),
+                     this, SLOT(refreshMaterialisedItemsForAccount(QString)));
     Q_ASSERT(dialog);
     dialog->show();
 }

--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -33,13 +33,41 @@ ApplicationWindow {
     width: 640
     height: 480
 
-    ListView {
+    ColumnLayout {
         anchors.fill: parent
-        model: root.materialisedItemsModel
-        delegate: FileProviderFileDelegate {
-            width: parent.width
-            height: 60
-            onEvictItem: root.materialisedItemsModel.evictItem(identifier, domainIdentifier)
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.margins: Style.standardSpacing
+
+            EnforcedPlainTextLabel {
+                text: qsTr("Materialised items")
+                font.bold: true
+                font.pointSize: Style.headerFontPtSize
+                Layout.fillWidth: true
+            }
+
+            CustomButton {
+                padding: Style.smallSpacing
+                textColor: Style.ncTextColor
+                textColorHovered: Style.ncHeaderTextColor
+                contentsFont.bold: true
+                bgColor: Style.ncBlue
+                text: qsTr("Reload")
+            }
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            clip: true
+            model: root.materialisedItemsModel
+            delegate: FileProviderFileDelegate {
+                width: parent.width
+                height: 60
+                onEvictItem: root.materialisedItemsModel.evictItem(identifier, domainIdentifier)
+            }
         }
     }
 }

--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -67,6 +67,9 @@ ApplicationWindow {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
+            Layout.leftMargin: Style.standardSpacing
+            Layout.rightMargin: Style.standardSpacing
+
             clip: true
             model: root.materialisedItemsModel
             delegate: FileProviderFileDelegate {

--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -25,6 +25,8 @@ import com.nextcloud.desktopclient 1.0
 ApplicationWindow {
     id: root
 
+    signal reloadMaterialisedItems(string accountUserIdAtHost)
+
     property var materialisedItemsModel: null
     property string accountUserIdAtHost: ""
 
@@ -32,6 +34,8 @@ ApplicationWindow {
     flags: Qt.Dialog | Qt.WindowStaysOnTopHint
     width: 640
     height: 480
+
+    Component.onCompleted: reloadMaterialisedItems(accountUserIdAtHost)
 
     ColumnLayout {
         anchors.fill: parent
@@ -54,6 +58,7 @@ ApplicationWindow {
                 contentsFont.bold: true
                 bgColor: Style.ncBlue
                 text: qsTr("Reload")
+                onClicked: reloadMaterialisedItems(accountUserIdAtHost)
             }
         }
 

--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -31,6 +31,7 @@ ApplicationWindow {
     property string accountUserIdAtHost: ""
 
     title: qsTr("Evict materialised files")
+    color: Style.backgroundColor
     flags: Qt.Dialog | Qt.WindowStaysOnTopHint
     width: 640
     height: 480

--- a/src/gui/macOS/ui/FileProviderFileDelegate.qml
+++ b/src/gui/macOS/ui/FileProviderFileDelegate.qml
@@ -90,11 +90,12 @@ Item {
             id: deleteButton
 
             Layout.minimumWidth: implicitWidth
-            Layout.fillHeight: true
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
 
             text: qsTr("Delete")
+            textColorHovered: Style.ncHeaderTextColor
             bgColor: Style.errorBoxBackgroundColor
+            contentsFont.bold: true
             onClicked: root.evictItem(root.identifier, root.domainIdentifier)
         }
     }

--- a/src/gui/macOS/ui/FileProviderStorageInfo.qml
+++ b/src/gui/macOS/ui/FileProviderStorageInfo.qml
@@ -31,7 +31,7 @@ GridLayout {
     required property real remoteUsedStorage
 
     Layout.fillWidth: true
-    columns: 2
+    columns: 3
 
     EnforcedPlainTextLabel {
         Layout.row: 0
@@ -49,6 +49,14 @@ GridLayout {
         text: qsTr("%1 GB of %2 GB remote files synced").arg(root.localUsedStorage.toFixed(2)).arg(root.remoteUsedStorage.toFixed(2));
         color: Style.ncSecondaryTextColor
         horizontalAlignment: Text.AlignRight
+    }
+
+    CustomButton {
+        Layout.row: 0
+        Layout.column: 2
+        Layout.alignment: Layout.AlignRight | Layout.AlignVCenter
+        text: qsTr("Evict local copies...")
+        onPressed: root.evictDialogRequested()
     }
 
     ProgressBar {

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -10,6 +10,7 @@ QtObject {
 
     // Colors
     readonly property color ncBlue:      Theme.wizardHeaderBackgroundColor
+    readonly property color ncHeaderTextColor: Theme.wizardHeaderTitleColor
     readonly property color ncTextColor: Theme.systemPalette.windowText
     readonly property color ncTextBrightColor: "white"
     readonly property color ncSecondaryTextColor: "#808080"


### PR DESCRIPTION
Adds an "evict local items" button in the storage section of the file provider settings and allows users to remove local copies of items to free up space

<img width="1255" alt="Screenshot 2024-02-20 at 17 09 40" src="https://github.com/nextcloud/desktop/assets/70155116/004fdf99-f35a-4c64-82f4-67584cd78440">


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
