### PR TITLE
Fix crash on setting folder permission on non-NTFS file systems on Windows

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -371,7 +371,7 @@ bool FileSystem::setFolderPermissions(const QString &path,
         qCWarning(lcFileSystem) << "error when calling GetSecurityDescriptorDacl" << path << GetLastError();
         return false;
     }
-    if (!daclPresent) {
+    if (!daclPresent || !resultDacl) {
         qCWarning(lcFileSystem) << "error when calling DACL needed to set a folder read-only or read-write is missing" << path;
         return false;
     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Adds an additional null check for `resultDacl` after calling `GetSecurityDescriptorDacl` since the value can be null for FAT32/exFAT file systems.

#7484