### PR TITLE
Bugfix/expandable folder status model

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -956,8 +956,7 @@ void FolderStatusModel::slotApplySelectiveSync()
 
 void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
 {
-    const auto parent = qobject_cast<QWidget *>(QObject::parent());
-    if (!parent->isVisible()) {
+    if (const auto parent = qobject_cast<QWidget *>(QObject::parent()); !parent || !parent->isVisible()) {
         return; // for https://github.com/owncloud/client/issues/2648#issuecomment-71377909
     }
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -823,7 +823,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     for (const auto undecidedIndex : qAsConst(undecidedIndexes)) {
         emit suggestExpand(index(undecidedIndex, 0, idx));
     }
-    /* Try to remove the the undecided lists the items that are not on the server. */
+    /* Try to remove from the undecided lists the items that are not on the server. */
     auto it = std::remove_if(selectiveSyncUndecidedList.begin(), selectiveSyncUndecidedList.end(),
         [&](const QString &s) { return selectiveSyncUndecidedSet.count(s); });
     if (it != selectiveSyncUndecidedList.end()) {

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -137,23 +137,20 @@ Qt::ItemFlags FolderStatusModel::flags(const QModelIndex &index) const
 
 QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid())
-        return QVariant();
-
-    if (role == Qt::EditRole)
-        return QVariant();
+    if (!index.isValid() || (role == Qt::EditRole))
+        return {};
 
     switch (classify(index)) {
     case AddButton: {
         if (role == FolderStatusDelegate::AddButton) {
-            return QVariant(true);
+            return true;
         } else if (role == Qt::ToolTipRole) {
             if (!_accountState->isConnected()) {
                 return tr("You need to be connected to add a folder");
             }
             return tr("Click this button to add a folder to synchronize.");
         }
-        return QVariant();
+        return {};
     }
     case SubFolder: {
         const auto &subfolderInfo = static_cast<SubFolderInfo *>(index.internalPointer())->_subs.at(index.row());
@@ -174,7 +171,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             if (supportsSelectiveSync) {
                 return subfolderInfo._checked;
             } else {
-                return QVariant();
+                return {};
             }
         case Qt::DecorationRole: {
             if (subfolderInfo._isNonDecryptable && subfolderInfo._checked) {
@@ -216,7 +213,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             }
             break;
         default:
-            return QVariant();
+            return {};
         }
     }
     case RootFolder:
@@ -311,7 +308,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             return tr("Synchronizing with local folder");
         }
     }
-    return QVariant();
+    return {};
 }
 
 bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value, int role)
