### PR TITLE
remove extra argument from QString::arg: string has only 1 placeholder

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1747,7 +1747,7 @@ QString FolderMan::trayTooltipStatusString(SyncResult::Status syncStatus, bool h
                 QString totalSizeStr = Utility::octetsToString(progress->totalSize());
                 if (progress->trustEta()) {
                     if (estimatedEta == 0) {
-                        folderMessage = tr("Syncing %1 (A few seconds left)").arg(totalSizeStr, Utility::durationToDescriptiveString1(estimatedEta));
+                        folderMessage = tr("Syncing %1 (A few seconds left)").arg(totalSizeStr);
                     } else {
                         folderMessage = tr("Syncing %1 (%2 left)").arg(totalSizeStr, Utility::durationToDescriptiveString1(estimatedEta));
                     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
