### PR TITLE
Fix .netrc parsing

### DIFF
--- a/src/cmd/netrcparser.cpp
+++ b/src/cmd/netrcparser.cpp
@@ -14,8 +14,7 @@
 
 #include <QDir>
 #include <QFile>
-#include <QTextStream>
-#include <QStringTokenizer>
+#include <QRegularExpression>
 
 #include <QDebug>
 
@@ -58,32 +57,33 @@ bool NetrcParser::parse()
     }
     QString content = netrc.readAll();
 
-    auto tokenizer = QStringTokenizer{content, u" \n\t"};
+    auto tokens = content.split(QRegularExpression("\\s+"));
 
     LoginPair pair;
     QString machine;
     bool isDefault = false;
-    for(auto itToken = tokenizer.cbegin(); itToken != tokenizer.cend(); ++itToken) {
-        const auto key = *itToken;
+    for(int i=0; i<tokens.count(); i++) {
+        const auto key = tokens[i];
         if (key == defaultKeyword) {
             tryAddEntryAndClear(machine, pair, isDefault);
             isDefault = true;
             continue; // don't read a value
         }
 
-        if (itToken != tokenizer.cend()) {
+        i++;
+        if (i > tokens.count()) {
             qDebug() << "error fetching value for" << key;
             return false;
         }
-        auto value = *(++itToken);
+        auto value = tokens[i];
 
         if (key == machineKeyword) {
             tryAddEntryAndClear(machine, pair, isDefault);
-            machine = value.toString();
+            machine = value;
         } else if (key == loginKeyword) {
-            pair.first = value.toString();
+            pair.first = value;
         } else if (key == passwordKeyword) {
-            pair.second = value.toString();
+            pair.second = value;
         } // ignore unsupported tokens
     }
     tryAddEntryAndClear(machine, pair, isDefault);

--- a/src/cmd/netrcparser.cpp
+++ b/src/cmd/netrcparser.cpp
@@ -56,6 +56,9 @@ bool NetrcParser::parse()
         return false;
     }
     QString content = netrc.readAll();
+    if (content.isEmpty()) {
+        return false;
+    }
 
     auto tokens = content.split(QRegularExpression("\\s+"));
 
@@ -71,9 +74,9 @@ bool NetrcParser::parse()
         }
 
         i++;
-        if (i > tokens.count()) {
+        if (i >= tokens.count()) {
             qDebug() << "error fetching value for" << key;
-            return false;
+            break;
         }
         auto value = tokens[i];
 

--- a/test/testnetrcparser.cpp
+++ b/test/testnetrcparser.cpp
@@ -53,11 +53,11 @@ private slots:
 
     void testValidNetrc() {
        NetrcParser parser(testfileC);
-       QEXPECT_FAIL("", "test currently broken, eventually will be fixed", Abort);
        QVERIFY(parser.parse());
        QCOMPARE(parser.find("foo"), qMakePair(QString("bar"), QString("baz")));
        QCOMPARE(parser.find("broken"), qMakePair(QString("bar2"), QString()));
        QCOMPARE(parser.find("funnysplit"), qMakePair(QString("bar3"), QString("baz3")));
+       QEXPECT_FAIL("", "Current implementation do not support spaces in username or password", Continue);
        QCOMPARE(parser.find("frob"), qMakePair(QString("user with spaces"), QString("space pwd")));
     }
 
@@ -69,7 +69,6 @@ private slots:
 
     void testValidNetrcWithDefault() {
        NetrcParser parser(testfileWithDefaultC);
-       QEXPECT_FAIL("", "test currently broken, eventually will be fixed", Abort);
        QVERIFY(parser.parse());
        QCOMPARE(parser.find("foo"), qMakePair(QString("bar"), QString("baz")));
        QCOMPARE(parser.find("dontknow"), qMakePair(QString("user"), QString("pass")));


### PR DESCRIPTION
Fixes: #7177

It seems that the current Tokenizer-implementation splits the netrc tokens on a (string) separator of " \n\t" instead of splitting on any of the whitespace characters which leads to the issue described in #7177.

This implementation splits the content of netrc on any whitespace character using a regex instead, but should otherwise use the same strategy for parsing. I'm not very familiar with C++ (or QT) and does not completely understand the code, so although this solution seems to work for me, I would appreciate a review :slightly_smiling_face: 

Thanks!

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
