### PR TITLE
Update propagatedownload.h

### DIFF
--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -24,7 +24,7 @@
 #include <QFile>
 
 #if !defined(Q_OS_MACOS) || __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15
-#include <filesystem>
+#include "filesystem.h"
 #endif
 
 namespace OCC {


### PR DESCRIPTION
change brackets of #include <filesystem> to "" as filesystem.h is present in the same diretory

OpenSUSE Build Service will not build the code for openSUSE Leap 15.5 because of this.

Signed-off-by: Natasha Ament-Teusink <stacheldrahtje@gmail.com>