### PR TITLE
Include folders when displaying the local metadata about a conflict.

### DIFF
--- a/src/gui/caseclashfilenamedialog.cpp
+++ b/src/gui/caseclashfilenamedialog.cpp
@@ -175,6 +175,7 @@ QString CaseClashFilenameDialog::caseClashConflictFile(const QString &conflictFi
 {
     const auto filePathFileInfo = QFileInfo(conflictFilePath);
     const auto conflictFileName = filePathFileInfo.fileName();
+    const auto lookingForDirectory = FileSystem::isDir(filePathFileInfo.absoluteFilePath());
 
     QDirIterator it(filePathFileInfo.path(), QDirIterator::Subdirectories);
 
@@ -182,15 +183,16 @@ QString CaseClashFilenameDialog::caseClashConflictFile(const QString &conflictFi
         const auto filePath = it.next();
         qCDebug(lcCaseClashConflictFialog) << filePath;
 
-        if (FileSystem::isDir(filePath)) {
+        if (FileSystem::isDir(filePath) && !lookingForDirectory) {
             continue;
         }
 
-        QFileInfo fileInfo(filePath);
-        const auto currentFileName = fileInfo.fileName();
-        if (currentFileName.compare(conflictFileName, Qt::CaseInsensitive) == 0 &&
-                currentFileName != conflictFileName) {
+        const auto currentFileName = QFileInfo(filePath).fileName();
+        if (currentFileName.compare(conflictFileName, Qt::CaseInsensitive) != 0) {
+            continue;
+        }
 
+        if (currentFileName != conflictFileName) {
             return filePath;
         }
     }


### PR DESCRIPTION
#### before:
![Screenshot 2024-12-11 at 19 47 48](https://github.com/user-attachments/assets/6361ea36-14c0-474f-b46f-f2e6a4f68d7d)

#### after:
![Screenshot 2024-12-11 at 19 51 49](https://github.com/user-attachments/assets/2977c114-302e-4c50-b989-40b5c4fd7518)

##### on Windows
![windows](https://github.com/user-attachments/assets/e516dfae-8c5c-44ee-9759-5895d6456be5)

