### PR TITLE
Fix closed account wizard being brought up when clicking tray icon

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -85,6 +85,7 @@ void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *
 
     wiz = new OwncloudSetupWizard(parent);
     connect(wiz, SIGNAL(ownCloudWizardDone(int)), obj, amember);
+    connect(wiz->_ocWizard, &OwncloudWizard::wizardClosed, obj, [] { wiz.clear(); });
     FolderMan::instance()->setSyncEnabled(false);
     wiz->startWizard();
 }

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -408,6 +408,15 @@ void OwncloudWizard::changeEvent(QEvent *e)
     QWizard::changeEvent(e);
 }
 
+void OwncloudWizard::hideEvent(QHideEvent *event)
+{
+    QWizard::hideEvent(event);
+#ifdef Q_OS_MACOS
+    // Closing the window on macOS hides it rather than closes it, so emit a wizardClosed here
+    emit wizardClosed();
+#endif
+}
+
 void OwncloudWizard::closeEvent(QCloseEvent *event)
 {
     emit wizardClosed();

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -408,6 +408,12 @@ void OwncloudWizard::changeEvent(QEvent *e)
     QWizard::changeEvent(e);
 }
 
+void OwncloudWizard::closeEvent(QCloseEvent *event)
+{
+    emit wizardClosed();
+    QWizard::closeEvent(event);
+}
+
 void OwncloudWizard::customizeStyle()
 {
     // HINT: Customize wizard's own style here, if necessary in the future (Dark-/Light-Mode switching)

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -114,6 +114,7 @@ signals:
 
 protected:
     void changeEvent(QEvent *) override;
+    void hideEvent(QHideEvent *) override;
     void closeEvent(QCloseEvent *) override;
 
 private:

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -110,9 +110,11 @@ signals:
     void needCertificate();
     void styleChanged();
     void onActivate();
+    void wizardClosed();
 
 protected:
     void changeEvent(QEvent *) override;
+    void closeEvent(QCloseEvent *) override;
 
 private:
     void customizeStyle();


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

When the wizard window is closed, kill off the account setup wizard instance