### PR TITLE
do not cause implicit hydration of virtual files during sync

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1036,7 +1036,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             item->_status = SyncFileItem::Status::NormalError;
         }
 
-        {
+        if (item->_type != CSyncEnums::ItemTypeVirtualFile) {
             const auto foundEditorsKeepingFileBusy = queryEditorsKeepingFileBusy(item, path);
             if (!foundEditorsKeepingFileBusy.isEmpty()) {
                 item->_instruction = CSYNC_INSTRUCTION_ERROR;


### PR DESCRIPTION
backport of #6606 
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
