### PR TITLE
avoid logs too verbose and with binary data

### DIFF
--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -237,25 +237,18 @@ void CALLBACK cfApiFetchDataCallback(const CF_CALLBACK_INFO *callbackInfo, const
 
     const auto alignAndSendData = [&](const QByteArray &receivedData) {
         QByteArray data = protrudingData + receivedData;
-        qCWarning(lcCfApiWrapper) << "protrudingData + receivedData:" << data;
         protrudingData.clear();
         if (data.size() < cfapiBlockSize) {
             protrudingData = data;
-            qCWarning(lcCfApiWrapper) << "protrudingData:" << protrudingData;
             sendTransferInfo(data, dataOffset);
             dataOffset += data.size();
             return;
         }
         const auto protudingSize = data.size() % cfapiBlockSize;
-        qCWarning(lcCfApiWrapper) << "protudingSize:" << protudingSize;
         protrudingData = data.right(protudingSize);
-        qCWarning(lcCfApiWrapper) << "data.right(protudingSize):" << protrudingData;
         data.chop(protudingSize);
-        qCWarning(lcCfApiWrapper) << "data.chop(protudingSize)" << data;
-        qCWarning(lcCfApiWrapper) << "sendTransferInfo(data:" << data << ", dataOffset:" << dataOffset << ")";
         sendTransferInfo(data, dataOffset);
         dataOffset += data.size();
-        qCWarning(lcCfApiWrapper) << "dataOffset:" << dataOffset;
     };
 
     QObject::connect(&socket, &QLocalSocket::readyRead, &loop, [&] {


### PR DESCRIPTION
with those logs, hydrating is causing too much log to be written and after some time (with big fixles), hydration is failing

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
