### PR TITLE
Fix crash when in debug mode when toggling enabled status of an account's virtual files (macOS)

### DIFF
--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -122,7 +122,7 @@ public:
         NSArray<NSString *> *const modifiedVfsAccounts = mutableVfsAccounts.copy;
         [_userDefaults setObject:modifiedVfsAccounts forKey:_accountsKey];
 
-        Q_ASSERT(vfsEnabledForAccount(userIdAtHost) == userIdAtHost);
+        Q_ASSERT(vfsEnabledForAccount(userIdAtHost) == setEnabled);
 
         return VfsAccountsAction::VfsAccountsEnabledChanged;
     }


### PR DESCRIPTION
Caused by comparing to the wrong thing in the Q_ASSERT *facepalm*

@camilasan 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
