### PR TITLE
Pull up the unified search view immediately on unified search field focus

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -38,6 +38,7 @@
         <file>src/gui/tray/UnifiedSearchResultItemSkeletonGradientRectangle.qml</file>
         <file>src/gui/tray/UnifiedSearchResultListItem.qml</file>
         <file>src/gui/tray/UnifiedSearchResultNothingFound.qml</file>
+        <file>src/gui/tray/UnifiedSearchPlaceholderView.qml</file>
         <file>src/gui/tray/UnifiedSearchResultSectionItem.qml</file>
         <file>src/gui/tray/ActivityItemContextMenu.qml</file>
         <file>src/gui/tray/ActivityItemActions.qml</file>

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -270,6 +270,7 @@ ApplicationWindow {
             onTextEdited: { UserModel.currentUser.unifiedSearchResultsListModel.searchTerm = trayWindowUnifiedSearchInputContainer.text }
             onClearText: { UserModel.currentUser.unifiedSearchResultsListModel.searchTerm = "" }
             onActiveFocusChanged: activateSearchFocus = activeFocus && focusReason !== Qt.TabFocusReason && focusReason !== Qt.BacktabFocusReason
+            Keys.onEscapePressed: activateSearchFocus = false
         }
 
         Rectangle {

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -296,6 +296,18 @@ ApplicationWindow {
             anchors.margins: Style.trayHorizontalMargin
         }
 
+        UnifiedSearchPlaceholderView {
+            id: unifiedSearchPlaceholderView
+
+            anchors.top: bottomUnifiedSearchInputSeparator.bottom
+            anchors.left: trayWindowMainItem.left
+            anchors.right: trayWindowMainItem.right
+            anchors.bottom: trayWindowMainItem.bottom
+            anchors.topMargin: Style.trayHorizontalMargin
+
+            visible: trayWindowUnifiedSearchInputContainer.activateSearchFocus && !UserModel.currentUser.unifiedSearchResultsListModel.searchTerm
+        }
+
         UnifiedSearchResultNothingFound {
             id: unifiedSearchResultNothingFound
 

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -229,7 +229,7 @@ ApplicationWindow {
                                              || unifiedSearchResultNothingFound.visible
                                              || unifiedSearchResultsErrorLabel.visible
                                              || unifiedSearchResultsListView.visible
-                                             || trayWindowUnifiedSearchInputContainer.activeFocus
+                                             || trayWindowUnifiedSearchInputContainer.activateSearchFocus
 
         anchors.fill: parent
         anchors.margins: Style.trayWindowBorderWidth
@@ -255,6 +255,8 @@ ApplicationWindow {
         UnifiedSearchInputContainer {
             id: trayWindowUnifiedSearchInputContainer
 
+            property bool activateSearchFocus: activeFocus
+
             anchors.top: trayWindowHeader.bottom
             anchors.left: trayWindowMainItem.left
             anchors.right: trayWindowMainItem.right
@@ -267,6 +269,7 @@ ApplicationWindow {
             isSearchInProgress: UserModel.currentUser.unifiedSearchResultsListModel.isSearchInProgress
             onTextEdited: { UserModel.currentUser.unifiedSearchResultsListModel.searchTerm = trayWindowUnifiedSearchInputContainer.text }
             onClearText: { UserModel.currentUser.unifiedSearchResultsListModel.searchTerm = "" }
+            onActiveFocusChanged: activateSearchFocus = activeFocus && focusReason !== Qt.TabFocusReason && focusReason !== Qt.BacktabFocusReason
         }
 
         Rectangle {

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -238,6 +238,11 @@ ApplicationWindow {
         Accessible.role: Accessible.Grouping
         Accessible.name: qsTr("Nextcloud desktop main dialog")
 
+        MouseArea {
+            anchors.fill: parent
+            onClicked: forceActiveFocus()
+        }
+
         TrayWindowHeader {
             id: trayWindowHeader
 

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -229,6 +229,7 @@ ApplicationWindow {
                                              || unifiedSearchResultNothingFound.visible
                                              || unifiedSearchResultsErrorLabel.visible
                                              || unifiedSearchResultsListView.visible
+                                             || trayWindowUnifiedSearchInputContainer.activeFocus
 
         anchors.fill: parent
         anchors.margins: Style.trayWindowBorderWidth

--- a/src/gui/tray/UnifiedSearchPlaceholderView.qml
+++ b/src/gui/tray/UnifiedSearchPlaceholderView.qml
@@ -37,7 +37,7 @@ ColumnLayout {
 
     EnforcedPlainTextLabel {
         text: qsTr("Start typing to search")
-        font.pixelSize: Style.subLinePixelSize * 1.25
+        font.pixelSize: Style.unifiedSearchPlaceholderViewSublineFontPixelSize
         wrapMode: Text.Wrap
         Layout.fillWidth: true
         horizontalAlignment: Text.AlignHCenter

--- a/src/gui/tray/UnifiedSearchPlaceholderView.qml
+++ b/src/gui/tray/UnifiedSearchPlaceholderView.qml
@@ -19,7 +19,7 @@ import QtQuick.Layouts
 import Style
 
 ColumnLayout {
-    id: unifiedSearchResultNothingFoundContainer
+    id: root
 
     spacing: Style.standardSpacing
 
@@ -29,7 +29,6 @@ ColumnLayout {
     }
 
     Image {
-        id: unifiedSearchResultsNoResultsLabelIcon
         source: "image://svgimage-custom-color/magnifying-glass.svg"
         sourceSize.width: Style.trayWindowHeaderHeight / 2
         sourceSize.height: Style.trayWindowHeaderHeight / 2
@@ -37,7 +36,6 @@ ColumnLayout {
     }
 
     EnforcedPlainTextLabel {
-        id: unifiedSearchResultsNoResultsLabel
         text: qsTr("Start typing to search")
         font.pixelSize: Style.subLinePixelSize * 1.25
         wrapMode: Text.Wrap

--- a/src/gui/tray/UnifiedSearchPlaceholderView.qml
+++ b/src/gui/tray/UnifiedSearchPlaceholderView.qml
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 by Claudio Cambra <claudio.cambra@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+import QtQml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Style
+
+ColumnLayout {
+    id: unifiedSearchResultNothingFoundContainer
+
+    spacing: Style.standardSpacing
+
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+    }
+
+    Image {
+        id: unifiedSearchResultsNoResultsLabelIcon
+        source: "image://svgimage-custom-color/magnifying-glass.svg"
+        sourceSize.width: Style.trayWindowHeaderHeight / 2
+        sourceSize.height: Style.trayWindowHeaderHeight / 2
+        Layout.alignment: Qt.AlignHCenter
+    }
+
+    EnforcedPlainTextLabel {
+        id: unifiedSearchResultsNoResultsLabel
+        text: qsTr("Start typing to search")
+        font.pixelSize: Style.subLinePixelSize * 1.25
+        wrapMode: Text.Wrap
+        Layout.fillWidth: true
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    Item {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+    }
+}

--- a/src/gui/tray/UnifiedSearchResultNothingFound.qml
+++ b/src/gui/tray/UnifiedSearchResultNothingFound.qml
@@ -38,7 +38,7 @@ ColumnLayout {
     EnforcedPlainTextLabel {
         id: unifiedSearchResultsNoResultsLabel
         text: qsTr("No results for")
-        font.pixelSize: Style.subLinePixelSize * 1.25
+        font.pixelSize: Style.unifiedSearchPlaceholderViewSublineFontPixelSize
         wrapMode: Text.Wrap
         Layout.fillWidth: true
         Layout.preferredHeight: Style.trayWindowHeaderHeight / 2
@@ -48,7 +48,7 @@ ColumnLayout {
     EnforcedPlainTextLabel {
         id: unifiedSearchResultsNoResultsLabelDetails
         text: unifiedSearchResultNothingFoundContainer.text
-        font.pixelSize: Style.topLinePixelSize * 1.25
+        font.pixelSize: Style.unifiedSearchPlaceholderViewTitleFontPixelSize
         wrapMode: Text.Wrap
         maximumLineCount: 2
         elide: Text.ElideRight

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -141,6 +141,8 @@ QtObject {
     readonly property int unifiedSearchResultSectionItemVerticalPadding: 8
     readonly property int unifiedSearchResultNothingFoundHorizontalMargin: 10
     readonly property int unifiedSearchInputContainerHeight: 40
+    readonly property int unifiedSearchPlaceholderViewTitleFontPixelSize: pixelSize * 1.25
+    readonly property int unifiedSearchPlaceholderViewSublineFontPixelSize: subLinePixelSize * 1.25
 
     readonly property int radioButtonCustomMarginLeftInner: 4
     readonly property int radioButtonCustomMarginLeftOuter: 5


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

> [!Important]
> Depends on #7498 

Replaces the activity view when the unified search field is focused 

<img width="497" alt="Screenshot 2024-11-19 at 14 04 12" src="https://github.com/user-attachments/assets/32dac508-772f-4c2f-82ca-5ab9f793ec01">
