### PR TITLE
fix spelling os UserStatus qml type when setting user status

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -54,36 +54,36 @@ ColumnLayout {
             }
 
             UserStatusSelectorButton {
-                checked: userStatusSelectorModel.onlineStatus === NC.userStatus.Online
+                checked: userStatusSelectorModel.onlineStatus === NC.UserStatus.Online
                 checkable: true
                 icon.source: userStatusSelectorModel.onlineIcon
                 icon.color: "transparent"
                 text: qsTr("Online")
-                onClicked: userStatusSelectorModel.onlineStatus = NC.userStatus.Online
+                onClicked: userStatusSelectorModel.onlineStatus = NC.UserStatus.Online
 
                 Layout.fillWidth: true
                 implicitWidth: 200 // Pretty much a hack to ensure all the buttons are equal in width
             }
             UserStatusSelectorButton {
-                checked: userStatusSelectorModel.onlineStatus === NC.userStatus.Away
+                checked: userStatusSelectorModel.onlineStatus === NC.UserStatus.Away
                 checkable: true
                 icon.source: userStatusSelectorModel.awayIcon
                 icon.color: "transparent"
                 text: qsTr("Away")
-                onClicked: userStatusSelectorModel.onlineStatus = NC.userStatus.Away
+                onClicked: userStatusSelectorModel.onlineStatus = NC.UserStatus.Away
 
                 Layout.fillWidth: true
                 implicitWidth: 200 // Pretty much a hack to ensure all the buttons are equal in width
 
             }
             UserStatusSelectorButton {
-                checked: userStatusSelectorModel.onlineStatus === NC.userStatus.DoNotDisturb
+                checked: userStatusSelectorModel.onlineStatus === NC.UserStatus.DoNotDisturb
                 checkable: true
                 icon.source: userStatusSelectorModel.dndIcon
                 icon.color: "transparent"
                 text: qsTr("Do not disturb")
                 secondaryText: qsTr("Mute all notifications")
-                onClicked: userStatusSelectorModel.onlineStatus = NC.userStatus.DoNotDisturb
+                onClicked: userStatusSelectorModel.onlineStatus = NC.UserStatus.DoNotDisturb
 
                 Layout.fillWidth: true
                 implicitWidth: 200 // Pretty much a hack to ensure all the buttons are equal in width
@@ -92,14 +92,14 @@ ColumnLayout {
                 Component.onCompleted: topButtonsLayout.updateMaxButtonHeight(implicitHeight)
             }
             UserStatusSelectorButton {
-                checked: userStatusSelectorModel.onlineStatus === NC.userStatus.Invisible ||
-                         userStatusSelectorModel.onlineStatus === NC.userStatus.Offline
+                checked: userStatusSelectorModel.onlineStatus === NC.UserStatus.Invisible ||
+                         userStatusSelectorModel.onlineStatus === NC.UserStatus.Offline
                 checkable: true
                 icon.source: userStatusSelectorModel.invisibleIcon
                 icon.color: "transparent"
                 text: qsTr("Invisible")
                 secondaryText: qsTr("Appear offline")
-                onClicked: userStatusSelectorModel.onlineStatus = NC.userStatus.Invisible
+                onClicked: userStatusSelectorModel.onlineStatus = NC.UserStatus.Invisible
 
                 Layout.fillWidth: true
                 implicitWidth: 200 // Pretty much a hack to ensure all the buttons are equal in width


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
