### PR TITLE
Fix release kind detection

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -59,7 +59,7 @@ for distribution in ${UBUNTU_DISTRIBUTIONS} ${DEBIAN_DISTRIBUTIONS}; do
 
     git merge ${DRONE_COMMIT}
 
-    read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable)
+    read basever revdate kind <<<$(admin/linux/debian/scripts/git2changelog.py /tmp/tmpchangelog stable "" "" ${DRONE_COMMIT})
     break
 done
 


### PR DESCRIPTION
The changes last made to the Ubuntu/Debian build scripts do not work well on the stable branches, as it is not detected properly if we are dealing with a release or not. This patch fixes this problem.
