### PR TITLE
mac-crafter: Add ability to produce DMGs

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -140,7 +140,7 @@ func createDmgForAppBundle(
         .appendingPathExtension("dmg")
         .path
 
-    guard shell("create-dmg --volname \(appName) --filesystem APFS --app-drop-link 600 0 \"\(dmgFilePath)\" \"\(appBundlePath)\"") == 0 else {
+    guard shell("create-dmg --volname \(appName) --filesystem APFS --app-drop-link 513 37 --window-size 787 276 \"\(dmgFilePath)\" \"\(appBundlePath)\"") == 0 else {
         throw PackagingError.packageCreateDmgFailed("Command failed.")
     }
 

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -21,6 +21,7 @@ enum PackagingError: Error {
     case packageNotarisationError(String)
     case packageSparkleBuildError(String)
     case packageSparkleSignError(String)
+    case packageCreateDmgFailed(String)
 }
 
 /// NOTE: Requires Packages utility. http://s.sudre.free.fr/Software/Packages/about.html
@@ -110,6 +111,58 @@ func packageAppBundle(
     print("Creating Sparkle TBZ file…")
     let sparklePackagePath =
         try buildSparklePackage(packagePath: packagePath, buildPath: buildPath)
+
+    if let sparklePackageSignKey {
+        print("Signing Sparkle TBZ file…")
+        try signSparklePackage(
+            sparkleTbzPath: sparklePackagePath,
+            buildPath: buildPath,
+            signKey: sparklePackageSignKey
+        )
+    }
+}
+
+func createDmgForAppBundle(
+    appBundlePath: String,
+    productPath: String,
+    buildPath: String,
+    appName: String,
+    packageSigningId: String?,
+    appleId: String?,
+    applePassword: String?,
+    appleTeamId: String?,
+    sparklePackageSignKey: String?
+) throws {
+    print("Creating DMG for the client…")
+    try installIfMissing("create-dmg", "brew install create-dmg")
+
+    let dmgFilePath = URL(fileURLWithPath: productPath)
+        .appendingPathComponent(appName)
+        .appendingPathExtension("dmg")
+        .path
+
+    guard shell("create-dmg --volname \(appName) --filesystem APFS --app-drop-link 600 0 \"\(dmgFilePath)\" \"\(appBundlePath)\"") == 0 else {
+        throw PackagingError.packageCreateDmgFailed("Command failed.")
+    }
+
+    if let packageSigningId {
+        print("Signing DMG with \(packageSigningId)…")
+        try codesign(identity: packageSigningId, path: dmgFilePath, options: "--force")
+
+        if let appleId, let applePassword, let appleTeamId {
+            print("Notarising DMG with Apple ID \(appleId)…")
+            try notarisePackage(
+                packagePath: dmgFilePath,
+                appleId: appleId,
+                applePassword: applePassword,
+                appleTeamId: appleTeamId
+            )
+        }
+    }
+
+    print("Creating Sparkle TBZ file…")
+    let sparklePackagePath =
+        try buildSparklePackage(packagePath: dmgFilePath, buildPath: buildPath)
 
     if let sparklePackageSignKey {
         print("Signing Sparkle TBZ file…")

--- a/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Packaging.swift
@@ -134,7 +134,6 @@ func createDmgForAppBundle(
     sparklePackageSignKey: String?
 ) throws {
     print("Creating DMG for the client…")
-    try installIfMissing("create-dmg", "brew install create-dmg")
 
     let dmgFilePath = URL(fileURLWithPath: productPath)
         .appendingPathComponent(appName)

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -282,6 +282,51 @@ struct Codesign: ParsableCommand {
     }
 }
 
+struct CreateDMG: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Creae a DMG for the client.")
+
+    @Argument(help: "Path to the desktop client app bundle.")
+    var appBundlePath: String
+
+    @Option(name: [.short, .long], help: "Path for the final product to be put.")
+    var productPath = "\(FileManager.default.currentDirectoryPath)/product"
+
+    @Option(name: [.short, .long], help: "Path for build files to be written.")
+    var buildPath = "\(FileManager.default.currentDirectoryPath)/build"
+
+    @Option(name: [.long], help: "The application's branded name.")
+    var appName = "Nextcloud"
+
+    @Option(name: [.long], help: "Apple ID, used for notarisation.")
+    var appleId: String?
+
+    @Option(name: [.long], help: "Apple ID password, used for notarisation.")
+    var applePassword: String?
+
+    @Option(name: [.long], help: "Apple Team ID, used for notarisation.")
+    var appleTeamId: String?
+
+    @Option(name: [.long], help: "Apple package signing ID.")
+    var packageSigningId: String?
+
+    @Option(name: [.long], help: "Sparkle package signing key.")
+    var sparklePackageSignKey: String?
+
+    mutating func run() throws {
+        try createDmgForAppBundle(
+            appBundlePath: appBundlePath,
+            productPath: productPath,
+            buildPath: buildPath,
+            appName: appName,
+            packageSigningId: packageSigningId,
+            appleId: appleId,
+            applePassword: applePassword,
+            appleTeamId: appleTeamId,
+            sparklePackageSignKey: sparklePackageSignKey
+        )
+    }
+}
+
 struct Package: ParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Packaging script for the client.")
 
@@ -334,7 +379,7 @@ struct Package: ParsableCommand {
 struct MacCrafter: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A tool to easily build a fully-functional Nextcloud Desktop Client for macOS.",
-        subcommands: [Build.self, Codesign.self, Package.self],
+        subcommands: [Build.self, Codesign.self, Package.self, CreateDMG.self],
         defaultSubcommand: Build.self
     )
 }

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -313,6 +313,7 @@ struct CreateDMG: ParsableCommand {
     var sparklePackageSignKey: String?
 
     mutating func run() throws {
+        try installIfMissing("create-dmg", "brew install create-dmg")
         try createDmgForAppBundle(
             appBundlePath: appBundlePath,
             productPath: productPath,


### PR DESCRIPTION
<img width="899" alt="Screenshot 2025-02-12 at 15 13 06" src="https://github.com/user-attachments/assets/8062a848-26f1-4492-8903-d1f7ea9b33f2" />

Closes #6911

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
