### PR TITLE
Add a context menu for the sharees search field

### DIFF
--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -94,6 +94,10 @@ TextField {
             }
         }
     }
+    onPressed: function(mouse) {
+        if (mouse.button !== Qt.RightButton) return;
+        contextMenu.popup(mouse.x, mouse.y);
+    }
 
     leftPadding: searchIcon.width + searchIcon.anchors.leftMargin + horizontalPaddingOffset
     rightPadding: clearTextButton.width + clearTextButton.anchors.rightMargin + horizontalPaddingOffset
@@ -164,6 +168,23 @@ TextField {
             onClicked: root.clear()
         }
     }
+
+    Menu {
+        id: contextMenu
+        MenuItem {
+            text: qsTr("Cut")
+            onTriggered: root.cut()
+        }
+        MenuItem {
+            text: qsTr("Copy")
+            onTriggered: root.copy()
+        }
+        MenuItem {
+            text: qsTr("Paste")
+            onTriggered: root.paste()
+        }
+    }
+
 
     Popup {
         id: suggestionsPopup

--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -42,7 +42,7 @@ TextField {
     readonly property double iconsScaleFactor: 0.6
 
     function triggerSuggestionsVisibility() {
-        shareeListView.count > 0 ? suggestionsPopup.open() : suggestionsPopup.close();
+        !contextMenu.opened && shareeListView.count > 0 ? suggestionsPopup.open() : suggestionsPopup.close();
     }
 
     placeholderText: enabled ? qsTr("Search for users or groups…") : qsTr("Sharing is not available for this folder")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Closes #6199

<img width="497" alt="Screenshot 2024-10-18 at 12 03 26" src="https://github.com/user-attachments/assets/902098e5-454a-46bc-bdec-aadbd8ad33fd">
