### PR TITLE
Code-sign client via mac-crafter so it may pass notarisation

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -33,7 +33,7 @@ func isAppExtension(_ path: String) -> Bool {
 func codesign(
     identity: String,
     path: String,
-    options: String = "--timestamp --force --preserve-metadata=entitlements --verbose=4 --options runtime"
+    options: String = "--timestamp --force --preserve-metadata=entitlements --verbose=4 --options runtime --deep"
 ) throws {
     print("Code-signing \(path)...")
     let command = "codesign -s \"\(identity)\" \(options) \(path)"
@@ -82,7 +82,7 @@ func codesignClientAppBundle(
     let sparkleFrameworkPath = "\(clientContentsDir)/Frameworks/Sparkle.framework"
     try codesign(identity: codeSignIdentity,
                  path: "\(sparkleFrameworkPath)/Resources/Autoupdate.app/Contents/MacOS/*",
-                 options: "--timestamp --force --verbose=4 --options runtime")
+                 options: "--timestamp --force --verbose=4 --options runtime --deep")
 
     print("Re-codesigning Sparkle library...")
     try codesign(identity: codeSignIdentity, path: "\(sparkleFrameworkPath)/Sparkle")
@@ -106,7 +106,7 @@ func codesignClientAppBundle(
                                        encoding: .utf8)
         try codesign(identity: codeSignIdentity,
                      path: appExtensionPath,
-                     options: "--timestamp --force --verbose=4 --options runtime --entitlements \(tmpEntitlementXmlPath)")
+                     options: "--timestamp --force --verbose=4 --options runtime --deep --entitlements \(tmpEntitlementXmlPath)")
     }
 
     // Now we do the final codesign bit

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -108,4 +108,8 @@ func codesignClientAppBundle(
                      path: appExtensionPath,
                      options: "--timestamp --force --verbose=4 --options runtime --entitlements \(tmpEntitlementXmlPath)")
     }
+
+    // Now we do the final codesign bit
+    print("Code-signing Nextcloud Desktop Client binaries...")
+    try codesign(identity: codeSignIdentity, path: "\(clientContentsDir)/MacOS/*")
 }

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -74,6 +74,16 @@ func codesignClientAppBundle(
     try recursivelyCodesign(path: "\(clientContentsDir)/PlugIns", identity: codeSignIdentity)
     try recursivelyCodesign(path: "\(clientContentsDir)/Resources", identity: codeSignIdentity)
 
-    print("Code-signing Nextcloud Desktop Client app bundle...")
-    try codesign(identity: codeSignIdentity, path: clientAppDir)
+    // Time to fix notarisation issues.
+    // Multiple components of the app will now have the get-task-allow entitlements.
+    // We need to strip these out manually.
+
+    print("Code-signing Sparkle autoupdater app (without entitlements)...")
+    let sparkleFrameworkPath = "\(clientContentsDir)/Frameworks/Sparkle.framework"
+    try codesign(identity: codeSignIdentity,
+                 path: "\(sparkleFrameworkPath)/Resources/Autoupdate.app/Contents/MacOS/*",
+                 options: "--timestamp --force --verbose=4 --options runtime")
+
+    print("Re-codesigning Sparkle library...")
+    try codesign(identity: codeSignIdentity, path: "\(sparkleFrameworkPath)/Sparkle")
 }

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -56,6 +56,13 @@ func recursivelyCodesign(path: String, identity: String) throws {
     }
 }
 
+func saveCodesignEntitlements(target: String, path: String) throws {
+    let command = "codesign -d --entitlements \(path) --xml \(target)"
+    guard shell(command) == 0 else {
+        throw CodeSigningError.failedToCodeSign("Failed to save entitlements for \(target).")
+    }
+}
+
 func codesignClientAppBundle(
     at clientAppDir: String, withCodeSignIdentity codeSignIdentity: String
 ) throws {

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -194,14 +194,11 @@ struct MacCrafter: ParsableCommand {
             throw MacCrafterError.craftError("Error crafting Nextcloud Desktop Client.")
         }
 
-        guard let codeSignIdentity else {
-            print("Crafted Nextcloud Desktop Client. Not codesigned.")
-            return
-        }
-
-        print("Code-signing Nextcloud Desktop Client libraries and frameworks...")
         let clientAppDir = "\(clientBuildDir)/image-\(buildType)-master/\(appName).app"
-        try codesignClientAppBundle(at: clientAppDir, withCodeSignIdentity: codeSignIdentity)
+        if let codeSignIdentity {
+            print("Code-signing Nextcloud Desktop Client libraries and frameworks...")
+            try codesignClientAppBundle(at: clientAppDir, withCodeSignIdentity: codeSignIdentity)
+        }
 
         print("Placing Nextcloud Desktop Client in \(productPath)...")
         if !fm.fileExists(atPath: productPath) {

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -15,10 +15,8 @@
 import ArgumentParser
 import Foundation
 
-struct MacCrafter: ParsableCommand {
-    static let configuration = CommandConfiguration(
-        abstract: "A tool to easily build a fully-functional Nextcloud Desktop Client for macOS."
-    )
+struct Build: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Client building script")
 
     enum MacCrafterError: Error {
         case failedEnumeration(String)
@@ -213,6 +211,30 @@ struct MacCrafter: ParsableCommand {
 
         print("Done!")
     }
+}
+
+struct Codesign: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Codesigning script for the client.")
+
+    @Argument(help: "Path to the Nextcloud Desktop Client app bundle.")
+    var appBundlePath = "\(FileManager.default.currentDirectoryPath)/product/Nextcloud.app"
+
+    @Option(name: [.short, .long], help: "Code signing identity for desktop client and libs.")
+    var codeSignIdentity: String
+
+    mutating func run() throws {
+        try codesignClientAppBundle(at: appBundlePath, withCodeSignIdentity: codeSignIdentity)
+    }
+}
+
+struct MacCrafter: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "A tool to easily build a fully-functional Nextcloud Desktop Client for macOS.",
+        subcommands: [Build.self, Codesign.self],
+        defaultSubcommand: Build.self
+    )
+
+
 }
 
 MacCrafter.main()

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -209,6 +209,9 @@ struct MacCrafter: ParsableCommand {
                 atPath: productPath, withIntermediateDirectories: true, attributes: nil
             )
         }
+        if fm.fileExists(atPath: "\(productPath)/\(appName).app") {
+            try fm.removeItem(atPath: "\(productPath)/\(appName).app")
+        }
         try fm.copyItem(atPath: clientAppDir, toPath: "\(productPath)/\(appName).app")
 
         print("Done!")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
