### PR TITLE
Make sure we do not renotify notifications when we have received the same etag as during the last check

### DIFF
--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -81,7 +81,7 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
     // In theory the server should five us a 304 Not Modified if there are no new notifications.
     // But in practice, the server doesn't always do that. So we need to compare the ETag headers.
     const auto postFetchEtagHeader = _accountState->notificationsEtagResponseHeader();
-    if (_preFetchEtagHeader == postFetchEtagHeader) {
+    if (!_preFetchEtagHeader.isEmpty() || _preFetchEtagHeader == postFetchEtagHeader) {
         qCInfo(lcServerNotification) << "Notifications ETag header is the same as before, no new notifications.";
         deleteLater();
         emit jobFinished();

--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -78,6 +78,17 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         return;
     }
 
+    // In theory the server should five us a 304 Not Modified if there are no new notifications.
+    // But in practice, the server doesn't always do that. So we need to compare the ETag headers.
+    const auto postFetchEtagHeader = _accountState->notificationsEtagResponseHeader();
+    if (_preFetchEtagHeader == postFetchEtagHeader) {
+        qCInfo(lcServerNotification) << "Notifications ETag header is the same as before, no new notifications.";
+        deleteLater();
+        emit jobFinished();
+        return;
+    }
+    _preFetchEtagHeader = postFetchEtagHeader;
+
     auto notifies = json.object().value("ocs").toObject().value("data").toArray();
 
     auto *ai = qvariant_cast<AccountState *>(sender()->property(propertyAccountStateC));

--- a/src/gui/tray/notificationhandler.h
+++ b/src/gui/tray/notificationhandler.h
@@ -30,6 +30,7 @@ private slots:
 private:
     QPointer<JsonApiJob> _notificationJob;
     AccountState *_accountState;
+    QString _preFetchEtagHeader;
 };
 }
 


### PR DESCRIPTION
Do this regardless of what the server's response is

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
