### PR TITLE
Fix macOS legacy build breakage caused by std::filesystem

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -194,6 +194,7 @@ bool FileSystem::getInode(const QString &filename, quint64 *inode)
     return false;
 }
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
 bool FileSystem::setFolderPermissions(const QString &path,
                                       FileSystem::FolderPermissions permissions) noexcept
 {
@@ -330,6 +331,7 @@ bool FileSystem::setFolderPermissions(const QString &path,
     }
 #endif
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     try {
         switch (permissions) {
         case OCC::FileSystem::FolderPermissions::ReadOnly:
@@ -344,6 +346,7 @@ bool FileSystem::setFolderPermissions(const QString &path,
         qCWarning(lcFileSystem()) << "exception when modifying folder permissions" << e.what() << e.path1().c_str() << e.path2().c_str();
         return false;
     }
+#endif
 
     return true;
 }
@@ -361,6 +364,6 @@ bool FileSystem::isFolderReadOnly(const std::filesystem::path &path) noexcept
         return false;
     }
 }
-
+#endif
 
 } // namespace OCC

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -23,7 +23,9 @@
 
 #include <ctime>
 #include <functional>
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
 #include <filesystem>
+#endif
 
 class QFile;
 
@@ -101,7 +103,9 @@ namespace FileSystem {
     bool OWNCLOUDSYNC_EXPORT setFolderPermissions(const QString &path,
                                                   FileSystem::FolderPermissions permissions) noexcept;
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     bool OWNCLOUDSYNC_EXPORT isFolderReadOnly(const std::filesystem::path &path) noexcept;
+#endif
 }
 
 /** @} */

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1443,6 +1443,7 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
             || _item->_instruction == CSYNC_INSTRUCTION_NEW
             || _item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA) {
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
             if (!_item->_remotePerm.isNull() &&
                 !_item->_remotePerm.hasPermission(RemotePermissions::CanAddFile) &&
                 !_item->_remotePerm.hasPermission(RemotePermissions::CanRename) &&
@@ -1494,6 +1495,7 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
                     _item->_errorString = tr("The folder %1 cannot be made read-only: %2").arg(e.path1().c_str(), e.what());
                 }
             }
+#endif
 
             const auto result = propagator()->updateMetadata(*_item);
             if (!result) {

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -673,6 +673,7 @@ void PropagateDownloadFile::startDownload()
         FileSystem::setFileReadOnly(_tmpFile.fileName(), false);
     }
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     try {
         const auto newDirPath = std::filesystem::path{_tmpFile.fileName().toStdWString()};
         Q_ASSERT(newDirPath.has_parent_path());
@@ -688,6 +689,7 @@ void PropagateDownloadFile::startDownload()
         emit propagator()->touchedFile(QString::fromStdWString(_parentPath.wstring()));
         _needParentFolderRestorePermissions = true;
     }
+#endif
 
     if (!_tmpFile.open(QIODevice::Append | QIODevice::Unbuffered)) {
         qCWarning(lcPropagateDownload) << "could not open temporary file" << _tmpFile.fileName();
@@ -1287,11 +1289,13 @@ void PropagateDownloadFile::downloadFinished()
         return;
     }
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     if (_needParentFolderRestorePermissions) {
         FileSystem::setFolderPermissions(QString::fromStdWString(_parentPath.wstring()), FileSystem::FolderPermissions::ReadWrite);
         emit propagator()->touchedFile(QString::fromStdWString(_parentPath.wstring()));
         _needParentFolderRestorePermissions = false;
     }
+#endif
 
     FileSystem::setFileHidden(filename, false);
 

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -23,7 +23,9 @@
 #include <QBuffer>
 #include <QFile>
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
 #include <filesystem>
+#endif
 
 namespace OCC {
 class PropagateDownloadEncrypted;
@@ -263,7 +265,9 @@ private:
 
     PropagateDownloadEncrypted *_downloadEncryptedHelper = nullptr;
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     std::filesystem::path _parentPath;
+#endif
     bool _needParentFolderRestorePermissions = false;
 };
 }

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -17,7 +17,9 @@
 #include <QJsonValue>
 
 #include <memory>
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
 #include <filesystem>
+#endif
 
 PathComponents::PathComponents(const char *path)
     : PathComponents { QString::fromUtf8(path) }
@@ -50,9 +52,11 @@ void DiskFileModifier::remove(const QString &relativePath)
     if (fi.isFile()) {
         QVERIFY(_rootDir.remove(relativePath));
     } else {
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
         const auto pathToDelete = fi.filePath().toStdWString();
         std::filesystem::permissions(pathToDelete, std::filesystem::perms::owner_exec, std::filesystem::perm_options::add);
         QVERIFY(std::filesystem::remove_all(pathToDelete));
+#endif
     }
 }
 

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -11,7 +11,9 @@
 
 #include <QtTest>
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
 #include <filesystem>
+#endif
 #include <iostream>
 
 using namespace OCC;
@@ -77,6 +79,7 @@ private slots:
         Logger::instance()->setLogDebug(true);
     }
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     void t7pl()
     {
         FakeFolder fakeFolder{ FileInfo() };
@@ -384,6 +387,7 @@ private slots:
         QCOMPARE(count, 2);
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+#endif
 
     static void setAllPerm(FileInfo *fi, OCC::RemotePermissions perm)
     {
@@ -592,6 +596,7 @@ private slots:
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
 
+#if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
     static void demo_perms(std::filesystem::perms p)
     {
         using std::filesystem::perms;
@@ -741,6 +746,7 @@ private slots:
         QVERIFY(testFolderStatus.permissions() & std::filesystem::perms::owner_read);
         QVERIFY(!static_cast<bool>(testFolderStatus.permissions() & std::filesystem::perms::owner_write));
     }
+#endif
 };
 
 QTEST_GUILESS_MAIN(TestPermissions)


### PR DESCRIPTION
std::filesystem is not supported on macOS under 10.15

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
