### PR TITLE
prevent event loop reentrance when handling ENCRYPT socket requests

### DIFF
--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -444,6 +444,13 @@ void SocketApi::slotReadSocket()
                                        << "with argument:" << argument;
                 socketApiJob->failure(QStringLiteral("command not found"));
             }
+        } else if (command.startsWith("ENCRYPT")) {
+            if (indexOfMethod != -1) {
+                ASSERT(thread() == QThread::currentThread())
+                staticMetaObject.method(indexOfMethod)
+                    .invoke(this, Qt::QueuedConnection, Q_ARG(QString, argument.toString()),
+                            Q_ARG(SocketListener *, listener.data()));
+            }
         } else {
             if (indexOfMethod != -1) {
                 // to ensure that listener is still valid we need to call it with Qt::DirectConnection


### PR DESCRIPTION
when receiving a shell integration socket command for ENCRYPT, a generic interface and generic code paths was used

the assumption was that the listener socket would need (and remain) valid while hanlding teh request

some code paths need to display error messages to the user via a QMessageBox

the issue is that this will execute a Qt event loop that will handle the socket disconnection while the socket variable from the caller seems it will stay valid and alive

prevent that by not using a blocking method invocation such that life time mishandling about the socket listener is not possible

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
