### PR TITLE
Check for availability of Big Sur (under 11.3) before using VFS progress tracking method

### DIFF
--- a/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
+++ b/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
@@ -42,17 +42,19 @@ public:
             return;
         }
 
-        NSProgress *const downloadProgress = [_manager globalProgressForKind:NSProgressFileOperationKindDownloading];
-        NSProgress *const uploadProgress = [_manager globalProgressForKind:NSProgressFileOperationKindUploading];
-        _downloadProgressObserver = [[ProgressObserver alloc] initWithProgress:downloadProgress];
-        _uploadProgressObserver = [[ProgressObserver alloc] initWithProgress:uploadProgress];
+        if (@available(macOS 11.3, *)) {
+            NSProgress *const downloadProgress = [_manager globalProgressForKind:NSProgressFileOperationKindDownloading];
+            NSProgress *const uploadProgress = [_manager globalProgressForKind:NSProgressFileOperationKindUploading];
+            _downloadProgressObserver = [[ProgressObserver alloc] initWithProgress:downloadProgress];
+            _uploadProgressObserver = [[ProgressObserver alloc] initWithProgress:uploadProgress];
 
-        _downloadProgressObserver.progressKVOChangeHandler = ^(NSProgress *const progress){
-            updateDownload(progress);
-        };
-        _uploadProgressObserver.progressKVOChangeHandler = ^(NSProgress *const progress){
-            updateUpload(progress);
-        };
+            _downloadProgressObserver.progressKVOChangeHandler = ^(NSProgress *const progress){
+                updateDownload(progress);
+            };
+            _uploadProgressObserver.progressKVOChangeHandler = ^(NSProgress *const progress){
+                updateUpload(progress);
+            };
+        }
     }
 
     ~MacImplementation() = default;


### PR DESCRIPTION
This selector was only made available on macOS 11.3. Just to be safe we should check for the availability

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
