### PR TITLE
flush logs every 5 lines written

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -37,6 +37,7 @@ namespace {
 
 constexpr int CrashLogSize = 20;
 constexpr auto MaxLogLinesCount = 50000;
+constexpr auto MaxLogLinesBeforeFlush = 10;
 
 static bool compressLog(const QString &originalName, const QString &targetName)
 {
@@ -145,8 +146,13 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
 
         if (_logstream) {
             (*_logstream) << msg << "\n";
-            if (_doFileFlush)
+            ++_linesCounter;
+            if (_doFileFlush ||
+                _linesCounter >= MaxLogLinesBeforeFlush ||
+                type == QtMsgType::QtWarningMsg || type == QtMsgType::QtCriticalMsg || type == QtMsgType::QtFatalMsg) {
                 _logstream->flush();
+                _linesCounter = 0;
+            }
         }
         if (_permanentDeleteLogStream && ctx.category && strcmp(ctx.category, lcPermanentLog().categoryName()) == 0) {
             (*_permanentDeleteLogStream) << msg << "\n";

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -110,6 +110,7 @@ private:
 
     QFile _logFile;
     bool _doFileFlush = false;
+    int _linesCounter = 0;
     int _logExpire = 0;
     bool _logDebug = false;
     QScopedPointer<QTextStream> _logstream;


### PR DESCRIPTION
should help not loosing too much logs in case of a crash or similar not nominal stop of the client

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
