### PR TITLE
Fix recursive codesign steps and final bundle codesign in mac-crafter

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -32,6 +32,10 @@ func isAppExtension(_ path: String) -> Bool {
     path.hasSuffix(".appex")
 }
 
+func isExecutable(_ path: String) -> Bool {
+    FileManager.default.isExecutableFile(atPath: path)
+}
+
 func codesign(identity: String, path: String, options: String = defaultCodesignOptions) throws {
     print("Code-signing \(path)...")
     let command = "codesign -s \"\(identity)\" \(options) \"\(path)\""
@@ -53,7 +57,10 @@ func recursivelyCodesign(
     }
 
     for case let enumeratedItem as String in pathEnumerator {
-        guard isLibrary(enumeratedItem) || isAppExtension(enumeratedItem) else { continue }
+        guard isLibrary(enumeratedItem) ||
+              isAppExtension(enumeratedItem) ||
+              isExecutable(enumeratedItem)
+        else { continue }
         try codesign(identity: identity, path: "\(path)/\(enumeratedItem)")
     }
 }

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-fileprivate let defaultCodesignOptions = "--timestamp --force --preserve-metadata=entitlements --verbose=4 --options runtime --deep"
+fileprivate let defaultCodesignOptions = "--timestamp --force --preserve-metadata=entitlements --verbose=4 --options runtime"
 
 enum CodeSigningError: Error {
     case failedToCodeSign(String)

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -133,4 +133,7 @@ func codesignClientAppBundle(
     // Now we do the final codesign bit
     print("Code-signing Nextcloud Desktop Client binaries...")
     try recursivelyCodesign(path: "\(clientContentsDir)/MacOS/", identity: codeSignIdentity)
+
+    print("Code-signing Nextcloud Desktop Client app bundle...")
+    try codesign(identity: codeSignIdentity, path: clientAppDir)
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

I believe this should be the final step