### PR TITLE
gui/tray: Prevent talk reply text field being too wide and breaking layout

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -227,13 +227,14 @@ RowLayout {
 
             Item {
                 Layout.fillWidth: true
+                visible: !talkReplyMessageSent.visible
             }
 
             EnforcedPlainTextLabel {
                 id: talkReplyMessageSent
 
                 height: (text === "") ? 0 : implicitHeight
-                width: parent.width
+                Layout.maximumWidth: parent.width / 2
                 Layout.alignment: Qt.AlignTop | Qt.AlignRight
 
                 text: root.activityData.messageSent


### PR DESCRIPTION
Fixes #6298

<img width="497" alt="Screenshot 2025-02-11 at 11 23 33" src="https://github.com/user-attachments/assets/d1e95793-5226-4053-b82d-1f77bf8cf58b" />

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
