### PR TITLE
Add missing brace in FileProviderXPC's fileProviderExtReachable

### DIFF
--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -146,6 +146,7 @@ void FileProviderXPC::createDebugArchiveForExtension(const QString &extensionAcc
 }
 
 bool FileProviderXPC::fileProviderExtReachable(const QString &extensionAccountId, const bool retry, const bool reconfigureOnFail)
+{
     const auto lastUnreachableTime = _unreachableAccountExtensions.value(extensionAccountId);
     if (!retry 
         && !reconfigureOnFail 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Silly oversight during rebase conflict resolution broke everything, sorry