### PR TITLE
Fix codesign path for app bundle main binaries

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -125,5 +125,5 @@ func codesignClientAppBundle(
 
     // Now we do the final codesign bit
     print("Code-signing Nextcloud Desktop Client binaries...")
-    try codesign(identity: codeSignIdentity, path: "\(clientContentsDir)/MacOS/*")
+    try recursivelyCodesign(path: "\(clientContentsDir)/MacOS/", identity: codeSignIdentity)
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
