### PR TITLE
Fix make_universal.py not taking into account 64-bit bundle dylibs

### DIFF
--- a/admin/osx/make_universal.py
+++ b/admin/osx/make_universal.py
@@ -34,7 +34,8 @@ def path_relative_to_package(app_package_file_path, file_path):
 def is_executable(file_path):
     output = str(execute(["file", file_path]))
     if (("Mach-O 64-bit dynamically linked shared library" in output)
-        or ("Mach-O 64-bit executable" in output)):
+        or ("Mach-O 64-bit executable" in output)
+            or ("Mach-O 64-bit bundle" in output)):
         return True
     return False
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
