### PR TITLE
lower minimum window height for ResolveConflictsDialog

### DIFF
--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -154,7 +154,7 @@ QtObject {
     readonly property int bigFontPixelSizeResolveConflictsDialog: 20
     readonly property int fontPixelSizeResolveConflictsDialog: 15
     readonly property int minimumWidthResolveConflictsDialog: 600
-    readonly property int minimumHeightResolveConflictsDialog: 800
+    readonly property int minimumHeightResolveConflictsDialog: 500
 
     readonly property double smallIconScaleFactor: 0.6
 


### PR DESCRIPTION
fixes #7785 

IMO there's no need for the `ResolveConflictsDialog` to be that tall, especially when it's just one or two files conflicting... and there's a scrollview anyway.

fwiw the QWidgets-based `OCC::ConflictDialog` that's still used to resolve only single file-conflicts has a height of `407` defined in its _.ui_ file

![Screenshot_20250124_111408](https://github.com/user-attachments/assets/9225380e-a14d-4bd0-afa3-4c6051c8ef3e)


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
