### PR TITLE
Optimize Ubuntu/Debian build

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -43,8 +43,19 @@ fi
 set -x
 
 cd "${DRONE_WORKSPACE}"
+git config --global user.email "drone@noemail.invalid"
+git config --global user.name "Drone User"
 git fetch --tags
-read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+
+for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
+    git fetch origin debian/dist/${distribution}/${DRONE_TARGET_BRANCH}
+    git checkout origin/debian/dist/${distribution}/${DRONE_TARGET_BRANCH}
+
+    git merge ${DRONE_COMMIT}
+
+    read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+    break
+done
 
 cd "${DRONE_DIR}"
 
@@ -64,8 +75,6 @@ cp -a ${DRONE_WORKSPACE} nextcloud-desktop_${basever}-${revdate}
 tar cjf nextcloud-desktop_${basever}-${revdate}.orig.tar.bz2 --exclude .git --exclude binary nextcloud-desktop_${basever}-${revdate}
 
 cd "${DRONE_WORKSPACE}"
-git config --global user.email "drone@noemail.invalid"
-git config --global user.name "Drone User"
 
 for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
     git checkout -- .

--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -22,6 +22,12 @@ else
     DEBIAN_DISTRIBUTIONS="bullseye bookworm testing"
 fi
 
+declare -A DIST_TO_OBS=(
+    ["bullseye"]="Debian_11"
+    ["bookworm"]="Debian_12"
+    ["testing"]="Debian_Testing"
+)
+
 pull_request=${DRONE_PULL_REQUEST:=master}
 
 if test -z "${DRONE_WORKSPACE}"; then
@@ -120,29 +126,34 @@ if test "${pull_request}" = "master"; then
             fi
         done
 
-        for distribution in ${DEBIAN_DISTRIBUTIONS}; do
-            pkgsuffix=".${distribution}"
-            pkgvertag="~${distribution}1"
-
-            package="${OBS_PACKAGE}${pkgsuffix}"
+        if test -n "${DEBIAN_DISTRIBUTIONS}"; then
+            package="nextcloud-desktop"
             OBS_SUBDIR="${OBS_PROJECT}/${package}"
 
             mkdir -p osc
             pushd osc
-            osc co ${OBS_PROJECT} ${package}
+            osc co "${OBS_PROJECT}" "${package}"
+
             if test "$(ls ${OBS_SUBDIR})"; then
                 osc delete ${OBS_SUBDIR}/*
             fi
 
-            cp ../nextcloud-desktop*.orig.tar.* ${OBS_SUBDIR}/
-            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.dsc ${OBS_SUBDIR}/
-            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.debian.tar* ${OBS_SUBDIR}/
-            cp ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}_source.changes ${OBS_SUBDIR}/
+            ln ../nextcloud-desktop*.orig.tar.* ${OBS_SUBDIR}/
+
+            for distribution in ${DEBIAN_DISTRIBUTIONS}; do
+                pkgsuffix=".${distribution}"
+                pkgvertag="~${distribution}1"
+                obs_dist="${DIST_TO_OBS[${distribution}]}"
+
+                ln ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.dsc ${OBS_SUBDIR}/nextcloud-desktop-${obs_dist}.dsc
+                ln ../nextcloud-desktop_*[0-9.][0-9]${pkgvertag}.debian.tar* ${OBS_SUBDIR}/
+            done
+
             osc add ${OBS_SUBDIR}/*
 
             cd ${OBS_SUBDIR}
-            osc commit -m "Travis update"
+            osc commit -m "Drone update"
             popd
-        done
+        fi
     fi
 fi


### PR DESCRIPTION
Two optimizations are implemented:

- the initial version setup is done using a configuration on the first distribution-specific branch to check fewer log entries
- the Debian packages are uploaded into a single package on the OpenSUSE Build Service, so the source archive needs to be uploaded only once (among other benefits)

If you approve, please, also merge the commit, as some of the checks seem to fail due to reasons not under my control, and I have no permissions to merge in such a case.