### PR TITLE
Add option to create developer builds of client via mac crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -110,6 +110,9 @@ struct Build: ParsableCommand {
     @Flag(help: "Create an installer package.")
     var package = false
 
+    @Flag(help: "Build in developer mode.")
+    var dev = false
+
     mutating func run() throws {
         print("Configuring build tooling.")
 
@@ -177,6 +180,11 @@ struct Build: ParsableCommand {
         if let overrideServerUrl {
             craftOptions.append("\(craftBlueprintName).overrideServerUrl=\(overrideServerUrl)")
             craftOptions.append("\(craftBlueprintName).forceOverrideServerUrl=\(forceOverrideServerUrl ? "True" : "False")")
+        }
+
+        if dev {
+            appName += "Dev"
+            craftOptions.append("\(craftBlueprintName).devMode=True")
         }
 
         if !disableAutoUpdater {


### PR DESCRIPTION
Depends on https://github.com/nextcloud/desktop-client-blueprints/pull/21

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
