### PR TITLE
gui/tray: Fix activity icon colours

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -104,7 +104,7 @@ RowLayout {
 
             cache: true
             fillMode: Image.PreserveAspectFit
-            source: Style.darkMode ? model.darkIcon : model.lightIcon
+            source: model.icon + "/" + palette.text
             sourceSize.height: 64
             sourceSize.width: 64
             mipmap: true // Addresses grainy downscale

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -65,8 +65,7 @@ QHash<int, QByteArray> ActivityListModel::roleNames() const
     roles[LinkRole] = "link";
     roles[MessageRole] = "message";
     roles[ActionRole] = "type";
-    roles[DarkIconRole] = "darkIcon";
-    roles[LightIconRole] = "lightIcon";
+    roles[IconRole] = "icon";
     roles[ActionTextRole] = "subject";
     roles[ActionsLinksRole] = "links";
     roles[ActionsLinksContextMenuRole] = "linksContextMenu";
@@ -288,10 +287,8 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
         return ActivityListModel::convertLinksToActionButtons(a);
     }
 
-    case DarkIconRole:
-    case LightIconRole: {
+    case IconRole:
         return generateIconPath();
-    }
     case ObjectTypeRole:
         return a._objectType;
     case ObjectIdRole:

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -226,7 +226,7 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
     };
 
     const auto generateIconPath = [&]() {
-        auto colorIconPath = role == DarkIconRole ? QStringLiteral("image://svgimage-custom-color/%1/white") : QStringLiteral("image://svgimage-custom-color/%1/black");
+        auto colorIconPath = QStringLiteral("image://svgimage-custom-color/%1");
         if (a._type == Activity::NotificationType && !a._talkNotificationData.userAvatar.isEmpty()) {
             return QStringLiteral("image://svgimage-custom-color/talk-bordered.svg");
         } else if (a._type == Activity::SyncResultType) {
@@ -250,24 +250,16 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             } else {
                 // File sync successful
                 if (a._fileAction == "file_created") {
-                    return a._previews.empty() ? QStringLiteral("image://svgimage-custom-color/add.svg/")
-                                               : QStringLiteral("image://svgimage-custom-color/add-bordered.svg/");
+                    return a._previews.empty() ? colorIconPath.arg("add.svg") : colorIconPath.arg("add-bordered.svg");
                 } else if (a._fileAction == "file_deleted") {
-                    return a._previews.empty() ? QStringLiteral("image://svgimage-custom-color/delete.svg/")
-                                               : QStringLiteral("image://svgimage-custom-color/delete-bordered.svg/");
+                    return a._previews.empty() ? colorIconPath.arg("delete.svg") : colorIconPath.arg("delete-bordered.svg");
                 } else {
-                    return a._previews.empty() ? colorIconPath.arg(QStringLiteral("change.svg"))
-                                               : QStringLiteral("image://svgimage-custom-color/change-bordered.svg/");
+                    return a._previews.empty() ? colorIconPath.arg("change.svg") : colorIconPath.arg("change-bordered.svg");
                 }
             }
         } else {
             // We have an activity
-            if (a._icon.isEmpty()) {
-                return colorIconPath.arg("activity.svg");
-            }
-
-            const QString basePath = QStringLiteral("image://tray-image-provider/") % a._icon % QStringLiteral("/");
-            return role == DarkIconRole ? QString(basePath + QStringLiteral("white")) : QString(basePath + QStringLiteral("black"));
+            return a._icon.isEmpty() ? colorIconPath.arg("activity.svg") : colorIconPath.arg(a._icon);
         }
     };
 

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -51,8 +51,7 @@ class ActivityListModel : public QAbstractListModel
 
 public:
     enum DataRole {
-        DarkIconRole = Qt::UserRole + 1,
-        LightIconRole,
+        IconRole = Qt::UserRole + 1,
         AccountRole,
         ObjectTypeRole,
         ObjectIdRole,

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -225,8 +225,7 @@ private slots:
 
             QVERIFY(!index.data(OCC::ActivityListModel::AccountRole).toString().isEmpty());
             QVERIFY(!index.data(OCC::ActivityListModel::ActionTextColorRole).toString().isEmpty());
-            QVERIFY(!index.data(OCC::ActivityListModel::DarkIconRole).toString().isEmpty());
-            QVERIFY(!index.data(OCC::ActivityListModel::LightIconRole).toString().isEmpty());
+            QVERIFY(!index.data(OCC::ActivityListModel::IconRole).toString().isEmpty());
             QVERIFY(!index.data(OCC::ActivityListModel::PointInTimeRole).toString().isEmpty());
 
             QVERIFY(index.data(OCC::ActivityListModel::ObjectTypeRole).canConvert<int>());


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fixes colouring of activity icons in dark mode as well as in dark/light mode switch

Fixes #7560