### PR TITLE
remove this call that is probably useless and crashing tests

### DIFF
--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -367,8 +367,6 @@ Theme::Theme()
 #if defined(Q_OS_WIN)
     // Windows does not provide a dark theme for Win32 apps so let's come up with a palette
     // Credit to https://github.com/Jorgen-VikingGod/Qt-Frameless-Window-DarkStyle
-    reserveDarkPalette = qApp->palette();
-
     reserveDarkPalette.setColor(QPalette::WindowText, Qt::white);
     reserveDarkPalette.setColor(QPalette::Button, QColor(127, 127, 127));
     reserveDarkPalette.setColor(QPalette::Light, QColor(20, 20, 20));


### PR DESCRIPTION
we initialize all colors in the palette, so this init methos is most probably not doing anything useful

crashes when doing in automated tests

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
