### PR TITLE
Only present proxy password delete error if it is not a "does not exist" error

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -363,6 +363,8 @@ void AccountManager::saveAccountHelper(Account *acc, QSettings &settings, bool s
         connect(job, &QKeychain::Job::finished, this, [](const QKeychain::Job *const incomingJob) {
             if (incomingJob->error() == QKeychain::NoError) {
                 qCInfo(lcAccountManager) << "Deleted proxy password from keychain";
+            } else if (incomingJob->error() == QKeychain::EntryNotFound) {
+                qCDebug(lcAccountManager) << "Proxy password not found in keychain, can't delete";
             } else {
                 qCWarning(lcAccountManager) << "Failed to delete proxy password to keychain" << incomingJob->errorString();
             }


### PR DESCRIPTION
Prevent error on deletion when the proxy password does not exist

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
