### PR TITLE
Bugfix. E2EE. Always migrate from 1.2 to 2.0, even with nested folders.

### DIFF
--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -955,15 +955,7 @@ bool FolderMetadata::isRootEncryptedFolder() const
 
 bool FolderMetadata::encryptedMetadataNeedUpdate() const
 {
-    // TODO: For now we do not migrated to V2 if a folder has subfolders, remove the following code and only leave "return latestSupportedMetadataVersion() > _existingMetadataVersion;"
-    if (latestSupportedMetadataVersion() <= _existingMetadataVersion) {
-        return false;
-    }
-
-    const auto foundNestedFoldersOrIsNestedFolder = !_isRootEncryptedFolder
-        || std::find_if(std::cbegin(_files), std::cend(_files), [](const auto &file) { return file.isDirectory(); }) != std::cend(_files);
-
-    return !foundNestedFoldersOrIsNestedFolder;
+    return latestSupportedMetadataVersion() > _existingMetadataVersion;
 }
 
 QByteArray FolderMetadata::certificateSha256Fingerprint() const


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
