### PR TITLE
Log path strings directly instead of accumulating

### DIFF
--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1216,7 +1216,7 @@ void SyncEngine::setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QS
     _localDiscoveryStyle = style;
     _localDiscoveryPaths = std::move(paths);
 
-    if (lcEngine().isInfoEnabled()) {
+    if (lcEngine().isInfoEnabled() && !_localDiscoveryPaths.empty()) {
         // only execute if logging is enabled
         auto debug = qInfo(lcEngine);
         debug << "paths to discover locally";

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1216,12 +1216,14 @@ void SyncEngine::setLocalDiscoveryOptions(LocalDiscoveryStyle style, std::set<QS
     _localDiscoveryStyle = style;
     _localDiscoveryPaths = std::move(paths);
 
-    const auto allPaths = std::accumulate(_localDiscoveryPaths.begin(), _localDiscoveryPaths.end(), QString{}, [] (auto first, auto second) -> QString {
-                              first += ", " + second;
-                              return first;
-    });
-
-    qCInfo(lcEngine()) << "paths to discover locally" << allPaths;
+    if (lcEngine().isInfoEnabled()) {
+        // only execute if logging is enabled
+        auto debug = qInfo(lcEngine);
+        debug << "paths to discover locally";
+        for (auto path : _localDiscoveryPaths) {
+            debug << path;
+        }
+    }
 
     // Normalize to make sure that no path is a contained in another.
     // Note: for simplicity, this code consider anything less than '/' as a path separator, so for


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
Accumulating all discovery paths into one string causes major slowdowns: #7377 
This fixes the issue by immediately writing the names out instead of accumulating them. Additionally a check is added to skip the loop entirely if logging is disabled for the given log level.