### PR TITLE
User 'Connection issue' instead of 'Network error' in systray notification

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -341,7 +341,7 @@ void ConnectionValidator::reportResult(Status status)
 
 void ConnectionValidator::showSystrayErrorMessage()
 {
-    Systray::instance()->showMessage(tr("Network Error"),
+    Systray::instance()->showMessage(tr("Connection issue"),
                                      _errors.join("<br>"),
                                      QSystemTrayIcon::Warning);
 }


### PR DESCRIPTION
Addressing @jancborchardt's https://github.com/nextcloud/server/pull/43281#pullrequestreview-1905819693 comment.