### PR TITLE
Bugfix account removal

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -402,8 +402,9 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
         settings.setValue(QLatin1String(authTypeC), acc->_credentials->authType());
 
         // HACK: Save http_user also as user
-        if (acc->_settingsMap.contains(httpUserC) && acc->_settingsMap.value(httpUserC).isValid()) {
-            settings.setValue(userC, acc->_settingsMap.value(httpUserC));
+        const auto settingsMap = acc->_settingsMap;
+        if (settingsMap.contains(httpUserC) && settingsMap.value(httpUserC).isValid()) {
+            settings.setValue(userC, settingsMap.value(httpUserC));
         }
     }
 

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -355,7 +355,7 @@ void WebFlowCredentials::forgetSensitiveData() {
 
     _account->deleteAppPassword();
 
-    const QString kck = keychainKey(_account->url().toString(), _user, _account->id());
+    const auto kck = keychainKey(_account->url().toString(), _user, _account->id());
     if (kck.isEmpty()) {
         qCDebug(lcWebFlowCredentials()) << "InvalidateToken: User is empty, bailing out!";
         return;

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -355,8 +355,8 @@ void OwncloudAdvancedSetupPage::stopSpinner()
 
 QUrl OwncloudAdvancedSetupPage::serverUrl() const
 {
-    const QString urlString = dynamic_cast<OwncloudWizard *>(wizard())->ocUrl();
-    const QString user = dynamic_cast<OwncloudWizard *>(wizard())->getCredentials()->user();
+    const auto urlString = dynamic_cast<OwncloudWizard *>(wizard())->ocUrl();
+    const auto user = dynamic_cast<OwncloudWizard *>(wizard())->getCredentials()->user();
 
     QUrl url(urlString);
     url.setUserName(user);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -358,7 +358,7 @@ QUrl Account::deprecatedPrivateLinkUrl(const QByteArray &numericFileId) const
  */
 void Account::clearCookieJar()
 {
-    auto jar = qobject_cast<CookieJar *>(_am->cookieJar());
+    const auto jar = qobject_cast<CookieJar *>(_am->cookieJar());
     ASSERT(jar);
     jar->setAllCookies(QList<QNetworkCookie>());
 }
@@ -529,11 +529,12 @@ void Account::setUserVisibleHost(const QString &host)
 QVariant Account::credentialSetting(const QString &key) const
 {
     if (_credentials) {
-        QString prefix = _credentials->authType();
-        QVariant value = _settingsMap.value(prefix + "_" + key);
+        const auto prefix = _credentials->authType();
+        auto value = _settingsMap.value(prefix + "_" + key);
         if (value.isNull()) {
             value = _settingsMap.value(key);
         }
+
         return value;
     }
     return QVariant();
@@ -828,9 +829,10 @@ void Account::writeAppPasswordOnce(QString appPassword){
 }
 
 void Account::retrieveAppPassword(){
+    const QString key = credentials()->user() + app_password;
     const QString kck = AbstractCredentials::keychainKey(
                 url().toString(),
-                credentials()->user() + app_password,
+                key,
                 id()
     );
 


### PR DESCRIPTION
- When removing an account, an invalid 'user' was being saved in the config file
- Accounts were not fully removed: after removing an account, after restarting the client, the client would prompt the user to grant access again to the deleted account.
- Potentially this could fix the login issue where users get constantly prompted to grant access given that at some point their user was invalid (Account::retrieveAppPassword) => I couldn't reproduce this.
