### PR TITLE
Fix Height for Resolve Conflicts Dialog

### DIFF
--- a/src/gui/ResolveConflictsDialog.qml
+++ b/src/gui/ResolveConflictsDialog.qml
@@ -46,10 +46,10 @@ ApplicationWindow {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.bottomMargin: 20
-        anchors.topMargin: 20
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        anchors.bottomMargin: 5
+        anchors.topMargin: 10
         spacing: 15
         z: 2
 
@@ -70,7 +70,7 @@ ApplicationWindow {
 
         RowLayout {
             Layout.fillWidth: true
-            Layout.topMargin: 15
+            Layout.topMargin: 5
 
             CheckBox {
                 id: selectExisting

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -154,7 +154,7 @@ QtObject {
     readonly property int bigFontPixelSizeResolveConflictsDialog: 20
     readonly property int fontPixelSizeResolveConflictsDialog: 15
     readonly property int minimumWidthResolveConflictsDialog: 600
-    readonly property int minimumHeightResolveConflictsDialog: 800
+    readonly property int minimumHeightResolveConflictsDialog: 300
 
     readonly property double smallIconScaleFactor: 0.6
 


### PR DESCRIPTION
Problem:

-With multiple conflicts to fix, sometimes the dialog box would expand beyond the screen in height and could not be resized to a smaller height.

Solution: 

-Adjusted height based on content
-Set more reasonable minimum height

Fixes #7785 #6228 

![Screenshot From 2025-01-31 12-04-14](https://github.com/user-attachments/assets/b0634615-efe3-4276-8509-2b35a53a7519)
![Screenshot From 2025-01-31 12-12-53](https://github.com/user-attachments/assets/cabe10ec-5764-4149-9678-8682c977d605)