### PR TITLE
Ensure paths are passed properly escaped into codesign command in mac-crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -36,7 +36,7 @@ func codesign(
     options: String = "--timestamp --force --preserve-metadata=entitlements --verbose=4 --options runtime --deep"
 ) throws {
     print("Code-signing \(path)...")
-    let command = "codesign -s \"\(identity)\" \(options) \(path)"
+    let command = "codesign -s \"\(identity)\" \(options) \"\(path)\""
     guard shell(command) == 0 else {
         throw CodeSigningError.failedToCodeSign("Failed to code-sign \(path).")
     }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
