### PR TITLE
remove most usages of transparent background: fix visual regressions

### DIFF
--- a/src/gui/PredefinedStatusButton.qml
+++ b/src/gui/PredefinedStatusButton.qml
@@ -35,7 +35,7 @@ AbstractButton {
     property string clearAtText: ""
 
     background: Rectangle {
-        color: root.hovered || root.checked ? palette.highlight : "transparent"
+        color: root.hovered || root.checked ? palette.highlight : palette.base
         radius: Style.slightlyRoundedButtonRadius
     }
 

--- a/src/gui/filedetails/FileTag.qml
+++ b/src/gui/filedetails/FileTag.qml
@@ -24,7 +24,7 @@ EnforcedPlainTextLabel {
         border.color: palette.dark
         border.width: Style.normalBorderWidth
         radius: Style.veryRoundedButtonRadius
-        color: "transparent"
+        color: palette.base
     }
 
     color: palette.midlight

--- a/src/gui/filedetails/NCTabButton.qml
+++ b/src/gui/filedetails/NCTabButton.qml
@@ -83,7 +83,7 @@ TabButton {
             implicitWidth: textWidth + Style.standardSpacing * 2
             implicitHeight: 2
 
-            color: tabButton.checked ? tabButton.accentColor : tabButton.hovered ? palette.highlight : "transparent"
+            color: tabButton.checked ? tabButton.accentColor : tabButton.hovered ? palette.highlight : palette.base
         }
     }
 }

