### PR TITLE
gui/tray: Fix colour for secondary text items being too pale

### DIFF
--- a/src/gui/macOS/ui/FileProviderFileDelegate.qml
+++ b/src/gui/macOS/ui/FileProviderFileDelegate.qml
@@ -81,7 +81,7 @@ Item {
                 EnforcedPlainTextLabel {
                     id: fileTypeLabel
                     text: root.fileTypeString
-                    color: palette.mid
+                    color: palette.dark
                 }
             }
         }

--- a/src/gui/macOS/ui/FileProviderFileDelegate.qml
+++ b/src/gui/macOS/ui/FileProviderFileDelegate.qml
@@ -81,7 +81,7 @@ Item {
                 EnforcedPlainTextLabel {
                     id: fileTypeLabel
                     text: root.fileTypeString
-                    color: palette.midlight
+                    color: palette.mid
                 }
             }
         }

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -74,7 +74,7 @@ Page {
                 Rectangle {
                     Layout.fillWidth: true
                     height: Style.normalBorderWidth
-                    color: palette.midlight
+                    color: palette.mid
                 }
 
                 FileProviderSyncStatus {

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -74,7 +74,7 @@ Page {
                 Rectangle {
                     Layout.fillWidth: true
                     height: Style.normalBorderWidth
-                    color: palette.mid
+                    color: palette.dark
                 }
 
                 FileProviderSyncStatus {

--- a/src/gui/macOS/ui/FileProviderStorageInfo.qml
+++ b/src/gui/macOS/ui/FileProviderStorageInfo.qml
@@ -48,7 +48,7 @@ GridLayout {
         Layout.fillWidth: true
         text: qsTr("%1 GB of %2 GB remote files synced").arg(root.localUsedStorage.toFixed(2)).arg(root.remoteUsedStorage.toFixed(2));
         elide: Text.ElideRight
-        color: palette.mid
+        color: palette.dark
         horizontalAlignment: Text.AlignRight
     }
 

--- a/src/gui/macOS/ui/FileProviderStorageInfo.qml
+++ b/src/gui/macOS/ui/FileProviderStorageInfo.qml
@@ -48,7 +48,7 @@ GridLayout {
         Layout.fillWidth: true
         text: qsTr("%1 GB of %2 GB remote files synced").arg(root.localUsedStorage.toFixed(2)).arg(root.remoteUsedStorage.toFixed(2));
         elide: Text.ElideRight
-        color: palette.midlight
+        color: palette.mid
         horizontalAlignment: Text.AlignRight
     }
 

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -126,7 +126,7 @@ ScrollView {
                 verticalAlignment: Image.AlignVCenter
                 horizontalAlignment: Image.AlignHCenter
                 fillMode: Image.PreserveAspectFit
-                source: "image://svgimage-custom-color/activity.svg/" + palette.midlight
+                source: "image://svgimage-custom-color/activity.svg/" + palette.mid
             }
 
             EnforcedPlainTextLabel {

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -126,7 +126,7 @@ ScrollView {
                 verticalAlignment: Image.AlignVCenter
                 horizontalAlignment: Image.AlignHCenter
                 fillMode: Image.PreserveAspectFit
-                source: "image://svgimage-custom-color/activity.svg/" + palette.mid
+                source: "image://svgimage-custom-color/activity.svg/" + palette.dark
             }
 
             EnforcedPlainTextLabel {

--- a/src/gui/tray/ListItemLineAndSubline.qml
+++ b/src/gui/tray/ListItemLineAndSubline.qml
@@ -30,7 +30,7 @@ ColumnLayout {
     property int sublineFontSize: Style.unifiedSearchResultSublineFontSize
 
     property color titleColor: palette.windowText
-    property color sublineColor: palette.mid
+    property color sublineColor: palette.dark
 
     EnforcedPlainTextLabel {
         id: title

--- a/src/gui/tray/ListItemLineAndSubline.qml
+++ b/src/gui/tray/ListItemLineAndSubline.qml
@@ -30,7 +30,7 @@ ColumnLayout {
     property int sublineFontSize: Style.unifiedSearchResultSublineFontSize
 
     property color titleColor: palette.windowText
-    property color sublineColor: palette.midlight
+    property color sublineColor: palette.mid
 
     EnforcedPlainTextLabel {
         id: title

--- a/src/gui/tray/NCBusyIndicator.qml
+++ b/src/gui/tray/NCBusyIndicator.qml
@@ -19,7 +19,7 @@ import Style
 BusyIndicator {
     id: root
 
-    property color color: palette.mid
+    property color color: palette.dark
     property string imageSource: "image://svgimage-custom-color/change.svg/"
 
     property int imageSourceSizeWidth: 64

--- a/src/gui/tray/NCBusyIndicator.qml
+++ b/src/gui/tray/NCBusyIndicator.qml
@@ -19,7 +19,7 @@ import Style
 BusyIndicator {
     id: root
 
-    property color color: palette.midlight
+    property color color: palette.mid
     property string imageSource: "image://svgimage-custom-color/change.svg/"
 
     property int imageSourceSizeWidth: 64

--- a/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
+++ b/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
@@ -26,7 +26,7 @@ ColumnLayout {
 
     property int fontSize: Style.unifiedSearchResultTitleFontSize
 
-    property string textColor: palette.midlight
+    property string textColor: palette.mid
 
     Accessible.role: Accessible.ListItem
     Accessible.name: unifiedSearchResultItemFetchMoreText.text

--- a/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
+++ b/src/gui/tray/UnifiedSearchResultFetchMoreTrigger.qml
@@ -26,7 +26,7 @@ ColumnLayout {
 
     property int fontSize: Style.unifiedSearchResultTitleFontSize
 
-    property string textColor: palette.mid
+    property string textColor: palette.dark
 
     Accessible.role: Accessible.ListItem
     Accessible.name: unifiedSearchResultItemFetchMoreText.text

--- a/src/gui/tray/UnifiedSearchResultItem.qml
+++ b/src/gui/tray/UnifiedSearchResultItem.qml
@@ -36,7 +36,7 @@ RowLayout {
     property int sublineFontSize: Style.unifiedSearchResultSublineFontSize
 
     property color titleColor: palette.buttonText
-    property color sublineColor: palette.mid
+    property color sublineColor: palette.dark
 
 
     Accessible.role: Accessible.ListItem

--- a/src/gui/tray/UnifiedSearchResultItem.qml
+++ b/src/gui/tray/UnifiedSearchResultItem.qml
@@ -36,7 +36,7 @@ RowLayout {
     property int sublineFontSize: Style.unifiedSearchResultSublineFontSize
 
     property color titleColor: palette.buttonText
-    property color sublineColor: palette.midlight
+    property color sublineColor: palette.mid
 
 
     Accessible.role: Accessible.ListItem


### PR DESCRIPTION
Closes #7711

<img width="786" alt="Screenshot 2025-01-07 at 15 03 18" src="https://github.com/user-attachments/assets/1c674754-4816-4f0f-8d0e-cf986c0c880c" />

<!-- 


Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
