### PR TITLE
Add some extra syncing details to the tray icon tooltip

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -137,11 +137,10 @@ public:
     bool startFromScratch(const QString &);
 
     /// Produce text for use in the tray tooltip
-    static QString trayTooltipStatusString(SyncResult::Status syncStatus, bool hasUnresolvedConflicts, bool paused);
+    static QString trayTooltipStatusString(SyncResult::Status syncStatus, bool hasUnresolvedConflicts, bool paused, ProgressInfo *progress);
 
     /// Compute status summarizing multiple folders
-    static void trayOverallStatus(const QList<Folder *> &folders,
-        SyncResult::Status *status, bool *unresolvedConflicts);
+    static void trayOverallStatus(const QList<Folder *> &folders, SyncResult::Status *status, bool *unresolvedConflicts, ProgressInfo **overallProgressInfo);
 
     // Escaping of the alias which is used in QSettings AND the file
     // system, thus need to be escaped.

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -566,11 +566,6 @@ void Systray::showTalkMessage(const QString &title, const QString &message, cons
 #endif
 }
 
-void Systray::setToolTip(const QString &tip)
-{
-    QSystemTrayIcon::setToolTip(tr("%1: %2").arg(Theme::instance()->appNameGUI(), tip));
-}
-
 bool Systray::syncIsPaused() const
 {
     return _syncIsPaused;

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -122,7 +122,6 @@ public slots:
     void showMessage(const QString &title, const QString &message, QSystemTrayIcon::MessageIcon icon = Information);
     void showUpdateMessage(const QString &title, const QString &message, const QUrl &webUrl);
     void showTalkMessage(const QString &title, const QString &message, const QString &replyTo, const QString &token, const OCC::AccountStatePtr &accountState);
-    void setToolTip(const QString &tip);
 
     void createCallDialog(const OCC::Activity &callNotification, const OCC::AccountStatePtr accountState);
     void createEditFileLocallyLoadingDialog(const QString &fileName);

--- a/src/libsync/syncengine.h
+++ b/src/libsync/syncengine.h
@@ -78,6 +78,11 @@ public:
     [[nodiscard]] SyncOptions syncOptions() const { return _syncOptions; }
     [[nodiscard]] bool ignoreHiddenFiles() const { return _ignore_hidden_files; }
 
+    [[nodiscard]] ProgressInfo *progressInfo() const
+    {
+        return _progressInfo.get();
+    }
+
     [[nodiscard]] ExcludedFiles &excludedFiles() const { return *_excludedFiles; }
     [[nodiscard]] SyncFileStatusTracker &syncFileStatusTracker() const { return *_syncFileStatusTracker; }
 


### PR DESCRIPTION
This pull request adds some more details to the tray icon tooltip text.

There was some unused code that updated some status bar text, so I opted to re-use that.  As of now it displays what the old code did -- the file size to be synced and the estimated time left if applicable.

On my Linux (KDE) system it will display that information per folder:
![Screenshot_20240829_172644](https://github.com/user-attachments/assets/5ed9187b-f594-4af1-9d78-4c829b03252a)

On Windows it will only display if there is only one folder to be synced.  The tooltip message will roughly look like that (still need to check that it doesn't get truncated):
![Screenshot_20240829_171619](https://github.com/user-attachments/assets/4e5e2ddb-6a48-4c32-9c31-430c4f3ea0bf)