--- a/src/gui/tray/ActivityItemActions.qml
+++ b/src/gui/tray/ActivityItemActions.qml
@@ -13,7 +13,7 @@ Repeater {
     property variant linksContextMenu: []
     property bool displayActions: false
 
-    property color moreActionsButtonColor: "transparent"
+    property color moreActionsButtonColor: palette.base
 
     property int maxActionButtons: 0
 

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -24,7 +24,7 @@ import Qt5Compat.GraphicalEffects
 
 ApplicationWindow {
     id: root
-    color: palette.base
+    color: palette.window
     flags: Qt.Dialog | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
 
     readonly property int windowSpacing: 10

--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -24,7 +24,7 @@ import Qt5Compat.GraphicalEffects
 
 ApplicationWindow {
     id: root
-    color: "transparent"
+    color: palette.base
     flags: Qt.Dialog | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
 
     readonly property int windowSpacing: 10

--- a/src/gui/tray/EditFileLocallyLoadingDialog.qml
+++ b/src/gui/tray/EditFileLocallyLoadingDialog.qml
@@ -9,7 +9,7 @@ ApplicationWindow {
     id: root
     flags: Qt.Dialog | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
 
-    color: "transparent"
+    color: palette.base
 
     width: 320
     height: contentLayout.implicitHeight

--- a/src/gui/tray/EditFileLocallyLoadingDialog.qml
+++ b/src/gui/tray/EditFileLocallyLoadingDialog.qml
@@ -9,7 +9,7 @@ ApplicationWindow {
     id: root
     flags: Qt.Dialog | Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
 
-    color: palette.base
+    color: palette.window
 
     width: 320
     height: contentLayout.implicitHeight

--- a/src/gui/tray/HeaderButton.qml
+++ b/src/gui/tray/HeaderButton.qml
@@ -38,7 +38,7 @@ Button {
     Layout.preferredHeight: Style.trayWindowHeaderHeight
 
     background: Rectangle {
-        color: root.hovered || root.visualFocus ? Style.currentUserHeaderTextColor : palette.base
+        color: root.hovered || root.visualFocus ? Style.currentUserHeaderTextColor : Style.currentUserHeaderColor
         opacity: 0.2
     }
 

--- a/src/gui/tray/HeaderButton.qml
+++ b/src/gui/tray/HeaderButton.qml
@@ -38,7 +38,7 @@ Button {
     Layout.preferredHeight: Style.trayWindowHeaderHeight
 
     background: Rectangle {
-        color: root.hovered || root.visualFocus ? Style.currentUserHeaderTextColor : "transparent"
+        color: root.hovered || root.visualFocus ? Style.currentUserHeaderTextColor : palette.base
         opacity: 0.2
     }
 

--- a/src/gui/tray/TrayFolderListItem.qml
+++ b/src/gui/tray/TrayFolderListItem.qml
@@ -36,7 +36,7 @@ MenuItem {
         Rectangle {
             anchors.fill: parent
             anchors.margins: Style.normalBorderWidth
-            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
         }
     }
 

--- a/src/gui/tray/TrayFolderListItem.qml
+++ b/src/gui/tray/TrayFolderListItem.qml
@@ -36,7 +36,7 @@ MenuItem {
         Rectangle {
             anchors.fill: parent
             anchors.margins: Style.normalBorderWidth
-            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
         }
     }
 

--- a/src/gui/tray/TrayFoldersMenuButton.qml
+++ b/src/gui/tray/TrayFoldersMenuButton.qml
@@ -100,7 +100,7 @@ HeaderButton {
                     width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
                     height: width
                     anchors.centerIn: parent
-                    color: root.hovered ? Style.currentUserHeaderTextColor : palette.base
+                    color: root.hovered ? Style.currentUserHeaderTextColor : palette.window
                     opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
                     radius: width * Style.trayFolderStatusIndicatorRadiusFactor
                     z: -1

--- a/src/gui/tray/TrayFoldersMenuButton.qml
+++ b/src/gui/tray/TrayFoldersMenuButton.qml
@@ -100,7 +100,7 @@ HeaderButton {
                     width: Style.folderStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
                     height: width
                     anchors.centerIn: parent
-                    color: root.hovered ? Style.currentUserHeaderTextColor : "transparent"
+                    color: root.hovered ? Style.currentUserHeaderTextColor : palette.base
                     opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
                     radius: width * Style.trayFolderStatusIndicatorRadiusFactor
                     z: -1

--- a/src/gui/tray/UnifiedSearchResultListItem.qml
+++ b/src/gui/tray/UnifiedSearchResultListItem.qml
@@ -46,7 +46,7 @@ MouseArea {
     Rectangle {
         id: unifiedSearchResultHoverBackground
         anchors.fill: parent
-        color: parent.containsMouse ? palette.highlight : palette.base
+        color: parent.containsMouse ? palette.highlight : palette.window
     }
 
     Loader {

--- a/src/gui/tray/UnifiedSearchResultListItem.qml
+++ b/src/gui/tray/UnifiedSearchResultListItem.qml
@@ -46,7 +46,7 @@ MouseArea {
     Rectangle {
         id: unifiedSearchResultHoverBackground
         anchors.fill: parent
-        color: (parent.containsMouse ? palette.highlight : "transparent")
+        color: parent.containsMouse ? palette.highlight : palette.base
     }
 
     Loader {

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -39,7 +39,7 @@ AbstractButton {
         anchors.margins: 1
         color: (userLine.hovered || userLine.visualFocus) &&
                !(userMoreButton.hovered || userMoreButton.visualFocus) ?
-                   palette.highlight : palette.base
+                   palette.highlight : palette.window
     }
 
     contentItem: RowLayout {
@@ -149,7 +149,7 @@ AbstractButton {
             background: Rectangle {
                 anchors.fill: parent
                 anchors.margins: 1
-                color: userMoreButton.hovered || userMoreButton.visualFocus ? palette.highlight : palette.base
+                color: userMoreButton.hovered || userMoreButton.visualFocus ? palette.highlight : palette.window
             }
 
             contentItem: Image {
@@ -188,7 +188,7 @@ AbstractButton {
                         Rectangle {
                             anchors.fill: parent
                             anchors.margins: 1
-                            color: parent.parent.hovered ? palette.highlight : palette.base
+                            color: parent.parent.hovered ? palette.highlight : palette.window
                         }
                     }
 
@@ -222,7 +222,7 @@ AbstractButton {
                         Rectangle {
                             anchors.fill: parent
                             anchors.margins: 1
-                            color: parent.parent.hovered ? palette.highlight : palette.base
+                            color: parent.parent.hovered ? palette.highlight : palette.window
                         }
                     }
 

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -149,7 +149,7 @@ AbstractButton {
             background: Rectangle {
                 anchors.fill: parent
                 anchors.margins: 1
-                color: userMoreButton.hovered || userMoreButton.visualFocus ? palette.highlight : "transparent"
+                color: userMoreButton.hovered || userMoreButton.visualFocus ? palette.highlight : palette.base
             }
 
             contentItem: Image {
@@ -188,7 +188,7 @@ AbstractButton {
                         Rectangle {
                             anchors.fill: parent
                             anchors.margins: 1
-                            color: parent.parent.hovered ? palette.highlight : "transparent"
+                            color: parent.parent.hovered ? palette.highlight : palette.base
                         }
                     }
 
@@ -222,7 +222,7 @@ AbstractButton {
                         Rectangle {
                             anchors.fill: parent
                             anchors.margins: 1
-                            color: parent.parent.hovered ? palette.highlight : "transparent"
+                            color: parent.parent.hovered ? palette.highlight : palette.base
                         }
                     }
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -308,7 +308,7 @@ ApplicationWindow {
 
                         background: Rectangle {
                             border.color: palette.dark
-                            color: palette.base
+                            color: palette.window
                             radius: Style.currentAccountButtonRadius
                         }
 
@@ -345,7 +345,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
                                 }
                             }
 
@@ -397,7 +397,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
                                 }
                             }
 
@@ -419,7 +419,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
                                 }
                             }
 
@@ -441,7 +441,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
                                 }
                             }
 
@@ -452,7 +452,7 @@ ApplicationWindow {
                     }
 
                     background: Rectangle {
-                        color: parent.hovered || parent.visualFocus ? Style.currentUserHeaderTextColor : palette.base
+                        color: parent.hovered || parent.visualFocus ? Style.currentUserHeaderTextColor : palette.window
                         opacity: 0.2
                     }
 
@@ -496,7 +496,7 @@ ApplicationWindow {
                                 height: width
                                 anchors.bottom: currentAccountAvatar.bottom
                                 anchors.right: currentAccountAvatar.right
-                                color: currentAccountButton.hovered ? Style.currentUserHeaderTextColor : palette.base
+                                color: currentAccountButton.hovered ? Style.currentUserHeaderTextColor : palette.window
                                 opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
                                 radius: width * Style.trayFolderStatusIndicatorRadiusFactor
                             }
@@ -663,7 +663,7 @@ ApplicationWindow {
 
                         background: Rectangle {
                             border.color: palette.dark
-                            color: palette.base
+                            color: palette.window
                             radius: 2
                         }
 
@@ -699,7 +699,7 @@ ApplicationWindow {
                                         Rectangle {
                                             anchors.fill: parent
                                             anchors.margins: 1
-                                            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
+                                            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.window
                                         }
                                     }
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -452,7 +452,7 @@ ApplicationWindow {
                     }
 
                     background: Rectangle {
-                        color: parent.hovered || parent.visualFocus ? Style.currentUserHeaderTextColor : palette.window
+                        color: currentAccountButton.hovered || currentAccountButton.visualFocus ? Style.currentUserHeaderTextColor : Style.currentUserHeaderColor
                         opacity: 0.2
                     }
 

--- a/src/gui/tray/Window.qml
+++ b/src/gui/tray/Window.qml
@@ -345,7 +345,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
                                 }
                             }
 
@@ -397,7 +397,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
                                 }
                             }
 
@@ -419,7 +419,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
                                 }
                             }
 
@@ -441,7 +441,7 @@ ApplicationWindow {
                                 Rectangle {
                                     anchors.fill: parent
                                     anchors.margins: 1
-                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+                                    color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
                                 }
                             }
 
@@ -452,7 +452,7 @@ ApplicationWindow {
                     }
 
                     background: Rectangle {
-                        color: parent.hovered || parent.visualFocus ? Style.currentUserHeaderTextColor : "transparent"
+                        color: parent.hovered || parent.visualFocus ? Style.currentUserHeaderTextColor : palette.base
                         opacity: 0.2
                     }
 
@@ -496,7 +496,7 @@ ApplicationWindow {
                                 height: width
                                 anchors.bottom: currentAccountAvatar.bottom
                                 anchors.right: currentAccountAvatar.right
-                                color: currentAccountButton.hovered ? Style.currentUserHeaderTextColor : "transparent"
+                                color: currentAccountButton.hovered ? Style.currentUserHeaderTextColor : palette.base
                                 opacity: Style.trayFolderStatusIndicatorMouseHoverOpacityFactor
                                 radius: width * Style.trayFolderStatusIndicatorRadiusFactor
                             }
@@ -699,7 +699,7 @@ ApplicationWindow {
                                         Rectangle {
                                             anchors.fill: parent
                                             anchors.margins: 1
-                                            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : "transparent"
+                                            color: parent.parent.hovered || parent.parent.visualFocus ? palette.highlight : palette.base
                                         }
                                     }
 

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -17,7 +17,7 @@ QtObject {
     readonly property color lightHover: Theme.darkMode ? Qt.lighter(backgroundColor, 2) : Qt.darker(backgroundColor, 1.05)
     readonly property color darkerHover: Theme.darkMode ? Qt.lighter(backgroundColor, 2.35) : Qt.darker(backgroundColor, 1.25)
     readonly property color menuBorder: Theme.darkMode ? Qt.lighter(backgroundColor, 2.5) : Qt.darker(backgroundColor, 1.5)
-    readonly property color backgroundColor: Theme.systemPalette.base
+    readonly property color backgroundColor: Theme.systemPalette.window
     readonly property color buttonBackgroundColor: Theme.systemPalette.button
     readonly property color positiveColor: Qt.rgba(0.38, 0.74, 0.38, 1)
 


### PR DESCRIPTION
with transparent backgrounds, most of teh time the result is hard to read

that is mostly unintended and unless there is some blur added, the UI becomes unusable

Close https://github.com/nextcloud/desktop/issues/6992

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
