### PR TITLE
Fix authentication issues for macOS File Provider Extension

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
@@ -105,6 +105,47 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
     }
 
     @objc func setupDomainAccount(user: String, serverUrl: String, password: String) {
+        let semaphore = DispatchSemaphore(value: 0)
+        var authAttemptState = AuthenticationAttemptResultState.connectionError // default
+        Task {
+            let authTestNcKit = NextcloudKit()
+            authTestNcKit.setup(user: user, userId: user, password: password, urlBase: serverUrl)
+
+            // Retry a few times if we have a connection issue
+            for authTimeout in AuthenticationTimeouts {
+                authAttemptState = await authTestNcKit.tryAuthenticationAttempt()
+                guard authAttemptState == .connectionError else { break }
+
+                Logger.fileProviderExtension.info(
+                    "\(user, privacy: .public) authentication try timed out. Trying again soon."
+                )
+                try? await Task.sleep(nanoseconds: authTimeout)
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        switch (authAttemptState) {
+        case .authenticationError:
+            Logger.fileProviderExtension.info(
+                "\(user, privacy: .public) authentication failed due to bad creds, stopping"
+            )
+            return
+        case .connectionError:
+            // Despite multiple connection attempts we are still getting connection issues, so quit.
+            Logger.fileProviderExtension.info(
+                "\(user, privacy: .public) authentication try failed, no connection."
+            )
+            return
+        case .success:
+            Logger.fileProviderExtension.info(
+                """
+                Authenticated! Nextcloud account set up in File Provider extension.
+                User: \(user, privacy: .public) at server: \(serverUrl, privacy: .public)
+                """
+            )
+        }
+
         let newNcAccount = Account(user: user, serverUrl: serverUrl, password: password)
         guard newNcAccount != ncAccount else { return }
         ncAccount = newNcAccount
@@ -122,39 +163,7 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
             remoteInterface: ncKit, changeNotificationInterface: self, domain: domain
         )
         ncKit.setup(delegate: changeObserver)
-
-        Task {
-            var authAttemptState = AuthenticationAttemptResultState.connectionError // default
-            for authTimeout in AuthenticationTimeouts { // Retry if we have a connection issue
-                authAttemptState = await ncKit.tryAuthenticationAttempt()
-                guard authAttemptState == .connectionError else { break }
-                Logger.fileProviderExtension.info(
-                    "\(user, privacy: .public) authentication try timed out. Trying again soon."
-                )
-                try? await Task.sleep(nanoseconds: authTimeout)
-            }
-
-            switch (authAttemptState) {
-            case .authenticationError:
-                Logger.fileProviderExtension.info(
-                    "\(user, privacy: .public) authentication failed due to bad creds, stopping"
-                )
-                ncAccount = nil
-                ncKit.setup(user: "", userId: "", password: "", urlBase: "") // In case ongoing ops
-            case .connectionError:
-                Logger.fileProviderExtension.info(
-                    "\(user, privacy: .public) authentication try failed due to internet connectivity issues."
-                )
-            case .success:
-                Logger.fileProviderExtension.info(
-                    """
-                    Authenticated! Nextcloud account set up in File Provider extension.
-                    User: \(user, privacy: .public) at server: \(serverUrl, privacy: .public)
-                    """
-                )
-                Task { @MainActor in signalEnumeratorAfterAccountSetup() }
-            }
-        }
+        signalEnumeratorAfterAccountSetup()
     }
 
     @objc func removeAccountConfig() {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
@@ -165,26 +165,6 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
             remoteInterface: ncKit, changeNotificationInterface: self, domain: domain
         )
         ncKit.setup(delegate: changeObserver)
-        
-        Task {
-            let (_, profile, _, error) = await ncKit.fetchUserProfile()
-            guard error == .success, let profile else {
-                // Note that since the authentication check checks for the user profile, this should
-                // not really occur
-                Logger.fileProviderExtension.error(
-                    """
-                    Unable to get user profile for user \(user, privacy: .public) 
-                    at server \(serverUrl, privacy: .public)
-                    error: \(error.errorDescription, privacy: .public)
-                    """
-                )
-                return
-            }
-            ncKit.setup(user: user, userId: profile.userId, password: password, urlBase: serverUrl)
-            semaphore.signal()
-        }
-        semaphore.wait()
-
         signalEnumeratorAfterAccountSetup()
     }
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
@@ -104,12 +104,14 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
         }
     }
 
