### PR TITLE
Add support for the new craft blueprint options relating to override server urls

### DIFF
--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -80,6 +80,9 @@ struct Build: ParsableCommand {
     @Option(name: [.long], help: "Sparkle package signing key.")
     var sparklePackageSignKey: String?
 
+    @Option(name: [.long], help: "Override server url.")
+    var overrideServerUrl: String?
+
     @Flag(help: "Reconfigure KDE Craft.")
     var reconfigureCraft = false
 
@@ -100,6 +103,9 @@ struct Build: ParsableCommand {
 
     @Flag(help: "Run a full rebuild.")
     var fullRebuild = false
+
+    @Flag(help: "Force override server URL.")
+    var forceOverrideServerUrl = false
 
     @Flag(help: "Create an installer package.")
     var package = false
@@ -167,6 +173,11 @@ struct Build: ParsableCommand {
             "\(craftBlueprintName).buildMacOSBundle=\(disableAppBundle ? "False" : "True")",
             "\(craftBlueprintName).buildFileProviderModule=\(buildFileProviderModule ? "True" : "False")"
         ]
+
+        if let overrideServerUrl {
+            craftOptions.append("\(craftBlueprintName).overrideServerUrl=\(overrideServerUrl)")
+            craftOptions.append("\(craftBlueprintName).forceOverrideServerUrl=\(forceOverrideServerUrl ? "True" : "False")")
+        }
 
         if !disableAutoUpdater {
             print("Configuring Sparkle auto-updater.")


### PR DESCRIPTION
Depends on https://github.com/nextcloud/desktop-client-blueprints/pull/18

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
