### PR TITLE
Call setDesktopFileName without `.desktop` suffix

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -230,9 +230,7 @@ Application::Application(int &argc, char **argv)
     //    setOrganizationName(QLatin1String(APPLICATION_VENDOR));
     setOrganizationDomain(QLatin1String(APPLICATION_REV_DOMAIN));
 
-    QString desktopFileName = QString(QLatin1String(LINUX_APPLICATION_ID)
-                                        + QLatin1String(".desktop"));
-    setDesktopFileName(desktopFileName);
+    setDesktopFileName(QString(LINUX_APPLICATION_ID));
 
     setApplicationName(_theme->appName());
     setWindowIcon(_theme->applicationIcon());


### PR DESCRIPTION
Fixes #7581

The motivation is explained in the issue.
I confirmed that this compiles and runs on my end,
but did not perform any other tests.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
