### PR TITLE
Fix opening of locally available groupfolders in web browser from tray drop-down

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -339,15 +339,22 @@ void User::parseNewGroupFolderPath(const QString &mountPoint)
     if (mountPoint.isEmpty()) {
         return;
     }
-    auto mountPointSplit = mountPoint.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+
+    auto sanitisedMountPoint = mountPoint;
+    sanitisedMountPoint.replace("//", "/");
+    auto mountPointSplit = sanitisedMountPoint.split('/', Qt::SkipEmptyParts);
 
     if (mountPointSplit.isEmpty()) {
         return;
     }
 
     const auto groupFolderName = mountPointSplit.takeLast();
-    const auto parentPath = mountPointSplit.join(QLatin1Char('/'));
-    _trayFolderInfos.push_back(QVariant::fromValue(TrayFolderInfo{groupFolderName, parentPath, mountPoint, TrayFolderInfo::GroupFolder}));
+    const auto parentPath = mountPointSplit.join('/');
+    const auto folderInfo = TrayFolderInfo(
+        groupFolderName, parentPath, sanitisedMountPoint, TrayFolderInfo::GroupFolder
+    );
+    const auto folderInfoVariant = QVariant::fromValue(folderInfo);
+    _trayFolderInfos.push_back(folderInfoVariant);
 }
 
 void User::prePendGroupFoldersWithLocalFolder()

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -906,7 +906,7 @@ void User::setCurrentUser(const bool &isCurrent)
 
 Folder *User::getFolder() const
 {
-    foreach (Folder *folder, FolderMan::instance()->map()) {
+    for (Folder *const folder : FolderMan::instance()->map()) {
         if (folder->accountState() == _account.data()) {
             return folder;
         }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -925,11 +925,9 @@ UnifiedSearchResultsListModel *User::getUnifiedSearchResultsListModel() const
     return _unifiedSearchResultsModel;
 }
 
-void User::openLocalFolder()
+void User::openLocalFolder() const
 {
-    const auto folder = getFolder();
-
-    if (folder) {
+    if (const auto folder = getFolder()) {
         QDesktopServices::openUrl(QUrl::fromLocalFile(folder->path()));
     }
 }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -913,7 +913,7 @@ void User::setCurrentUser(const bool &isCurrent)
 
 Folder *User::getFolder() const
 {
-    for (Folder *const folder : FolderMan::instance()->map()) {
+    for (const auto &folder : FolderMan::instance()->map()) {
         if (folder->accountState() == _account.data()) {
             return folder;
         }

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -76,7 +76,7 @@ public:
     [[nodiscard]] Folder *getFolder() const;
     ActivityListModel *getActivityModel();
     [[nodiscard]] UnifiedSearchResultsListModel *getUnifiedSearchResultsListModel() const;
-    void openLocalFolder();
+    void openLocalFolder() const;
     void openFolderLocallyOrInBrowser(const QString &fullRemotePath);
     [[nodiscard]] QString name() const;
     [[nodiscard]] QString server(bool shortened = true) const;


### PR DESCRIPTION
Caused by bad paths not being found locally -- usually double-slashes. Ensure we parse received group folder paths correctly even if the server makes a mistake

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
