### PR TITLE
doc: delete section containing non-existing images

### DIFF
--- a/doc/building.rst
+++ b/doc/building.rst
@@ -215,19 +215,6 @@ System requirements
 - Microsoft Visual Studio 2022 and tools to compile C++
 - `KDE Craft <https://community.kde.org/Craft>`_
 
-Setting up Microsoft Visual Studio
-----------------------------------
-
-1. Click on 'Modify' in the Visual Studio Installer:
-
-  .. image:: ./images/building/visual-studio-installer.png
-    :alt: Visual Studio Installer
-
-2. Select 'Desktop development with C++'
-
-  .. image:: ./images/building/desktop-development-with-cpp.png
-    :alt: Desktop development with C++
-
 Handling the dependencies 
 -------------------------
 We handle the dependencies using `KDE Craft <https://community.kde.org/Craft>`_ because it is easy to set it up and it makes the maintenance much more reliable in all platforms.


### PR DESCRIPTION
Those images where deleted in 6d3335bd60ba ("Update instructions to build on Windows.") and are no longer available. Hence, drop the whole section referencing them.

Fixes: 6d3335bd60ba1cb499985fc15e0b918fe8c404f4