### PR TITLE
Bugfix. Federated share activity show 'Decline' action button.

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -883,7 +883,9 @@ QVariantList ActivityListModel::convertLinksToActionButtons(const Activity &acti
 
         // Use the isDismissable model role to present custom dismiss button if needed
         // Also don't show "View chat" for talk activities, default action will open chat anyway
-        if (activityLink._verb == "DELETE" || (activityLink._verb == "WEB" && activity._objectType == "chat")) {
+        const auto isUseCustomDeleteAction = activityLink._verb == "DELETE"
+            && activity._objectType != QStringLiteral("remote_share");
+        if (isUseCustomDeleteAction || (activityLink._verb == "WEB" && activity._objectType == "chat")) {
             continue;
         }
 

--- a/test/activitylistmodeltestutils.cpp
+++ b/test/activitylistmodeltestutils.cpp
@@ -403,6 +403,41 @@ void FakeRemoteActivityStorage::initActivityData()
 
         _startingId++;
     }
+
+    for (quint32 i = 0; i < _numItemsToInsert; i++) {
+        QJsonObject activity;
+        activity.insert(QStringLiteral("activity_id"), _startingId);
+        activity.insert(QStringLiteral("object_type"), "remote_share");
+        activity.insert(QStringLiteral("subject"), QStringLiteral("You received document.docx as a remote share from admin@https://example.de"));
+        activity.insert(QStringLiteral("subjectRich"), QStringLiteral("You received {share} as a remote share from {user}"));
+        activity.insert(QStringLiteral("message"), QStringLiteral(""));
+        activity.insert(QStringLiteral("object_name"), QStringLiteral(""));
+        activity.insert(QStringLiteral("datetime"), QDateTime::currentDateTime().toString(Qt::ISODate));
+        activity.insert(QStringLiteral("icon"), QStringLiteral("http://example.de/core/img/actions/share.svg"));
+
+        QJsonArray actionsArray;
+
+        QJsonObject primaryAction;
+        primaryAction.insert(QStringLiteral("label"), QStringLiteral("Accept"));
+        primaryAction.insert(QStringLiteral("link"), QStringLiteral("/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/6"));
+        primaryAction.insert(QStringLiteral("type"), QStringLiteral("POST"));
+        primaryAction.insert(QStringLiteral("primary"), true);
+        actionsArray.push_back(primaryAction);
+
+        QJsonObject secondaryAction;
+        secondaryAction.insert(QStringLiteral("label"), QStringLiteral("Decline"));
+        secondaryAction.insert(QStringLiteral("link"), QString(QStringLiteral("/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/6")));
+        secondaryAction.insert(QStringLiteral("type"), QStringLiteral("DELETE"));
+        secondaryAction.insert(QStringLiteral("primary"), false);
+        actionsArray.push_back(secondaryAction);
+
+        activity.insert(QStringLiteral("actions"), actionsArray);
+
+        _activityData.push_back(activity);
+
+        _startingId++;
+    }
+
     _startingId--;
 }
 

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -297,6 +297,14 @@ private slots:
                         QVERIFY(actionsLinksContextMenu.isEmpty());
                     }
 
+                    // remote shares must have 'Accept' and 'Decline' actions
+                    if (objectType == QStringLiteral("remote_share")) {
+                        QVERIFY(actionsLinks.size() == 2);
+                        QVERIFY(actionsLinks[0].value<OCC::ActivityLink>()._primary);
+                        QVERIFY(actionsLinks[0].value<OCC::ActivityLink>()._verb == QStringLiteral("POST"));
+                        QVERIFY(actionsLinks[1].value<OCC::ActivityLink>()._verb == QStringLiteral("DELETE"));
+                    }
+
                     if ((objectType == QStringLiteral("chat") || objectType == QStringLiteral("call")
                             || objectType == QStringLiteral("room"))) {
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
