### PR TITLE
fix dev application name to keep a consitant migration behaviour for the dev and prod build

### DIFF
--- a/NEXTCLOUD.cmake
+++ b/NEXTCLOUD.cmake
@@ -1,6 +1,8 @@
+# keep the application name and short name the same or different for dev and prod build
+# or some migration logic will behave differently for each build
 if(NEXTCLOUD_DEV)
     set( APPLICATION_NAME       "NextcloudDev" )
-    set( APPLICATION_SHORTNAME  "NextDev" )
+    set( APPLICATION_SHORTNAME  "NextcloudDev" )
     set( APPLICATION_EXECUTABLE "nextclouddev" )
     set( APPLICATION_ICON_NAME  "Nextcloud" )
 else()


### PR DESCRIPTION
keep application name and short name the same or different for the dev and prod build or some migration behaviour will work differently for each build

for example [`Application::setupConfigFile in src/gui/application.cpp:L519`](https://github.com/kaikli/nextcloud-desktop-client/blob/fix-dev-app-name/src/gui/application.cpp#L519):
- prod: `$XDG_DATA_DIR/Nextcloud` -> `$XDG_CONFIG_DIR/Nextcloud`
- dev: `$XDG_DATA_DIR/NextDev` -> `$XDG_CONFIG_DIR/Nextcloud`