### PR TITLE
Fix mac-crafter codesign executable check path building

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -70,11 +70,12 @@ func recursivelyCodesign(
     }
 
     for case let enumeratedItem as String in pathEnumerator {
-        let isExecutableFile = try isExecutable(path + "/" + enumeratedItem)
+        let enumeratedItemPath = "\(path)/\(enumeratedItem)"
+        let isExecutableFile = try isExecutable(enumeratedItemPath)
         guard isLibrary(enumeratedItem) || isAppExtension(enumeratedItem) || isExecutableFile else {
             continue
         }
-        try codesign(identity: identity, path: "\(path)/\(enumeratedItem)", options: options)
+        try codesign(identity: identity, path: enumeratedItemPath, options: options)
     }
 }
 

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -70,7 +70,7 @@ func recursivelyCodesign(
     }
 
     for case let enumeratedItem as String in pathEnumerator {
-        let isExecutableFile = try isExecutable(fm.currentDirectoryPath + "/" + path + "/" + enumeratedItem)
+        let isExecutableFile = try isExecutable(path + "/" + enumeratedItem)
         guard isLibrary(enumeratedItem) || isAppExtension(enumeratedItem) || isExecutableFile else {
             continue
         }

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -145,6 +145,15 @@ func codesignClientAppBundle(
     }
 
     // Now we do the final codesign bit
+    let binariesDir = "\(clientContentsDir)/MacOS"
     print("Code-signing Nextcloud Desktop Client binaries...")
-    try recursivelyCodesign(path: "\(clientContentsDir)/MacOS/", identity: codeSignIdentity)
+    try recursivelyCodesign(path: binariesDir, identity: codeSignIdentity)
+
+    guard let appName = clientAppDir.components(separatedBy: "/").last, clientAppDir.hasSuffix(".app") else {
+        throw AppBundleSigningError.couldNotEnumerate("Failed to determine main executable name.")
+    }
+
+    // Sign the main executable last
+    let mainExecutableName = String(appName.dropLast(".app".count))
+    try codesign(identity: codeSignIdentity, path: "\(binariesDir)/\(mainExecutableName)")
 }

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -275,7 +275,10 @@ struct Codesign: ParsableCommand {
     var codeSignIdentity: String
 
     mutating func run() throws {
-        try codesignClientAppBundle(at: appBundlePath, withCodeSignIdentity: codeSignIdentity)
+        let absolutePath = appBundlePath.hasPrefix("/")
+            ? appBundlePath
+            : "\(FileManager.default.currentDirectoryPath)/\(appBundlePath)"
+        try codesignClientAppBundle(at: absolutePath, withCodeSignIdentity: codeSignIdentity)
     }
 }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
