### PR TITLE
E2EE. Fix root metadata fetching path for non-root remote sync folder. Refactoring. Stabilizing paths.

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -681,6 +681,12 @@ bool Utility::isCaseClashConflictFile(const QString &name)
     return bname.contains(QStringLiteral("(case clash from"));
 }
 
+QString Utility::leadingSlashPath(const QString &path)
+{
+    static const auto slash = QLatin1Char('/');
+    return !path.startsWith(slash) ? QString(slash + path) : path;
+}
+
 QString Utility::trailingSlashPath(const QString &path)
 {
     static const auto slash = QLatin1Char('/');
@@ -690,13 +696,13 @@ QString Utility::trailingSlashPath(const QString &path)
 QString Utility::noLeadingSlashPath(const QString &path)
 {
     static const auto slash = QLatin1Char('/');
-    return path.startsWith(slash) ? path.mid(1) : path;
+    return path.size() > 1 && path.startsWith(slash) ? path.mid(1) : path;
 }
 
 QString Utility::noTrailingSlashPath(const QString &path)
 {
     static const auto slash = QLatin1Char('/');
-    return path.endsWith(slash) ? path.chopped(1) : path;
+    return path.size() > 1 && path.endsWith(slash) ? path.chopped(1) : path;
 }
 
 QString Utility::fullRemotePathToRemoteSyncRootRelative(const QString &fullRemotePath, const QString &remoteSyncRoot)

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -266,7 +266,8 @@ namespace Utility {
      * @brief Registers the desktop app as a handler for a custom URI to enable local editing
      */
     OCSYNC_EXPORT void registerUriHandlerForLocalEditing();
-
+    
+    OCSYNC_EXPORT QString leadingSlashPath(const QString &path);
     OCSYNC_EXPORT QString trailingSlashPath(const QString &path);
     OCSYNC_EXPORT QString noLeadingSlashPath(const QString &path);
     OCSYNC_EXPORT QString noTrailingSlashPath(const QString &path);

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -857,6 +857,9 @@ void ShareModel::slotDeleteE2EeShare(const SharePtr &share) const
         return;
     }
 
+    Q_ASSERT(folder->remotePath() == QStringLiteral("/")
+             || Utility::noLeadingSlashPath(share->path()).startsWith(Utility::noLeadingSlashPath(Utility::noTrailingSlashPath(folder->remotePath()))));
+
     const auto removeE2eeShareJob = new UpdateE2eeFolderUsersMetadataJob(account,
                                                                          folder->journalDb(),
                                                                          folder->remotePath(),

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1537,7 +1537,7 @@ void FolderMan::leaveShare(const QString &localFile)
 {
     const auto localFileNoTrailingSlash = localFile.endsWith('/') ? localFile.chopped(1) : localFile;
     if (const auto folder = FolderMan::instance()->folderForPath(localFileNoTrailingSlash)) {
-        const auto filePathRelative = QString(localFileNoTrailingSlash).remove(folder->path());
+        const auto filePathRelative = Utility::noLeadingSlashPath(QString(localFileNoTrailingSlash).remove(folder->path()));
 
         SyncJournalFileRecord rec;
         if (folder->journalDb()->getFileRecord(filePathRelative, &rec)
@@ -1551,8 +1551,7 @@ void FolderMan::leaveShare(const QString &localFile)
                                                                                  folder->journalDb(),
                                                                                  folder->remotePath(),
                                                                                  UpdateE2eeFolderUsersMetadataJob::Remove,
-                //TODO: Might need to add a slash to "filePathRelative" once the server is working
-                                                                                 filePathRelative,
+                                                                                 folder->remotePathTrailingSlash() + filePathRelative,
                                                                                  folder->accountState()->account()->davUser());
             _removeE2eeShareJob->setParent(this);
             _removeE2eeShareJob->start(true);

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -488,7 +488,7 @@ void ShareManager::createShare(const QString &path,
     job->getSharedWithMe();
 }
 
-void ShareManager::createE2EeShareJob(const QString &path,
+void ShareManager::createE2EeShareJob(const QString &fullRemotePath,
                                       const ShareePtr sharee,
                                       const Share::Permissions permissions,
                                       const QString &password)
@@ -506,11 +506,14 @@ void ShareManager::createE2EeShareJob(const QString &path,
         return;
     }
 
+    Q_ASSERT(folder->remotePath() == QStringLiteral("/") ||
+        Utility::noLeadingSlashPath(fullRemotePath).startsWith(Utility::noLeadingSlashPath(Utility::noTrailingSlashPath(folder->remotePath()))));
+
     const auto createE2eeShareJob = new UpdateE2eeFolderUsersMetadataJob(_account,
                                                                          folder->journalDb(),
                                                                          folder->remotePath(),
                                                                          UpdateE2eeFolderUsersMetadataJob::Add,
-                                                                         path,
+                                                                         fullRemotePath,
                                                                          sharee->shareWith(),
                                                                          QSslCertificate{},
                                                                          this);

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -416,7 +416,7 @@ public:
         /**
      * Tell the manager to create and start new UpdateE2eeShareMetadataJob job
      *
-     * @param path The path of the share relative to the user folder on the server
+     * @param fullRemotePath The path of the share relative to the user folder on the server
      * @param shareType The type of share (TypeUser, TypeGroup, TypeRemote)
      * @param Permissions The share permissions
      * @param folderId The id for an E2EE folder
@@ -425,7 +425,7 @@ public:
      * On success the signal shareCreated is emitted
      * In case of a server error the serverError signal is emitted
      */
-    void createE2EeShareJob(const QString &path,
+    void createE2EeShareJob(const QString &fullRemotePath,
                             const ShareePtr sharee,
                             const Share::Permissions permissions,
                             const QString &password = "");

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -550,13 +550,7 @@ void SocketApi::processEncryptRequest(const QString &localFile)
     auto path = rec._path;
     // Folder records have directory paths in Foo/Bar/ convention...
     // But EncryptFolderJob expects directory path Foo/Bar convention
-    auto choppedPath = path;
-    if (choppedPath.endsWith('/') && choppedPath != QStringLiteral("/")) {
-        choppedPath.chop(1);
-    }
-    if (choppedPath.startsWith('/') && choppedPath != QStringLiteral("/")) {
-        choppedPath = choppedPath.mid(1);
-    }
+    const auto choppedPath = Utility::noTrailingSlashPath(Utility::noLeadingSlashPath(path));
 
     auto job = new OCC::EncryptFolderJob(account, folder->journalDb(), choppedPath, choppedPath, folder->remotePath(), rec.numericFileId());
     job->setParent(this);

--- a/src/libsync/basepropagateremotedeleteencrypted.cpp
+++ b/src/libsync/basepropagateremotedeleteencrypted.cpp
@@ -57,17 +57,17 @@ void BasePropagateRemoteDeleteEncrypted::storeFirstErrorString(const QString &er
 
 void BasePropagateRemoteDeleteEncrypted::fetchMetadataForPath(const QString &path)
 {
-    qCDebug(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED) << "Folder is encrypted, let's its metadata.";
-    _fullFolderRemotePath = _propagator->fullRemotePath(path);
-
+    qCDebug(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED) << "Folder is encrypted, let's fetch its metadata.";
+ 
     SyncJournalFileRecord rec;
-    if (!_propagator->_journal->getRootE2eFolderRecord(Utility::fullRemotePathToRemoteSyncRootRelative(_fullFolderRemotePath, _propagator->remotePath()), &rec) || !rec.isValid()) {
+    if (!_propagator->_journal->getRootE2eFolderRecord(Utility::noLeadingSlashPath(path), &rec) || !rec.isValid()) {
         taskFailed();
         return;
     }
 
     _encryptedFolderMetadataHandler.reset(new EncryptedFolderMetadataHandler(_propagator->account(),
-                                                                                       _fullFolderRemotePath,
+                                                                                       _propagator->fullRemotePath(path),
+                                                                                       _propagator->remotePath(),
                                                                                        _propagator->_journal,
                                                                                        rec.path()));
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -2024,10 +2024,11 @@ void ProcessDirectoryJob::chopVirtualFileSuffix(QString &str) const
 DiscoverySingleDirectoryJob *ProcessDirectoryJob::startAsyncServerQuery()
 {
     if (_dirItem && _dirItem->isEncrypted() && _dirItem->_encryptedFileName.isEmpty()) {
-        _discoveryData->_topLevelE2eeFolderPaths.insert(QLatin1Char('/') + _dirItem->_file);
+        _discoveryData->_topLevelE2eeFolderPaths.insert(_discoveryData->_remoteFolder + _dirItem->_file);
     }
     auto serverJob = new DiscoverySingleDirectoryJob(_discoveryData->_account,
-                                                     _discoveryData->_remoteFolder + _currentFolder._server,
+                                                     _currentFolder._server,
+                                                     _discoveryData->_remoteFolder,
                                                      _discoveryData->_topLevelE2eeFolderPaths,
                                                      this);
     if (!_dirItem) {

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -145,6 +145,7 @@ class DiscoverySingleDirectoryJob : public QObject
 public:
     explicit DiscoverySingleDirectoryJob(const AccountPtr &account,
                                          const QString &path,
+                                         const QString &remoteRootFolderPath,
         /* TODO for topLevelE2eeFolderPaths, from review: I still do not get why giving the whole QSet instead of just the parent of the folder we are in
         sounds to me like it would be much more efficient to just have the e2ee parent folder that we are
         inside*/
@@ -179,6 +180,7 @@ private:
 
     QVector<RemoteInfo> _results;
     QString _subPath;
+    QString _remoteRootFolderPath;
     QByteArray _firstEtag;
     QByteArray _fileId;
     QByteArray _localFileId;

--- a/src/libsync/encryptedfoldermetadatahandler.h
+++ b/src/libsync/encryptedfoldermetadatahandler.h
@@ -50,7 +50,7 @@ public:
     };
     Q_ENUM(UnlockFolderWithResult);
 
-    explicit EncryptedFolderMetadataHandler(const AccountPtr &account, const QString &folderPath, SyncJournalDb *const journalDb, const QString &pathForTopLevelFolder, QObject *parent = nullptr);
+    explicit EncryptedFolderMetadataHandler(const AccountPtr &account, const QString &folderPath, const QString &remoteFolderRoot, SyncJournalDb *const journalDb, const QString &pathForTopLevelFolder, QObject *parent = nullptr);
 
     [[nodiscard]] QSharedPointer<FolderMetadata> folderMetadata() const;
 
@@ -101,8 +101,9 @@ public: signals:
 
 private:
     AccountPtr _account;
-    QString _folderPath;
     QPointer<SyncJournalDb> _journalDb;
+    QString _folderFullRemotePath;
+    QString _remoteFolderRoot;
     QByteArray _folderId;
     QByteArray _folderToken;
 

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -93,13 +93,14 @@ public:
     };
     Q_ENUM(FolderType)
 
-    FolderMetadata(AccountPtr account, FolderType folderType = FolderType::Nested);
+    FolderMetadata(AccountPtr account, const QString &remoteFolderRoot, FolderType folderType = FolderType::Nested);
     /*
     * construct metadata based on RootEncryptedFolderInfo
     * as per E2EE V2, the encryption key and users that have access are only stored in root(top-level) encrypted folder's metadata
     * see: https://github.com/nextcloud/end_to_end_encryption_rfc/blob/v2.1/RFC.md
     */
     FolderMetadata(AccountPtr account,
+                   const QString &remoteFolderRoot,
                    const QByteArray &metadata,
                    const RootEncryptedFolderInfo &rootEncryptedFolderInfo,
                    const QByteArray &signature,
@@ -197,6 +198,7 @@ signals:
 
 private:
     AccountPtr _account;
+    QString _remoteFolderRoot;
     QByteArray _initialMetadata;
 
     bool _isRootEncryptedFolder = false;

--- a/src/libsync/propagatedownloadencrypted.cpp
+++ b/src/libsync/propagatedownloadencrypted.cpp
@@ -15,14 +15,7 @@ PropagateDownloadEncrypted::PropagateDownloadEncrypted(OwncloudPropagator *propa
     , _item(item)
     , _info(_item->_file)
 {
-    const auto rootPath = [=]() {
-        const auto result = _propagator->remotePath();
-        if (result.startsWith('/')) {
-            return result.mid(1);
-        } else {
-            return result;
-        }
-    }();
+    const auto rootPath = Utility::noLeadingSlashPath(_propagator->remotePath());
     const auto remoteFilename = _item->_encryptedFileName.isEmpty() ? _item->_file : _item->_encryptedFileName;
     const auto remotePath = QString(rootPath + remoteFilename);
     const auto remoteParentPath = remotePath.left(remotePath.lastIndexOf('/'));
@@ -42,8 +35,7 @@ void PropagateDownloadEncrypted::start()
         emit failed();
         return;
     }
-    _encryptedFolderMetadataHandler.reset(
-        new EncryptedFolderMetadataHandler(_propagator->account(), _remoteParentPath, _propagator->_journal, rec.path()));
+    _encryptedFolderMetadataHandler.reset(new EncryptedFolderMetadataHandler(_propagator->account(), _remoteParentPath, _propagator->remotePath(), _propagator->_journal, rec.path()));
 
     connect(_encryptedFolderMetadataHandler.data(),
             &EncryptedFolderMetadataHandler::fetchFinished,

--- a/src/libsync/propagateuploadencrypted.cpp
+++ b/src/libsync/propagateuploadencrypted.cpp
@@ -20,26 +20,12 @@ Q_LOGGING_CATEGORY(lcPropagateUploadEncrypted, "nextcloud.sync.propagator.upload
 PropagateUploadEncrypted::PropagateUploadEncrypted(OwncloudPropagator *propagator, const QString &remoteParentPath, SyncFileItemPtr item, QObject *parent)
     : QObject(parent)
     , _propagator(propagator)
-    , _remoteParentPath(remoteParentPath)
+    , _remoteParentPath(Utility::noLeadingSlashPath(remoteParentPath))
     , _item(item)
 {
-    const auto rootPath = [=]() {
-        const auto result = _propagator->remotePath();
-        if (result.startsWith('/')) {
-            return result.mid(1);
-        } else {
-            return result;
-        }
-    }();
-    _remoteParentAbsolutePath = [=] {
-        auto path = QString(rootPath + _remoteParentPath);
-        if (path.endsWith('/')) {
-            path.chop(1);
-        }
-        return path;
-    }();
+    const auto rootPath = Utility::trailingSlashPath(Utility::noLeadingSlashPath(_propagator->remotePath()));
+    _remoteParentAbsolutePath = Utility::noTrailingSlashPath(rootPath + _remoteParentPath);
 }
-
 
 void PropagateUploadEncrypted::start()
 {
@@ -63,6 +49,7 @@ void PropagateUploadEncrypted::start()
     }
     _encryptedFolderMetadataHandler.reset(new EncryptedFolderMetadataHandler(_propagator->account(),
                                                                                        _remoteParentAbsolutePath,
+                                                                                       _propagator->remotePath(),
                                                                                        _propagator->_journal,
                                                                                        rec.path()));
 
@@ -143,7 +130,7 @@ void PropagateUploadEncrypted::slotFetchMetadataJobFinished(int statusCode, cons
 
     encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
 
-    _item->_encryptedFileName = _remoteParentPath + QLatin1Char('/') + encryptedFile.encryptedFilename;
+    _item->_encryptedFileName =  Utility::trailingSlashPath(_remoteParentPath) + encryptedFile.encryptedFilename;
     _item->_e2eEncryptionStatusRemote = metadata->existingMetadataEncryptionStatus();
     _item->_e2eEncryptionServerCapability =
         EncryptionStatusEnums::fromEndToEndEncryptionApiVersion(_propagator->account()->capabilities().clientSideEncryptionVersion());
@@ -193,8 +180,8 @@ void PropagateUploadEncrypted::slotUploadMetadataFinished(int statusCode, const 
 
     qCDebug(lcPropagateUploadEncrypted) << "Encrypted Info:" << outputInfo.path() << outputInfo.fileName() << outputInfo.size();
     qCDebug(lcPropagateUploadEncrypted) << "Finalizing the upload part, now the actuall uploader will take over";
-    emit finalized(outputInfo.path() + QLatin1Char('/') + outputInfo.fileName(),
-                   _remoteParentPath + QLatin1Char('/') + outputInfo.fileName(),
+    emit finalized(Utility::trailingSlashPath(outputInfo.path()) + outputInfo.fileName(),
+                   Utility::trailingSlashPath(_remoteParentPath) + outputInfo.fileName(),
                    outputInfo.size());
 }
 

--- a/src/libsync/updatee2eefoldermetadatajob.cpp
+++ b/src/libsync/updatee2eefoldermetadatajob.cpp
@@ -32,8 +32,9 @@ namespace OCC {
 UpdateE2eeFolderMetadataJob::UpdateE2eeFolderMetadataJob(OwncloudPropagator *propagator, const SyncFileItemPtr &item, const QString &encryptedRemotePath)
     : PropagatorJob(propagator),
     _item(item),
-    _encryptedRemotePath(encryptedRemotePath)
+    _encryptedRemotePath(Utility::noLeadingSlashPath(propagator->fullRemotePath(encryptedRemotePath)))
 {
+    Q_ASSERT(propagator->remotePath() == QStringLiteral("/") || _encryptedRemotePath.startsWith(Utility::noLeadingSlashPath(propagator->remotePath())));
 }
 
 void UpdateE2eeFolderMetadataJob::start()
@@ -47,7 +48,7 @@ void UpdateE2eeFolderMetadataJob::start()
         return;
     }
     _encryptedFolderMetadataHandler.reset(
-            new EncryptedFolderMetadataHandler(propagator()->account(), _encryptedRemotePath, propagator()->_journal, rec.path()));
+        new EncryptedFolderMetadataHandler(propagator()->account(), _encryptedRemotePath, propagator()->remotePath() , propagator()->_journal, rec.path()));
 
     connect(_encryptedFolderMetadataHandler.data(), &EncryptedFolderMetadataHandler::fetchFinished,
             this, &UpdateE2eeFolderMetadataJob::slotFetchMetadataJobFinished);

--- a/src/libsync/updatee2eefolderusersmetadatajob.h
+++ b/src/libsync/updatee2eefolderusersmetadatajob.h
@@ -42,7 +42,7 @@ public:
         QString password;
     };
     
-    explicit UpdateE2eeFolderUsersMetadataJob(const AccountPtr &account, SyncJournalDb *journalDb,const QString &syncFolderRemotePath, const Operation operation, const QString &path = {}, const QString &folderUserId = {}, const QSslCertificate &certificate = QSslCertificate{}, QObject *parent = nullptr);
+    explicit UpdateE2eeFolderUsersMetadataJob(const AccountPtr &account, SyncJournalDb *journalDb,const QString &syncFolderRemotePath, const Operation operation, const QString &fullRemotePath = {}, const QString &folderUserId = {}, const QSslCertificate &certificate = QSslCertificate{}, QObject *parent = nullptr);
     ~UpdateE2eeFolderUsersMetadataJob() override = default;
 
 public:
@@ -91,7 +91,7 @@ private:
     QPointer<SyncJournalDb> _journalDb;
     QString _syncFolderRemotePath;
     Operation _operation = Invalid;
-    QString _path;
+    QString _fullRemotePath;
     QString _folderUserId;
     QSslCertificate _folderUserCertificate;
     QByteArray _folderToken;

--- a/src/libsync/updatemigratede2eemetadatajob.cpp
+++ b/src/libsync/updatemigratede2eemetadatajob.cpp
@@ -30,13 +30,14 @@ namespace OCC {
 
 UpdateMigratedE2eeMetadataJob::UpdateMigratedE2eeMetadataJob(OwncloudPropagator *propagator,
                                                              const SyncFileItemPtr &syncFileItem,
-                                                             const QString &path,
+                                                             const QString &fullRemotePath,
                                                              const QString &folderRemotePath)
     : PropagatorJob(propagator)
     , _item(syncFileItem)
-    , _path(path)
-    , _folderRemotePath(folderRemotePath)
+    , _fullRemotePath(fullRemotePath)
+    , _folderRemotePath(Utility::noLeadingSlashPath(Utility::noTrailingSlashPath(folderRemotePath)))
 {
+    Q_ASSERT(_fullRemotePath == QStringLiteral("/") || _fullRemotePath.startsWith(_folderRemotePath));
 }
 
 void UpdateMigratedE2eeMetadataJob::start()
@@ -45,7 +46,7 @@ void UpdateMigratedE2eeMetadataJob::start()
                                                                                      propagator()->_journal,
                                                                                      _folderRemotePath,
                                                                                      UpdateE2eeFolderUsersMetadataJob::Add,
-                                                                                     _path,
+                                                                                     _fullRemotePath,
                                                                                      propagator()->account()->davUser(),
                                                                                      propagator()->account()->e2e()->_certificate);
     updateMedatadaAndSubfoldersJob->setParent(this);
@@ -83,9 +84,9 @@ PropagatorJob::JobParallelism UpdateMigratedE2eeMetadataJob::parallelism() const
     return PropagatorJob::JobParallelism::WaitForFinished;
 }
 
-QString UpdateMigratedE2eeMetadataJob::path() const
+QString UpdateMigratedE2eeMetadataJob::fullRemotePath() const
 {
-    return _path;
+    return _fullRemotePath;
 }
 
 void UpdateMigratedE2eeMetadataJob::addSubJobItem(const QString &key, const SyncFileItemPtr &syncFileItem)

--- a/src/libsync/updatemigratede2eemetadatajob.h
+++ b/src/libsync/updatemigratede2eemetadatajob.h
@@ -33,7 +33,7 @@ public:
 
     [[nodiscard]] JobParallelism parallelism() const override;
 
-    [[nodiscard]] QString path() const;
+    [[nodiscard]] QString fullRemotePath() const;
 
     void addSubJobItem(const QString &key, const SyncFileItemPtr &syncFileItem);
 
@@ -43,7 +43,7 @@ private slots:
 private:
     SyncFileItemPtr _item;
     QHash<QString, SyncFileItemPtr> _subJobItems;
-    QString _path;
+    QString _fullRemotePath;
     QString _folderRemotePath;
 };
 

--- a/src/libsync/vfs/cfapi/hydrationjob.cpp
+++ b/src/libsync/vfs/cfapi/hydrationjob.cpp
@@ -43,14 +43,14 @@ void OCC::HydrationJob::setAccount(const AccountPtr &account)
     _account = account;
 }
 
-QString OCC::HydrationJob::remotePath() const
+QString OCC::HydrationJob::remoteSyncRootPath() const
 {
-    return _remotePath;
+    return _remoteSyncRootPath;
 }
 
-void OCC::HydrationJob::setRemotePath(const QString &remotePath)
+void OCC::HydrationJob::setRemoteSyncRootPath(const QString &path)
 {
-    _remotePath = remotePath;
+    _remoteSyncRootPath = Utility::noLeadingSlashPath(path);
 }
 
 QString OCC::HydrationJob::localPath() const
@@ -137,10 +137,10 @@ void OCC::HydrationJob::start()
 {
     Q_ASSERT(_account);
     Q_ASSERT(_journal);
-    Q_ASSERT(!_remotePath.isEmpty() && !_localPath.isEmpty());
+    Q_ASSERT(!_remoteSyncRootPath.isEmpty() && !_localPath.isEmpty());
     Q_ASSERT(!_requestId.isEmpty() && !_folderPath.isEmpty());
 
-    Q_ASSERT(_remotePath.endsWith('/'));
+    Q_ASSERT(_remoteSyncRootPath.endsWith('/'));
     Q_ASSERT(_localPath.endsWith('/'));
     Q_ASSERT(!_folderPath.startsWith('/'));
 
@@ -305,7 +305,7 @@ void OCC::HydrationJob::slotFetchMetadataJobFinished(int statusCode, const QStri
         if (encryptedFileExactName == file.encryptedFilename) {
             qCDebug(lcHydration) << "Found matching encrypted metadata for file, starting download" << _requestId << _folderPath;
             _transferDataSocket = _transferDataServer->nextPendingConnection();
-            _job = new GETEncryptedFileJob(_account, _remotePath + e2eMangledName(), _transferDataSocket, {}, {}, 0, file, this);
+            _job = new GETEncryptedFileJob(_account, Utility::trailingSlashPath(_remoteSyncRootPath) + e2eMangledName(), _transferDataSocket, {}, {}, 0, file, this);
 
             connect(qobject_cast<GETEncryptedFileJob *>(_job), &GETEncryptedFileJob::finishedSignal, this, &HydrationJob::onGetFinished);
             _job->start();
@@ -347,7 +347,7 @@ void OCC::HydrationJob::handleNewConnection()
 {
     qCInfo(lcHydration) << "Got new connection starting GETFileJob" << _requestId << _folderPath;
     _transferDataSocket = _transferDataServer->nextPendingConnection();
-    _job = new GETFileJob(_account, _remotePath + _folderPath, _transferDataSocket, {}, {}, 0, this);
+    _job = new GETFileJob(_account, Utility::trailingSlashPath(_remoteSyncRootPath) + _folderPath, _transferDataSocket, {}, {}, 0, this);
     connect(_job, &GETFileJob::finishedSignal, this, &HydrationJob::onGetFinished);
     _job->start();
 }
@@ -356,25 +356,17 @@ void OCC::HydrationJob::handleNewConnectionForEncryptedFile()
 {
     // TODO: the following code is borrowed from PropagateDownloadEncrypted (should we factor it out and reuse? YES! Should we do it now? Probably not, as, this would imply modifying PropagateDownloadEncrypted, so we need a separate PR)
     qCInfo(lcHydration) << "Got new connection for encrypted file. Getting required info for decryption...";
-    const auto rootPath = [=]() {
-        const auto result = _remotePath;
-        if (result.startsWith('/')) {
-            return result.mid(1);
-        } else {
-            return result;
-        }
-    }();
-
     const auto remoteFilename = e2eMangledName();
-    const auto remotePath = QString(rootPath + remoteFilename);
-    const auto _remoteParentPath = remotePath.left(remotePath.lastIndexOf('/'));
+    const QString fullRemotePath = Utility::trailingSlashPath(_remoteSyncRootPath) + remoteFilename;
+    const auto containingFolderFullRemotePath = fullRemotePath.left(fullRemotePath.lastIndexOf('/'));
 
     SyncJournalFileRecord rec;
-    if (!_journal->getRootE2eFolderRecord(Utility::fullRemotePathToRemoteSyncRootRelative(_remoteParentPath, rootPath), &rec) || !rec.isValid()) {
+    if (!_journal->getRootE2eFolderRecord(Utility::fullRemotePathToRemoteSyncRootRelative(containingFolderFullRemotePath, _remoteSyncRootPath), &rec) || !rec.isValid()) {
         emitFinished(Error);
         return;
     }
-    _encryptedFolderMetadataHandler.reset(new EncryptedFolderMetadataHandler(_account, _remoteParentPath, _journal, rec.path()));
+    _encryptedFolderMetadataHandler.reset(
+        new EncryptedFolderMetadataHandler(_account, containingFolderFullRemotePath, _remoteSyncRootPath, _journal, rec.path()));
     connect(_encryptedFolderMetadataHandler.data(),
             &EncryptedFolderMetadataHandler::fetchFinished,
             this,

--- a/src/libsync/vfs/cfapi/hydrationjob.h
+++ b/src/libsync/vfs/cfapi/hydrationjob.h
@@ -46,8 +46,8 @@ public:
     AccountPtr account() const;
     void setAccount(const AccountPtr &account);
 
-    QString remotePath() const;
-    void setRemotePath(const QString &remotePath);
+    [[nodiscard]] QString remoteSyncRootPath() const;
+    void setRemoteSyncRootPath(const QString &path);
 
     QString localPath() const;
     void setLocalPath(const QString &localPath);
@@ -99,7 +99,7 @@ private:
     void startServerAndWaitForConnections();
 
     AccountPtr _account;
-    QString _remotePath;
+    QString _remoteSyncRootPath;
     QString _localPath;
     SyncJournalDb *_journal = nullptr;
     bool _isCancelled = false;

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -445,7 +445,7 @@ void VfsCfApi::scheduleHydrationJob(const QString &requestId, const QString &fol
 
     auto job = new HydrationJob(this);
     job->setAccount(params().account);
-    job->setRemotePath(params().remotePath);
+    job->setRemoteSyncRootPath(params().remotePath);
     job->setLocalPath(params().filesystemPath);
     job->setJournal(params().journal);
     job->setRequestId(requestId);

--- a/test/testclientsideencryptionv2.cpp
+++ b/test/testclientsideencryptionv2.cpp
@@ -96,7 +96,7 @@ private slots:
 
     void testInitializeNewRootFolderMetadataThenEncryptAndDecrypt()
     {
-        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, FolderMetadata::FolderType::Root));
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/", FolderMetadata::FolderType::Root));
         QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
         metadataSetupCompleteSpy.wait();
         QCOMPARE(metadataSetupCompleteSpy.count(), 1);
@@ -178,7 +178,7 @@ private slots:
         QJsonDocument ocsDoc = QJsonDocument::fromJson(QStringLiteral("{\"ocs\": {\"data\": {\"meta-data\": \"%1\"}}}").arg(QString::fromUtf8(encryptedMetadataCopy)).toUtf8());
         
 
-        QScopedPointer<FolderMetadata> metadataFromJson(new FolderMetadata(_account,
+        QScopedPointer<FolderMetadata> metadataFromJson(new FolderMetadata(_account, "/",
             ocsDoc.toJson(),
             RootEncryptedFolderInfo::makeDefault(), signature));
         QSignalSpy metadataSetupExistingCompleteSpy(metadataFromJson.data(), &FolderMetadata::setupComplete);
@@ -190,7 +190,7 @@ private slots:
     void testE2EeFolderMetadataSharing()
     {
         // instantiate empty metadata, add a file, and share with a second user "sharee"
-        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, FolderMetadata::FolderType::Root));
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/", FolderMetadata::FolderType::Root));
         QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
         metadataSetupCompleteSpy.wait();
         QCOMPARE(metadataSetupCompleteSpy.count(), 1);
@@ -280,7 +280,7 @@ private slots:
         QJsonDocument ocsDoc =
             QJsonDocument::fromJson(QStringLiteral("{\"ocs\": {\"data\": {\"meta-data\": \"%1\"}}}").arg(QString::fromUtf8(encryptedMetadataCopy)).toUtf8());
 
-        QScopedPointer<FolderMetadata> metadataFromJsonForSecondUser(new FolderMetadata(_secondAccount, ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
+        QScopedPointer<FolderMetadata> metadataFromJsonForSecondUser(new FolderMetadata(_secondAccount, "/", ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
         QSignalSpy metadataSetupExistingCompleteSpy(metadataFromJsonForSecondUser.data(), &FolderMetadata::setupComplete);
         metadataSetupExistingCompleteSpy.wait();
         QCOMPARE(metadataSetupExistingCompleteSpy.count(), 1);
@@ -303,7 +303,7 @@ private slots:
         QJsonDocument ocsDocFromSecondUser = QJsonDocument::fromJson(
             QStringLiteral("{\"ocs\": {\"data\": {\"meta-data\": \"%1\"}}}").arg(QString::fromUtf8(encryptedMetadataFromSecondUser)).toUtf8());
 
-        QScopedPointer<FolderMetadata> metadataFromJsonForFirstUserToCheckCrossSharing(new FolderMetadata(_account,
+        QScopedPointer<FolderMetadata> metadataFromJsonForFirstUserToCheckCrossSharing(new FolderMetadata(_account, "/",
                                                                                                           ocsDocFromSecondUser.toJson(),
                                                                                                           RootEncryptedFolderInfo::makeDefault(),
                                                                                                           signatureAfterSecondUserModification));

--- a/test/testsecurefiledrop.cpp
+++ b/test/testsecurefiledrop.cpp
@@ -79,7 +79,7 @@ private slots:
         _account->e2e()->_publicKey = publicKey;
         _account->e2e()->_privateKey = privateKey;
 
-        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, FolderMetadata::FolderType::Root));
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/",  FolderMetadata::FolderType::Root));
         QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
         metadataSetupCompleteSpy.wait();
         QCOMPARE(metadataSetupCompleteSpy.count(), 1);
@@ -146,7 +146,7 @@ private slots:
         const auto signature = metadata->metadataSignature();
         QJsonDocument ocsDoc =
             QJsonDocument::fromJson(QStringLiteral("{\"ocs\": {\"data\": {\"meta-data\": \"%1\"}}}").arg(QString::fromUtf8(encryptedMetadata)).toUtf8());
-        _parsedMetadataWithFileDrop.reset(new FolderMetadata(_account, ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
+        _parsedMetadataWithFileDrop.reset(new FolderMetadata(_account, "/",  ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
 
         QSignalSpy metadataWithFileDropSetupCompleteSpy(_parsedMetadataWithFileDrop.data(), &FolderMetadata::setupComplete);
         metadataWithFileDropSetupCompleteSpy.wait();
@@ -167,7 +167,7 @@ private slots:
         QJsonDocument ocsDoc =
             QJsonDocument::fromJson(QStringLiteral("{\"ocs\": {\"data\": {\"meta-data\": \"%1\"}}}").arg(QString::fromUtf8(encryptedMetadata)).toUtf8());
         
-        _parsedMetadataAfterProcessingFileDrop.reset(new FolderMetadata(_account, ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
+        _parsedMetadataAfterProcessingFileDrop.reset(new FolderMetadata(_account, "/", ocsDoc.toJson(), RootEncryptedFolderInfo::makeDefault(), signature));
 
         QSignalSpy metadataAfterProcessingFileDropSetupCompleteSpy(_parsedMetadataAfterProcessingFileDrop.data(), &FolderMetadata::setupComplete);
         metadataAfterProcessingFileDropSetupCompleteSpy.wait();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
