### PR TITLE
doc: Rename first header on macos vfs doc entry, fixing title in index

### DIFF
--- a/doc/macosvfs.rst
+++ b/doc/macosvfs.rst
@@ -6,7 +6,7 @@ macOS Virtual Files
 
 .. index:: macosvfs
 
-Introduction
+macOS Vitual Files client
 ============
 
 Virtual file-based synchronisation for Nextcloud desktop users is now


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Fixes the following entry (should display macOS Virtual Files client)

<img width="673" alt="Screenshot 2024-11-27 at 15 30 30" src="https://github.com/user-attachments/assets/55911fb5-f2bf-44da-8bf0-5a6069661b43">

