### PR TITLE
changing default chunk size to 100MB

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -244,7 +244,7 @@ int ConfigFile::timeout() const
 qint64 ConfigFile::chunkSize() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
-    return settings.value(QLatin1String(chunkSizeC), 10LL * 1000LL * 1000LL).toLongLong(); // default to 10 MB
+    return settings.value(QLatin1String(chunkSizeC), 100LL * 1024LL * 1024LL).toLongLong(); // 100MiB
 }
 
 qint64 ConfigFile::maxChunkSize() const

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -55,7 +55,7 @@ public:
      * starting value and is then gradually adjusted within the
      * minChunkSize / maxChunkSize bounds.
      */
-    qint64 _initialChunkSize = 10 * 1000 * 1000; // 10MB
+    qint64 _initialChunkSize = 100LL * 1024LL * 1024LL; // 100MiB
 
     /** The target duration of chunk uploads for dynamic chunk sizing.
      *

--- a/test/testuploadreset.cpp
+++ b/test/testuploadreset.cpp
@@ -33,7 +33,7 @@ private slots:
                 {"chunking", "1.0"},
                 {"httpErrorCodesThatResetFailingChunkedUploads", QVariantList{500} } } } });
 
-        const int size = 100 * 1000 * 1000; // 100 MB
+        const auto size = 200LL * 1024LL * 1024LL; // 200 MiB
         fakeFolder.localModifier().insert("A/a0", size);
         QDateTime modTime = QDateTime::currentDateTime();
         fakeFolder.localModifier().setModTime("A/a0", modTime);


### PR DESCRIPTION
goal is to have better performance and uniform behavior between all files clients

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
