### PR TITLE
ensure log context category is valid before reading it

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -148,7 +148,7 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
             if (_doFileFlush)
                 _logstream->flush();
         }
-        if (_permanentDeleteLogStream && strcmp(ctx.category, lcPermanentLog().categoryName()) == 0) {
+        if (_permanentDeleteLogStream && ctx.category && strcmp(ctx.category, lcPermanentLog().categoryName()) == 0) {
             (*_permanentDeleteLogStream) << msg << "\n";
             _permanentDeleteLogStream->flush();
             if (_permanentDeleteLogFile.size() > 10LL * 1024LL) {


### PR DESCRIPTION
category of logs accessed via log context can be null in such a case, strcmp will crash

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
