### PR TITLE
Fix "Pause sync for all" / "Resume sync for all" state when manipulating folder sync outside of tray

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -436,12 +436,17 @@ void Systray::slotCurrentUserChanged()
 void Systray::slotUpdateSyncPausedState()
 {
     const auto folderMap = FolderMan::instance()->map();
-    for (const auto *folder : folderMap) {
+    for (const auto folder : folderMap) {
+        connect(folder, &Folder::syncPausedChanged, this, &Systray::slotUpdateSyncPausedState, Qt::UniqueConnection);
         if (!folder->syncPaused()) {
             _syncIsPaused = false;
-            break;
+            emit syncIsPausedChanged();
+            return;
         }
     }
+
+    _syncIsPaused = true;
+    emit syncIsPausedChanged();
 }
 
 void Systray::slotUnpauseAllFolders()

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -127,14 +127,7 @@ void Systray::create()
     }
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
-
-    const auto folderMap = FolderMan::instance()->map();
-    for (const auto *folder : folderMap) {
-        if (!folder->syncPaused()) {
-            _syncIsPaused = false;
-            break;
-        }
-    }
+    slotUpdateSyncPausedState();
 }
 
 void Systray::showWindow(WindowPosition position)
@@ -438,6 +431,17 @@ void Systray::slotCurrentUserChanged()
 
     // Rebuild App list
     UserAppsModel::instance()->buildAppList();
+}
+
+void Systray::slotUpdateSyncPausedState()
+{
+    const auto folderMap = FolderMan::instance()->map();
+    for (const auto *folder : folderMap) {
+        if (!folder->syncPaused()) {
+            _syncIsPaused = false;
+            break;
+        }
+    }
 }
 
 void Systray::slotUnpauseAllFolders()

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -128,6 +128,7 @@ void Systray::create()
     hideWindow();
     emit activated(QSystemTrayIcon::ActivationReason::Unknown);
     slotUpdateSyncPausedState();
+    connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &Systray::slotUpdateSyncPausedState);
 }
 
 void Systray::showWindow(WindowPosition position)

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -581,6 +581,7 @@ void Systray::setSyncIsPaused(const bool syncIsPaused)
     } else {
         slotUnpauseAllFolders();
     }
+    emit syncIsPausedChanged();
 }
 
 /********************************************************************************************/

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -152,6 +152,7 @@ public slots:
     void presentShareViewInTray(const QString &localPath);
 
 private slots:
+    void slotUpdateSyncPausedState();
     void slotUnpauseAllFolders();
     void slotPauseAllFolders();
 


### PR DESCRIPTION
This fixes incongruencies between the button's text and the actual current overall sync pause status when modifying folder sync states from, for instance, the settings window

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
