### PR TITLE
Add typical Syncthing files to default exclusion

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -42,6 +42,11 @@ System Volume Information
 *.unison
 .nfs*
 
+# (default) metadata files created by Syncthing
+.stfolder
+.stignore
+.stversions
+
 My Saved Places.
 
 \#*#


### PR DESCRIPTION
For increasing default interoperability between Syncthing & Nextcloud if users may want to sync a (sub-)directory with both tools without thinking about that those hidden files synced by Nextcloud might break Syncthing.

I want to propose this change:
- because I think it should typically increases the "just works" interoperability between Nextcloud Desktop & Syncthing if they are working on the same directory
- because I saw no other issue / PR which already did propose the same

If you think this change is too problematic or have some other reason, feel free to reject.

### For context

[Syncthing](https://syncthing.net/) is another file synchronization client. However, it is based on peer-to-peer connections in a cluster of devices than on syncing everything with a central server. Hence I think there are non-niche use cases where it makes sense to use both together (e.g. Nextcloud allows me fast access to (just some of) my files from everywhere & allows easy sharing those in any granularity; Syncthing allows syncing a directory from/to Android, requires no dedicated server & can utilize local connections).

Syncthing uses these three directories/files as follows:
- `.stfolder`: empty directory, used to determine that this directory is part of a Syncthing folder synchronization
  - syncing this dir via Nextcloud to another device may hinder a Syncthing client in adding this directory as sync folder
  - Syncthing also stops syncing a folder if this dir is missing, e.g. when this is on a an external drive which is currently not mounted
- `.stignore`: ignore file for local Syncthing client
  - could be useful for in usecases if Nextcloud syncs this
  - Syncthing does not sync this file because it is meant to be local only
  - and for Syncthing users [there are workarounds available](https://forum.syncthing.net/t/syncronize-stignore-file/557) so that its content can still be synced, which should also be helpful for Nextcloud
- `.stversions`: if enabled, Syncthing stores old versions of files here (on incoming change or deletion)
  - same concept as `.stignore`, not synced because it is meant to be local only
  - depending on use case, it can be useful to sync this dir
  - however, IMO its the better default to not intervene into Syncthings procedures
    - e.g. letting other cloud users delete data from that directory
    - or keeping files uploaded which the user thinks was deleted
  - because if users really want to sync this directory, they can exclude it for those cases

### TODO for me:

- [x] Sign-Off Commit
- [ ] Build client & test if default excludes are correctly applied