### PR TITLE
Fix adding account and skipping folder configuration crash.

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -509,7 +509,6 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     }
 
     acc->setCredentials(CredentialsFactory::create(authType));
-    acc->setDisplayName(acc->credentials()->user());
 
     acc->setNetworkProxySetting(settings.value(networkProxySettingC).value<Account::AccountNetworkProxySetting>());
     acc->setProxyType(settings.value(networkProxyTypeC).value<QNetworkProxy::ProxyType>());

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -334,7 +334,7 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.setValue(QLatin1String(versionC), maxAccountVersion);
     settings.setValue(QLatin1String(urlC), acc->_url.toString());
     settings.setValue(QLatin1String(davUserC), acc->_davUser);
-    settings.setValue(QLatin1String(displayNameC), acc->_displayName);
+    settings.setValue(QLatin1String(displayNameC), acc->davDisplayName());
     settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
     settings.setValue(QLatin1String(serverColorC), acc->_serverColor);
     settings.setValue(QLatin1String(serverTextColorC), acc->_serverTextColor);
@@ -498,7 +498,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     acc->_davUser = settings.value(QLatin1String(davUserC)).toString();
 
     acc->_settingsMap.insert(QLatin1String(userC), settings.value(userC));
-    acc->_displayName = settings.value(QLatin1String(displayNameC), "").toString();
+    acc->setDavDisplayName(settings.value(QLatin1String(displayNameC), "").toString());
     const QString authTypePrefix = authType + "_";
     const auto settingsChildKeys = settings.childKeys();
     for (const auto &key : settingsChildKeys) {
@@ -509,6 +509,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     }
 
     acc->setCredentials(CredentialsFactory::create(authType));
+    acc->setDisplayName(acc->credentials()->user());
 
     acc->setNetworkProxySetting(settings.value(networkProxySettingC).value<Account::AccountNetworkProxySetting>());
     acc->setProxyType(settings.value(networkProxyTypeC).value<QNetworkProxy::ProxyType>());

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -328,36 +328,36 @@ void AccountManager::saveAccountState(AccountState *a)
     qCDebug(lcAccountManager) << "Saved account state settings, status:" << settings->status();
 }
 
