### PR TITLE
Fix materialised storage use calculation (macOS VFS)

### DIFF
--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -211,16 +211,17 @@ public slots:
             const auto qDomainIdentifier = QString::fromNSString(domain.identifier);
             QVector<FileProviderItemMetadata> qMaterialisedItems;
             qMaterialisedItems.reserve(items.count);
+            unsigned long long storageUsage = 0;
             for (const id<NSFileProviderItem> item in items) {
                 const auto itemMetadata = FileProviderItemMetadata::fromNSFileProviderItem(item, qDomainIdentifier);
-                const auto storageUsage = _storageUsage.value(qDomainIdentifier) + itemMetadata.documentSize();
+                storageUsage += itemMetadata.documentSize();
                 qCDebug(lcFileProviderSettingsController) << "Adding item" << itemMetadata.identifier()
                                                           << "with size" << itemMetadata.documentSize()
                                                           << "to storage usage for account" << qDomainIdentifier
                                                           << "with total size" << storageUsage;
                 qMaterialisedItems.append(itemMetadata);
-                _storageUsage.insert(qDomainIdentifier, storageUsage);
             }
+            _storageUsage.insert(qDomainIdentifier, storageUsage);
             _materialisedFiles.insert(qDomainIdentifier, qMaterialisedItems);
 
             emit q->localStorageUsageForAccountChanged(qDomainIdentifier);


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fixes #7129
