### PR TITLE
when locking a file set If-Match header to ensure etag is correct

### DIFF
--- a/src/gui/editlocallyjob.cpp
+++ b/src/gui/editlocallyjob.cpp
@@ -467,11 +467,11 @@ void EditLocallyJob::processLocalItem()
     if (rec.isDirectory() || !_accountState->account()->capabilities().filesLockAvailable()) {
         openFile();
     } else {
-        lockFile();
+        lockFile(rec._etag);
     }
 }
 
-void EditLocallyJob::lockFile()
+void EditLocallyJob::lockFile(const QString &etag)
 {
     Q_ASSERT(_accountState);
     Q_ASSERT(_accountState->account());
@@ -506,6 +506,7 @@ void EditLocallyJob::lockFile()
     _folderForFile->accountState()->account()->setLockFileState(_relPath,
                                                                 _folderForFile->remotePathTrailingSlash(),
                                                                 _folderForFile->path(),
+                                                                etag,
                                                                 _folderForFile->journalDb(),
                                                                 SyncFileItem::LockStatus::LockedItem,
                                                                 SyncFileItem::LockOwnerType::TokenLock);

--- a/src/gui/editlocallyjob.h
+++ b/src/gui/editlocallyjob.h
@@ -65,7 +65,7 @@ private slots:
 
     void processLocalItem();
     void openFile();
-    void lockFile();
+    void lockFile(const QString &etag);
 
     void fileAlreadyLocked();
     void fileLockSuccess(const OCC::SyncFileItemPtr &item);

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -696,6 +696,7 @@ void Folder::slotFilesLockReleased(const QSet<QString> &files)
         _accountState->account()->setLockFileState(remoteFilePath,
                                                    remotePathTrailingSlash(),
                                                    path(),
+                                                   rec._etag,
                                                    journalDb(),
                                                    SyncFileItem::LockStatus::UnlockedItem,
                                                    lockOwnerType);
@@ -744,6 +745,7 @@ void Folder::slotLockedFilesFound(const QSet<QString> &files)
         _accountState->account()->setLockFileState(remoteFilePath,
                                                    remotePathTrailingSlash(),
                                                    path(),
+                                                   rec._etag,
                                                    journalDb(),
                                                    SyncFileItem::LockStatus::LockedItem,
                                                    SyncFileItem::LockOwnerType::TokenLock);

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1096,6 +1096,7 @@ void SocketApi::setFileLock(const QString &localFile, const SyncFileItem::LockSt
     shareFolder->accountState()->account()->setLockFileState(fileData.serverRelativePath,
                                                              shareFolder->remotePathTrailingSlash(),
                                                              shareFolder->path(),
+                                                             record._etag,
                                                              shareFolder->journalDb(),
                                                              lockState,
                                                              (lockState == SyncFileItem::LockStatus::UnlockedItem) ? static_cast<SyncFileItem::LockOwnerType>(record._lockstate._lockOwnerType) : SyncFileItem::LockOwnerType::UserLock);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -983,6 +983,7 @@ std::shared_ptr<UserStatusConnector> Account::userStatusConnector() const
 void Account::setLockFileState(const QString &serverRelativePath,
                                const QString &remoteSyncPathWithTrailingSlash,
                                const QString &localSyncPath,
+                               const QString &etag,
                                SyncJournalDb * const journal,
                                const SyncFileItem::LockStatus lockStatus,
                                const SyncFileItem::LockOwnerType lockOwnerType)
@@ -993,7 +994,7 @@ void Account::setLockFileState(const QString &serverRelativePath,
         return;
     }
     lockStatusJobInProgress.push_back(lockStatus);
-    auto job = std::make_unique<LockFileJob>(sharedFromThis(), journal, serverRelativePath, remoteSyncPathWithTrailingSlash, localSyncPath, lockStatus, lockOwnerType);
+    auto job = std::make_unique<LockFileJob>(sharedFromThis(), journal, serverRelativePath, remoteSyncPathWithTrailingSlash, localSyncPath, etag, lockStatus, lockOwnerType);
     connect(job.get(), &LockFileJob::finishedWithoutError, this, [this, serverRelativePath, lockStatus]() {
         removeLockStatusChangeInprogress(serverRelativePath, lockStatus);
         Q_EMIT lockFileSuccess();

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -345,7 +345,7 @@ public:
 
     void setLockFileState(const QString &serverRelativePath,
                           const QString &remoteSyncPathWithTrailingSlash,
-                          const QString &localSyncPath,
+                          const QString &localSyncPath, const QString &etag,
                           SyncJournalDb * const journal,
                           const SyncFileItem::LockStatus lockStatus,
                           const SyncFileItem::LockOwnerType lockOwnerType);

--- a/src/libsync/lockfilejobs.h
+++ b/src/libsync/lockfilejobs.h
@@ -24,6 +24,7 @@ public:
                          const QString &path,
                          const QString &remoteSyncPathWithTrailingSlash,
                          const QString &localSyncPath,
+                         const QString &etag,
                          const SyncFileItem::LockStatus requestedLockState,
                          const SyncFileItem::LockOwnerType lockOwnerType,
                          QObject *parent = nullptr);
@@ -62,6 +63,7 @@ private:
     QString _lockToken;
     QString _remoteSyncPathWithTrailingSlash;
     QString _localSyncPath;
+    QString _existingEtag;
 };
 
 }

--- a/test/testlockfile.cpp
+++ b/test/testlockfile.cpp
@@ -43,6 +43,7 @@ private slots:
         fakeFolder.account()->setLockFileState(QStringLiteral("/") + testFileName,
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
+                                               {},
                                                &fakeFolder.syncJournal(),
                                                OCC::SyncFileItem::LockStatus::LockedItem,
                                                OCC::SyncFileItem::LockOwnerType::UserLock);
@@ -89,6 +90,7 @@ private slots:
         fakeFolder.account()->setLockFileState(QStringLiteral("/") + testFileName,
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
+                                               {},
                                                &fakeFolder.syncJournal(),
                                                OCC::SyncFileItem::LockStatus::LockedItem,
                                                OCC::SyncFileItem::LockOwnerType::UserLock);
@@ -114,6 +116,7 @@ private slots:
         fakeFolder.account()->setLockFileState(QStringLiteral("/") + testFileName,
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
+                                               {},
                                                &fakeFolder.syncJournal(),
                                                OCC::SyncFileItem::LockStatus::LockedItem,
                                                OCC::SyncFileItem::LockOwnerType::UserLock);
@@ -142,6 +145,7 @@ private slots:
         fakeFolder.account()->setLockFileState(QStringLiteral("/") + testFileName,
                                                QStringLiteral("/"),
                                                fakeFolder.localPath(),
+                                               {},
                                                &fakeFolder.syncJournal(),
                                                OCC::SyncFileItem::LockStatus::LockedItem,
                                                OCC::SyncFileItem::LockOwnerType::UserLock);
@@ -168,6 +172,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::LockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -207,6 +212,7 @@ private slots:
                                                 QStringLiteral("/") + testFileName,
                                                 QStringLiteral("/"),
                                                 fakeFolder.localPath(),
+                                                {},
                                                 OCC::SyncFileItem::LockStatus::LockedItem,
                                                 OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -225,6 +231,7 @@ private slots:
                                                   QStringLiteral("/") + testFileName,
                                                   QStringLiteral("/"),
                                                   fakeFolder.localPath(),
+                                                  {},
                                                   OCC::SyncFileItem::LockStatus::UnlockedItem,
                                                   OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -285,6 +292,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::LockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -339,6 +347,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::LockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -393,6 +402,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::UnlockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -445,6 +455,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::UnlockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -484,6 +495,7 @@ private slots:
                                                 QStringLiteral("/") + testFileName,
                                                 QStringLiteral("/"),
                                                 fakeFolder.localPath(),
+                                                {},
                                                 OCC::SyncFileItem::LockStatus::LockedItem,
                                                 OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -502,6 +514,7 @@ private slots:
                                                   QStringLiteral("/") + testFileName,
                                                   QStringLiteral("/"),
                                                   fakeFolder.localPath(),
+                                                  {},
                                                   OCC::SyncFileItem::LockStatus::UnlockedItem,
                                                   OCC::SyncFileItem::LockOwnerType::UserLock);
 
@@ -556,6 +569,7 @@ private slots:
                                         QStringLiteral("/") + testFileName,
                                         QStringLiteral("/"),
                                         fakeFolder.localPath(),
+                                        {},
                                         OCC::SyncFileItem::LockStatus::UnlockedItem,
                                         OCC::SyncFileItem::LockOwnerType::UserLock);
 


### PR DESCRIPTION
the file being locked may have been changed sinc the client synced it

so the server side file may have a modified etag. In such cases we do not want to lock the file and would rather sync the nex server changes before being able to lock the file

that would ensure that on client side the file being locked is matching teh state of teh file on server side and would prevent inadvertently overriding server changes

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
