### PR TITLE
content access denied error during discovery: verify server access

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -48,6 +48,7 @@ AccountState::AccountState(const AccountPtr &account)
     , _state(AccountState::Disconnected)
     , _connectionStatus(ConnectionValidator::Undefined)
     , _waitingForNewCredentials(false)
+    , _termsOfServiceChecker(_account)
     , _maintenanceToConnectedDelay(60000 + (QRandomGenerator::global()->generate() % (4 * 60000))) // 1-5min delay
     , _remoteWipe(new RemoteWipe(_account))
     , _isDesktopNotificationsAllowed(true)
@@ -64,10 +65,18 @@ AccountState::AccountState(const AccountPtr &account)
             this, &AccountState::slotPushNotificationsReady);
     connect(account.data(), &Account::serverUserStatusChanged, this,
         &AccountState::slotServerUserStatusChanged);
+    connect(&_termsOfServiceChecker, &TermsOfServiceChecker::done,
+            this, [this] ()
+            {
+                if (_termsOfServiceChecker.needToSign()) {
+                    slotConnectionValidatorResult(ConnectionValidator::NeedToSignTermsOfService, {});
+                }
+            });
     connect(account.data(), &Account::termsOfServiceNeedToBeChecked,
-            this, [this] () {
-        checkConnectivity();
-    });
+            this, [this] ()
+            {
+                _termsOfServiceChecker.start();
+            });
 
     connect(this, &AccountState::isConnectedChanged, [=]{
         // Get the Apps available on the server if we're now connected.

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -362,7 +362,7 @@ void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status sta
     _lastConnectionValidatorStatus = status;
 
     if ((_lastConnectionValidatorStatus == ConnectionValidator::NeedToSignTermsOfService && status == ConnectionValidator::Connected) ||
-        status == ConnectionValidator::NeedToSignTermsOfService) {
+        (status == ConnectionValidator::NeedToSignTermsOfService && _lastConnectionValidatorStatus != status)) {
 
         emit termsOfServiceChanged(_account);
     }

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -227,6 +227,7 @@ private:
     bool _waitingForNewCredentials = false;
     QDateTime _timeOfLastETagCheck;
     QPointer<ConnectionValidator> _connectionValidator;
+    TermsOfServiceChecker _termsOfServiceChecker;
     QByteArray _notificationsEtagResponseHeader;
     QByteArray _navigationAppsEtagResponseHeader;
 

--- a/src/gui/connectionvalidator.h
+++ b/src/gui/connectionvalidator.h
@@ -75,6 +75,37 @@ namespace OCC {
 
 class UserInfo;
 
+class TermsOfServiceChecker : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool needToSign READ needToSign NOTIFY needToSignChanged FINAL)
+public:
+    explicit TermsOfServiceChecker(AccountPtr account,
+                                   QObject *parent = nullptr);
+
+    explicit TermsOfServiceChecker(QObject *parent = nullptr);
+
+    [[nodiscard]] bool needToSign() const;
+
+public slots:
+    void start();
+
+signals:
+    void needToSignChanged();
+
+    void done();
+
+private slots:
+    void slotServerTermsOfServiceRecieved(const QJsonDocument &reply);
+
+private:
+    void checkServerTermsOfService();
+
+    AccountPtr _account;
+    bool _needToSign = false;
+};
+
 class ConnectionValidator : public QObject
 {
     Q_OBJECT
@@ -130,7 +161,8 @@ protected slots:
 
     void slotCapabilitiesRecieved(const QJsonDocument &);
     void slotUserFetched(OCC::UserInfo *userInfo);
-    void slotServerTermsOfServiceRecieved(const QJsonDocument &reply);
+
+    void termsOfServiceCheckDone();
 
 private:
 #ifndef TOKEN_AUTH_ONLY
@@ -138,7 +170,6 @@ private:
 #endif
     void reportResult(Status status);
     void checkServerCapabilities();
-    void checkServerTermsOfService();
     void fetchUser();
 
     /** Sets the account's server version
@@ -147,10 +178,13 @@ private:
      */
     bool setAndCheckServerVersion(const QString &version);
 
+    void checkServerTermsOfService();
+
     const QStringList _previousErrors;
     QStringList _errors;
     AccountStatePtr _accountState;
     AccountPtr _account;
+    TermsOfServiceChecker _termsOfServiceChecker;
     bool _isCheckingServerAndAuth = false;
 };
 }


### PR DESCRIPTION
will trigger a check of the server connectivity in case of content access denied reporting when listing folders during discovery

should allow discovering early that terms of service need to be signed

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
