### PR TITLE
Fix release kind detection

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -59,7 +59,7 @@ for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
 
     git merge ${DRONE_COMMIT}
 
-    read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+    read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable "" "" ${DRONE_COMMIT})
     break
 done
 


### PR DESCRIPTION
The changes last made to the Ubuntu/Debian build scripts do not work well on the stable branches, as it is not detected properly if we are dealing with a release or not. This patch fixes this problem.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
