### PR TITLE
fix(settings): Use broken lock icon when not using https

### DIFF
--- a/src/gui/sslbutton.cpp
+++ b/src/gui/sslbutton.cpp
@@ -173,7 +173,7 @@ void SslButton::updateAccountState(AccountState *accountState)
         QSslCipher cipher = account->_sessionCipher;
         setToolTip(tr("This connection is encrypted using %1 bit %2.\n").arg(cipher.usedBits()).arg(cipher.name()));
     } else {
-        setIcon(QIcon(QLatin1String(":/client/theme/lock-http.svg")));
+        setIcon(QIcon(QLatin1String(":/client/theme/lock-broken.svg")));
         setToolTip(tr("This connection is NOT secure as it is not encrypted.\n"));
     }
 }


### PR DESCRIPTION
Fixes #6723

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
