### PR TITLE
remove deprecated code only usefull for very old Qt releases

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -31,11 +31,7 @@
 #include <QPushButton>
 #include <type_traits>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <qt6keychain/keychain.h>
-#else
-#include <qt5keychain/keychain.h>
-#endif
 
 namespace {
 constexpr auto urlC = "url";

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -243,13 +243,9 @@ Application::Application(int &argc, char **argv)
     //    setOrganizationName(QLatin1String(APPLICATION_VENDOR));
     setOrganizationDomain(QLatin1String(APPLICATION_REV_DOMAIN));
 
-    // setDesktopFilename to provide wayland compatibility (in general: conformance with naming standards)
-    // but only on Qt >= 5.7, where setDesktopFilename was introduced
-#if (QT_VERSION >= 0x050700)
     QString desktopFileName = QString(QLatin1String(LINUX_APPLICATION_ID)
                                         + QLatin1String(".desktop"));
     setDesktopFileName(desktopFileName);
-#endif
 
     setApplicationName(_theme->appName());
     setWindowIcon(_theme->applicationIcon());
@@ -987,13 +983,7 @@ QString substLang(const QString &lang)
 void Application::setupTranslations()
 {
     QStringList uiLanguages;
-// uiLanguages crashes on Windows with 4.8.0 release builds
-#if (QT_VERSION >= 0x040801) || (QT_VERSION >= 0x040800 && !defined(Q_OS_WIN))
     uiLanguages = QLocale::system().uiLanguages();
-#else
-    // older versions need to fall back to the systems locale
-    uiLanguages << QLocale::system().name();
-#endif
 
     QString enforcedLocale = Theme::instance()->enforcedLocale();
     if (!enforcedLocale.isEmpty()) {

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -293,7 +293,6 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
     // We attempt to work with servers >= 7.0.0 but warn users.
     // Check usages of Account::serverVersionUnsupported() for details.
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
     // Record that the server supports HTTP/2
     // Actual decision if we should use HTTP/2 is done in AccessManager::createRequest
     if (auto job = qobject_cast<AbstractNetworkJob *>(sender())) {
@@ -302,7 +301,6 @@ bool ConnectionValidator::setAndCheckServerVersion(const QString &version)
                 reply->attribute(QNetworkRequest::Http2WasUsedAttribute).toBool());
         }
     }
-#endif
     return true;
 }
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -46,12 +46,6 @@
 
 #include <KZip>
 
