### PR TITLE
[socketapi] Replace QClipboard with KSystemClipboard when available

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(gui)
 find_package(Qt5 REQUIRED COMPONENTS Widgets Svg Qml Quick QuickControls2 QuickWidgets Xml Network)
 find_package(KF5Archive REQUIRED)
+find_package(KF5GuiAddons)
 
 if(QUICK_COMPILER)
         find_package(Qt5QuickCompiler)
@@ -562,6 +563,14 @@ target_link_libraries(nextcloudCore
   Qt5::QuickWidgets
   KF5::Archive
   )
+
+if(KF5GuiAddons_FOUND)
+  target_link_libraries(nextcloudCore
+    PUBLIC
+    KF5::GuiAddons
+  )
+  add_definitions(-DHAVE_KGUIADDONS)
+endif()
 
 add_subdirectory(socketapi)
 

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -67,7 +67,6 @@
 #include <QJsonObject>
 #include <QWidget>
 
-#include <QClipboard>
 #include <QDesktopServices>
 
 #include <QProcess>
@@ -77,6 +76,12 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+#ifdef HAVE_KGUIADDONS
+#include <QMimeData>
+#include <KSystemClipboard>
+#else
+#include <QClipboard>
+#endif
 
 // This is the version that is returned when the client asks for the VERSION.
 // The first number should be changed if there is an incompatible change that breaks old clients.
@@ -193,6 +198,17 @@ static QString buildMessage(const QString &verb, const QString &path, const QStr
         msg.append(QDir::toNativeSeparators(fi.absoluteFilePath()));
     }
     return msg;
+}
+
+void setClipboardText(const QString &text)
+{
+#ifdef HAVE_KGUIADDONS
+    auto mimeData = new QMimeData();
+    mimeData->setText(text);
+    KSystemClipboard::instance()->setMimeData(mimeData, QClipboard::Clipboard);
+#else
+    QApplication::clipboard()->setText(text);
+#endif
 }
 }
 
@@ -902,7 +918,7 @@ void SocketApi::command_COPY_PUBLIC_LINK(const QString &localFile, SocketListene
 #ifdef Q_OS_WIN
 void SocketApi::command_COPYASPATH(const QString &localFile, SocketListener *)
 {
-    QApplication::clipboard()->setText(localFile);
+    setClipboardText(localFile);
 }
 
 void SocketApi::command_OPENNEWWINDOW(const QString &localFile, SocketListener *)
@@ -995,7 +1011,7 @@ void SocketApi::command_MAKE_ONLINE_ONLY(const QString &filesArg, SocketListener
 
 void SocketApi::copyUrlToClipboard(const QString &link)
 {
-    QApplication::clipboard()->setText(link);
+    setClipboardText(link);
 }
 
 void SocketApi::command_RESOLVE_CONFLICT(const QString &localFile, SocketListener *)


### PR DESCRIPTION
This is necessary in Wayland sessions for the clipboard related actions of the socketapi to work. Indeed, QClipboard does its job only if we got a window with the focus in such session.

In the case of the socketapi, it is generally the file manager asking the desktop client to put something in the clipboard. At this point in time no window of the client have the focus, so nothing gets added to the clipboard.

KSystemClipboard on the other hand, uses the wlr data control protocol under wayland sessions ensuring something ends up in the clipboard as expected. When not in a wayland session it falls back to QClipboard so no behavior is lost.
