### PR TITLE
disable our code for network timeout

### DIFF
--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -45,6 +45,8 @@ public:
     explicit AbstractNetworkJob(const AccountPtr &account, const QString &path, QObject *parent = nullptr);
     ~AbstractNetworkJob() override;
 
+    static bool enableTimeout;
+
     virtual void start();
 
     [[nodiscard]] AccountPtr account() const { return _account; }

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -60,6 +60,8 @@ class TestChunkingNG : public QObject
 private slots:
     void initTestCase()
     {
+        AbstractNetworkJob::enableTimeout = true;
+
         OCC::Logger::instance()->setLogFlush(true);
         OCC::Logger::instance()->setLogDebug(true);
 

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -50,6 +50,8 @@ class TestRemoteDiscovery : public QObject
 private slots:
     void initTestCase()
     {
+        AbstractNetworkJob::enableTimeout = true;
+
         OCC::Logger::instance()->setLogFlush(true);
         OCC::Logger::instance()->setLogDebug(true);
 


### PR DESCRIPTION
seems we have an issue with Windows and QTimer instances used to detect network timeout

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
