### PR TITLE
github: Implement issue types in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -2,6 +2,7 @@ name: "🐞 Bug report"
 description: "Help us to improve by reporting a bug"
 title: "[Bug]: "
 labels: ["bug", "0. Needs triage"]
+type: "Bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,6 +2,7 @@
 name: 🚀 Feature request
 about: Suggest an idea for this app
 labels: 0. Needs triage, enhancement
+type: Enhancement
 ---
 
 <!--- Please keep this note for other contributors -->


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