-    @objc func setupDomainAccount(user: String, serverUrl: String, password: String) {
+    @objc func setupDomainAccount(
+        user: String, userId: String, serverUrl: String, password: String
+    ) {
         let semaphore = DispatchSemaphore(value: 0)
         var authAttemptState = AuthenticationAttemptResultState.connectionError // default
         Task {
             let authTestNcKit = NextcloudKit()
-            authTestNcKit.setup(user: user, userId: user, password: password, urlBase: serverUrl)
+            authTestNcKit.setup(user: user, userId: userId, password: password, urlBase: serverUrl)
 
             // Retry a few times if we have a connection issue
             for authTimeout in AuthenticationTimeouts {
@@ -146,13 +148,13 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
             )
         }
 
-        let newNcAccount = Account(user: user, serverUrl: serverUrl, password: password)
+        let newNcAccount = Account(user: user, id: userId, serverUrl: serverUrl, password: password)
         guard newNcAccount != ncAccount else { return }
         ncAccount = newNcAccount
         ncKit.setup(
             account: newNcAccount.ncKitAccount,
             user: newNcAccount.username,
-            userId: newNcAccount.username,
+            userId: newNcAccount.id,
             password: newNcAccount.password,
             urlBase: newNcAccount.serverUrl,
             userAgent: "Nextcloud-macOS/FileProviderExt",

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
@@ -46,11 +46,12 @@ class FileProviderSocketLineProcessor: NSObject, LineProcessor {
             delegate.removeAccountConfig()
         } else if command == "ACCOUNT_DETAILS" {
             guard let accountDetailsSubsequence = splitLine.last else { return }
-            let splitAccountDetails = accountDetailsSubsequence.split(separator: "~", maxSplits: 2)
+            let splitAccountDetails = accountDetailsSubsequence.split(separator: "~", maxSplits: 3)
 
             let user = String(splitAccountDetails[0])
-            let serverUrl = String(splitAccountDetails[1])
-            let password = String(splitAccountDetails[2])
+            let userId = String(splitAccountDetails[1])
+            let serverUrl = String(splitAccountDetails[2])
+            let password = String(splitAccountDetails[3])
 
             delegate.setupDomainAccount(user: user, serverUrl: serverUrl, password: password)
         }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
@@ -53,7 +53,7 @@ class FileProviderSocketLineProcessor: NSObject, LineProcessor {
             let serverUrl = String(splitAccountDetails[2])
             let password = String(splitAccountDetails[3])
 
-            delegate.setupDomainAccount(user: user, serverUrl: serverUrl, password: password)
+            delegate.setupDomainAccount(user: user, userId: userId, serverUrl: serverUrl, password: password)
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -21,6 +21,7 @@
 
 - (void)getExtensionAccountIdWithCompletionHandler:(void(^)(NSString *extensionAccountId, NSError *error))completionHandler;
 - (void)configureAccountWithUser:(NSString *)user
+                          userId:(NSString *)userId
                        serverUrl:(NSString *)serverUrl
                         password:(NSString *)password;
 - (void)removeAccountConfig;

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
@@ -48,11 +48,13 @@ class ClientCommunicationService: NSObject, NSFileProviderServiceSource, NSXPCLi
         completionHandler(accountUserId, nil)
     }
 
-    func configureAccount(withUser user: String, 
+    func configureAccount(withUser user: String,
+                          userId: String,
                           serverUrl: String,
                           password: String) {
         Logger.desktopClientConnection.info("Received configure account information over client communication service")
         self.fpExtension.setupDomainAccount(user: user,
+                                            userId: userId,
                                             serverUrl: serverUrl,
                                             password: password)
     }

--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -213,13 +213,15 @@ void FileProviderSocketController::sendAccountDetails() const
 
     const auto credentials = account->credentials();
     Q_ASSERT(credentials);
-    const auto accountUser = account->davUser();
-    const auto accountUrl = account->url().toString();
-    const auto accountPassword = credentials->password();
+    const auto accountUser = credentials->user(); // User-provided username/email
+    const auto accountUserId = account->davUser(); // Backing user id on server
+    const auto accountUrl = account->url().toString(); // Server base URL
+    const auto accountPassword = credentials->password(); // Account password
 
     // We cannot use colons as separators here due to "https://" in the url
     const auto message = QString(QStringLiteral("ACCOUNT_DETAILS:") +
                                  accountUser + "~" +
+                                 accountUserId + "~" +
                                  accountUrl + "~" +
                                  accountPassword);
     sendMessage(message);

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -64,11 +64,13 @@ void FileProviderXPC::authenticateExtension(const QString &extensionAccountId) c
     const auto account = accountState->account();
     const auto credentials = account->credentials();
     NSString *const user = credentials->user().toNSString();
+    NSString *const userId = account->davUser().toNSString();
     NSString *const serverUrl = account->url().toString().toNSString();
     NSString *const password = credentials->password().toNSString();
 
     const auto clientCommService = (NSObject<ClientCommunicationProtocol> *)_clientCommServices.value(extensionAccountId);
     [clientCommService configureAccountWithUser:user
+                                         userId:userId
                                       serverUrl:serverUrl
                                        password:password];
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Depends on https://github.com/claucambra/NextcloudFileProviderKit/pull/22

Improve the authentication phase of the File Provider Extension by:

* Verifying account details are correct before signalling the extension is ready to perform file operations
* Reattempting authentication check if necessary due to bad connection
* Adding timeouts for said authentication check to prevent server overloading
* Properly using user and userId roles to fix LDAP authentication issues

Fixes #6783
