### PR TITLE
only use VFS update instruction when sync engine would do nothing

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1681,8 +1681,9 @@ void ProcessDirectoryJob::processFileFinalize(
     }
 
     if (_discoveryData->_syncOptions._vfs &&
-        item->_type == CSyncEnums::ItemTypeFile &&
-        !_discoveryData->_syncOptions._vfs->isPlaceHolderInSync(_discoveryData->_localDir + path._local)) {
+            (item->_type == CSyncEnums::ItemTypeFile || item->_type == CSyncEnums::ItemTypeDirectory) &&
+            item->_instruction == CSyncEnums::CSYNC_INSTRUCTION_NONE &&
+            !_discoveryData->_syncOptions._vfs->isPlaceHolderInSync(_discoveryData->_localDir + path._local)) {
         item->_instruction = CSyncEnums::CSYNC_INSTRUCTION_UPDATE_VFS_METADATA;
     }
 


### PR DESCRIPTION
will ensure we do not erroneously use this instruction when we should not

Close https://github.com/nextcloud/desktop/issues/6721

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
