### PR TITLE
fix bug report breakage

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -74,7 +74,7 @@ body:
         - "Windows"
         - "macOS"
         - "Linux"
-        - "Other" (e.g. FreeBSD)
+        - "Other (e.g. FreeBSD)"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Fixing my mistake in #7006 with the quotes that broke the form!

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
