### PR TITLE
fix(logger): Set narrower permissions on temporaryFolderLogDirPath

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -238,6 +238,12 @@ void Logger::setupTemporaryFolderLogDir()
     auto dir = temporaryFolderLogDirPath();
     if (!QDir().mkpath(dir))
         return;
+
+    // Since we're using the temp folder, lock down permissions to owner only
+    QFile::Permissions perm = QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner;
+    QFile file(dir);
+    dir.setPermissions(perm);
+    
     setLogDebug(true);
     setLogExpire(4 /*hours*/);
     setLogDir(dir);


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
