### PR TITLE
Bugfix. E2EE. Use 'double' for legacy metadata.

### DIFF
--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -694,7 +694,7 @@ QByteArray FolderMetadata::encryptedMetadataLegacy()
     // multiple toBase64() just to keep with the old (wrong way)
     const auto encryptedMetadataKey = encryptDataWithPublicKey(metadataKeyForEncryption().toBase64().toBase64(), _account->e2e()->_publicKey).toBase64();
     const QJsonObject metadata{
-        {versionKey, QString::number(version, 'f', 1)},
+        {versionKey, version},
         {metadataKeyKey, QJsonValue::fromVariant(encryptedMetadataKey)},
         {"checksum", QJsonValue::fromVariant(computeMetadataKeyChecksum(encryptedMetadataKey))},
     };


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
