### PR TITLE
Fix encoding used for override server url

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -384,7 +384,7 @@ Theme::Theme()
     _forceOverrideServerUrl = true;
 #endif
 #ifdef APPLICATION_SERVER_URL
-    setOverrideServerUrl(QString::fromLatin1(APPLICATION_SERVER_URL));
+    setOverrideServerUrl(QString::fromUtf8(APPLICATION_SERVER_URL));
 #endif
 }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fixes issues when displaying names of multiple override server urls (e.g. those that contain umlauts)
