### PR TITLE
Pin Craft Qt version to 6.7.2 and binary cache version to 24.08

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -27,6 +27,7 @@ ShortPath/EnableJunctions = False
 
 Packager/RepositoryUrl = https://files.kde.org/craft/Qt6
 Packager/PackageType = NullsoftInstallerPackager
+Packager/CacheVersion = 24.08
 
 ContinuousIntegration/Enabled = True
 
@@ -41,6 +42,7 @@ Packager/CacheDir = ${Variables:Root}\cache
 [BlueprintSettings]
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
+libs/qt6.version = 6.7.2
 
 [windows-msvc2022_64-cl]
 QtSDK/Compiler = msvc2022_64


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
