### PR TITLE
Add packaging capability to Mac Crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Craft.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Craft.swift
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2024 by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+func archToCraftTarget(_ arch: String) -> String {
+    return arch == "arm64" ? "macos-clang-arm64" : "macos-64-clang"
+}

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -19,6 +19,8 @@ enum PackagingError: Error {
     case packageBuildError(String)
     case packageSigningError(String)
     case packageNotarisationError(String)
+    case packageSparkleBuildError(String)
+    case packageSparkleSignError(String)
 }
 
 func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
@@ -57,3 +59,17 @@ func notarisePackage(
     }
 }
 
+func buildSparklePackage(packagePath: String, buildPath: String) throws -> String {
+    let sparkleTbzPath = "\(packagePath).tbz"
+    guard shell("tar cf \(sparkleTbzPath) \(packagePath)") == 0 else {
+        throw PackagingError.packageSparkleBuildError("Could not create Sparkle package tbz!")
+    }
+    return sparkleTbzPath
+}
+
+func signSparklePackage(sparkleTbzPath: String, buildPath: String, signKey: String) throws
+{
+    guard shell("\(buildPath)/bin/sign_update -s \(signKey) \(sparkleTbzPath)") == 0 else {
+        throw PackagingError.packageSparkleSignError("Could not sign Sparkle package tbz!")
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -23,6 +23,7 @@ enum PackagingError: Error {
     case packageSparkleSignError(String)
 }
 
+/// NOTE: Requires Packages utility. http://s.sudre.free.fr/Software/Packages/about.html
 fileprivate func buildPackage(appName: String, buildWorkPath: String, productPath: String) throws -> String {
     let packageFile = "\(appName).pkg"
     let pkgprojPath = "\(buildWorkPath)/admin/osx/macosx.pkgproj"

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -23,13 +23,12 @@ enum PackagingError: Error {
     case packageSparkleSignError(String)
 }
 
-func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
-    let projectName = "Nextcloud" // TODO: Get specific name
-    let packageFile = "\(projectName).pkg"
+func buildPackage(appName: String, buildWorkPath: String, productPath: String) throws -> String {
+    let packageFile = "\(appName).pkg"
     let sparkleFile = "\(packageFile).tbz"
     let pkgprojPath = "\(buildWorkPath)/admin/osx/macosx.pkgproj"
 
-    guard shell("packagesutil --file \(pkgprojPath) set project name \(projectName)") == 0 else {
+    guard shell("packagesutil --file \(pkgprojPath) set project name \(appName)") == 0 else {
         throw PackagingError.projectNameSettingError("Could not set project name in pkgproj!")
     }
     guard shell("packagesbuild -v --build-folder \(productPath) -F \(productPath) \(pkgprojPath)") == 0 else {

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -25,7 +25,6 @@ enum PackagingError: Error {
 
 func buildPackage(appName: String, buildWorkPath: String, productPath: String) throws -> String {
     let packageFile = "\(appName).pkg"
-    let sparkleFile = "\(packageFile).tbz"
     let pkgprojPath = "\(buildWorkPath)/admin/osx/macosx.pkgproj"
 
     guard shell("packagesutil --file \(pkgprojPath) set project name \(appName)") == 0 else {

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -23,7 +23,7 @@ enum PackagingError: Error {
     case packageSparkleSignError(String)
 }
 
-func buildPackage(appName: String, buildWorkPath: String, productPath: String) throws -> String {
+fileprivate func buildPackage(appName: String, buildWorkPath: String, productPath: String) throws -> String {
     let packageFile = "\(appName).pkg"
     let pkgprojPath = "\(buildWorkPath)/admin/osx/macosx.pkgproj"
 
@@ -36,7 +36,7 @@ func buildPackage(appName: String, buildWorkPath: String, productPath: String) t
     return "\(productPath)/\(packageFile)"
 }
 
-func signPackage(packagePath: String, packageSigningId: String) throws {
+fileprivate func signPackage(packagePath: String, packageSigningId: String) throws {
     let packagePathNew = "\(packagePath).new"
     guard shell("productsign --timestamp --sign '\(packageSigningId)' \(packagePath) \(packagePathNew)") == 0 else {
         throw PackagingError.packageSigningError("Could not sign pkg file!")
@@ -46,7 +46,7 @@ func signPackage(packagePath: String, packageSigningId: String) throws {
     try fm.moveItem(atPath: packagePathNew, toPath: packagePath)
 }
 
-func notarisePackage(
+fileprivate func notarisePackage(
     packagePath: String, appleId: String, applePassword: String, appleTeamId: String
 ) throws {
     guard shell("xcrun notarytool submit \(packagePath) --apple-id \(appleId) --password \(applePassword) --team-id \(appleTeamId) --wait") == 0 else {
@@ -57,7 +57,7 @@ func notarisePackage(
     }
 }
 
-func buildSparklePackage(packagePath: String, buildPath: String) throws -> String {
+fileprivate func buildSparklePackage(packagePath: String, buildPath: String) throws -> String {
     let sparkleTbzPath = "\(packagePath).tbz"
     guard shell("tar cf \(sparkleTbzPath) \(packagePath)") == 0 else {
         throw PackagingError.packageSparkleBuildError("Could not create Sparkle package tbz!")
@@ -65,8 +65,7 @@ func buildSparklePackage(packagePath: String, buildPath: String) throws -> Strin
     return sparkleTbzPath
 }
 
-func signSparklePackage(sparkleTbzPath: String, buildPath: String, signKey: String) throws
-{
+fileprivate func signSparklePackage(sparkleTbzPath: String, buildPath: String, signKey: String) throws {
     guard shell("\(buildPath)/bin/sign_update -s \(signKey) \(sparkleTbzPath)") == 0 else {
         throw PackagingError.packageSparkleSignError("Could not sign Sparkle package tbz!")
     }

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -71,3 +71,52 @@ func signSparklePackage(sparkleTbzPath: String, buildPath: String, signKey: Stri
         throw PackagingError.packageSparkleSignError("Could not sign Sparkle package tbz!")
     }
 }
+
+func packageAppBundle(
+    productPath: String,
+    buildPath: String,
+    craftTarget: String,
+    craftBlueprintName: String,
+    appName: String,
+    packageSigningId: String?,
+    appleId: String?,
+    applePassword: String?,
+    appleTeamId: String?,
+    sparklePackageSignKey: String?
+) throws {
+    print("Creating pkg file for client…")
+    let buildWorkPath = "\(buildPath)/\(craftTarget)/build/\(craftBlueprintName)/work/build"
+    let packagePath = try buildPackage(
+        appName: appName,
+        buildWorkPath: buildWorkPath,
+        productPath: productPath
+    )
+
+    if let packageSigningId {
+        print("Signing pkg with \(packageSigningId)…")
+        try signPackage(packagePath: packagePath, packageSigningId: packageSigningId)
+
+        if let appleId, let applePassword, let appleTeamId {
+            print("Notarising pkg with Apple ID \(appleId)…")
+            try notarisePackage(
+                packagePath: packagePath,
+                appleId: appleId,
+                applePassword: applePassword,
+                appleTeamId: appleTeamId
+            )
+        }
+    }
+
+    print("Creating Sparkle TBZ file…")
+    let sparklePackagePath =
+        try buildSparklePackage(packagePath: packagePath, buildPath: buildPath)
+
+    if let sparklePackageSignKey {
+        print("Signing Sparkle TBZ file…")
+        try signSparklePackage(
+            sparkleTbzPath: sparklePackagePath,
+            buildPath: buildPath,
+            signKey: sparklePackageSignKey
+        )
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -17,6 +17,7 @@ import Foundation
 enum PackagingError: Error {
     case projectNameSettingError(String)
     case packageBuildError(String)
+    case packageSigningError(String)
 }
 
 func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
@@ -32,5 +33,15 @@ func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
         throw PackagingError.packageBuildError("Error building pkg file!")
     }
     return "\(productPath)/\(packageFile)"
+}
+
+func signPackage(packagePath: String, packageSigningId: String) throws {
+    let packagePathNew = "\(packagePath).new"
+    guard shell("productsign --timestamp --sign '\(packageSigningId)' \(packagePath) \(packagePathNew)") == 0 else {
+        throw PackagingError.packageSigningError("Could not sign pkg file!")
+    }
+    let fm = FileManager.default
+    try fm.removeItem(atPath: packagePath)
+    try fm.moveItem(atPath: packagePathNew, toPath: packagePath)
 }
 

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+import Foundation
+
+enum PackagingError: Error {
+    case projectNameSettingError(String)
+    case packageBuildError(String)
+}
+
+func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
+    let projectName = "Nextcloud" // TODO: Get specific name
+    let packageFile = "\(projectName).pkg"
+    let sparkleFile = "\(packageFile).tbz"
+    let pkgprojPath = "\(buildWorkPath)/admin/osx/macosx.pkgproj"
+
+    guard shell("packagesutil --file \(pkgprojPath) set project name \(projectName)") == 0 else {
+        throw PackagingError.projectNameSettingError("Could not set project name in pkgproj!")
+    }
+    guard shell("packagesbuild -v --build-folder \(productPath) -F \(productPath) \(pkgprojPath)") == 0 else {
+        throw PackagingError.packageBuildError("Error building pkg file!")
+    }
+    return "\(productPath)/\(packageFile)"
+}
+

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -18,6 +18,7 @@ enum PackagingError: Error {
     case projectNameSettingError(String)
     case packageBuildError(String)
     case packageSigningError(String)
+    case packageNotarisationError(String)
 }
 
 func buildPackage(buildWorkPath: String, productPath: String) throws -> String {
@@ -43,5 +44,16 @@ func signPackage(packagePath: String, packageSigningId: String) throws {
     let fm = FileManager.default
     try fm.removeItem(atPath: packagePath)
     try fm.moveItem(atPath: packagePathNew, toPath: packagePath)
+}
+
+func notarisePackage(
+    packagePath: String, appleId: String, applePassword: String, appleTeamId: String
+) throws {
+    guard shell("xcrun notarytool submit \(packagePath) --apple-id \(appleId) --password \(applePassword) --team-id \(appleTeamId) --wait") == 0 else {
+        throw PackagingError.packageNotarisationError("Failure when notarising package!")
+    }
+    guard shell("xcrun stapler staple \(packagePath)") == 0 else {
+        throw PackagingError.packageNotarisationError("Could not staple notarisation on package!")
+    }
 }
 

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -77,6 +77,9 @@ struct Build: ParsableCommand {
     @Option(name: [.long], help: "Apple package signing ID.")
     var packageSigningId: String?
 
+    @Option(name: [.long], help: "Sparkle package signing key.")
+    var sparklePackageSignKey: String?
+
     @Flag(help: "Reconfigure KDE Craft.")
     var reconfigureCraft = false
 
@@ -240,6 +243,17 @@ struct Build: ParsableCommand {
                         appleTeamId: appleTeamId
                     )
                 }
+            }
+
+            let sparklePackagePath =
+                try buildSparklePackage(packagePath: packagePath, buildPath: buildPath)
+
+            if let sparklePackageSignKey {
+                try signSparklePackage(
+                    sparkleTbzPath: sparklePackagePath,
+                    buildPath: buildPath,
+                    signKey: sparklePackageSignKey
+                )
             }
         }
 

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -128,7 +128,7 @@ struct Build: ParsableCommand {
         let craftMasterDir = "\(buildPath)/craftmaster"
         let craftMasterIni = "\(repoRootDir)/craftmaster.ini"
         let craftMasterPy = "\(craftMasterDir)/CraftMaster.py"
-        let craftTarget = arch == "arm64" ? "macos-clang-arm64" : "macos-64-clang"
+        let craftTarget = archToCraftTarget(arch)
         let craftCommand =
             "python3 \(craftMasterPy) --config \(craftMasterIni) --target \(craftTarget) -c"
 

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -65,6 +65,9 @@ struct Build: ParsableCommand {
     @Option(name: [.long], help: "Git clone command; include options such as depth.")
     var gitCloneCommand = "git clone --depth=1"
 
+    @Option(name: [.long], help: "Apple package signing ID.")
+    var packageSigningId: String?
+
     @Flag(help: "Reconfigure KDE Craft.")
     var reconfigureCraft = false
 
@@ -216,6 +219,10 @@ struct Build: ParsableCommand {
         if package {
             let packagePath =
                 try buildPackage(buildWorkPath: buildWorkPath, productPath: productPath)
+
+            if let packageSigningId {
+                try signPackage(packagePath: packagePath, packageSigningId: packageSigningId)
+            }
         }
 
         print("Done!")

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -260,14 +260,61 @@ struct Codesign: ParsableCommand {
     }
 }
 
+struct Package: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Packaging script for the client.")
+
+    @Option(name: [.short, .long], help: "Architecture.")
+    var arch = "arm64"
+
+    @Option(name: [.short, .long], help: "Path for build files to be written.")
+    var buildPath = "\(FileManager.default.currentDirectoryPath)/build"
+
+    @Option(name: [.short, .long], help: "Path for the final product to be put.")
+    var productPath = "\(FileManager.default.currentDirectoryPath)/product"
+
+    @Option(name: [.long], help: "Nextcloud Desktop Client craft blueprint name.")
+    var craftBlueprintName = "nextcloud-client"
+
+    @Option(name: [.long], help: "The application's branded name.")
+    var appName = "Nextcloud"
+
+    @Option(name: [.long], help: "Apple ID, used for notarisation.")
+    var appleId: String?
+
+    @Option(name: [.long], help: "Apple ID password, used for notarisation.")
+    var applePassword: String?
+
+    @Option(name: [.long], help: "Apple Team ID, used for notarisation.")
+    var appleTeamId: String?
+
+    @Option(name: [.long], help: "Apple package signing ID.")
+    var packageSigningId: String?
+
+    @Option(name: [.long], help: "Sparkle package signing key.")
+    var sparklePackageSignKey: String?
+
+    mutating func run() throws {
+        try packageAppBundle(
+            productPath: productPath,
+            buildPath: buildPath,
+            craftTarget: archToCraftTarget(arch),
+            craftBlueprintName: craftBlueprintName,
+            appName: appName,
+            packageSigningId: packageSigningId,
+            appleId: appleId,
+            applePassword: applePassword,
+            appleTeamId: appleTeamId,
+            sparklePackageSignKey: sparklePackageSignKey
+        )
+    }
+}
+
 struct MacCrafter: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A tool to easily build a fully-functional Nextcloud Desktop Client for macOS.",
-        subcommands: [Build.self, Codesign.self],
+        subcommands: [Build.self, Codesign.self, Package.self],
         defaultSubcommand: Build.self
     )
-
-
 }
 
 MacCrafter.main()

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -189,7 +189,7 @@ struct Build: ParsableCommand {
             )
         }
 
-        print("Crafting Nextcloud Desktop Client...")
+        print("Crafting \(appName) Desktop Client...")
 
         let allOptionsString = craftOptions.map({ "--options \"\($0)\"" }).joined(separator: " ")
 
@@ -231,7 +231,11 @@ struct Build: ParsableCommand {
         if package {
             print("Creating pkg file for client…")
             let packagePath =
-                try buildPackage(buildWorkPath: buildWorkPath, productPath: productPath)
+            try buildPackage(
+                appName: appName,
+                buildWorkPath: buildWorkPath,
+                productPath: productPath
+            )
 
             if let packageSigningId {
                 print("Signing pkg with \(packageSigningId)…")

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -65,6 +65,15 @@ struct Build: ParsableCommand {
     @Option(name: [.long], help: "Git clone command; include options such as depth.")
     var gitCloneCommand = "git clone --depth=1"
 
+    @Option(name: [.long], help: "Apple ID, used for notarisation.")
+    var appleId: String?
+
+    @Option(name: [.long], help: "Apple ID password, used for notarisation.")
+    var applePassword: String?
+
+    @Option(name: [.long], help: "Apple Team ID, used for notarisation.")
+    var appleTeamId: String?
+
     @Option(name: [.long], help: "Apple package signing ID.")
     var packageSigningId: String?
 
@@ -222,6 +231,15 @@ struct Build: ParsableCommand {
 
             if let packageSigningId {
                 try signPackage(packagePath: packagePath, packageSigningId: packageSigningId)
+
+                if let appleId, let applePassword, let appleTeamId {
+                    try notarisePackage(
+                        packagePath: packagePath,
+                        appleId: appleId,
+                        applePassword: applePassword,
+                        appleTeamId: appleTeamId
+                    )
+                }
             }
         }
 

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -228,41 +228,18 @@ struct Build: ParsableCommand {
         try fm.copyItem(atPath: clientAppDir, toPath: "\(productPath)/\(appName).app")
 
         if package {
-            print("Creating pkg file for client…")
-            let buildWorkPath = "\(clientBuildDir)/work/build"
-            let packagePath = try buildPackage(
+            try packageAppBundle(
+                productPath: productPath,
+                buildPath: buildPath,
+                craftTarget: craftTarget,
+                craftBlueprintName: craftBlueprintName,
                 appName: appName,
-                buildWorkPath: buildWorkPath,
-                productPath: productPath
+                packageSigningId: packageSigningId,
+                appleId: appleId,
+                applePassword: applePassword,
+                appleTeamId: appleTeamId,
+                sparklePackageSignKey: sparklePackageSignKey
             )
-
-            if let packageSigningId {
-                print("Signing pkg with \(packageSigningId)…")
-                try signPackage(packagePath: packagePath, packageSigningId: packageSigningId)
-
-                if let appleId, let applePassword, let appleTeamId {
-                    print("Notarising pkg with Apple ID \(appleId)…")
-                    try notarisePackage(
-                        packagePath: packagePath,
-                        appleId: appleId,
-                        applePassword: applePassword,
-                        appleTeamId: appleTeamId
-                    )
-                }
-            }
-
-            print("Creating Sparkle TBZ file…")
-            let sparklePackagePath =
-                try buildSparklePackage(packagePath: packagePath, buildPath: buildPath)
-
-            if let sparklePackageSignKey {
-                print("Signing Sparkle TBZ file…")
-                try signSparklePackage(
-                    sparkleTbzPath: sparklePackagePath,
-                    buildPath: buildPath,
-                    signKey: sparklePackageSignKey
-                )
-            }
         }
 
         print("Done!")

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -229,13 +229,16 @@ struct Build: ParsableCommand {
         try fm.copyItem(atPath: clientAppDir, toPath: "\(productPath)/\(appName).app")
 
         if package {
+            print("Creating pkg file for client…")
             let packagePath =
                 try buildPackage(buildWorkPath: buildWorkPath, productPath: productPath)
 
             if let packageSigningId {
+                print("Signing pkg with \(packageSigningId)…")
                 try signPackage(packagePath: packagePath, packageSigningId: packageSigningId)
 
                 if let appleId, let applePassword, let appleTeamId {
+                    print("Notarising pkg with Apple ID \(appleId)…")
                     try notarisePackage(
                         packagePath: packagePath,
                         appleId: appleId,
@@ -245,10 +248,12 @@ struct Build: ParsableCommand {
                 }
             }
 
+            print("Creating Sparkle TBZ file…")
             let sparklePackagePath =
                 try buildSparklePackage(packagePath: packagePath, buildPath: buildPath)
 
             if let sparklePackageSignKey {
+                print("Signing Sparkle TBZ file…")
                 try signSparklePackage(
                     sparkleTbzPath: sparklePackagePath,
                     buildPath: buildPath,

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -193,7 +193,6 @@ struct Build: ParsableCommand {
 
         let allOptionsString = craftOptions.map({ "--options \"\($0)\"" }).joined(separator: " ")
 
-        let buildWorkPath = "\(buildPath)/\(craftTarget)/build"
         let clientBuildDir = "\(buildPath)/\(craftTarget)/build/\(craftBlueprintName)"
         if fullRebuild {
             do {
@@ -230,8 +229,8 @@ struct Build: ParsableCommand {
 
         if package {
             print("Creating pkg file for client…")
-            let packagePath =
-            try buildPackage(
+            let buildWorkPath = "\(clientBuildDir)/work/build"
+            let packagePath = try buildPackage(
                 appName: appName,
                 buildWorkPath: buildWorkPath,
                 productPath: productPath

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -86,6 +86,9 @@ struct Build: ParsableCommand {
     @Flag(help: "Run a full rebuild.")
     var fullRebuild = false
 
+    @Flag(help: "Create an installer package.")
+    var package = false
+
     mutating func run() throws {
         print("Configuring build tooling.")
 
@@ -175,6 +178,7 @@ struct Build: ParsableCommand {
 
         let allOptionsString = craftOptions.map({ "--options \"\($0)\"" }).joined(separator: " ")
 
+        let buildWorkPath = "\(buildPath)/\(craftTarget)/build"
         let clientBuildDir = "\(buildPath)/\(craftTarget)/build/\(craftBlueprintName)"
         if fullRebuild {
             do {
@@ -208,6 +212,11 @@ struct Build: ParsableCommand {
             try fm.removeItem(atPath: "\(productPath)/\(appName).app")
         }
         try fm.copyItem(atPath: clientAppDir, toPath: "\(productPath)/\(appName).app")
+
+        if package {
+            let packagePath =
+                try buildPackage(buildWorkPath: buildWorkPath, productPath: productPath)
+        }
 
         print("Done!")
     }


### PR DESCRIPTION
Adds the ability to create a pkg directly from mac crafter

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
