### PR TITLE
Fix poor translation strings for blacklisted error reason strings

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -436,19 +436,21 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const Entries &ent
             item->_errorString = tr("The filename cannot be encoded on your file system.");
             break;
         case CSYNC_FILE_EXCLUDE_SERVER_BLACKLISTED:
-            item->_errorString = tr("The filename is blacklisted on the server.");
+            const auto errorString = tr("The filename is blacklisted on the server.");
+            QString reasonString;
             if (hasForbiddenFilename) {
-                item->_errorString += tr(" Reason: the entire filename is forbidden.");
+                reasonString = tr("Reason: the entire filename is forbidden.");
             }
             if (hasForbiddenBasename) {
-                item->_errorString += tr(" Reason: the filename has a forbidden base name (filename start).");
+                reasonString = tr("Reason: the filename has a forbidden base name (filename start).");
             }
             if (hasForbiddenExtension) {
-                item->_errorString += tr(" Reason: the file has a forbidden extension (.%1).").arg(extension);
+                reasonString = tr("Reason: the file has a forbidden extension (.%1).").arg(extension);
             }
             if (containsForbiddenCharacters) {
-                item->_errorString += tr(" Reason: the filename contains a forbidden character (%1).").arg(forbiddenCharMatch);
+                reasonString = tr("Reason: the filename contains a forbidden character (%1).").arg(forbiddenCharMatch);
             }
+            item->_errorString = reasonString.isEmpty() ? errorString : QString("%1 %2").arg(errorString, reasonString);
             item->_status = SyncFileItem::FileNameInvalidOnServer;
             break;
         }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fix for the core issue behind https://github.com/nextcloud/desktop/pull/7296
