### PR TITLE
Fix sync errors when trying to delete video component of live photos

### DIFF
--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -88,6 +88,8 @@ public:
     bool _isShared = false;
     qint64 _lastShareStateFetchedTimestamp = 0;
     bool _sharedByMe = false;
+    bool _isLivePhoto = false;
+    QString _livePhotoFile;
 };
 
 QDebug& operator<<(QDebug &stream, const SyncJournalFileRecord::EncryptionStatus status);

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -718,6 +718,9 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
     item->_lockTimeout = serverEntry.lockTimeout;
     item->_lockToken = serverEntry.lockToken;
 
+    item->_isLivePhoto = serverEntry.isLivePhoto;
+    item->_livePhotoFile = serverEntry.livePhotoFile;
+
     // Check for missing server data
     {
         QStringList missingData;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -547,6 +547,7 @@ void ProcessDirectoryJob::processFile(PathTuple path,
                            << " | e2eeMangledName: " << dbEntry.e2eMangledName() << "/" << serverEntry.e2eMangledName
                            << " | file lock: " << localFileIsLocked << "//" << serverFileIsLocked
                            << " | file lock type: " << localFileLockType << "//" << serverFileLockType
+                           << " | live photo: " << dbEntry._isLivePhoto << "//" << serverEntry.isLivePhoto
                            << " | metadata missing: /" << localEntry.isMetadataMissing << '/';
 
     qCInfo(lcDisco).nospace() << processingLog;
@@ -1122,7 +1123,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                 qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
             }
             return;
-        } else if (serverEntry.isLivePhoto && QMimeDatabase().mimeTypeForFile(item->_file).inherits(QStringLiteral("video/quicktime"))) {
+        } else if (dbEntry._isLivePhoto && QMimeDatabase().mimeTypeForFile(item->_file).inherits(QStringLiteral("video/quicktime"))) {
             // This is a live photo's video file; the server won't allow deletion of this file
             // so we need to *not* propagate the .mov deletion to the server and redownload the file
             qCInfo(lcDisco) << "Live photo video file deletion detected, redownloading" << item->_file;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1122,6 +1122,12 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                 qCWarning(lcDisco) << "Failed to delete a file record from the local DB" << path._original;
             }
             return;
+        } else if (serverEntry.isLivePhoto && QMimeDatabase().mimeTypeForFile(item->_file).inherits(QStringLiteral("video/quicktime"))) {
+            // This is a live photo's video file; the server won't allow deletion of this file
+            // so we need to *not* propagate the .mov deletion to the server and redownload the file
+            qCInfo(lcDisco) << "Live photo video file deletion detected, redownloading" << item->_file;
+            item->_direction = SyncFileItem::Down;
+            item->_instruction = CSYNC_INSTRUCTION_SYNC;
         } else if (!serverModified) {
             // Removed locally: also remove on the server.
             if (!dbEntry._serverHasIgnoredFiles) {

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -400,7 +400,8 @@ void DiscoverySingleDirectoryJob::start()
           << "http://owncloud.org/ns:dDC"
           << "http://owncloud.org/ns:permissions"
           << "http://owncloud.org/ns:checksums"
-          << "http://nextcloud.org/ns:is-encrypted";
+          << "http://nextcloud.org/ns:is-encrypted"
+          << "http://nextcloud.org/ns:metadata-files-live-photo";
 
     if (_isRootPath)
         props << "http://owncloud.org/ns:data-fingerprint";
@@ -549,6 +550,10 @@ static void propertyMapToRemoteInfo(const QMap<QString, QString> &map, RemotePer
         }
         if (property == "lock-token") {
             result.lockToken = value;
+        }
+        if (property == "metadata-files-live-photo") {
+            result.livePhotoFile = value;
+            result.isLivePhoto = true;
         }
     }
 

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -87,6 +87,9 @@ struct RemoteInfo
     qint64 lockTime = 0;
     qint64 lockTimeout = 0;
     QString lockToken;
+
+    bool isLivePhoto = false;
+    QString livePhotoFile;
 };
 
 struct LocalInfo

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -126,6 +126,8 @@ SyncJournalFileRecord SyncFileItem::toSyncJournalFileRecordWithInode(const QStri
     rec._lockstate._lockTime = _lockTime;
     rec._lockstate._lockTimeout = _lockTimeout;
     rec._lockstate._lockToken = _lockToken;
+    rec._isLivePhoto = _isLivePhoto;
+    rec._livePhotoFile = _livePhotoFile;
 
     // Update the inode if possible
     rec._inode = _inode;
@@ -167,6 +169,8 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
     item->_sharedByMe = rec._sharedByMe;
     item->_isShared = rec._isShared;
     item->_lastShareStateFetchedTimestamp = rec._lastShareStateFetchedTimestamp;
+    item->_isLivePhoto = rec._isLivePhoto;
+    item->_livePhotoFile = rec._livePhotoFile;
     return item;
 }
 
