### PR TITLE
Fix stuttering and freezing of client while computing sync state changes (macOS VFS)

### DIFF
--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -14,6 +14,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QDateTime>
 
 #include "accountstate.h"
 
@@ -34,7 +35,7 @@ class FileProviderXPC : public QObject
 public:
     explicit FileProviderXPC(QObject *parent = nullptr);
 
-    [[nodiscard]] bool fileProviderExtReachable(const QString &extensionAccountId) const;
+    [[nodiscard]] bool fileProviderExtReachable(const QString &extensionAccountId);
 
     // Returns enabled and set state of fast enumeration for the given extension
     [[nodiscard]] std::optional<std::pair<bool, bool>> fastEnumerationStateForExtension(const QString &extensionAccountId) const;
@@ -53,6 +54,7 @@ private slots:
 
 private:
     QHash<QString, void*> _clientCommServices;
+    QDateTime _lastUnreachableTime;
 };
 
 } // namespace OCC::Mac

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -54,7 +54,7 @@ private slots:
 
 private:
     QHash<QString, void*> _clientCommServices;
-    QDateTime _lastUnreachableTime;
+    QHash<QString, QDateTime> _unreachableAccountExtensions;
 };
 
 } // namespace OCC::Mac

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -22,7 +22,7 @@
 
 namespace {
     constexpr int64_t semaphoreWaitDelta = 1000000000; // 1 seconds
-    constexpr auto reachableRetryTimeout = 60; // 60 seconds
+    constexpr auto reachableRetryTimeout = 300; // seconds
 }
 
 namespace OCC::Mac {

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -21,7 +21,7 @@
 #include "gui/macOS/fileproviderxpc_mac_utils.h"
 
 namespace {
-    constexpr int64_t semaphoreWaitDelta = 3000000000; // 3 seconds
+    constexpr int64_t semaphoreWaitDelta = 1000000000; // 1 seconds
     constexpr auto reachableRetryTimeout = 60; // 60 seconds
 }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Every time we compute the overall sync state we check if the File Provider Extension is reachable so we can display if this has encountered a problem. The issue is that if it is not reachable, we wait 3 seconds to receive a reply, and if we do not, we wait all of those 3 seconds. Now have that happen every single time we need to compute the sync state.

This PR addresses the problem by slashing the wait time down to 1 second and adding a reachability check timeout of 300 seconds, so we will (worst case) encounter a 1 second freeze every 5 minutes instead
