### PR TITLE
Fix clickable area of macOS VFS settings checkboxes

### DIFF
--- a/src/gui/macOS/ui/FileProviderFastEnumerationSettings.qml
+++ b/src/gui/macOS/ui/FileProviderFastEnumerationSettings.qml
@@ -34,7 +34,6 @@ Column {
 
     CheckBox {
         id: fastEnumerationEnabledCheckBox
-        width: parent.width
         text: qsTr("Enable fast sync")
         checked: root.fastEnumerationEnabled
         onClicked: root.fastEnumerationEnabledToggled(checked)

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -78,7 +78,6 @@ Page {
 
         CheckBox {
             id: vfsEnabledCheckBox
-            Layout.fillWidth: true
             text: qsTr("Enable virtual files")
             checked: root.controller.vfsEnabledForAccount(root.accountUserIdAtHost)
             onClicked: root.controller.setVfsEnabledForAccount(root.accountUserIdAtHost, checked)


### PR DESCRIPTION
Stop them filling the entire container width, as this makes what looks like whitespace clickable

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
