### PR TITLE
set the parent folder read/write always when downloading a new file

### DIFF
--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -220,6 +220,11 @@ public:
      */
     void setDeleteExistingFolder(bool enabled);
 
+protected:
+    void done(const SyncFileItem::Status status, const QString &errorString, const ErrorCategory category) override;
+
+    void makeParentFolderModifiable(const QString &fileName);
+
 private slots:
     /// Called when ComputeChecksum on the local file finishes,
     /// maybe the local and remote checksums are identical?


### PR DESCRIPTION
that would also cover code paths for virtual files

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
