### PR TITLE
remove assert that is being hit always when running debug builds

### DIFF
--- a/src/gui/iconutils.cpp
+++ b/src/gui/iconutils.cpp
@@ -128,7 +128,6 @@ QImage createSvgImageWithCustomColor(const QString &fileName,
     }
 
     const auto result = drawSvgWithCustomFillColor(sourceSvg, customColor, originalSize, sizeToUse);
-    Q_ASSERT(!result.isNull());
 
     if (result.isNull()) {
         qCWarning(lcIconUtils) << "Failed to load pixmap for" << fileName;


### PR DESCRIPTION
makes no sense as I have to always patch it out to be able to run a debug build

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
