### PR TITLE
you cannot call non const method on a temp const QString

### DIFF
--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -219,7 +219,8 @@ SyncFileItemPtr SyncFileItem::fromProperties(const QString &filePath, const QMap
         const auto intConvertedValue = properties.value(QStringLiteral("lock-timeout")).toULongLong(&ok);
         item->_lockTimeout = ok ? intConvertedValue : 0;
     }
-    const auto lastModifiedValue = properties.value(QStringLiteral("getlastmodified")).replace("GMT", "+0000");
+    auto getlastmodified = properties.value(QStringLiteral("getlastmodified"));
+    const auto lastModifiedValue = getlastmodified.replace(QStringLiteral("GMT"), QStringLiteral("+0000"));
     const auto date = QDateTime::fromString(lastModifiedValue, Qt::RFC2822Date);
     Q_ASSERT(date.isValid());
     if (date.toSecsSinceEpoch() > 0) {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
