### PR TITLE
Narrow down ReadWrite folder permission to owner

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -456,7 +456,7 @@ bool FileSystem::setFolderPermissions(const QString &path,
         case OCC::FileSystem::FolderPermissions::ReadOnly:
             break;
         case OCC::FileSystem::FolderPermissions::ReadWrite:
-            std::filesystem::permissions(stdStrPath, writePerms, std::filesystem::perm_options::add);
+            std::filesystem::permissions(stdStrPath, std::filesystem::perms::owner_write, std::filesystem::perm_options::add);
             break;
         }
     } catch (const std::filesystem::filesystem_error &e) {


### PR DESCRIPTION
[#6839](https://github.com/nextcloud/desktop/pull/6839) seem to add `group_write` and `others_write` along with `owner_write` permission when setting `FileSystem::FolderPermissions::ReadWrite` permission to a folder, which is addressed in #6863. Please let me know if I'm missing any context.

Resolves #6863 