### PR TITLE
fix colours in dark mode

### DIFF
--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -38,7 +38,6 @@ TextField {
     }
 
     readonly property int horizontalPaddingOffset: Style.trayHorizontalMargin
-    readonly property color placeholderColor: palette.dark
     readonly property double iconsScaleFactor: 0.6
 
     function triggerSuggestionsVisibility() {
@@ -46,7 +45,6 @@ TextField {
     }
 
     placeholderText: enabled ? qsTr("Search for users or groups…") : qsTr("Sharing is not available for this folder")
-    placeholderTextColor: placeholderColor
     verticalAlignment: Qt.AlignVCenter
     implicitHeight: Math.max(Style.talkReplyTextFieldPreferredHeight, contentHeight)
 
@@ -109,7 +107,7 @@ TextField {
         fillMode: Image.PreserveAspectFit
         horizontalAlignment: Image.AlignLeft
 
-        source: "image://svgimage-custom-color/search.svg" + "/" + root.placeholderColor
+        source: "image://svgimage-custom-color/search.svg" + "/" + palette.placeholderText
         sourceSize: Qt.size(parent.height * root.iconsScaleFactor, parent.height * root.iconsScaleFactor)
 
         visible: !root.shareeModel.fetchOngoing
@@ -125,7 +123,7 @@ TextField {
         }
 
         width: height
-        color: root.placeholderColor
+        color: palette.placeholderText
         visible: root.shareeModel.fetchOngoing
         running: visible
     }
@@ -147,7 +145,7 @@ TextField {
         mipmap: true
         fillMode: Image.PreserveAspectFit
 
-        source: "image://svgimage-custom-color/clear.svg" + "/" + root.placeholderColor
+        source: "image://svgimage-custom-color/clear.svg" + "/" + palette.placeholderText
         sourceSize: Qt.size(parent.height * root.iconsScaleFactor, parent.height * root.iconsScaleFactor)
 
         visible: root.text

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -126,7 +126,7 @@ ScrollView {
                 verticalAlignment: Image.AlignVCenter
                 horizontalAlignment: Image.AlignHCenter
                 fillMode: Image.PreserveAspectFit
-                source: "image://svgimage-custom-color/activity.svg/" + palette.dark
+                source: "image://svgimage-custom-color/activity.svg/" + palette.windowText
             }
 
             EnforcedPlainTextLabel {

--- a/src/gui/tray/UnifiedSearchInputContainer.qml
+++ b/src/gui/tray/UnifiedSearchInputContainer.qml
@@ -27,8 +27,7 @@ TextField {
 
     property bool isSearchInProgress: false
 
-    readonly property color textFieldIconsColor: palette.dark
-    readonly property color placeholderColor: palette.dark
+    readonly property color textFieldIconsColor: palette.placeholderText
 
     readonly property int iconInset: Style.smallSpacing
 

--- a/src/gui/tray/UnifiedSearchPlaceholderView.qml
+++ b/src/gui/tray/UnifiedSearchPlaceholderView.qml
@@ -29,7 +29,7 @@ ColumnLayout {
     }
 
     Image {
-        source: "image://svgimage-custom-color/magnifying-glass.svg"
+        source: `image://svgimage-custom-color/magnifying-glass.svg/${palette.windowText}`
         sourceSize.width: Style.trayWindowHeaderHeight / 2
         sourceSize.height: Style.trayWindowHeaderHeight / 2
         Layout.alignment: Qt.AlignHCenter

--- a/src/gui/tray/UnifiedSearchResultNothingFound.qml
+++ b/src/gui/tray/UnifiedSearchResultNothingFound.qml
@@ -29,7 +29,7 @@ ColumnLayout {
 
     Image {
         id: unifiedSearchResultsNoResultsLabelIcon
-        source: "image://svgimage-custom-color/magnifying-glass.svg"
+        source: `image://svgimage-custom-color/magnifying-glass.svg/${palette.windowText}`
         sourceSize.width: Style.trayWindowHeaderHeight / 2
         sourceSize.height: Style.trayWindowHeaderHeight / 2
         Layout.alignment: Qt.AlignHCenter

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -258,7 +258,12 @@ QVariant ActivityListModel::data(const QModelIndex &index, int role) const
             }
         } else {
             // We have an activity
-            return a._icon.isEmpty() ? colorIconPath.arg("activity.svg") : colorIconPath.arg(a._icon);
+            if (a._icon.isEmpty()) {
+                return colorIconPath.arg("activity.svg");
+            }
+
+            // using tray-image-provider here as it can read from URLs
+            return QStringLiteral("image://tray-image-provider/%1").arg(a._icon);
         }
     };
 


### PR DESCRIPTION
- use `placeholderText` for `TextField` icons (introduced in Qt 5.12 according to https://doc.qt.io/qt-6/qpalette.html#ColorRole-enum)
- use `windowText` for the large icons in activity view/search results
- also fix retrieval of icons from the server