### PR TITLE
ensure our overlay icons appear first

### DIFF
--- a/shell_integration/windows/WinShellExt.wxs.in
+++ b/shell_integration/windows/WinShellExt.wxs.in
@@ -42,11 +42,11 @@
             There is a limit in Windows (oh wonder^^) so that only the first 15 extensions get invoked, this is why to use that dirty little trick to get ahead ;)
             See: https://docs.microsoft.com/en-us/windows/win32/shell/context-menu-handlers?redirectedfrom=MSDN#employing-the-verb-selection-model
         -->
-        <?define OverlayNameError       = "                @APPLICATION_SHORTNAME@Error" ?>
-        <?define OverlayNameOK          = "                @APPLICATION_SHORTNAME@OK" ?>
-        <?define OverlayNameOKShared    = "                @APPLICATION_SHORTNAME@OKShared" ?>
-        <?define OverlayNameSync        = "                @APPLICATION_SHORTNAME@Sync" ?>
-        <?define OverlayNameWarning     = "                @APPLICATION_SHORTNAME@Warning" ?>
+        <?define OverlayNameError       = "                          @APPLICATION_SHORTNAME@Error" ?>
+        <?define OverlayNameOK          = "                          @APPLICATION_SHORTNAME@OK" ?>
+        <?define OverlayNameOKShared    = "                          @APPLICATION_SHORTNAME@OKShared" ?>
+        <?define OverlayNameSync        = "                          @APPLICATION_SHORTNAME@Sync" ?>
+        <?define OverlayNameWarning     = "                          @APPLICATION_SHORTNAME@Warning" ?>
 
         <?define OverlayDescription     = "@APPLICATION_SHORTNAME@ overlay handler" ?>
 

--- a/shell_integration/windows/WinShellExtConstants.h.in
+++ b/shell_integration/windows/WinShellExtConstants.h.in
@@ -35,11 +35,11 @@
 // There is a limit in Windows (oh wonder^^) so that only the first 15 extensions get invoked, this is why to use that dirty little trick to get ahead ;)
 // See: https://docs.microsoft.com/en-us/windows/win32/shell/context-menu-handlers?redirectedfrom=MSDN#employing-the-verb-selection-model
 //
-#define OVERLAY_NAME_ERROR          L"                @APPLICATION_SHORTNAME@Error"
-#define OVERLAY_NAME_OK             L"                @APPLICATION_SHORTNAME@OK"
-#define OVERLAY_NAME_OK_SHARED      L"                @APPLICATION_SHORTNAME@OKShared"
-#define OVERLAY_NAME_SYNC           L"                @APPLICATION_SHORTNAME@Sync"
-#define OVERLAY_NAME_WARNING        L"                @APPLICATION_SHORTNAME@Warning"
+#define OVERLAY_NAME_ERROR          L"                          @APPLICATION_SHORTNAME@Error"
+#define OVERLAY_NAME_OK             L"                          @APPLICATION_SHORTNAME@OK"
+#define OVERLAY_NAME_OK_SHARED      L"                          @APPLICATION_SHORTNAME@OKShared"
+#define OVERLAY_NAME_SYNC           L"                          @APPLICATION_SHORTNAME@Sync"
+#define OVERLAY_NAME_WARNING        L"                          @APPLICATION_SHORTNAME@Warning"
 
 #define OVERLAY_DESCRIPTION         L"@APPLICATION_SHORTNAME@ overlay handler"
 


### PR DESCRIPTION
add extra spaces to be alphabetically sorted first

overlay icons cannot work if they appear after the first ones

this would ensure our icons appear first and be usable

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
