### PR TITLE
ci(clang-tidy-review): Fix for qt6 + swap to docker-ci container

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -26,6 +26,8 @@ jobs:
         /usr/bin/git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master
+      env: 
+        LD_LIBRARY_PATH: ${{ github.workspace }}/Python/ # workaround for https://github.com/actions/setup-python/issues/871 ever since clang-tidy-pr-comments became composite w/ embedded python version req
       with:
         # The GitHub token (or a personal access token)
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -21,7 +21,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 HEAD^ | clang-tidy-diff -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+        git diff -U0 HEAD^ | clang-tidy-diff.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master
       with:

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -21,7 +21,9 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+        pwd && ls -alt
+        /usr/bin/git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        /usr/bin/git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master
       with:

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -21,13 +21,10 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        pwd && ls -alt
         /usr/bin/git config --global --add safe.directory "$GITHUB_WORKSPACE"
         /usr/bin/git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
-      uses: platisd/clang-tidy-pr-comments@v1.4.3 # >1.4.3 switches to compose and runs into below mentioned issue w/o great workarounds (needs to be fixed by them not us)
-      #env: 
-        #LD_LIBRARY_PATH: /__w/_tool/Python/ # workaround for https://github.com/actions/setup-python/issues/871 ever since clang-tidy-pr-comments became composite w/ embedded python version req
+      uses: platisd/clang-tidy-pr-comments@v1.4.3 # >1.4.3 switches to composite method w/ a forced python version and breaks things: https://github.com/actions/setup-python/issues/871
       with:
         # The GitHub token (or a personal access token)
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -25,9 +25,9 @@ jobs:
         /usr/bin/git config --global --add safe.directory "$GITHUB_WORKSPACE"
         /usr/bin/git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
-      uses: platisd/clang-tidy-pr-comments@master
-      env: 
-        LD_LIBRARY_PATH: ${{ github.workspace }}/Python/ # workaround for https://github.com/actions/setup-python/issues/871 ever since clang-tidy-pr-comments became composite w/ embedded python version req
+      uses: platisd/clang-tidy-pr-comments@v1.4.3 # >1.4.3 switches to compose and runs into below mentioned issue w/o great workarounds (needs to be fixed by them not us)
+      #env: 
+        #LD_LIBRARY_PATH: /__w/_tool/Python/ # workaround for https://github.com/actions/setup-python/issues/871 ever since clang-tidy-pr-comments became composite w/ embedded python version req
       with:
         # The GitHub token (or a personal access token)
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 2
     - name: Prepare compile_commands.json
       run: |
-        cmake -G Ninja -B build -DCMAKE_PREFIX_PATH=/opt/qt6.6.3 -DQT_MAJOR_VERSION=6 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1
+        cmake -G Ninja -B build -DCMAKE_PREFIX_PATH=/opt/qt6.6.3 -DQT_MAJOR_VERSION=6 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1 -DOPENSSL_ROOT_DIR=/usr/local/lib64
         cd build && ninja
     - name: Create results directory
       run: |

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -6,19 +6,15 @@ on:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-6.6.3-2
     steps:
     - uses: actions/checkout@v4
       with:
           fetch-depth: 2
-    - name: Install clang-tidy
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-tidy
-        sudo apt-get install -y ninja-build zlib1g-dev texlive-latex-base qtwebengine5-dev qttools5-dev-tools qttools5-dev qtquickcontrols2-5-dev qt5keychain-dev qtdeclarative5-dev qtbase5-dev python3-sphinx libssl-dev libsqlite3-dev libqt5websockets5-dev libqt5svg5-dev pkg-config libkf5archive-dev libcloudproviders-dev libcmocka-dev libdbus-1-dev qtbase5-private-dev qt5-qmake inkscape
     - name: Prepare compile_commands.json
       run: |
-        cmake -G Ninja -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1
+        cmake -G Ninja -B build -DCMAKE_PREFIX_PATH=/opt/qt6.6.3 -DQT_MAJOR_VERSION=6 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_UPDATER=ON -DBUILD_TESTING=1
         cd build && ninja
     - name: Create results directory
       run: |

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -21,7 +21,7 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 HEAD^ | clang-tidy-diff.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+        git diff -U0 HEAD^ | clang-tidy-diff-15.py -checks='-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast' -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
       uses: platisd/clang-tidy-pr-comments@master
       with:


### PR DESCRIPTION
* Fix cmake command line for qt6 (as already has been done for other CI tests)
* Switch to the ci-client-qt6 image for consistency with other tests and to eliminate package install step

Let's see how the CI run likes it in the first pass...