### PR TITLE
Add additional options to make cross-compiling client feasible with Mac Crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -33,7 +33,7 @@ struct MacCrafter: ParsableCommand {
     @Option(name: [.short, .long], help: "Code signing identity for desktop client and libs.")
     var codeSignIdentity: String?
 
-    @Option(name: [.short, .customLong("buildPath")], help: "Path for build files to be written.")
+    @Option(name: [.short, .long], help: "Path for build files to be written.")
     var buildPath = "\(FileManager.default.currentDirectoryPath)/build"
 
     @Option(name: [.short, .long], help: "Architecture.")

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -36,6 +36,9 @@ struct MacCrafter: ParsableCommand {
     @Option(name: [.short, .long], help: "Path for build files to be written.")
     var buildPath = "\(FileManager.default.currentDirectoryPath)/build"
 
+    @Option(name: [.short, .long], help: "Path for the final product to be put.")
+    var productPath = "\(FileManager.default.currentDirectoryPath)/product"
+
     @Option(name: [.short, .long], help: "Architecture.")
     var arch = "arm64"
 
@@ -199,6 +202,10 @@ struct MacCrafter: ParsableCommand {
         print("Code-signing Nextcloud Desktop Client libraries and frameworks...")
         let clientAppDir = "\(clientBuildDir)/image-\(buildType)-master/\(appName).app"
         try codesignClientAppBundle(at: clientAppDir, withCodeSignIdentity: codeSignIdentity)
+
+        print("Placing Nextcloud Desktop Client in product directory...")
+        try fm.createDirectory(atPath: productPath, withIntermediateDirectories: true, attributes: nil)
+        try fm.copyItem(atPath: clientAppDir, toPath: productPath)
 
         print("Done!")
     }

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -36,6 +36,9 @@ struct MacCrafter: ParsableCommand {
     @Option(name: [.short, .customLong("buildPath")], help: "Path for build files to be written.")
     var buildPath = "\(FileManager.default.currentDirectoryPath)/build"
 
+    @Option(name: [.short, .long], help: "Architecture.")
+    var arch = "arm64"
+
     @Option(name: [.long], help: "Brew installation script URL.")
     var brewInstallShUrl = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
 
@@ -106,7 +109,7 @@ struct MacCrafter: ParsableCommand {
         let craftMasterDir = "\(buildPath)/craftmaster"
         let craftMasterIni = "\(repoRootDir)/craftmaster.ini"
         let craftMasterPy = "\(craftMasterDir)/CraftMaster.py"
-        let craftTarget = "macos-clang-arm64"
+        let craftTarget = arch == "arm64" ? "macos-clang-arm64" : "macos-64-clang"
         let craftCommand =
             "python3 \(craftMasterPy) --config \(craftMasterIni) --target \(craftTarget) -c"
 
@@ -140,6 +143,7 @@ struct MacCrafter: ParsableCommand {
 
         var craftOptions = [
             "\(craftBlueprintName).srcDir=\(repoRootDir)",
+            "\(craftBlueprintName).osxArchs=\(arch)",
             "\(craftBlueprintName).buildTests=\(buildTests ? "True" : "False")",
             "\(craftBlueprintName).buildMacOSBundle=\(disableAppBundle ? "False" : "True")",
             "\(craftBlueprintName).buildFileProviderModule=\(buildFileProviderModule ? "True" : "False")"
@@ -193,8 +197,6 @@ struct MacCrafter: ParsableCommand {
         }
 
         print("Code-signing Nextcloud Desktop Client libraries and frameworks...")
-
-
         let clientAppDir = "\(clientBuildDir)/image-\(buildType)-master/\(appName).app"
         try codesignClientAppBundle(at: clientAppDir, withCodeSignIdentity: codeSignIdentity)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
