### PR TITLE
fix(docs): parameter promptDeleteAllFiles defaults to false not true

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -51,7 +51,7 @@ Some interesting values that can be set on the configuration file are:
 |                                  |                          | The client adjusts the chunk size until each chunk upload takes approximately this long.               |
 |                                  |                          | Set to 0 to disable dynamic chunk sizing.                                                              |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
-| ``promptDeleteAllFiles``         | ``true``                 | If a UI prompt should ask for confirmation if it was detected that all files and folders were deleted. |
+| ``promptDeleteAllFiles``         | ``false``                 | If a UI prompt should ask for confirmation if it was detected that all files and folders were deleted. |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``timeout``                      | ``300``                  | The timeout for network connections in seconds.                                                        |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
The default was changed to false in #1201

https://github.com/nextcloud/desktop/blob/0071daad61916a57fc8cd6d76002f121a0134a9d/src/libsync/configfile.cpp#L1020

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
