### PR TITLE
Bugfix. Exclude list. Fix stuck 'excluded' status in Windows Explorer after removing the exclude pattern.

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -450,6 +450,7 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
         return;
     } else if (item->_instruction == CSYNC_INSTRUCTION_NONE) {
         _hasNoneFiles = true;
+        _syncFileStatusTracker->slotCheckAndRemoveSilentlyExcluded(item->_file);
         if (_account->capabilities().uploadConflictFiles() && Utility::isConflictFile(item->_file)) {
             // For uploaded conflict files, files with no action performed on them should
             // be displayed: but we mustn't overwrite the instruction if something happens

--- a/src/libsync/syncfilestatustracker.cpp
+++ b/src/libsync/syncfilestatustracker.cpp
@@ -172,7 +172,17 @@ void SyncFileStatusTracker::slotPathTouched(const QString &fileName)
 void SyncFileStatusTracker::slotAddSilentlyExcluded(const QString &folderPath)
 {
     _syncProblems[folderPath] = SyncFileStatus::StatusExcluded;
+    _syncSilentExcludes[folderPath] = SyncFileStatus::StatusExcluded;
     emit fileStatusChanged(getSystemDestination(folderPath), resolveSyncAndErrorStatus(folderPath, NotShared));
+}
+
+void SyncFileStatusTracker::slotCheckAndRemoveSilentlyExcluded(const QString &folderPath)
+{
+    const auto foundIt = _syncSilentExcludes.find(folderPath);
+    if (foundIt != _syncSilentExcludes.end()) {
+        _syncSilentExcludes.erase(foundIt);
+        emit fileStatusChanged(getSystemDestination(folderPath), SyncFileStatus::StatusUpToDate);
+    }
 }
 
 void SyncFileStatusTracker::incSyncCountAndEmitStatusChanged(const QString &relativePath, SharedFlag sharedFlag)
@@ -231,9 +241,11 @@ void SyncFileStatusTracker::slotAboutToPropagate(SyncFileItemVector &items)
 
         if (hasErrorStatus(*item)) {
             _syncProblems[item->destination()] = SyncFileStatus::StatusError;
+            _syncSilentExcludes.erase(item->destination());
             invalidateParentPaths(item->destination());
         } else if (hasExcludedStatus(*item)) {
             _syncProblems[item->destination()] = SyncFileStatus::StatusExcluded;
+            _syncSilentExcludes.erase(item->destination());
         }
 
         SharedFlag sharedFlag = item->_remotePerm.hasPermission(RemotePermissions::IsShared) ? Shared : NotShared;
@@ -281,6 +293,7 @@ void SyncFileStatusTracker::slotItemCompleted(const SyncFileItemPtr &item)
     } else {
         _syncProblems.erase(item->destination());
     }
+    _syncSilentExcludes.erase(item->destination());
 
     SharedFlag sharedFlag = item->_remotePerm.hasPermission(RemotePermissions::IsShared) ? Shared : NotShared;
     if (item->_instruction != CSYNC_INSTRUCTION_NONE

--- a/src/libsync/syncfilestatustracker.h
+++ b/src/libsync/syncfilestatustracker.h
@@ -42,6 +42,7 @@ public slots:
     void slotPathTouched(const QString &fileName);
     // path relative to folder
     void slotAddSilentlyExcluded(const QString &folderPath);
+    void slotCheckAndRemoveSilentlyExcluded(const QString &folderPath);
 
 signals:
     void fileStatusChanged(const QString &systemFileName, OCC::SyncFileStatus fileStatus);
@@ -74,6 +75,7 @@ private:
     SyncEngine *_syncEngine;
 
     ProblemsMap _syncProblems;
+    ProblemsMap _syncSilentExcludes;
     QSet<QString> _dirtyPaths;
     // Counts the number direct children currently being synced (has unfinished propagation jobs).
     // We'll show a file/directory as SYNC as long as its sync count is > 0.


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
