### PR TITLE
Bundle macOS File Provider module logs into main debug archive

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -150,7 +150,13 @@ bool createDebugArchive(const QString &filename)
         const auto xpc = fileProvider->xpc();
         const auto vfsAccounts = OCC::Mac::FileProviderSettingsController::instance()->vfsEnabledAccounts();
         for (const auto &accountUserIdAtHost : vfsAccounts) {
-            const auto vfsLogFilename = QStringLiteral("macOS_vfs_%1.log").arg(accountUserIdAtHost);
+            const auto accountState = OCC::AccountManager::instance()->accountFromUserId(accountUserIdAtHost);
+            if (!accountState) {
+                qWarning() << "Could not find account for" << accountUserIdAtHost;
+                continue;
+            }
+            const auto account = accountState->account();
+            const auto vfsLogFilename = QStringLiteral("macOS_vfs_%1.log").arg(account->davUser());
             const auto vfsLogPath = tempDir.filePath(vfsLogFilename);
             xpc->createDebugArchiveForExtension(accountUserIdAtHost, vfsLogPath);
             zip.addLocalFile(vfsLogPath, vfsLogFilename);

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "generalsettings.h"
-#include "macOS/fileprovider.h"
 #include "ui_generalsettings.h"
 
 #include "theme.h"
@@ -33,6 +32,7 @@
 #endif
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
+#include "macOS/fileprovider.h"
 #include "macOS/fileprovidersettingscontroller.h"
 #endif
 

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -45,7 +45,7 @@ public slots:
     void configureExtensions();
     void authenticateExtension(const QString &extensionAccountId) const;
     void unauthenticateExtension(const QString &extensionAccountId) const;
-    void createDebugArchiveForExtension(const QString &extensionAccountId, const QString &filename) const;
+    void createDebugArchiveForExtension(const QString &extensionAccountId, const QString &filename);
 
     void setFastEnumerationEnabledForExtension(const QString &extensionAccountId, bool enabled) const;
 

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -111,9 +111,13 @@ void FileProviderXPC::slotAccountStateChanged(const AccountState::State state) c
         break;
     }
 }
-void FileProviderXPC::createDebugArchiveForExtension(const QString &extensionAccountId, const QString &filename) const
+void FileProviderXPC::createDebugArchiveForExtension(const QString &extensionAccountId, const QString &filename)
 {
     qCInfo(lcFileProviderXPC) << "Creating debug archive for extension" << extensionAccountId << "at" << filename;
+    if (!fileProviderExtReachable(extensionAccountId)) {
+        qCWarning(lcFileProviderXPC) << "Extension is not reachable. Cannot create debug archive";
+        return;
+    }
     // You need to fetch the contents from the extension and then create the archive from the client side.
     // The extension is not allowed to ask for permission to write into the file system as it is not a user facing process.
     const auto clientCommService = (NSObject<ClientCommunicationProtocol> *)_clientCommServices.value(extensionAccountId);

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -153,11 +153,6 @@ Page {
                     text: qsTr("Signal file provider domain")
                     onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
                 }
-
-                Button {
-                    text: qsTr("Create debug archive")
-                    onClicked: root.controller.createDebugArchive(root.accountUserIdAtHost)
-                }
             }
         }
     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Removes need for users to create the debug logs separately for macOS VFS
