### PR TITLE
mac-crafter: Fix codesigning of app bundle when auto-updater is excluded

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -123,14 +123,21 @@ func codesignClientAppBundle(
     // Multiple components of the app will now have the get-task-allow entitlements.
     // We need to strip these out manually.
 
-    print("Code-signing Sparkle autoupdater app (without entitlements)...")
     let sparkleFrameworkPath = "\(frameworksPath)/Sparkle.framework"
-    try recursivelyCodesign(path: "\(sparkleFrameworkPath)/Resources/Autoupdate.app",
-                            identity: codeSignIdentity,
-                            options: "--timestamp --force --verbose=4 --options runtime --deep")
+    if FileManager.default.fileExists(atPath: "\(sparkleFrameworkPath)/Resources/Autoupdate.app") {
+        print("Code-signing Sparkle autoupdater app (without entitlements)...")
 
-    print("Re-codesigning Sparkle library...")
-    try codesign(identity: codeSignIdentity, path: "\(sparkleFrameworkPath)/Sparkle")
+        try recursivelyCodesign(
+            path: "\(sparkleFrameworkPath)/Resources/Autoupdate.app",
+            identity: codeSignIdentity,
+            options: "--timestamp --force --verbose=4 --options runtime --deep"
+        )
+
+        print("Re-codesigning Sparkle library...")
+        try codesign(identity: codeSignIdentity, path: "\(sparkleFrameworkPath)/Sparkle")
+    } else {
+        print("Build does not have Sparkle, skipping.")
+    }
 
     print("Code-signing app extensions (removing get-task-allow entitlements)...")
     let fm = FileManager.default

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -21,6 +21,7 @@ enum CodeSigningError: Error {
 }
 
 enum AppBundleSigningError: Error {
+    case doesNotExist(String)
     case couldNotEnumerate(String)
 }
 
@@ -64,6 +65,10 @@ func recursivelyCodesign(
     skip: [String] = []
 ) throws {
     let fm = FileManager.default
+    guard fm.fileExists(atPath: path) else {
+        throw AppBundleSigningError.doesNotExist("Item at \(path) does not exist.")
+    }
+
     guard let pathEnumerator = fm.enumerator(atPath: path) else {
         throw AppBundleSigningError.couldNotEnumerate(
             "Failed to enumerate directory at \(path)."


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
