### PR TITLE
notifications: Do not assume root activity link is the correct "join call" link

### DIFF
--- a/src/gui/tray/CallNotificationDialog.qml
+++ b/src/gui/tray/CallNotificationDialog.qml
@@ -227,7 +227,7 @@ ApplicationWindow {
                         Layout.preferredHeight: Style.callNotificationPrimaryButtonMinHeight
 
                         onClicked: {
-                            Qt.openUrlExternally(root.link);
+                            Qt.openUrlExternally(modelData.link);
                             root.closeNotification();
                         }
 


### PR DESCRIPTION
Use the link in the activity's 'links'

Fixes https://github.com/nextcloud/desktop/issues/6147

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
