### PR TITLE
Use davUser instead of direct credentials user in file provider

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -200,7 +200,7 @@ void FileProviderSocketController::sendAccountDetails() const
 
     const auto credentials = account->credentials();
     Q_ASSERT(credentials);
-    const auto accountUser = credentials->user();
+    const auto accountUser = account->davUser();
     const auto accountUrl = account->url().toString();
     const auto accountPassword = credentials->password();
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Closes https://github.com/nextcloud/desktop/issues/6662
