### PR TITLE
Make sure to not repeat the update channels list when loading the settings for a second account.

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -282,6 +282,7 @@ void GeneralSettings::loadMiscSettings()
 
 #if defined(BUILD_UPDATER)
     const auto validUpdateChannels = cfgFile.validUpdateChannels();
+    _ui->updateChannel->clear();
     _ui->updateChannel->addItems(validUpdateChannels);
     const auto currentUpdateChannelIndex = validUpdateChannels.indexOf(cfgFile.currentUpdateChannel());
     _ui->updateChannel->setCurrentIndex(currentUpdateChannelIndex != -1? currentUpdateChannelIndex : 0);


### PR DESCRIPTION
When adding a new account, the combo box would list each update channels twice.