@@ -235,6 +239,11 @@ SyncFileItemPtr SyncFileItem::fromProperties(const QString &filePath, const QMap
 
     if (properties.contains(QStringLiteral("checksums"))) {
         item->_checksumHeader = findBestChecksum(properties.value("checksums").toUtf8());
+    }
+
+    if (properties.contains(QStringLiteral("metadata-files-live-photo"))) {
+        item->_isLivePhoto = true;
+        item->_livePhotoFile = properties.value(QStringLiteral("metadata-files-live-photo"));
     }
 
     // direction and instruction are decided later

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -340,6 +340,9 @@ public:
     bool _isAnyInvalidCharChild = false;
     bool _isAnyCaseClashChild = false;
 
+    bool _isLivePhoto = false;
+    QString _livePhotoFile;
+
     QString _discoveryResult;
 };
 

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -411,6 +411,7 @@ FakePropfindReply::FakePropfindReply(FileInfo &remoteRootFileInfo, QNetworkAcces
         xml.writeTextElement(ncUri, QStringLiteral("lock-time"), QString::number(fileInfo.lockTime));
         xml.writeTextElement(ncUri, QStringLiteral("lock-timeout"), QString::number(fileInfo.lockTimeout));
         xml.writeTextElement(ncUri, QStringLiteral("is-encrypted"), fileInfo.isEncrypted ? QString::number(1) : QString::number(0));
+        xml.writeTextElement(ncUri, QStringLiteral("metadata-files-live-photo"), fileInfo.isLivePhoto ? QString::number(1) : QString::number(0));
         buffer.write(fileInfo.extraDavProperties);
         xml.writeEndElement(); // prop
         xml.writeTextElement(davUri, QStringLiteral("status"), QStringLiteral("HTTP/1.1 200 OK"));

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -223,6 +223,13 @@ void FileInfo::setModTimeKeepEtag(const QString &relativePath, const QDateTime &
     file->lastModified = modTime;
 }
 
+void FileInfo::setIsLivePhoto(const QString &relativePath, const bool isLivePhoto)
+{
+    const auto file = find(relativePath);
+    Q_ASSERT(file);
+    file->isLivePhoto = isLivePhoto;
+}
+
 void FileInfo::modifyLockState(const QString &relativePath, LockState lockState, int lockType, const QString &lockOwner, const QString &lockOwnerId, const QString &lockEditorId, quint64 lockTime, quint64 lockTimeout)
 {
     FileInfo *file = findInvalidatingEtags(relativePath);

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -142,6 +142,8 @@ public:
 
     void setModTimeKeepEtag(const QString &relativePath, const QDateTime &modTime);
 
+    void setIsLivePhoto(const QString &relativePath, bool isLivePhoto);
+
     void modifyLockState(const QString &relativePath, LockState lockState, int lockType, const QString &lockOwner, const QString &lockOwnerId, const QString &lockEditorId, quint64 lockTime, quint64 lockTimeout) override;
 
     void setE2EE(const QString &relativepath, const bool enabled) override;

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -188,6 +188,7 @@ public:
     quint64 lockTime = 0;
     quint64 lockTimeout = 0;
     bool isEncrypted = false;
+    bool isLivePhoto = false;
 
     // Sorted by name to be able to compare trees
     QMap<QString, FileInfo> children;


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Live photos uploaded to the server are composed of an image file (usually a .jpeg or a .heic) and a video file (a .mov file), which get presented to the user via the iOS and Web UIs as a single "live photo", like in the Apple Photos applications

To maintain this representation the server treats these image/video pairs as inseparable -- the video cannot be deleted by itself, only a delete of the image will lead to the deletion of the video. This means we cannot issue deletes for the videos, as the server will reject this and we will end up showered in sync errors.

This PR therefore changes the local discovery behaviour to not propagate the local deletion of live photo mov files to the server, and to instead simply re-download the file if it has been deleted