-void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool saveCredentials)
+void AccountManager::saveAccountHelper(Account *account, QSettings &settings, bool saveCredentials)
 {
     qCDebug(lcAccountManager) << "Saving settings to" << settings.fileName();
     settings.setValue(QLatin1String(versionC), maxAccountVersion);
-    settings.setValue(QLatin1String(urlC), acc->_url.toString());
-    settings.setValue(QLatin1String(davUserC), acc->_davUser);
-    settings.setValue(QLatin1String(displayNameC), acc->davDisplayName());
-    settings.setValue(QLatin1String(serverVersionC), acc->_serverVersion);
-    settings.setValue(QLatin1String(serverColorC), acc->_serverColor);
-    settings.setValue(QLatin1String(serverTextColorC), acc->_serverTextColor);
-    settings.setValue(QLatin1String(serverHasValidSubscriptionC), acc->serverHasValidSubscription());
+    settings.setValue(QLatin1String(urlC), account->_url.toString());
+    settings.setValue(QLatin1String(davUserC), account->_davUser);
+    settings.setValue(QLatin1String(displayNameC), account->davDisplayName());
+    settings.setValue(QLatin1String(serverVersionC), account->_serverVersion);
+    settings.setValue(QLatin1String(serverColorC), account->_serverColor);
+    settings.setValue(QLatin1String(serverTextColorC), account->_serverTextColor);
+    settings.setValue(QLatin1String(serverHasValidSubscriptionC), account->serverHasValidSubscription());
 
-    if (!acc->_skipE2eeMetadataChecksumValidation) {
+    if (!account->_skipE2eeMetadataChecksumValidation) {
         settings.remove(QLatin1String(skipE2eeMetadataChecksumValidationC));
     } else {
-        settings.setValue(QLatin1String(skipE2eeMetadataChecksumValidationC), acc->_skipE2eeMetadataChecksumValidation);
+        settings.setValue(QLatin1String(skipE2eeMetadataChecksumValidationC), account->_skipE2eeMetadataChecksumValidation);
     }
-    settings.setValue(networkProxySettingC, static_cast<std::underlying_type_t<Account::AccountNetworkProxySetting>>(acc->networkProxySetting()));
-    settings.setValue(networkProxyTypeC, acc->proxyType());
-    settings.setValue(networkProxyHostNameC, acc->proxyHostName());
-    settings.setValue(networkProxyPortC, acc->proxyPort());
-    settings.setValue(networkProxyNeedsAuthC, acc->proxyNeedsAuth());
-    settings.setValue(networkProxyUserC, acc->proxyUser());
-    settings.setValue(networkUploadLimitSettingC, static_cast<std::underlying_type_t<Account::AccountNetworkTransferLimitSetting>>(acc->uploadLimitSetting()));
-    settings.setValue(networkDownloadLimitSettingC, static_cast<std::underlying_type_t<Account::AccountNetworkTransferLimitSetting>>(acc->downloadLimitSetting()));
-    settings.setValue(networkUploadLimitC, acc->uploadLimit());
-    settings.setValue(networkDownloadLimitC, acc->downloadLimit());
+    settings.setValue(networkProxySettingC, static_cast<std::underlying_type_t<Account::AccountNetworkProxySetting>>(account->networkProxySetting()));
+    settings.setValue(networkProxyTypeC, account->proxyType());
+    settings.setValue(networkProxyHostNameC, account->proxyHostName());
+    settings.setValue(networkProxyPortC, account->proxyPort());
+    settings.setValue(networkProxyNeedsAuthC, account->proxyNeedsAuth());
+    settings.setValue(networkProxyUserC, account->proxyUser());
+    settings.setValue(networkUploadLimitSettingC, static_cast<std::underlying_type_t<Account::AccountNetworkTransferLimitSetting>>(account->uploadLimitSetting()));
+    settings.setValue(networkDownloadLimitSettingC, static_cast<std::underlying_type_t<Account::AccountNetworkTransferLimitSetting>>(account->downloadLimitSetting()));
+    settings.setValue(networkUploadLimitC, account->uploadLimit());
+    settings.setValue(networkDownloadLimitC, account->downloadLimit());
 
-    const auto proxyPasswordKey = QString(acc->userIdAtHostWithPort() + networkProxyPasswordKeychainKeySuffixC);
-    if (const auto proxyPassword = acc->proxyPassword(); proxyPassword.isEmpty()) {
+    const auto proxyPasswordKey = QString(account->userIdAtHostWithPort() + networkProxyPasswordKeychainKeySuffixC);
+    if (const auto proxyPassword = account->proxyPassword(); proxyPassword.isEmpty()) {
         const auto job = new QKeychain::DeletePasswordJob(Theme::instance()->appName(), this);
         job->setKey(proxyPasswordKey);
         connect(job, &QKeychain::Job::finished, this, [](const QKeychain::Job *const incomingJob) {
@@ -384,27 +384,27 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
         job->start();
     }
 
-    if (acc->_credentials) {
+    if (account->_credentials) {
         if (saveCredentials) {
             // Only persist the credentials if the parameter is set, on migration from 1.8.x
             // we want to save the accounts but not overwrite the credentials
             // (This is easier than asynchronously fetching the credentials from keychain and then
             // re-persisting them)
-            acc->_credentials->persist();
+            account->_credentials->persist();
         }
 
-        const auto settingsMapKeys = acc->_settingsMap.keys();
+        const auto settingsMapKeys = account->_settingsMap.keys();
         for (const auto &key : settingsMapKeys) {
-            if (!acc->_settingsMap.value(key).isValid()) {
+            if (!account->_settingsMap.value(key).isValid()) {
                 continue;
             }
 
-            settings.setValue(key, acc->_settingsMap.value(key));
+            settings.setValue(key, account->_settingsMap.value(key));
         }
-        settings.setValue(QLatin1String(authTypeC), acc->_credentials->authType());
+        settings.setValue(QLatin1String(authTypeC), account->_credentials->authType());
 
         // HACK: Save http_user also as user
-        const auto settingsMap = acc->_settingsMap;
+        const auto settingsMap = account->_settingsMap;
         if (settingsMap.contains(httpUserC) && settingsMap.value(httpUserC).isValid()) {
             settings.setValue(userC, settingsMap.value(httpUserC));
         }
@@ -412,9 +412,9 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
 
     // Save accepted certificates.
     settings.beginGroup(QLatin1String(generalC));
-    qCInfo(lcAccountManager) << "Saving " << acc->approvedCerts().count() << " unknown certs.";
+    qCInfo(lcAccountManager) << "Saving " << account->approvedCerts().count() << " unknown certs.";
     QByteArray certs;
-    const auto approvedCerts = acc->approvedCerts();
+    const auto approvedCerts = account->approvedCerts();
     for (const auto &cert : approvedCerts) {
         certs += cert.toPem() + '\n';
     }
@@ -424,13 +424,13 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.endGroup();
 
     // Save cookies.
-    if (acc->_networkAccessManager) {
-        auto *jar = qobject_cast<CookieJar *>(acc->_networkAccessManager->cookieJar());
+    if (account->_networkAccessManager) {
+        const auto jar = qobject_cast<CookieJar *>(account->_networkAccessManager->cookieJar());
         if (jar) {
-            qCInfo(lcAccountManager) << "Saving cookies." << acc->cookieJarPath();
-            if (!jar->save(acc->cookieJarPath()))
+            qCInfo(lcAccountManager) << "Saving cookies." << account->cookieJarPath();
+            if (!jar->save(account->cookieJarPath()))
             {
-                qCWarning(lcAccountManager) << "Failed to save cookies to" << acc->cookieJarPath();
+                qCWarning(lcAccountManager) << "Failed to save cookies to" << account->cookieJarPath();
             }
         }
     }

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -123,7 +123,7 @@ AccountManager::AccountsRestoreResult AccountManager::restore(const bool alsoRes
             if (const auto acc = loadAccountHelper(*settings)) {
                 acc->_id = accountId;
                 const auto accState = new AccountState(acc);
-                const auto jar = qobject_cast<CookieJar*>(acc->_am->cookieJar());
+                const auto jar = qobject_cast<CookieJar*>(acc->_networkAccessManager->cookieJar());
                 Q_ASSERT(jar);
                 if (jar) {
                     jar->restore(acc->cookieJarPath());
@@ -305,12 +305,12 @@ void AccountManager::save(bool saveCredentials)
     qCInfo(lcAccountManager) << "Saved all account settings, status:" << settings->status();
 }
 
-void AccountManager::saveAccount(Account *a)
+void AccountManager::saveAccount(Account *newAccountData)
 {
-    qCDebug(lcAccountManager) << "Saving account" << a->url().toString();
+    qCDebug(lcAccountManager) << "Saving account" << newAccountData->url().toString();
     const auto settings = ConfigFile::settingsWithGroup(QLatin1String(accountsC));
-    settings->beginGroup(a->id());
-    saveAccountHelper(a, *settings, false); // don't save credentials they might not have been loaded yet
+    settings->beginGroup(newAccountData->id());
+    saveAccountHelper(newAccountData, *settings, false); // don't save credentials they might not have been loaded yet
     settings->endGroup();
 
     settings->sync();
@@ -424,8 +424,8 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
     settings.endGroup();
 
     // Save cookies.
-    if (acc->_am) {
-        auto *jar = qobject_cast<CookieJar *>(acc->_am->cookieJar());
+    if (acc->_networkAccessManager) {
+        auto *jar = qobject_cast<CookieJar *>(acc->_networkAccessManager->cookieJar());
         if (jar) {
             qCInfo(lcAccountManager) << "Saving cookies." << acc->cookieJarPath();
             if (!jar->save(acc->cookieJarPath()))

--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -91,8 +91,8 @@ public:
     static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
 public slots:
-    /// Saves account data, not including the credentials
-    void saveAccount(OCC::Account *a);
+    /// Saves account data when adding user, when updating e.g. dav user, not including the credentials
+    void saveAccount(OCC::Account *newAccountData);
 
     /// Saves account state data, not including the account
     void saveAccountState(OCC::AccountState *a);

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -202,8 +202,10 @@ void AccountState::signOutByUi()
 
 void AccountState::freshConnectionAttempt()
 {
-    if (isConnected())
+    if (isConnected()) {
         setState(Disconnected);
+    }
+
     checkConnectivity();
 }
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -365,7 +365,7 @@ Application::Application(int &argc, char **argv)
     }
 
     _theme->setSystrayUseMonoIcons(ConfigFile().monoIcons());
-    connect(_theme, &Theme::systrayUseMonoIconsChanged, this, &Application::slotUseMonoIconsChanged);
+    connect(_theme, &Theme::systrayUseMonoIconsChanged, _gui, &ownCloudGui::slotComputeOverallSyncStatus);
     connect(this, &Application::systemPaletteChanged,
             _theme, &Theme::systemPaletteHasChanged);
 
@@ -589,7 +589,7 @@ void Application::slotAccountStateRemoved(AccountState *accountState)
 {
     if (_gui) {
         disconnect(accountState, &AccountState::stateChanged,
-            _gui.data(), &ownCloudGui::slotAccountStateChanged);
+            _gui.data(), &ownCloudGui::slotComputeOverallSyncStatus);
         disconnect(accountState->account().data(), &Account::serverVersionChanged,
             _gui.data(), &ownCloudGui::slotTrayMessageIfServerUnsupported);
     }
@@ -611,7 +611,7 @@ void Application::slotAccountStateRemoved(AccountState *accountState)
 void Application::slotAccountStateAdded(AccountState *accountState)
 {
     connect(accountState, &AccountState::stateChanged,
-        _gui.data(), &ownCloudGui::slotAccountStateChanged);
+        _gui.data(), &ownCloudGui::slotComputeOverallSyncStatus);
     connect(accountState->account().data(), &Account::serverVersionChanged,
         _gui.data(), &ownCloudGui::slotTrayMessageIfServerUnsupported);
     connect(accountState, &AccountState::termsOfServiceChanged,
@@ -714,11 +714,6 @@ void Application::setupLogging()
                           << "version:" << _theme->version()
                           << "os:" << Utility::platformName();
     qCInfo(lcApplication) << "Arguments:" << qApp->arguments();
-}
-
-void Application::slotUseMonoIconsChanged(bool)
-{
-    _gui->slotComputeOverallSyncStatus();
 }
 
 void Application::slotParseMessage(const QString &msg, QObject *)

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -101,7 +101,6 @@ signals:
 protected slots:
     void slotParseMessage(const QString &, QObject *);
     void slotCheckConnection();
-    void slotUseMonoIconsChanged(bool);
     void slotCleanup();
     void slotAccountStateAdded(OCC::AccountState *accountState);
     void slotAccountStateRemoved(OCC::AccountState *accountState);

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -118,6 +118,8 @@ ownCloudGui::ownCloudGui(Application *parent)
 
     FolderMan *folderMan = FolderMan::instance();
     connect(folderMan, &FolderMan::folderSyncStateChange, this, &ownCloudGui::slotSyncStateChange);
+    connect(folderMan, &FolderMan::folderSyncStateChange, this, &ownCloudGui::slotComputeOverallSyncStatus);
+
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
     connect(Mac::FileProvider::instance()->socketServer(), &Mac::FileProviderSocketServer::syncStateChanged, this, &ownCloudGui::slotComputeOverallSyncStatus);
@@ -240,8 +242,6 @@ void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
 
 void ownCloudGui::slotSyncStateChange(Folder *folder)
 {
-    slotComputeOverallSyncStatus();
-
     if (!folder) {
         return; // Valid, just a general GUI redraw was needed.
     }
@@ -371,7 +371,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 #else
         QStringList messages;
         messages.append(tr("Disconnected from accounts:"));
-        for (const auto &accountState : problemAccounts) {
+        for (const auto &accountState : qAsConst(problemAccounts)) {
             QString message = tr("Account %1: %2").arg(accountState->account()->displayName(), accountState->stateString(accountState->state()));
             if (!accountState->connectionErrors().empty()) {
                 message += QLatin1String("\n");

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -258,19 +258,9 @@ void ownCloudGui::slotSyncStateChange(Folder *folder)
     }
 }
 
-void ownCloudGui::slotFoldersChanged()
-{
-    slotComputeOverallSyncStatus();
-}
-
 void ownCloudGui::slotOpenPath(const QString &path)
 {
     showInFileManager(path);
-}
-
-void ownCloudGui::slotAccountStateChanged()
-{
-    slotComputeOverallSyncStatus();
 }
 
 void ownCloudGui::slotTrayMessageIfServerUnsupported(Account *account)

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -79,7 +79,6 @@ public slots:
     void slotFolderOpenAction(const QString &alias);
     void slotUpdateProgress(const QString &folder, const OCC::ProgressInfo &progress);
     void slotShowGuiMessage(const QString &title, const QString &message);
-    void slotFoldersChanged();
     void slotShowSettings();
     void slotShowSyncProtocol();
     void slotShutdown();
@@ -92,7 +91,6 @@ public slots:
     void slotSettingsDialogActivated();
     void slotHelp();
     void slotOpenPath(const QString &path);
-    void slotAccountStateChanged();
     void slotTrayMessageIfServerUnsupported(OCC::Account *account);
     void slotNeedToAcceptTermsOfService(OCC::AccountPtr account,
                                         OCC::AccountState::State state);

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -701,7 +701,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
     }
 
     // notify others.
-    _ocWizard->done(QWizard::Accepted);
+    _ocWizard->done(result);
     emit ownCloudWizardDone(result);
 }
 
@@ -711,7 +711,10 @@ void OwncloudSetupWizard::slotSkipFolderConfiguration()
 
     disconnect(_ocWizard, &OwncloudWizard::basicSetupFinished,
         this, &OwncloudSetupWizard::slotAssistantFinished);
-    _ocWizard->close();
+
+    _ocWizard->done(QDialog::Rejected);
+
+    // Accept to check connectivity, only skip folder setup
     emit ownCloudWizardDone(QDialog::Accepted);
 }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -66,7 +66,7 @@ OwncloudSetupWizard::~OwncloudSetupWizard()
     _ocWizard->deleteLater();
 }
 
-static QPointer<OwncloudSetupWizard> wiz = nullptr;
+static QPointer<OwncloudSetupWizard> owncloudSetupWizard = nullptr;
 
 void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *parent)
 {
@@ -78,25 +78,26 @@ void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *
 
         Theme::instance()->setStartLoginFlowAutomatically(true);
     }
-    if (!wiz.isNull()) {
+    if (!owncloudSetupWizard.isNull()) {
         bringWizardToFrontIfVisible();
         return;
     }
 
-    wiz = new OwncloudSetupWizard(parent);
-    connect(wiz, SIGNAL(ownCloudWizardDone(int)), obj, amember);
-    connect(wiz->_ocWizard, &OwncloudWizard::wizardClosed, obj, [] { wiz.clear(); });
+    owncloudSetupWizard = new OwncloudSetupWizard(parent);
+    connect(owncloudSetupWizard, SIGNAL(ownCloudWizardDone(int)), obj, amember);
+    connect(owncloudSetupWizard->_ocWizard, &OwncloudWizard::wizardClosed, obj, [] { owncloudSetupWizard.clear(); });
+
     FolderMan::instance()->setSyncEnabled(false);
-    wiz->startWizard();
+    owncloudSetupWizard->startWizard();
 }
 
 bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
 {
-    if (wiz.isNull()) {
+    if (owncloudSetupWizard.isNull()) {
         return false;
     }
 
-    ownCloudGui::raiseDialog(wiz->_ocWizard);
+    ownCloudGui::raiseDialog(owncloudSetupWizard->_ocWizard);
     return true;
 }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -727,7 +727,7 @@ AccountState *OwncloudSetupWizard::applyAccountChanges()
     auto manager = AccountManager::instance();
 
     auto newState = manager->addAccount(newAccount);
-    manager->save();
+    manager->saveAccount(newAccount.data());
     return newState;
 }
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -261,7 +261,7 @@ void SettingsDialog::accountAdded(AccountState *s)
     _actionForAccount.insert(s->account().data(), accountAction);
     accountAction->trigger();
 
-    connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotFoldersChanged);
+    connect(accountSettings, &AccountSettings::folderChanged, _gui, &ownCloudGui::slotComputeOverallSyncStatus);
     connect(accountSettings, &AccountSettings::openFolderAlias,
         _gui, &ownCloudGui::slotFolderOpenAction);
     connect(accountSettings, &AccountSettings::showIssuesList, this, &SettingsDialog::showIssuesList);

--- a/src/gui/tray/TrayFoldersMenuButton.qml
+++ b/src/gui/tray/TrayFoldersMenuButton.qml
@@ -11,6 +11,7 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
+pragma NativeMethodBehavior: AcceptThisObject
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -171,10 +171,6 @@ void Account::setDisplayName(const QString &username)
         displayName.append(QString::number(port));
     }
 
-    if (displayName == _displayName) {
-        return;
-    }
-
     _displayName = displayName;
 }
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -156,13 +156,23 @@ void Account::setAvatar(const QImage &img)
 
 QString Account::displayName() const
 {
-    auto displayName = QString("%1@%2").arg(credentials() ? credentials()->user() : "", _url.host());
+    return _displayName;
+}
+
+void Account::setDisplayName(const QString &username)
+{
+    auto displayName = QString("%1@%2").arg(username, _url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         displayName.append(QLatin1Char(':'));
         displayName.append(QString::number(port));
     }
-    return displayName;
+
+    if (displayName == _displayName) {
+        return;
+    }
+
+    _displayName = displayName;
 }
 
 QString Account::userIdAtHostWithPort() const
@@ -178,12 +188,12 @@ QString Account::userIdAtHostWithPort() const
 
 QString Account::davDisplayName() const
 {
-    return _displayName;
+    return _davDisplayName;
 }
 
 void Account::setDavDisplayName(const QString &newDisplayName)
 {
-    _displayName = newDisplayName;
+    _davDisplayName = newDisplayName;
     emit accountChangedDisplayName();
     emit prettyNameChanged();
 }

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -156,13 +156,13 @@ void Account::setAvatar(const QImage &img)
 
 QString Account::displayName() const
 {
-    QString dn = QString("%1@%2").arg(credentials()->user(), _url.host());
-    int port = url().port();
+    auto displayName = QString("%1@%2").arg(credentials() ? credentials()->user() : "", _url.host());
+    const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
-        dn.append(QLatin1Char(':'));
-        dn.append(QString::number(port));
+        displayName.append(QLatin1Char(':'));
+        displayName.append(QString::number(port));
     }
-    return dn;
+    return displayName;
 }
 
 QString Account::userIdAtHostWithPort() const

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -159,19 +159,19 @@ void Account::setAvatar(const QImage &img)
 
 QString Account::displayName() const
 {
-    return _displayName;
-}
+    auto credentialsUser = _davUser;
+    if (_credentials && !_credentials->user().isEmpty()) {
+        credentialsUser = _credentials->user();
+    }
 
-void Account::setDisplayName(const QString &username)
-{
-    auto displayName = QString("%1@%2").arg(username, _url.host());
+    auto displayName = QString("%1@%2").arg(credentialsUser, _url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         displayName.append(QLatin1Char(':'));
         displayName.append(QString::number(port));
     }
 
-    _displayName = displayName;
+    return displayName;
 }
 
 QString Account::userIdAtHostWithPort() const

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -519,7 +519,7 @@ private:
     QColor _serverTextColor = QColorConstants::White;
     bool _skipE2eeMetadataChecksumValidation = false;
     QScopedPointer<AbstractSslErrorHandler> _sslErrorHandler;
-    QSharedPointer<QNetworkAccessManager> _am;
+    QSharedPointer<QNetworkAccessManager> _networkAccessManager;
     QScopedPointer<AbstractCredentials> _credentials;
     bool _http2Supported = false;
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -146,6 +146,7 @@ public:
 
     /// The name of the account as shown in the toolbar
     [[nodiscard]] QString displayName() const;
+    void setDisplayName(const QString &username);
 
     /// User id in a form 'user@example.de, optionally port is added (if it is not 80 or 443)
     [[nodiscard]] QString userIdAtHostWithPort() const;
@@ -493,6 +494,7 @@ private:
     QWeakPointer<Account> _sharedThis;
     QString _id;
     QString _davUser;
+    QString _davDisplayName;
     QString _displayName;
     QTimer _pushNotificationsReconnectTimer;
 #ifndef TOKEN_AUTH_ONLY

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -146,7 +146,6 @@ public:
 
     /// The name of the account as shown in the toolbar
     [[nodiscard]] QString displayName() const;
-    void setDisplayName(const QString &username);
 
     /// User id in a form 'user@example.de, optionally port is added (if it is not 80 or 443)
     [[nodiscard]] QString userIdAtHostWithPort() const;

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -86,7 +86,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
     Q_OBJECT
     Q_PROPERTY(QString id MEMBER _id)
     Q_PROPERTY(QString davUser MEMBER _davUser)
-    Q_PROPERTY(QString displayName MEMBER _displayName)
+    Q_PROPERTY(QString davDisplayName MEMBER _davDisplayName)
     Q_PROPERTY(QString prettyName READ prettyName NOTIFY prettyNameChanged)
     Q_PROPERTY(QUrl url MEMBER _url)
     Q_PROPERTY(bool e2eEncryptionKeysGenerationAllowed MEMBER _e2eEncryptionKeysGenerationAllowed)


### PR DESCRIPTION
- when adding account on mac OS and skipping the folder configuration step, it would crash and it would add an empty user as an account.
- the dialog for configuring folder it was never going away once the user would click on skip.