### PR TITLE
properly catch std::filesystem exceptions

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1205,10 +1205,16 @@ void PropagateDownloadFile::downloadFinished()
         // Preserve the existing file permissions.
         const auto existingFile = QFileInfo{filename};
 #ifdef Q_OS_WIN
-        const auto existingPermissions = FileSystem::filePermissionsWin(filename);
-        const auto tmpFilePermissions = FileSystem::filePermissionsWin(_tmpFile.fileName());
-        if (existingPermissions != tmpFilePermissions) {
-            FileSystem::setFilePermissionsWin(_tmpFile.fileName(), existingPermissions);
+        try {
+            const auto existingPermissions = FileSystem::filePermissionsWin(filename);
+            const auto tmpFilePermissions = FileSystem::filePermissionsWin(_tmpFile.fileName());
+            if (existingPermissions != tmpFilePermissions) {
+                FileSystem::setFilePermissionsWin(_tmpFile.fileName(), existingPermissions);
+            }
+        }
+        catch (std::filesystem::filesystem_error e)
+        {
+            qCWarning(lcPropagateDownload()) << _item->_instruction << _item->_file << e.what();
         }
 #else
         if (existingFile.permissions() != _tmpFile.permissions()) {


### PR DESCRIPTION
will prevent std::terminate from being called with uncatched exceptions

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
