### PR TITLE
mac-crafter: Close isExecutable command outpipe file handle after use

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -45,7 +45,9 @@ func isExecutable(_ path: String) throws -> Bool {
         throw CodeSigningError.failedToCodeSign("Failed to determine if \(path) is an executable.")
     }
 
-    let outputData = outPipe.fileHandleForReading.readDataToEndOfFile()
+    let outputFileHandle = outPipe.fileHandleForReading
+    let outputData = outputFileHandle.readDataToEndOfFile()
+    try outputFileHandle.close()
     let output = String(data: outputData, encoding: .utf8) ?? ""
     return output.contains("Mach-O 64-bit executable")
 }


### PR DESCRIPTION
Prevents exhaustion of fds

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
