### PR TITLE
Add section on Apple ATS to docs troubleshooting section

### DIFF
--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -92,6 +92,20 @@ might be required in some situations, for example behind CloudFlare which
 has been seen limiting upload chunks to 100mb. In other situations,
 limiting ``targetChunkUploadDuration`` can help to avoid time-outs.
 
+Connection issues with the macOS client on "insecure" connections
+-----------------------------------------------------------------
+When using macOS devices to connect to a Nextcloud server that uses a what maybe
+be classified as an insecure connection (i.e. connecting to a server with a
+self-signed certificate, or a certificate with what Apple may consider an
+insufficiently secure cipher), the macOS client may not connect to the server.
+This is because macOS requires a valid certificate to establish a connection.
+
+To resolve this issue, you must ensure the server is signed with a certificate
+that is accepted by Apple's App Transport Security requirements. More
+information on the requirements can be found in Apple's documentation pages.
+
+https://developer.apple.com/documentation/security/preventing-insecure-network-connections
+
 Isolating other issues
 ----------------------
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
