### PR TITLE
Handle NeedToSignTermsOfService account state in file provider components

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -581,6 +581,7 @@ void FileProviderDomainManager::slotAccountStateChanged(const AccountState * con
         break;
     case AccountState::SignedOut:
     case AccountState::AskingCredentials:
+    case AccountState::RedirectDetected:
     case AccountState::NeedToSignTermsOfService:
     {
         // Disconnect File Provider domain while unauthenticated

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -581,6 +581,7 @@ void FileProviderDomainManager::slotAccountStateChanged(const AccountState * con
         break;
     case AccountState::SignedOut:
     case AccountState::AskingCredentials:
+    case AccountState::NeedToSignTermsOfService:
     {
         // Disconnect File Provider domain while unauthenticated
         const auto trReason = tr("This account is not authenticated. Please check your account state in the %1 application.").arg(APPLICATION_NAME);

--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -174,6 +174,7 @@ void FileProviderSocketController::slotAccountStateChanged(const AccountState::S
     case AccountState::SignedOut:
     case AccountState::AskingCredentials:
     case AccountState::RedirectDetected:
+    case AccountState::NeedToSignTermsOfService:
         // Notify File Provider that it should show the not authenticated message
         sendNotAuthenticated();
         break;

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -101,6 +101,7 @@ void FileProviderXPC::slotAccountStateChanged(const AccountState::State state) c
     case AccountState::SignedOut:
     case AccountState::AskingCredentials:
     case AccountState::RedirectDetected:
+    case AccountState::NeedToSignTermsOfService:
         // Notify File Provider that it should show the not authenticated message
         unauthenticateExtension(extensionAccountId);
         break;


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
