### PR TITLE
gui/macOS: Improve/fix illegal File Provider domain handling for macOS VFS

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -43,6 +43,19 @@ static constexpr auto bundleExtensions = std::array{
     QLatin1StringView(".saver"),
     QLatin1StringView(".mdimporter")
 };
+static const QRegularExpression illegalChars("[:/]");
+
+inline bool hasBundleExtension(const QString &domainId)
+{
+    return std::any_of(bundleExtensions.begin(), bundleExtensions.end(), [&domainId](const auto &ext) {
+        return domainId.endsWith(ext);
+    });
+}
+
+inline bool illegalDomainIdentifier(const QString &domainId)
+{
+    return !domainId.isEmpty() && !illegalChars.match(domainId).hasMatch() && hasBundleExtension(domainId);
+}
 
 QString domainIdentifierForAccount(const OCC::Account * const account)
 {
@@ -50,7 +63,6 @@ QString domainIdentifierForAccount(const OCC::Account * const account)
     auto domainId = account->userIdAtHostWithPort();
     Q_ASSERT(!domainId.isEmpty());
 
-    static const QRegularExpression illegalChars("[:/]");
     domainId.replace(illegalChars, "-");
 
     // Some url domains like .app cause issues on macOS as these are also bundle extensions.

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -174,6 +174,26 @@ public:
                         qCInfo(lcMacFileProviderDomainManager) << "Found existing file provider domain for account:"
                                                                << accountState->account()->displayName();
                         [domain retain];
+
+                        if (illegalDomainIdentifier(QString::fromNSString(domain.identifier))) {
+                            qCWarning(lcMacFileProviderDomainManager) << "Found existing file provider domain with illegal domain identifier:"
+                                                                      << domain.identifier
+                                                                      << "removing and recreating";
+                            [NSFileProviderManager removeDomain:domain completionHandler:^(NSError * const error) {
+                                if (error) {
+                                    qCWarning(lcMacFileProviderDomainManager) << "Error removing file provider domain with illegal domain identifier: "
+                                                                              << error.code
+                                                                              << error.localizedDescription;
+                                    
+                                } else {
+                                    qCInfo(lcMacFileProviderDomainManager) << "Successfully removed file provider domain with illegal domain identifier: "
+                                                                           << domain.identifier;
+                                }
+                                [domain release];
+                            }];
+                            return;
+                        }
+                        
                         _registeredDomains.insert(accountId, domain);
 
                         NSFileProviderManager * const fpManager = [NSFileProviderManager managerForDomain:domain];

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -81,23 +81,23 @@ QString domainIdentifierForAccount(const OCC::Account * const account)
     return domainId;
 }
 
-QString domainIdentifierForAccount(const OCC::AccountPtr account)
+inline QString domainIdentifierForAccount(const OCC::AccountPtr account)
 {
     return domainIdentifierForAccount(account.get());
 }
 
-QString domainDisplayNameForAccount(const OCC::Account * const account)
+inline QString domainDisplayNameForAccount(const OCC::Account * const account)
 {
     Q_ASSERT(account);
     return account->displayName();
 }
 
-QString domainDisplayNameForAccount(const OCC::AccountPtr account)
+inline QString domainDisplayNameForAccount(const OCC::AccountPtr account)
 {
     return domainDisplayNameForAccount(account.get());
 }
 
-QString accountIdFromDomainId(const QString &domainId)
+inline QString accountIdFromDomainId(const QString &domainId)
 {
     return domainId;
 }
@@ -122,7 +122,7 @@ QString accountIdFromDomainId(NSString * const domainId)
 }
 
 API_AVAILABLE(macos(11.0))
-QString accountIdFromDomain(NSFileProviderDomain * const domain)
+inline QString accountIdFromDomain(NSFileProviderDomain * const domain)
 {
     return accountIdFromDomainId(domain.identifier);
 }

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -104,7 +104,21 @@ QString accountIdFromDomainId(const QString &domainId)
 
 QString accountIdFromDomainId(NSString * const domainId)
 {
-    return accountIdFromDomainId(QString::fromNSString(domainId));
+    auto qDomainId = QString::fromNSString(domainId);
+    if (!qDomainId.contains('-')) {
+        return qDomainId.replace("(.)", ".");
+    }
+    // Using slashes as the replacement for illegal chars was unwise and we now have to pay the
+    // price of doing so...
+    const auto accounts = OCC::AccountManager::instance()->accounts();
+    for (const auto &accountState : accounts) {
+        const auto account = accountState->account();
+        const auto convertedDomainId = domainIdentifierForAccount(account);
+        if (convertedDomainId == qDomainId) {
+            return account->userIdAtHostWithPort();
+        }
+    }
+    Q_UNREACHABLE();
 }
 
 API_AVAILABLE(macos(11.0))


### PR DESCRIPTION
- Avoid accidentally turning File Provider domain locations into bundles (Closes #7694)
- Fix conversion of sanitised domain identifiers into account identifiers

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
