### PR TITLE
Censor account details string in file provider logging

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -101,7 +101,11 @@ void FileProviderSocketController::sendMessage(const QString &message) const
         return;
     }
 
-    qCInfo(lcFileProviderSocketController) << "Sending File Provider socket message:" << message;
+    if (message.contains("ACCOUNT_DETAILS:")) {
+        qCDebug(lcFileProviderSocketController) << "Sending File Provider socket message: ACCOUNT_DETAILS:****";
+    } else {
+        qCDebug(lcFileProviderSocketController) << "Sending File Provider socket message:" << message;
+    }
     const auto lineEndChar = '\n';
     const auto messageToSend = message.endsWith(lineEndChar) ? message : message + lineEndChar;
     const auto bytesToSend = messageToSend.toUtf8();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
