### PR TITLE
Fix crash when setting badge for a path that results in a nil URL (macOS FinderSyncExt)

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
@@ -194,7 +194,7 @@
 
 #pragma mark - SyncClientProxyDelegate implementation
 
-- (void)setResultForPath:(NSString*)path result:(NSString*)result
+- (void)setResult:(NSString *)result forPath:(NSString*)path
 {
 	NSString *normalizedPath = [path decomposedStringWithCanonicalMapping];
 	[[FIFinderSyncController defaultController] setBadgeIdentifier:result forURL:[NSURL fileURLWithPath:normalizedPath]];

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
@@ -196,8 +196,12 @@
 
 - (void)setResult:(NSString *)result forPath:(NSString*)path
 {
-	NSString *normalizedPath = [path decomposedStringWithCanonicalMapping];
-	[[FIFinderSyncController defaultController] setBadgeIdentifier:result forURL:[NSURL fileURLWithPath:normalizedPath]];
+    NSString *const normalizedPath = path.decomposedStringWithCanonicalMapping;
+    NSURL *const urlForPath = [NSURL fileURLWithPath:normalizedPath];
+    if (urlForPath == nil) {
+        return;
+    }
+    [FIFinderSyncController.defaultController setBadgeIdentifier:result forURL:urlForPath];
 }
 
 - (void)reFetchFileNameCacheForPath:(NSString*)path

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncSocketLineProcessor.m
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncSocketLineProcessor.m
@@ -42,7 +42,7 @@
         
         dispatch_async(dispatch_get_main_queue(), ^{
             NSLog(@"Setting result %@ for path %@", result, path);
-            [self.delegate setResultForPath:path result:result];
+            [self.delegate setResult:result forPath:path];
         });
     } else if([command isEqualToString:@"UPDATE_VIEW"]) {
         NSString *path = [split objectAtIndex:1];

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/SyncClient.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/SyncClient.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol SyncClientDelegate <NSObject>
-- (void)setResultForPath:(NSString *)path result:(NSString *)result;
+- (void)setResult:(NSString *)result forPath:(NSString *)path;
 - (void)reFetchFileNameCacheForPath:(NSString *)path;
 - (void)registerPath:(NSString *)path;
 - (void)unregisterPath:(NSString *)path;


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
