### PR TITLE
Only display server name in multiple override servers dropdown

### DIFF
--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -63,8 +63,7 @@ OwncloudSetupPage::OwncloudSetupPage(QWidget *parent)
             const auto serverObject = serverJson.toObject();
             const auto serverName = serverObject.value("name").toString();
             const auto serverUrl = serverObject.value("url").toString();
-            const auto serverDisplayString = QString("%1 (%2)").arg(serverName, serverUrl);
-            _ui.comboBox->addItem(serverDisplayString, serverUrl);
+            _ui.comboBox->addItem(serverName, serverUrl);
         }
     } else if (theme->forceOverrideServerUrl()) {
         _ui.comboBox->hide();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

This matches the mobile clients
