### PR TITLE
add test skeleton for OCC::FolderStatusModel

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -29,6 +29,7 @@
 class TestFolderMan;
 class TestCfApiShellExtensionsIPC;
 class TestShareModel;
+class TestFolderStatusModel;
 class ShareTestHelper;
 class EndToEndTestHelper;
 class TestSyncConflictsModel;
@@ -413,6 +414,7 @@ private:
     friend class ::TestCfApiShellExtensionsIPC;
     friend class ::ShareTestHelper;
     friend class ::EndToEndTestHelper;
+    friend class ::TestFolderStatusModel;
 };
 
 } // namespace OCC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,8 @@ nextcloud_add_test(SyncConflictsModel)
 nextcloud_add_test(DateFieldBackend)
 nextcloud_add_test(ClientStatusReporting)
 
+nextcloud_add_test(FolderStatusModel)
+
 target_link_libraries(SecureFileDropTest PRIVATE Nextcloud::sync)
 configure_file(fake2eelocksucceeded.json "${PROJECT_BINARY_DIR}/bin/fake2eelocksucceeded.json" COPYONLY)
 configure_file(fakefiledrope2eefoldermetadata.json "${PROJECT_BINARY_DIR}/bin/fakefiledrope2eefoldermetadata.json" COPYONLY)

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -562,6 +562,7 @@ public:
     [[nodiscard]] OCC::AccountPtr account() const { return _account; }
     [[nodiscard]] OCC::SyncEngine &syncEngine() const { return *_syncEngine; }
     [[nodiscard]] OCC::SyncJournalDb &syncJournal() const { return *_journalDb; }
+    [[nodiscard]] FakeQNAM* networkAccessManager() const { return _fakeQnam; }
 
     FileModifier &localModifier() { return _localModifier; }
     FileInfo &remoteModifier() { return _fakeQnam->currentRemoteState(); }

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) by Matthieu Gallien <matthieu.gallien@nextcloud.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include <QtTest>
+#include <QStandardPaths>
+#include <QAbstractItemModelTester>
+
+#include "accountstate.h"
+#include "folderman.h"
+#include "folderstatusmodel.h"
+#include "logger.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+
+using namespace OCC;
+using namespace OCC::Utility;
+
+class TestFolderStatusModel : public QObject
+{
+    Q_OBJECT
+
+    std::unique_ptr<FolderMan> _folderMan;
+
+public:
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        Logger::instance()->setLogFlush(true);
+        Logger::instance()->setLogDebug(true);
+
+        QStandardPaths::setTestModeEnabled(true);
+
+        _folderMan.reset(new FolderMan{});
+    }
+
+    void startModel()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+
+        const auto account = fakeFolder.account();
+        const auto capabilities = QVariantMap {
+                                              {QStringLiteral("end-to-end-encryption"), QVariantMap {
+                                                                                            {QStringLiteral("enabled"), true},
+                                                                                            {QStringLiteral("api-version"), QString::number(2.0)},
+                                                                                            }},
+                                              };
+        account->setCapabilities(capabilities);
+        account->setCredentials(new FakeCredentials{fakeFolder.networkAccessManager()});
+        account->setUrl(QUrl(("owncloud://somehost/owncloud")));
+        auto accountState = FakeAccountState(account);
+        QVERIFY(accountState.isConnected());
+
+        auto folderDef = folderDefinition(fakeFolder.localPath());
+        folderDef.targetPath = "";
+        const auto folder = FolderMan::instance()->addFolder(&accountState, folderDef);
+        QVERIFY(folder);
+
+        FolderStatusModel test;
+        test.setAccountState(&accountState);
+
+        QSKIP("Initial test implementation is known to be broken");
+        QAbstractItemModelTester modeltester(&test);
+
+        test.fetchMore({});
+    }
+};
+
+QTEST_MAIN(TestFolderStatusModel)
+#include "testfolderstatusmodel.moc"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
