### PR TITLE
Fix "The host name did not match any of the valid hosts for this certificate" notification even when the certificate was valid

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -362,7 +362,6 @@ void OwncloudSetupWizard::slotConnectToOCUrl(const QString &url)
 void OwncloudSetupWizard::testOwnCloudConnect()
 {
     AccountPtr account = _ocWizard->account();
-
     auto *job = new PropfindJob(account, "/", this);
     job->setIgnoreCredentialFailure(true);
     // There is custom redirect handling in the error handler,

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -238,7 +238,7 @@ void AbstractNetworkJob::slotFinished()
         _account->handleInvalidCredentials();
     }
 
-    if (const auto discard = finished()) {
+    if (finished()) {
         qCDebug(lcNetworkJob) << "Network job" << metaObject()->className() << "finished for" << path();
         deleteLater();
     }

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -127,6 +127,7 @@ QNetworkReply *AbstractNetworkJob::addTimer(QNetworkReply *reply)
 QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb, const QUrl &url,
     QNetworkRequest req, QIODevice *requestBody)
 {
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = requestBody;
     if (_requestBody) {
@@ -139,6 +140,7 @@ QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb, const QUr
 QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb, const QUrl &url,
     QNetworkRequest req, const QByteArray &requestBody)
 {
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = nullptr;
     adoptRequest(reply);
@@ -150,6 +152,7 @@ QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb,
                                                QNetworkRequest req,
                                                QHttpMultiPart *requestBody)
 {
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = nullptr;
     adoptRequest(reply);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -483,11 +483,6 @@ QSslConfiguration Account::getOrCreateSslConfig()
     //  "An internal error number 1060 happened. SSL handshake failed, client certificate was requested: SSL error: sslv3 alert handshake failure"
     QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
 
-    // Try hard to reuse session for different requests
-    sslConfig.setSslOption(QSsl::SslOptionDisableSessionTickets, false);
-    sslConfig.setSslOption(QSsl::SslOptionDisableSessionSharing, false);
-    sslConfig.setSslOption(QSsl::SslOptionDisableSessionPersistence, false);
-
     sslConfig.setOcspStaplingEnabled(Theme::instance()->enableStaplingOCSP());
 
     return sslConfig;

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -522,12 +522,6 @@ void CheckServerJob::metaDataChangedSlot()
 
 bool CheckServerJob::finished()
 {
-    if (reply()->request().url().scheme() == QLatin1String("https")
-        && reply()->sslConfiguration().sessionTicket().isEmpty()
-        && reply()->error() == QNetworkReply::NoError) {
-        qCWarning(lcCheckServerJob) << "No SSL session identifier / session ticket is used, this might impact sync performance negatively.";
-    }
-
     mergeSslConfigurationForSslButton(reply()->sslConfiguration(), account());
 
     // The server installs to /owncloud. Let's try that if the file wasn't found
@@ -540,14 +534,14 @@ bool CheckServerJob::finished()
         return false;
     }
 
-    QByteArray body = reply()->peek(4 * 1024);
-    int httpStatus = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const auto body = reply()->peek(4 * 1024);
+    const auto httpStatus = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     if (body.isEmpty() || httpStatus != 200) {
         qCWarning(lcCheckServerJob) << "error: status.php replied " << httpStatus << body;
         emit instanceNotFound(reply());
     } else {
         QJsonParseError error{};
-        auto status = QJsonDocument::fromJson(body, &error);
+        const auto status = QJsonDocument::fromJson(body, &error);
         // empty or invalid response
         if (error.error != QJsonParseError::NoError || status.isNull()) {
             qCWarning(lcCheckServerJob) << "status.php from server is not valid JSON!" << body << reply()->request().url() << error.errorString();


### PR DESCRIPTION
- I am trying to solve this: the client was complaining about invalid certificates even though the certificate was valid with
"The host name did not match any of the valid hosts for this certificate"
- I only could reproduce what was reported with stable-3.13 and Qt 5 on Linux.
- We might have hit a Qt5 bug, but I couldn't find reports. 
- The issue was gone once the setting of ssl options were removed in https://github.com/nextcloud/desktop/commit/52996774b588b3bba9d99d9d18a3e7c41a421a33.


