### PR TITLE
docs: conf file option moveToTrash is no longer Linux specific

### DIFF
--- a/doc/conffile.rst
+++ b/doc/conffile.rst
@@ -56,7 +56,6 @@ Some interesting values that can be set on the configuration file are:
 | ``timeout``                      | ``300``                  | The timeout for network connections in seconds.                                                        |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``moveToTrash``                  | ``false``                | If non-locally deleted files should be moved to trash instead of deleting them completely.             |
-|                                  |                          | This option only works on linux                                                                        |
 +----------------------------------+--------------------------+--------------------------------------------------------------------------------------------------------+
 | ``showExperimentalOptions``      | ``false``                | Whether to show experimental options that are still undergoing testing in the user interface.          |
 |                                  |                          | Turning this on does not enable experimental behavior on its own. It does enable user interface        |


### PR DESCRIPTION
Since #5698 / #3362 this option is no longer restricted to Linux. (It's also now in the GUI too).

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
