### PR TITLE
Fix QML errors caused by illegal customisation of text field backgrounds on native styles

### DIFF
--- a/src/gui/filedetails/NCInputTextField.qml
+++ b/src/gui/filedetails/NCInputTextField.qml
@@ -54,10 +54,5 @@ TextField {
     }
 
     verticalAlignment: Qt.AlignVCenter
-    background: Rectangle {
-        border.color: palette.dark
-        radius: Style.trayWindowRadius
-        color: palette.window
-    }
 }
 

--- a/src/gui/filedetails/ShareView.qml
+++ b/src/gui/filedetails/ShareView.qml
@@ -142,6 +142,7 @@ ColumnLayout {
     ShareeSearchField {
         id: shareeSearchField
         Layout.fillWidth: true
+        Layout.topMargin: Style.smallSpacing
         Layout.leftMargin: root.horizontalPadding
         Layout.rightMargin: root.horizontalPadding
 

--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -50,12 +50,6 @@ TextField {
     verticalAlignment: Qt.AlignVCenter
     implicitHeight: Math.max(Style.talkReplyTextFieldPreferredHeight, contentHeight)
 
-    background: Rectangle {
-        border.color: palette.dark
-        radius: Style.trayWindowRadius
-        color: palette.window
-    }
-
     onActiveFocusChanged: triggerSuggestionsVisibility()
     onTextChanged: triggerSuggestionsVisibility()
     Keys.onPressed: {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fixes following errors:

```
2024-10-21 02:01:40:645 [ warning default qrc:/qml/src/gui/filedetails/ShareeSearchField.qml:53 ]:	qrc:/qml/src/gui/filedetails/ShareeSearchField.qml:53:17: QML QQuickRectangle: The current style does not support customization of this control (property: "background" item: QQuickRectangle(0x600001d42140, parent=0x0, geometry=0,0 0x0)). Please customize a non-native style (such as Basic, Fusion, Material, etc). For more information, see: https://doc.qt.io/qt-6/qtquickcontrols2-customize.html#customization-reference
2024-10-21 02:01:40:645 [ warning default qrc:/qml/src/gui/filedetails/NCInputTextField.qml:57 ]:	qrc:/qml/src/gui/filedetails/NCInputTextField.qml:57:17: QML QQuickRectangle: The current style does not support customization of this control (property: "background" item: QQuickRectangle(0x600001d42220, parent=0x0, geometry=0,0 0x0)). Please customize a non-native style (such as Basic, Fusion, Material, etc). For more information, see: https://doc.qt.io/qt-6/qtquickcontrols2-customize.html#customization-reference
```
