### PR TITLE
use a longer maximum timeout during chunk uploads

### DIFF
--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -718,14 +718,12 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
 
 void PropagateUploadFileCommon::adjustLastJobTimeout(AbstractNetworkJob *job, qint64 fileSize)
 {
+    constexpr auto maximumTimeout = qint64(120 * 60 * 1000);
     constexpr double threeMinutes = 3.0 * 60 * 1000;
 
-    job->setTimeout(qBound(
-        job->timeoutMsec(),
-        // Calculate 3 minutes for each gigabyte of data
-        qRound64(threeMinutes * fileSize / 1e9),
-        // Maximum of 30 minutes
-        static_cast<qint64>(30 * 60 * 1000)));
+    job->setTimeout(qBound(job->timeoutMsec(),
+                           qRound64(threeMinutes * fileSize / 1e9) /*Calculate 3 minutes for each gigabyte of data*/,
+                           maximumTimeout));
 }
 
 void PropagateUploadFileCommon::slotJobDestroyed(QObject *job)


### PR DESCRIPTION
Close #5394

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
