### PR TITLE
fix path of sync run log file

### DIFF
--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -32,7 +32,10 @@ void SyncRunFileLog::start(const QString &folderPath)
 {
     const qint64 logfileMaxSize = 10 * 1024 * 1024; // 10MiB
 
-    const QString logpath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    const QString logpath =
+        !Utility::isWindows()
+        ? QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)
+        : QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     if(!QDir(logpath).exists()) {
         QDir().mkdir(logpath);
     }


### PR DESCRIPTION
This should fix the issue https://github.com/nextcloud/desktop/issues/7654 where the old log location is used after moving the files to the new location on linux.

I have tested it locally and it seems to solve the problem, but I'm not really sure why the log should be stored in the config directory at all. If we want to solve this, we need to exclude the log files from the migration in [src/gui/application.cpp:L549](https://github.com/kaikli/nextcloud-desktop-client/blob/master/src/gui/application.cpp#L549) and move the other log files in $XDG_CONFIG_DIR/Nextcloud/logs to the data directory.

Thats the reason why I have also created a second pull request https://github.com/nextcloud/desktop/pull/7665 with a consistent log directory. Please choose one of them.