### PR TITLE
Fix QtWebEngineProcess crash on macOS when building with mac-crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -79,7 +79,9 @@ func codesignClientAppBundle(
     print("Code-signing QtWebEngineProcess...")
     let qtWebEngineProcessPath =
         "\(frameworksPath)/QtWebEngineCore.framework/Versions/A/Helpers/QtWebEngineProcess.app"
-    try codesign(identity: codeSignIdentity, path: qtWebEngineProcessPath)
+    try codesign(identity: codeSignIdentity,
+                 path: qtWebEngineProcessPath,
+                 options: "--timestamp --force --verbose=4 --options runtime --deep --entitlements \(qtWebEngineProcessPath)/Contents/Resources/QtWebEngineProcess.entitlements")
 
     print("Code-signing QtWebEngine...")
     try codesign(identity: codeSignIdentity, path: "\(frameworksPath)/QtWebEngineCore.framework")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
