### PR TITLE
fix the if check for invalid virtual LNK files

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1679,7 +1679,7 @@ void ProcessDirectoryJob::processFileFinalize(
         item->_type = CSyncEnums::ItemTypeVirtualFileDehydration;
     }
 
-    if (item->_instruction != CSyncEnums::CSYNC_INSTRUCTION_NONE &&
+    if (item->_instruction == CSyncEnums::CSYNC_INSTRUCTION_NONE &&
         !item->isDirectory() &&
         _discoveryData->_syncOptions._vfs &&
         _discoveryData->_syncOptions._vfs->mode() == OCC::Vfs::Off &&


### PR DESCRIPTION
should ensure we fix the DB metadata of LNK windows shortcuts with virtual files type

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
