### PR TITLE
Bugfix nextcloudcmd when syncing results in deleting all files

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -532,6 +532,7 @@ restart_sync:
     SyncOptions syncOptions;
     syncOptions.fillFromEnvironmentVariables();
     syncOptions.verifyChunkSizes();
+    syncOptions.setIsCmd(true);
     SyncEngine engine(account, options.source_dir, syncOptions, folder, &db);
     engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
     engine.setNetworkLimits(options.uplimit, options.downlimit);

--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -529,10 +529,10 @@ restart_sync:
         selectiveSyncFixup(&db, selectiveSyncList);
     }
 
-    SyncOptions opt;
-    opt.fillFromEnvironmentVariables();
-    opt.verifyChunkSizes();
-    SyncEngine engine(account, options.source_dir, opt, folder, &db);
+    SyncOptions syncOptions;
+    syncOptions.fillFromEnvironmentVariables();
+    syncOptions.verifyChunkSizes();
+    SyncEngine engine(account, options.source_dir, syncOptions, folder, &db);
     engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
     engine.setNetworkLimits(options.uplimit, options.downlimit);
     QObject::connect(&engine, &SyncEngine::finished,

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1628,12 +1628,6 @@ bool Folder::virtualFilesEnabled() const
 
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, std::function<void(bool)> callback)
 {
-    ConfigFile cfgFile;
-    if (!cfgFile.promptDeleteFiles()) {
-        callback(false);
-        return;
-    }
-
     const QString msg = dir == SyncFileItem::Down ? tr("All files in the sync folder \"%1\" folder were deleted on the server.\n"
                                                  "These deletes will be synchronized to your local sync folder, making such files "
                                                  "unavailable unless you have a right to restore. \n"
@@ -1644,7 +1638,7 @@ void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, std::functio
                                                  "Are you sure you want to sync those actions with the server?\n"
                                                  "If this was an accident and you decide to keep your files, they will be re-synced from the server.");
     auto msgBox = new QMessageBox(QMessageBox::Warning, tr("Remove All Files?"),
-        msg.arg(shortGuiLocalPath()), QMessageBox::NoButton);
+    msg.arg(shortGuiLocalPath()), QMessageBox::NoButton);
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
     msgBox->setWindowFlags(msgBox->windowFlags() | Qt::WindowStaysOnTopHint);
     msgBox->addButton(tr("Remove all files"), QMessageBox::DestructiveRole);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1628,21 +1628,14 @@ bool Folder::virtualFilesEnabled() const
 
 void Folder::slotAboutToRemoveAllFiles(SyncFileItem::Direction dir, std::function<void(bool)> callback)
 {
-    const QString msg = dir == SyncFileItem::Down ? tr("All files in the sync folder \"%1\" folder were deleted on the server.\n"
-                                                 "These deletes will be synchronized to your local sync folder, making such files "
-                                                 "unavailable unless you have a right to restore. \n"
-                                                 "If you decide to restore the files, they will be re-synced with the server if you have rights to do so.\n"
-                                                 "If you decide to delete the files, they will be unavailable to you, unless you are the owner.")
-                                            : tr("All the files in your local sync folder \"%1\" were deleted. These deletes will be "
-                                                 "synchronized with your server, making such files unavailable unless restored.\n"
-                                                 "Are you sure you want to sync those actions with the server?\n"
-                                                 "If this was an accident and you decide to keep your files, they will be re-synced from the server.");
-    auto msgBox = new QMessageBox(QMessageBox::Warning, tr("Remove All Files?"),
-    msg.arg(shortGuiLocalPath()), QMessageBox::NoButton);
+    const QString msg = dir == SyncFileItem::Down ? tr("All files in the server folder \"%1\" were deleted.\n\nIf you restore the files, they will be uploaded again to the server.")
+                                                  : tr("All files in the local folder \"%1\" were deleted.\n\nIf you restore the files, they will be downloaded again from the server.");
+    auto msgBox = new QMessageBox(QMessageBox::Warning, tr("Remove all files?"),
+                                  msg.arg(shortGuiLocalPath()), QMessageBox::NoButton);
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
     msgBox->setWindowFlags(msgBox->windowFlags() | Qt::WindowStaysOnTopHint);
-    msgBox->addButton(tr("Remove all files"), QMessageBox::DestructiveRole);
-    QPushButton *keepBtn = msgBox->addButton(tr("Keep files"), QMessageBox::AcceptRole);
+    msgBox->addButton(tr("Proceed to remove all files"), QMessageBox::DestructiveRole);
+    QPushButton *keepBtn = msgBox->addButton(tr("Restore files"), QMessageBox::AcceptRole);
     bool oldPaused = syncPaused();
     setSyncPaused(true);
     connect(msgBox, &QMessageBox::finished, this, [msgBox, keepBtn, callback, oldPaused, this] {

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -898,7 +898,8 @@ void SyncEngine::slotDiscoveryFinished()
         qCInfo(lcEngine) << "#### Post-Reconcile end #################################################### " << _stopWatch.addLapTime(QStringLiteral("Post-Reconcile Finished")) << "ms";
     };
 
-    if (!_hasNoneFiles && _hasRemoveFile && ConfigFile().promptDeleteFiles()) {
+    const auto displayDialog = ConfigFile().promptDeleteFiles() && !_syncOptions.isCmd();
+    if (!_hasNoneFiles && _hasRemoveFile && displayDialog) {
         qCInfo(lcEngine) << "All the files are going to be changed, asking the user";
         int side = 0; // > 0 means more deleted on the server.  < 0 means more deleted on the client
         for (const auto &it : _syncItems) {

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -898,10 +898,10 @@ void SyncEngine::slotDiscoveryFinished()
         qCInfo(lcEngine) << "#### Post-Reconcile end #################################################### " << _stopWatch.addLapTime(QStringLiteral("Post-Reconcile Finished")) << "ms";
     };
 
-    if (!_hasNoneFiles && _hasRemoveFile) {
+    if (!_hasNoneFiles && _hasRemoveFile && ConfigFile().promptDeleteFiles()) {
         qCInfo(lcEngine) << "All the files are going to be changed, asking the user";
         int side = 0; // > 0 means more deleted on the server.  < 0 means more deleted on the client
-        foreach (const auto &it, _syncItems) {
+        for (const auto &it : _syncItems) {
             if (it->_instruction == CSYNC_INSTRUCTION_REMOVE) {
                 side += it->_direction == SyncFileItem::Down ? 1 : -1;
             }

--- a/src/libsync/syncoptions.cpp
+++ b/src/libsync/syncoptions.cpp
@@ -21,6 +21,7 @@ using namespace OCC;
 
 SyncOptions::SyncOptions()
     : _vfs(new VfsOff)
+    , _isCmd(false)
 {
 }
 
@@ -90,4 +91,14 @@ void SyncOptions::setPathPattern(const QString &pattern)
 {
     _fileRegex.setPatternOptions(Utility::fsCasePreserving() ? QRegularExpression::CaseInsensitiveOption : QRegularExpression::NoPatternOption);
     _fileRegex.setPattern(pattern);
+}
+
+void SyncOptions::setIsCmd(const bool isCmd)
+{
+    _isCmd = isCmd;
+}
+
+bool SyncOptions::isCmd() const
+{
+    return _isCmd;
 }

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -93,7 +93,6 @@ public:
      */
     void verifyChunkSizes();
 
-
     /** A regular expression to match file names
      * If no pattern is provided the default is an invalid regular expression.
      */
@@ -109,6 +108,10 @@ public:
      */
     void setPathPattern(const QString &pattern);
 
+    /** sync had been started via nextcloudcmd command line   */
+    [[nodiscard]] bool isCmd() const;
+    void setIsCmd(const bool isCmd);
+
 private:
     /**
      * Only sync files that match the expression
@@ -118,6 +121,8 @@ private:
 
     qint64 _minChunkSize = chunkV2MinChunkSize;
     qint64 _maxChunkSize = chunkV2MaxChunkSize;
+
+    bool _isCmd = false;
 };
 
 }

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -1910,6 +1910,75 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    void testRemoveAllFilesWithNextcloudCmd()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        auto nextcloudCmdSyncOptions = fakeFolder.syncEngine().syncOptions();
+        nextcloudCmdSyncOptions.setIsCmd(true);
+        fakeFolder.syncEngine().setSyncOptions(nextcloudCmdSyncOptions);
+        ConfigFile().setPromptDeleteFiles(true);
+        QSignalSpy displayDialogSignal(&fakeFolder.syncEngine(), &SyncEngine::aboutToRemoveAllFiles);
+
+        fakeFolder.remoteModifier().mkdir("folder");
+        fakeFolder.remoteModifier().insert("folder/file1");
+        fakeFolder.remoteModifier().insert("folder/file2");
+        fakeFolder.remoteModifier().insert("folder/file3");
+        fakeFolder.remoteModifier().mkdir("folder2");
+        fakeFolder.remoteModifier().insert("file1");
+        fakeFolder.remoteModifier().insert("file2");
+        fakeFolder.remoteModifier().insert("file3");
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("folder");
+        fakeFolder.remoteModifier().remove("folder2");
+        fakeFolder.remoteModifier().remove("file1");
+        fakeFolder.remoteModifier().remove("file2");
+        fakeFolder.remoteModifier().remove("file3");
+
+        QVERIFY(fakeFolder.syncOnce());
+        // the signal to display the dialog should not be emitted
+        QCOMPARE(displayDialogSignal.count(), 0);
+        QCOMPARE(fakeFolder.remoteModifier().find("folder"), nullptr);
+        QCOMPARE(fakeFolder.remoteModifier().find("folder2"), nullptr);
+        QCOMPARE(fakeFolder.remoteModifier().find("file1"), nullptr);
+    }
+
+    void testRemoveAllFilesWithoutNextcloudCmd()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        auto nextcloudCmdSyncOptions = fakeFolder.syncEngine().syncOptions();
+        nextcloudCmdSyncOptions.setIsCmd(false);
+        fakeFolder.syncEngine().setSyncOptions(nextcloudCmdSyncOptions);
+        ConfigFile().setPromptDeleteFiles(true);
+        QSignalSpy displayDialogSignal(&fakeFolder.syncEngine(), &SyncEngine::aboutToRemoveAllFiles);
+
+        fakeFolder.remoteModifier().mkdir("folder");
+        fakeFolder.remoteModifier().insert("folder/file1");
+        fakeFolder.remoteModifier().insert("folder/file2");
+        fakeFolder.remoteModifier().insert("folder/file3");
+        fakeFolder.remoteModifier().mkdir("folder2");
+        fakeFolder.remoteModifier().insert("file1");
+        fakeFolder.remoteModifier().insert("file2");
+        fakeFolder.remoteModifier().insert("file3");
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        fakeFolder.remoteModifier().remove("folder");
+        fakeFolder.remoteModifier().remove("folder2");
+        fakeFolder.remoteModifier().remove("file1");
+        fakeFolder.remoteModifier().remove("file2");
+        fakeFolder.remoteModifier().remove("file3");
+
+        QVERIFY(fakeFolder.syncOnce());
+        // the signal to show the dialog should be emitted
+        QCOMPARE(displayDialogSignal.count(), 1);
+        QCOMPARE(fakeFolder.remoteModifier().find("folder"), nullptr);
+        QCOMPARE(fakeFolder.remoteModifier().find("folder2"), nullptr);
+        QCOMPARE(fakeFolder.remoteModifier().find("file1"), nullptr);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)


### PR DESCRIPTION
- Fix for https://github.com/nextcloud/desktop/issues/3144
- Makes warning more concise:
  - warning when deleting all files in the server
    - before: 
    ![Screenshot 2024-06-04 at 20 06 29](https://github.com/nextcloud/desktop/assets/241266/4fb3abec-7815-4713-9dda-935e94bf555c)
    - after:
    ![Screenshot 2024-06-04 at 20 18 01](https://github.com/nextcloud/desktop/assets/241266/fb8d8a15-cbd0-4e22-b34d-af0e9d5da566)

  - warning when deleting all local files
    - before: 
    ![Screenshot 2024-06-04 at 20 06 29](https://github.com/nextcloud/desktop/assets/241266/9c3432cb-986d-4d8d-904a-f36cbf3fd57d)
    - after:
    ![Screenshot 2024-06-04 at 20 19 54](https://github.com/nextcloud/desktop/assets/241266/1070bf52-f411-4178-bb6c-b3ccb32b8a12)