@@ -865,9 +862,9 @@ QStringList FolderStatusModel::createBlackList(const FolderStatusModel::SubFolde
 {
     switch (root._checked) {
     case Qt::Unchecked:
-        return QStringList(root._path);
+        return {root._path};
     case Qt::Checked:
-        return QStringList();
+        return {};
     case Qt::PartiallyChecked:
         break;
     }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -101,6 +101,14 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
 
     endResetModel();
     emit dirtyChanged();
+
+    // Automatically fetch the subfolders to prevent showing the expansion chevron if there are no subfolders
+    for (auto i = 0; i < _folders.size(); ++i) {
+        const auto idx = index(i);
+        if (canFetchMore(idx)) {
+            fetchMore(idx);
+        }
+    }
 }
 
 

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -845,11 +845,10 @@ void FolderStatusModel::slotLscolFinishedWithError(QNetworkReply *reply)
     if (parentInfo) {
         qCDebug(lcFolderStatus) << reply->errorString();
         parentInfo->_lastErrorString = reply->errorString();
-        auto error = reply->error();
 
         parentInfo->resetSubs(this, idx);
 
-        if (error == QNetworkReply::ContentNotFoundError) {
+        if (reply->error() == QNetworkReply::ContentNotFoundError) {
             parentInfo->_fetched = true;
         } else {
             ASSERT(!parentInfo->hasLabel());

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -688,8 +688,8 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
 {
     const auto job = qobject_cast<LsColJob *>(sender());
     ASSERT(job);
-    const auto idx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
-    const auto parentInfo = infoForIndex(idx);
+    const auto parentIdx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
+    const auto parentInfo = infoForIndex(parentIdx);
     if (!parentInfo) {
         return;
     }
@@ -697,7 +697,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     ASSERT(parentInfo->_subs.isEmpty());
 
     if (parentInfo->hasLabel()) {
-        beginRemoveRows(idx, 0, 0);
+        beginRemoveRows(parentIdx, 0, 0);
         parentInfo->_hasError = false;
         parentInfo->_fetchingLabel = false;
         endRemoveRows();
@@ -819,13 +819,13 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     }
 
     if (!newSubs.isEmpty()) {
-        beginInsertRows(idx, 0, newSubs.size() - 1);
+        beginInsertRows(parentIdx, 0, newSubs.size() - 1);
         parentInfo->_subs = std::move(newSubs);
         endInsertRows();
     }
 
     for (const auto undecidedIndex : qAsConst(undecidedIndexes)) {
-        emit suggestExpand(index(undecidedIndex, 0, idx));
+        emit suggestExpand(index(undecidedIndex, 0, parentIdx));
     }
     /* Try to remove from the undecided lists the items that are not on the server. */
     const auto it = std::remove_if(selectiveSyncUndecidedList.begin(), selectiveSyncUndecidedList.end(),

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -95,7 +95,7 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
     std::sort(_folders.begin(), _folders.end(), sortByFolderHeader);
 
     // Set the root _pathIdx after the sorting
-    for (int i = 0; i < _folders.size(); ++i) {
+    for (auto i = 0; i < _folders.size(); ++i) {
         _folders[i]._pathIdx << i;
     }
 
@@ -115,8 +115,7 @@ Qt::ItemFlags FolderStatusModel::flags(const QModelIndex &index) const
 
     switch (classify(index)) {
     case AddButton: {
-        Qt::ItemFlags ret;
-        ret = Qt::ItemNeverHasChildren;
+        const auto ret = Qt::ItemNeverHasChildren;
         if (!_accountState->isConnected()) {
             return ret;
         }
@@ -224,13 +223,13 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
         break;
     }
 
-    const SubFolderInfo &folderInfo = _folders.at(index.row());
+    const auto folderInfo = _folders.at(index.row());
     const auto folder = folderInfo._folder;
     if (!folder)
         return {};
 
-    const SubFolderInfo::Progress &progress = folderInfo._progress;
-    const bool accountConnected = _accountState->isConnected();
+    const auto progress = folderInfo._progress;
+    const auto accountConnected = _accountState->isConnected();
 
     switch (role) {
     case FolderStatusDelegate::FolderPathRole:
@@ -272,7 +271,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
     }
     case FolderStatusDelegate::FolderStatusIconRole:
         if (accountConnected) {
-            auto theme = Theme::instance();
+            const auto theme = Theme::instance();
             const auto status = folder->syncResult().status();
             if (folder->syncPaused()) {
                 return theme->folderDisabledIcon();
@@ -318,19 +317,19 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
 bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
     if (role == Qt::CheckStateRole) {
-        auto info = infoForIndex(index);
+        const auto info = infoForIndex(index);
         Q_ASSERT(info->_folder && info->_folder->supportsSelectiveSync());
-        auto checked = static_cast<Qt::CheckState>(value.toInt());
+        const auto checked = static_cast<Qt::CheckState>(value.toInt());
 
-        if (info && info->_checked != checked) {
+        if (info->_checked != checked) {
             info->_checked = checked;
             if (checked == Qt::Checked) {
                 // If we are checked, check that we may need to check the parent as well if
                 // all the siblings are also checked
-                QModelIndex parent = index.parent();
-                auto parentInfo = infoForIndex(parent);
+                const auto parent = index.parent();
+                const auto parentInfo = infoForIndex(parent);
                 if (parentInfo && parentInfo->_checked != Qt::Checked) {
-                    bool hasUnchecked = false;
+                    auto hasUnchecked = false;
                     for (const auto &sub : parentInfo->_subs) {
                         if (sub._checked != Qt::Checked) {
                             hasUnchecked = true;
@@ -344,7 +343,7 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
                     }
                 }
                 // also check all the children
-                for (int i = 0; i < info->_subs.count(); ++i) {
+                for (auto i = 0; i < info->_subs.count(); ++i) {
                     if (info->_subs.at(i)._checked != Qt::Checked) {
                         setData(this->index(i, 0, index), Qt::Checked, Qt::CheckStateRole);
                     }
@@ -352,14 +351,14 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
             }
 
             if (checked == Qt::Unchecked) {
-                QModelIndex parent = index.parent();
-                auto parentInfo = infoForIndex(parent);
+                const auto parent = index.parent();
+                const auto parentInfo = infoForIndex(parent);
                 if (parentInfo && parentInfo->_checked == Qt::Checked) {
                     setData(parent, Qt::PartiallyChecked, Qt::CheckStateRole);
                 }
 
                 // Uncheck all the children
-                for (int i = 0; i < info->_subs.count(); ++i) {
+                for (auto i = 0; i < info->_subs.count(); ++i) {
                     if (info->_subs.at(i)._checked != Qt::Unchecked) {
                         setData(this->index(i, 0, index), Qt::Unchecked, Qt::CheckStateRole);
                     }
@@ -367,8 +366,8 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
             }
 
             if (checked == Qt::PartiallyChecked) {
-                QModelIndex parent = index.parent();
-                auto parentInfo = infoForIndex(parent);
+                const auto parent = index.parent();
+                const auto parentInfo = infoForIndex(parent);
                 if (parentInfo && parentInfo->_checked != Qt::PartiallyChecked) {
                     setData(parent, Qt::PartiallyChecked, Qt::CheckStateRole);
                 }
@@ -397,7 +396,7 @@ int FolderStatusModel::rowCount(const QModelIndex &parent) const
         }
         return _folders.count() + 1; // +1 for the "add folder" button
     }
-    auto info = infoForIndex(parent);
+    const auto info = infoForIndex(parent);
     if (!info)
         return 0;
     if (info->hasLabel())
@@ -407,7 +406,7 @@ int FolderStatusModel::rowCount(const QModelIndex &parent) const
 
 FolderStatusModel::ItemType FolderStatusModel::classify(const QModelIndex &index) const
 {
-    if (auto sub = static_cast<SubFolderInfo *>(index.internalPointer())) {
+    if (const auto sub = static_cast<SubFolderInfo *>(index.internalPointer())) {
         if (sub->hasLabel()) {
             return FetchLabel;
         } else {
@@ -424,7 +423,7 @@ FolderStatusModel::SubFolderInfo *FolderStatusModel::infoForIndex(const QModelIn
 {
     if (!index.isValid())
         return nullptr;
-    if (auto parentInfo = static_cast<SubFolderInfo *>(index.internalPointer())) {
+    if (const auto parentInfo = static_cast<SubFolderInfo *>(index.internalPointer())) {
         if (parentInfo->hasLabel()) {
             return nullptr;
         }
@@ -461,17 +460,17 @@ QModelIndex FolderStatusModel::indexForPath(Folder *folder, const QString &path)
         return {};
     }
 
-    int slashPos = path.lastIndexOf('/');
+    const auto slashPos = path.lastIndexOf('/');
     if (slashPos == -1) {
         // first level folder
         for (int i = 0; i < _folders.size(); ++i) {
-            auto &info = _folders.at(i);
+            const auto &info = _folders.at(i);
             if (info._folder == folder) {
                 if (path.isEmpty()) { // the folder object
                     return index(i, 0);
                 }
                 for (int j = 0; j < info._subs.size(); ++j) {
-                    const QString subName = info._subs.at(j)._name;
+                    const auto subName = info._subs.at(j)._name;
                     if (subName == path) {
                         return index(j, 0, index(i));
                     }
@@ -482,7 +481,7 @@ QModelIndex FolderStatusModel::indexForPath(Folder *folder, const QString &path)
         return {};
     }
 
-    auto parent = indexForPath(f, path.left(slashPos));
+    const auto parent = indexForPath(folder, path.left(slashPos));
     if (!parent.isValid())
         return parent;
 
@@ -491,11 +490,11 @@ QModelIndex FolderStatusModel::indexForPath(Folder *folder, const QString &path)
         return parent;
     }
 
-    auto parentInfo = infoForIndex(parent);
+    const auto parentInfo = infoForIndex(parent);
     if (!parentInfo) {
         return {};
     }
-    for (int i = 0; i < parentInfo->_subs.size(); ++i) {
+    for (auto i = 0; i < parentInfo->_subs.size(); ++i) {
         if (parentInfo->_subs.at(i)._name == path.mid(slashPos + 1)) {
             return index(i, 0, parent);
         }
@@ -544,14 +543,14 @@ QModelIndex FolderStatusModel::parent(const QModelIndex &child) const
     case FetchLabel:
         break;
     }
-    auto pathIdx = static_cast<SubFolderInfo *>(child.internalPointer())->_pathIdx;
-    int i = 1;
+    const auto pathIdx = static_cast<SubFolderInfo *>(child.internalPointer())->_pathIdx;
+    auto i = 1;
     ASSERT(pathIdx.at(0) < _folders.count());
     if (pathIdx.count() == 1) {
         return createIndex(pathIdx.at(0), 0 /*, nullptr*/);
     }
 
-    const SubFolderInfo *info = &_folders[pathIdx.at(0)];
+    auto info = &_folders[pathIdx.at(0)];
     while (i < pathIdx.count() - 1) {
         ASSERT(pathIdx.at(i) < info->_subs.count());
         info = &info->_subs.at(pathIdx.at(i));
@@ -565,7 +564,7 @@ bool FolderStatusModel::hasChildren(const QModelIndex &parent) const
     if (!parent.isValid())
         return true;
 
-    auto info = infoForIndex(parent);
+    const auto info = infoForIndex(parent);
     if (!info)
         return false;
 
@@ -587,7 +586,7 @@ bool FolderStatusModel::canFetchMore(const QModelIndex &parent) const
     if (_accountState->state() != AccountState::Connected) {
         return false;
     }
-    auto info = infoForIndex(parent);
+    const auto info = infoForIndex(parent);
     if (!info || info->_fetched || info->_fetchingJob)
         return false;
     if (info->_hasError) {
@@ -600,21 +599,21 @@ bool FolderStatusModel::canFetchMore(const QModelIndex &parent) const
 
 void FolderStatusModel::fetchMore(const QModelIndex &parent)
 {
-    auto info = infoForIndex(parent);
+    const auto info = infoForIndex(parent);
 
     if (!info || info->_fetched || info->_fetchingJob)
         return;
     info->resetSubs(this, parent);
-    QString path = info->_folder->remotePathTrailingSlash();
+    auto path = info->_folder->remotePathTrailingSlash();
 
     // info->_path always contains non-mangled name, so we need to use mangled when requesting nested folders for encrypted subfolders as required by LsColJob
-    const QString infoPath = (info->isEncrypted() && !info->_e2eMangledName.isEmpty()) ? info->_e2eMangledName : info->_path;
+    const auto infoPath = (info->isEncrypted() && !info->_e2eMangledName.isEmpty()) ? info->_e2eMangledName : info->_path;
 
     if (infoPath != QLatin1String("/")) {
         path += infoPath;
     }
 
-    auto *job = new LsColJob(_accountState->account(), path);
+    const auto job = new LsColJob(_accountState->account(), path);
     info->_fetchingJob = job;
     auto props = QList<QByteArray>() << "resourcetype"
                                      << "http://owncloud.org/ns:size"
@@ -647,18 +646,18 @@ void FolderStatusModel::fetchMore(const QModelIndex &parent)
 
 void FolderStatusModel::resetAndFetch(const QModelIndex &parent)
 {
-    auto info = infoForIndex(parent);
+    const auto info = infoForIndex(parent);
     info->resetSubs(this, parent);
     fetchMore(parent);
 }
 
 void FolderStatusModel::slotGatherPermissions(const QString &href, const QMap<QString, QString> &map)
 {
-    auto it = map.find("permissions");
+    const auto it = map.find("permissions");
     if (it == map.end())
         return;
 
-    auto job = sender();
+    const auto job = sender();
     auto permissionMap = job->property(propertyPermissionMap).toMap();
     job->setProperty(propertyPermissionMap, QVariant()); // avoid a detach of the map while it is modified
     ASSERT(!href.endsWith(QLatin1Char('/')), "LsColXMLParser::parse should remove the trailing slash before calling us.");
@@ -668,11 +667,11 @@ void FolderStatusModel::slotGatherPermissions(const QString &href, const QMap<QS
 
 void FolderStatusModel::slotGatherEncryptionStatus(const QString &href, const QMap<QString, QString> &properties)
 {
-    auto it = properties.find("is-encrypted");
+    const auto it = properties.find("is-encrypted");
     if (it == properties.end())
         return;
 
-    auto job = sender();
+    const auto job = sender();
     auto encryptionMap = job->property(propertyEncryptionMap).toMap();
     job->setProperty(propertyEncryptionMap, QVariant()); // avoid a detach of the map while it is modified
     ASSERT(!href.endsWith(QLatin1Char('/')), "LsColXMLParser::parse should remove the trailing slash before calling us.");
@@ -682,10 +681,10 @@ void FolderStatusModel::slotGatherEncryptionStatus(const QString &href, const QM
 
 void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
 {
-    auto job = qobject_cast<LsColJob *>(sender());
+    const auto job = qobject_cast<LsColJob *>(sender());
     ASSERT(job);
-    QModelIndex idx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
-    auto parentInfo = infoForIndex(idx);
+    const auto idx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
+    const auto parentInfo = infoForIndex(idx);
     if (!parentInfo) {
         return;
     }
@@ -703,12 +702,12 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     parentInfo->_fetchingJob = nullptr;
     parentInfo->_fetched = true;
 
-    QUrl url = parentInfo->_folder->remoteUrl();
+    const auto url = parentInfo->_folder->remoteUrl();
     const auto pathToRemove = Utility::trailingSlashPath(url.path());
 
     QStringList selectiveSyncBlackList;
-    bool ok1 = true;
-    bool ok2 = true;
+    auto ok1 = true;
+    auto ok2 = true;
     if (parentInfo->_checked == Qt::PartiallyChecked) {
         selectiveSyncBlackList = parentInfo->_folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok1);
     }
@@ -728,7 +727,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     const auto permissionMap = job->property(propertyPermissionMap).toMap();
     const auto encryptionMap = job->property(propertyEncryptionMap).toMap();
 
-    QStringList sortedSubfolders = list;
+    auto sortedSubfolders = list;
     if (!sortedSubfolders.isEmpty())
         sortedSubfolders.removeFirst(); // skip the parent item (first in the list)
     Utility::sortFilenames(sortedSubfolders);
@@ -752,7 +751,8 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
         newInfo._path = relativePath;
 
         newInfo._isNonDecryptable = newInfo.isEncrypted()
-            && _accountState->account()->e2e() && !_accountState->account()->e2e()->_publicKey.isNull()
+            && _accountState->account()->e2e()
+            && !_accountState->account()->e2e()->_publicKey.isNull()
             && _accountState->account()->e2e()->_privateKey.isNull();
 
         SyncJournalFileRecord rec;
@@ -774,7 +774,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
             newInfo._name = removeTrailingSlash(relativePath).split('/').last();
         }
 
-        const auto& folderInfo = job->_folderInfos.value(path);
+        const auto &folderInfo = job->_folderInfos.value(path);
         newInfo._size = folderInfo.size;
         newInfo._fileId = folderInfo.fileId;
         if (relativePath.isEmpty())
@@ -804,7 +804,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
                 undecidedIndexes.append(newInfo._pathIdx.last());
 
                 // Remove all the items from the selectiveSyncUndecidedSet that starts with this path
-                QString relativePathNext = relativePath;
+                auto relativePathNext = relativePath;
                 relativePathNext[relativePathNext.length() - 1].unicode()++;
                 auto it2 = selectiveSyncUndecidedSet.lower_bound(relativePathNext);
                 selectiveSyncUndecidedSet.erase(it, it2);
@@ -823,7 +823,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
         emit suggestExpand(index(undecidedIndex, 0, idx));
     }
     /* Try to remove from the undecided lists the items that are not on the server. */
-    auto it = std::remove_if(selectiveSyncUndecidedList.begin(), selectiveSyncUndecidedList.end(),
+    const auto it = std::remove_if(selectiveSyncUndecidedList.begin(), selectiveSyncUndecidedList.end(),
         [&](const QString &s) { return selectiveSyncUndecidedSet.count(s); });
     if (it != selectiveSyncUndecidedList.end()) {
         selectiveSyncUndecidedList.erase(it, selectiveSyncUndecidedList.end());
@@ -835,9 +835,9 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
 
 void FolderStatusModel::slotLscolFinishedWithError(QNetworkReply *reply)
 {
-    auto job = qobject_cast<LsColJob *>(sender());
+    const auto job = qobject_cast<LsColJob *>(sender());
     ASSERT(job);
-    QModelIndex idx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
+    const auto idx = qvariant_cast<QPersistentModelIndex>(job->property(propertyParentIndexC));
     if (!idx.isValid()) {
         return;
     }
@@ -874,12 +874,12 @@ QStringList FolderStatusModel::createBlackList(const FolderStatusModel::SubFolde
 
     QStringList result;
     if (root._fetched) {
-        for (int i = 0; i < root._subs.count(); ++i) {
+        for (auto i = 0; i < root._subs.count(); ++i) {
             result += createBlackList(root._subs.at(i), oldBlackList);
         }
     } else {
         // We did not load from the server so we reuse the one from the old black list
-        const QString path = root._path;
+        const auto path = root._path;
         for (const auto &it : oldBlackList) {
             if (it.startsWith(path))
                 result += it;
@@ -892,7 +892,7 @@ void FolderStatusModel::slotUpdateFolderState(Folder *folder)
 {
     if (!folder)
         return;
-    for (int i = 0; i < _folders.count(); ++i) {
+    for (auto i = 0; i < _folders.count(); ++i) {
         if (_folders.at(i)._folder == folder) {
             emit dataChanged(index(i), index(i));
         }
@@ -908,13 +908,13 @@ void FolderStatusModel::slotApplySelectiveSync()
         }
         const auto folder = folderInfo._folder;
 
-        bool ok = false;
+        auto ok = false;
         auto oldBlackList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
         if (!ok) {
             qCWarning(lcFolderStatus) << "Could not read selective sync list from db.";
             continue;
         }
-        QStringList blackList = createBlackList(folderInfo, oldBlackList);
+        const auto blackList = createBlackList(folderInfo, oldBlackList);
         folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, blackList);
 
         auto blackListSet = blackList.toSet();
@@ -922,7 +922,7 @@ void FolderStatusModel::slotApplySelectiveSync()
 
         // The folders that were undecided or blacklisted and that are now checked should go on the white list.
         // The user confirmed them already just now.
-        QStringList toAddToWhiteList = ((oldBlackListSet + folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok).toSet()) - blackListSet).values();
+        const auto toAddToWhiteList = ((oldBlackListSet + folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok).toSet()) - blackListSet).values();
 
         if (!toAddToWhiteList.isEmpty()) {
             auto whiteList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncWhiteList, &ok);
@@ -1014,7 +1014,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
 
     // find the single item to display:  This is going to be the bigger item, or the last completed
     // item if no items are in progress.
-    SyncFileItem curItem = progress._lastCompletedItem;
+    auto curItem = progress._lastCompletedItem;
     qint64 curItemProgress = -1; // -1 means finished
     qint64 biggerItemSize = 0;
     quint64 estimatedUpBw = 0;
@@ -1045,13 +1045,13 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
         curItemProgress = curItem._size;
     }
 
-    QString itemFileName = curItem._file;
-    QString kindString = Progress::asActionString(curItem);
+    const auto itemFileName = curItem._file;
+    const auto kindString = Progress::asActionString(curItem);
 
     QString fileProgressString;
     if (ProgressInfo::isSizeDependent(curItem)) {
-        QString s1 = Utility::octetsToString(curItemProgress);
-        QString s2 = Utility::octetsToString(curItem._size);
+        const auto s1 = Utility::octetsToString(curItemProgress);
+        const auto s2 = Utility::octetsToString(curItem._size);
         //quint64 estimatedBw = progress.fileProgress(curItem).estimatedBandwidth;
         if (estimatedUpBw || estimatedDownBw) {
             /*
@@ -1095,15 +1095,15 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
     pi->_progressString = fileProgressString;
 
     // overall progress
-    qint64 completedSize = progress.completedSize();
-    qint64 completedFile = progress.completedFiles();
-    qint64 currentFile = progress.currentFile();
-    qint64 totalSize = qMax(completedSize, progress.totalSize());
-    qint64 totalFileCount = qMax(currentFile, progress.totalFiles());
+    const auto completedSize = progress.completedSize();
+    const auto completedFile = progress.completedFiles();
+    const auto currentFile = progress.currentFile();
+    const auto totalSize = qMax(completedSize, progress.totalSize());
+    const auto totalFileCount = qMax(currentFile, progress.totalFiles());
     QString overallSyncString;
     if (totalSize > 0) {
-        QString s1 = Utility::octetsToString(completedSize);
-        QString s2 = Utility::octetsToString(totalSize);
+        const auto s1 = Utility::octetsToString(completedSize);
+        const auto s2 = Utility::octetsToString(totalSize);
 
         const auto estimatedEta = progress.totalProgress().estimatedEta;
 
@@ -1137,7 +1137,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
 
     pi->_overallSyncString = overallSyncString;
 
-    int overallPercent = 0;
+    auto overallPercent = 0;
     if (totalFileCount > 0) {
         // Add one 'byte' for each file so the percentage is moving when deleting or renaming files
         overallPercent = qRound(double(completedSize + completedFile) / double(totalSize + totalFileCount) * 100.0);
@@ -1179,18 +1179,13 @@ void FolderStatusModel::slotFolderSyncStateChange(Folder *folder)
         // Reset progress info.
         pi = SubFolderInfo::Progress();
     } else if (state == SyncResult::NotYetStarted) {
-        FolderMan *folderMan = FolderMan::instance();
-        int pos = folderMan->scheduleQueue().indexOf(folder);
+        const auto folderMan = FolderMan::instance();
+        auto pos = folderMan->scheduleQueue().indexOf(folder);
         for (auto other : folderMan->map()) {
             if (other != folder && other->isSyncRunning())
                 pos += 1;
         }
-        QString message;
-        if (pos <= 0) {
-            message = tr("Waiting …");
-        } else {
-            message = tr("Waiting for %n other folder(s) …", "", pos);
-        }
+        const auto message = pos <= 0 ? tr("Waiting …") : tr("Waiting for %n other folder(s) …", "", pos);
         pi = SubFolderInfo::Progress();
         pi._overallSyncString = message;
     } else if (state == SyncResult::SyncPrepare) {
@@ -1223,14 +1218,14 @@ void FolderStatusModel::resetFolders()
 
 void FolderStatusModel::slotSyncAllPendingBigFolders()
 {
-    for (int i = 0; i < _folders.count(); ++i) {
+    for (auto i = 0; i < _folders.count(); ++i) {
         if (!_folders[i]._fetched) {
             _folders[i]._folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, QStringList());
             continue;
         }
         auto folder = _folders.at(i)._folder;
 
-        bool ok = false;
+        auto ok = false;
         auto undecidedList = folder->journalDb()->getSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, &ok);
         if (!ok) {
             qCWarning(lcFolderStatus) << "Could not read selective sync list from db.";
@@ -1283,8 +1278,8 @@ void FolderStatusModel::slotSyncAllPendingBigFolders()
 
 void FolderStatusModel::slotSyncNoPendingBigFolders()
 {
-    for (int i = 0; i < _folders.count(); ++i) {
-        auto folder = _folders.at(i)._folder;
+    for (auto i = 0; i < _folders.count(); ++i) {
+        const auto folder = _folders.at(i)._folder;
 
         // clear the undecided list
         folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncUndecidedList, QStringList());
@@ -1298,8 +1293,8 @@ void FolderStatusModel::slotNewBigFolder()
     const auto folder = qobject_cast<Folder *>(sender());
     ASSERT(folder);
 
-    int folderIndex = -1;
-    for (int i = 0; i < _folders.count(); ++i) {
+    auto folderIndex = -1;
+    for (auto i = 0; i < _folders.count(); ++i) {
         if (_folders.at(i)._folder == folder) {
             folderIndex = i;
             break;
@@ -1321,10 +1316,10 @@ void FolderStatusModel::slotShowFetchProgress()
     while (it.hasNext()) {
         it.next();
         if (it.value().elapsed() > 800) {
-            auto idx = it.key();
-            auto *info = infoForIndex(idx);
+            const auto idx = it.key();
+            const auto info = infoForIndex(idx);
             if (info && info->_fetchingJob) {
-                bool add = !info->hasLabel();
+                const auto add = !info->hasLabel();
                 if (add) {
                     beginInsertRows(idx, 0, 0);
                 }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -200,13 +200,15 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             break;
         case FileIdRole:
             return subfolderInfo._fileId;
-        case FolderStatusDelegate::FolderPathRole: {
+        case FolderStatusDelegate::FolderPathRole:
+        {
             if (const auto folder = subfolderInfo._folder) {
                 return {folder->path() + subfolderInfo._path};
             }
             return {};
         }
         }
+        return {};
     }
     case FetchLabel: {
         const auto folderInfo = static_cast<SubFolderInfo *>(index.internalPointer());


### PR DESCRIPTION
Two things in this PR:

1. Code cleanup in general across `FolderStatusModel`
2. Fetch the first level of folders from root, fixing "fake" expandable folders

Fixes following bug:


https://github.com/nextcloud/desktop/assets/70155116/2c1868be-3c12-4982-a072-ec8d666746c8



<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
