### PR TITLE
Fix text colour for NCInputTextEdit

### DIFF
--- a/src/gui/filedetails/NCInputTextEdit.qml
+++ b/src/gui/filedetails/NCInputTextEdit.qml
@@ -27,6 +27,7 @@ TextEdit {
     readonly property alias submitButton: submitButton
 
     clip: true
+    color: Style.ncTextColor
     textMargin: Style.smallSpacing
     wrapMode: TextEdit.Wrap
     selectByMouse: true


### PR DESCRIPTION
Fixes text colour for `NCInputTextEdit` in dark mode

After fix:

<img width="497" alt="Screenshot 2024-06-13 at 19 00 10" src="https://github.com/nextcloud/desktop/assets/70155116/ed969f0a-0a30-4227-ba24-1a83bf212cb1">

Before fix:

<img width="497" alt="Screenshot 2024-06-13 at 19 02 31" src="https://github.com/nextcloud/desktop/assets/70155116/ea4af3e2-7622-4d2b-b801-f64a3c27380d">

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
