### PR TITLE
avoid wrong usage of QStringBuilder via auto type deduction

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1481,7 +1481,7 @@ void Folder::warnOnNewExcludedItem(const SyncJournalFileRecord &record, const QS
     // Note: This assumes we're getting file watcher notifications
     // for folders only on creation and deletion - if we got a notification
     // on content change that would create spurious warnings.
-    const auto fullPath = _canonicalLocalPath + path;
+    const auto fullPath = QString{_canonicalLocalPath + path};
     QFileInfo fi(fullPath);
     if (!FileSystem::fileExists(fullPath))
         return;

--- a/src/gui/proxyauthhandler.cpp
+++ b/src/gui/proxyauthhandler.cpp
@@ -58,7 +58,7 @@ void ProxyAuthHandler::handleProxyAuthenticationRequired(
     }
 
     const auto account = qobject_cast<Account *>(sender());
-    const auto key = proxy.hostName() + QLatin1Char(':') + QString::number(proxy.port());
+    const auto key = QString{proxy.hostName() + QLatin1Char(':') + QString::number(proxy.port())};
 
     // If the proxy server has changed, forget what we know.
     if (key != _proxy) {


### PR DESCRIPTION
detected via https://github.com/KDE/clazy/blob/master/docs/checks/README-auto-unexpected-qstringbuilder.md#auto-unexpected-qstringbuilder

also reported by g++ via compile time warnings

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