-#define QTLEGACY (QT_VERSION < QT_VERSION_CHECK(5,9,0))
-
-#if !(QTLEGACY)
-#include <QOperatingSystemVersion>
-#endif
-
 namespace {
 struct ZipEntry {
     QString localFilename;
@@ -208,11 +202,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     // Hide on non-Windows, or WindowsVersion < 10.
     // The condition should match the default value of ConfigFile::showInExplorerNavigationPane.
 #ifdef Q_OS_WIN
-    #if QTLEGACY
-        if (QSysInfo::windowsVersion() < QSysInfo::WV_WINDOWS10)
-    #else
         if (QOperatingSystemVersion::current() < QOperatingSystemVersion::Windows10)
-    #endif
             _ui->showInExplorerNavigationPaneCheckBox->setVisible(false);
 #else
     // Hide on non-Windows

--- a/src/gui/openfilemanager.cpp
+++ b/src/gui/openfilemanager.cpp
@@ -21,12 +21,7 @@
 #include <QUrl>
 #include <QDesktopServices>
 #include <QApplication>
-
-#define QTLEGACY (QT_VERSION < QT_VERSION_CHECK(5,9,0))
-
-#if !(QTLEGACY)
 #include <QOperatingSystemVersion>
-#endif
 
 namespace OCC {
 
@@ -95,11 +90,7 @@ void showInFileManager(const QString &localPath)
 {
     if (Utility::isWindows()) {
 #ifdef Q_OS_WIN
-        #if QTLEGACY
-            if (QSysInfo::windowsVersion() < QSysInfo::WV_WINDOWS10)
-        #else
             if (QOperatingSystemVersion::current() < QOperatingSystemVersion::Windows7)
-        #endif
                 return;
 #endif
 

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -21,11 +21,7 @@
 
 #include <QApplication>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <qt6keychain/keychain.h>
-#else
-#include <qt5keychain/keychain.h>
-#endif
 
 using namespace OCC;
 using namespace QKeychain;

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -20,11 +20,7 @@
 #include <QSslConfiguration>
 #include <QNetworkCookie>
 #include <QNetworkCookieJar>
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-#include <QNetworkConfiguration>
-#else
 #include <QNetworkInformation>
-#endif
 #include <QUuid>
 
 #include "cookiejar.h"
@@ -39,17 +35,6 @@ Q_LOGGING_CATEGORY(lcAccessManager, "nextcloud.sync.accessmanager", QtInfoMsg)
 AccessManager::AccessManager(QObject *parent)
     : QNetworkAccessManager(parent)
 {
-#if defined(Q_OS_MAC)
-    // FIXME Workaround http://stackoverflow.com/a/15707366/2941 https://bugreports.qt-project.org/browse/QTBUG-30434
-    QNetworkProxy proxy = this->proxy();
-    proxy.setHostName(" ");
-    setProxy(proxy);
-#endif
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0) && !defined(Q_OS_LINUX)
-    // Atempt to workaround for https://github.com/owncloud/client/issues/3969
-    setConfiguration(QNetworkConfiguration());
-#endif
     setCookieJar(new CookieJar);
 }
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -53,11 +53,7 @@
 
 #include <qsslconfiguration.h>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <qt6keychain/keychain.h>
-#else
-#include <qt5keychain/keychain.h>
-#endif
 
 #include "creds/abstractcredentials.h"
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -39,12 +39,7 @@
 #include <QSettings>
 #include <QNetworkProxy>
 #include <QStandardPaths>
-
-#define QTLEGACY (QT_VERSION < QT_VERSION_CHECK(5,9,0))
-
-#if !(QTLEGACY)
 #include <QOperatingSystemVersion>
-#endif
 
 #define DEFAULT_REMOTE_POLL_INTERVAL 30000 // default remote poll time in milliseconds
 #define DEFAULT_MAX_LOG_LINES 20000
@@ -224,11 +219,7 @@ bool ConfigFile::showInExplorerNavigationPane() const
 {
     const bool defaultValue =
 #ifdef Q_OS_WIN
-    #if QTLEGACY
-        (QSysInfo::windowsVersion() < QSysInfo::WV_WINDOWS10);
-    #else
         QOperatingSystemVersion::current() >= QOperatingSystemVersion::Windows10;
-    #endif
 #else
         false
 #endif

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -22,11 +22,7 @@
 #include <QJsonDocument>
 #include <QBuffer>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <qt6keychain/keychain.h>
-#else
-#include <qt5keychain/keychain.h>
-#endif
 
 #include "account.h"
 #include "accessmanager.h"

--- a/src/libsync/creds/keychainchunk.h
+++ b/src/libsync/creds/keychainchunk.h
@@ -18,11 +18,7 @@
 
 #include <QObject>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <qt6keychain/keychain.h>
-#else
-#include <qt5keychain/keychain.h>
-#endif
 
 #include "accountfwd.h"
 

--- a/src/libsync/iconjob.cpp
+++ b/src/libsync/iconjob.cpp
@@ -20,9 +20,7 @@ IconJob::IconJob(AccountPtr account, const QUrl &url, QObject *parent)
     : QObject(parent)
 {
     QNetworkRequest request(url);
-#if (QT_VERSION >= 0x050600)
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
-#endif
     const auto reply = account->sendRawRequest(QByteArrayLiteral("GET"), url, request);
     connect(reply, &QNetworkReply::finished, this, &IconJob::finished);
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -274,11 +274,6 @@ void SyncEngine::deleteStaleErrorBlacklistEntries(const SyncFileItemVector &sync
     }
 }
 
-#if (QT_VERSION < 0x050600)
-template <typename T>
-constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
-#endif
-
 void SyncEngine::conflictRecordMaintenance()
 {
     // Remove stale conflict entries from the database

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -268,11 +268,9 @@ QIcon Theme::themeIcon(const QString &name, bool sysTray) const
     }
 
 #ifdef Q_OS_MAC
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     // This defines the icon as a template and enables automatic macOS color handling
     // See https://bugreports.qt.io/browse/QTBUG-42109
     cached.setIsMask(_mono && sysTray);
-#endif
 #endif
 
     return cached;


### PR DESCRIPTION
we require Qt > 6.0 so any conditionnal code for older releases can be deleted

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
