### PR TITLE
Fix looks of share note text field

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -13,7 +13,7 @@
         <file>src/gui/filedetails/FileDetailsWindow.qml</file>
         <file>src/gui/filedetails/FileTag.qml</file>
         <file>src/gui/filedetails/NCInputDateField.qml</file>
-        <file>src/gui/filedetails/NCInputTextEdit.qml</file>
+        <file>src/gui/filedetails/NCInputTextArea.qml</file>
         <file>src/gui/filedetails/NCInputTextField.qml</file>
         <file>src/gui/filedetails/NCTabButton.qml</file>
         <file>src/gui/filedetails/ShareeDelegate.qml</file>

--- a/src/gui/filedetails/NCInputTextArea.qml
+++ b/src/gui/filedetails/NCInputTextArea.qml
@@ -19,28 +19,20 @@ import QtQuick.Layouts
 import com.nextcloud.desktopclient
 import Style
 
-TextEdit {
+TextArea {
     id: root
 
     readonly property color accentColor: palette.highlight
     readonly property color secondaryColor: palette.placeholderText
     readonly property alias submitButton: submitButton
 
-    clip: true
-    textMargin: Style.smallSpacing
-    wrapMode: TextEdit.Wrap
-    selectByMouse: true
-    height: Math.max(Style.talkReplyTextFieldPreferredHeight, contentHeight)
+    // no implicitHeight here -- let the textarea take as much as it needs
+    // otherwise it will cut off some text vertically on multi-line strings...
 
-    Rectangle {
-        id: textFieldBorder
-        anchors.fill: parent
-        radius: Style.trayWindowRadius
-        border.width: Style.normalBorderWidth
-        border.color: root.activeFocus ? root.accentColor : root.secondaryColor
-        color: palette.base
-        z: -1
-    }
+    selectByMouse: true
+    rightPadding: submitButton.width
+
+    wrapMode: TextEdit.Wrap
 
     Button {
         id: submitButton
@@ -61,4 +53,3 @@ TextEdit {
         onClicked: root.editingFinished()
     }
 }
-

--- a/src/gui/filedetails/NCInputTextEdit.qml
+++ b/src/gui/filedetails/NCInputTextEdit.qml
@@ -23,7 +23,7 @@ TextEdit {
     id: root
 
     readonly property color accentColor: palette.highlight
-    readonly property color secondaryColor: palette.dark
+    readonly property color secondaryColor: palette.placeholderText
     readonly property alias submitButton: submitButton
 
     clip: true

--- a/src/gui/filedetails/NCInputTextField.qml
+++ b/src/gui/filedetails/NCInputTextField.qml
@@ -23,7 +23,7 @@ TextField {
     id: root
 
     readonly property color accentColor: Style.ncBlue
-    readonly property color secondaryColor: palette.dark
+    readonly property color secondaryColor: palette.placeholderText
     readonly property alias submitButton: submitButton
     property bool validInput: true
 

--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -38,7 +38,6 @@ GridLayout {
     signal toggleAllowResharing(bool enable)
     signal togglePasswordProtect(bool enable)
     signal toggleExpirationDate(bool enable)
-    signal toggleNoteToRecipient(bool enable)
     signal permissionModeChanged(int permissionMode)
 
     signal setLinkShareLabel(string label)
@@ -252,7 +251,6 @@ GridLayout {
                     onToggleHideDownload: root.toggleHideDownload(enable)
                     onTogglePasswordProtect: root.togglePasswordProtect(enable)
                     onToggleExpirationDate: root.toggleExpirationDate(enable)
-                    onToggleNoteToRecipient: root.toggleNoteToRecipient(enable)
                     onPermissionModeChanged: root.permissionModeChanged(permissionMode)
 
                     onSetLinkShareLabel: root.setLinkShareLabel(label)

--- a/src/gui/filedetails/ShareDetailsPage.qml
+++ b/src/gui/filedetails/ShareDetailsPage.qml
@@ -277,7 +277,7 @@ Page {
                     horizontalAlignment: Image.AlignHCenter
                     fillMode: Image.Pad
 
-                    source: "image://svgimage-custom-color/edit.svg/" + palette.dark
+                    source: "image://svgimage-custom-color/edit.svg/" + palette.windowText
                     sourceSize.width: scrollContentsColumn.rowIconWidth
                     sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
@@ -501,7 +501,7 @@ Page {
                     horizontalAlignment: Image.AlignHCenter
                     fillMode: Image.Pad
 
-                    source: "image://svgimage-custom-color/lock-https.svg/" + palette.dark
+                    source: "image://svgimage-custom-color/lock-https.svg/" + palette.windowText
                     sourceSize.width: scrollContentsColumn.rowIconWidth
                     sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
@@ -607,7 +607,7 @@ Page {
                     horizontalAlignment: Image.AlignHCenter
                     fillMode: Image.Pad
 
-                    source: "image://svgimage-custom-color/calendar.svg/" + palette.dark
+                    source: "image://svgimage-custom-color/calendar.svg/" + palette.windowText
                     sourceSize.width: scrollContentsColumn.rowIconWidth
                     sourceSize.height: scrollContentsColumn.rowIconWidth
                 }
@@ -692,7 +692,7 @@ Page {
                     horizontalAlignment: Image.AlignHCenter
                     fillMode: Image.Pad
 
-                    source: "image://svgimage-custom-color/edit.svg/" + palette.dark
+                    source: "image://svgimage-custom-color/edit.svg/" + palette.windowText
                     sourceSize.width: scrollContentsColumn.rowIconWidth
                     sourceSize.height: scrollContentsColumn.rowIconWidth
                 }

--- a/src/gui/filedetails/ShareView.qml
+++ b/src/gui/filedetails/ShareView.qml
@@ -263,7 +263,6 @@ ColumnLayout {
                     onToggleHideDownload: shareModel.toggleHideDownloadFromQml(model.share, enable)
                     onTogglePasswordProtect: shareModel.toggleSharePasswordProtectFromQml(model.share, enable)
                     onToggleExpirationDate: shareModel.toggleShareExpirationDateFromQml(model.share, enable)
-                    onToggleNoteToRecipient: shareModel.toggleShareNoteToRecipientFromQml(model.share, enable)
                     onPermissionModeChanged: shareModel.changePermissionModeFromQml(model.share, permissionMode)
 
                     onSetLinkShareLabel: shareModel.setLinkShareLabelFromQml(model.share, label)

--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -1088,26 +1088,6 @@ void ShareModel::toggleShareExpirationDateFromQml(const QVariant &share, const b
     toggleShareExpirationDate(ptr, enable);
 }
 
-void ShareModel::toggleShareNoteToRecipient(const SharePtr &share, const bool enable) const
-{
-    if (share.isNull()) {
-        return;
-    }
-
-    const QString note = enable ? tr("Enter a note for the recipient") : QString();
-    if (const auto linkShare = share.objectCast<LinkShare>()) {
-        linkShare->setNote(note);
-    } else if (const auto userGroupShare = share.objectCast<UserGroupShare>()) {
-        userGroupShare->setNote(note);
-    }
-}
-
-void ShareModel::toggleShareNoteToRecipientFromQml(const QVariant &share, const bool enable) const
-{
-    const auto ptr = share.value<SharePtr>();
-    toggleShareNoteToRecipient(ptr, enable);
-}
-
 void ShareModel::changePermissionModeFromQml(const QVariant &share, const OCC::ShareModel::SharePermissionsMode permissionMode)
 {
     const auto sharePtr = share.value<SharePtr>();

--- a/src/gui/filedetails/sharemodel.h
+++ b/src/gui/filedetails/sharemodel.h
@@ -190,8 +190,6 @@ public slots:
     void toggleSharePasswordProtectFromQml(const QVariant &share, const bool enable);
     void toggleShareExpirationDate(const OCC::SharePtr &share, const bool enable) const;
     void toggleShareExpirationDateFromQml(const QVariant &share, const bool enable) const;
-    void toggleShareNoteToRecipient(const OCC::SharePtr &share, const bool enable) const;
-    void toggleShareNoteToRecipientFromQml(const QVariant &share, const bool enable) const;
     void changePermissionModeFromQml(const QVariant &share, const OCC::ShareModel::SharePermissionsMode permissionMode);
 
     void setLinkShareLabel(const QSharedPointer<OCC::LinkShare> &linkShare, const QString &label) const;

--- a/src/gui/tray/NCBusyIndicator.qml
+++ b/src/gui/tray/NCBusyIndicator.qml
@@ -19,7 +19,7 @@ import Style
 BusyIndicator {
     id: root
 
-    property color color: palette.dark
+    property color color: palette.windowText
     property string imageSource: "image://svgimage-custom-color/change.svg/"
 
     property int imageSourceSizeWidth: 64

--- a/test/testsharemodel.cpp
+++ b/test/testsharemodel.cpp
@@ -820,7 +820,7 @@ private slots:
         helper.resetTestData();
 
         // Test with an existing link share.
-        // This one has a pre-existing password
+        // This one has a pre-existing note
         helper.appendShareReplyData(_testLinkShareDefinition);
         QCOMPARE(helper.shareCount(), 1);
 
@@ -844,7 +844,7 @@ private slots:
         const auto linkSharePtr = sharePtr.dynamicCast<LinkShare>(); // Need to connect to signal
         QSignalSpy noteSet(linkSharePtr.data(), &LinkShare::noteSet);
 
-        model.toggleShareNoteToRecipient(sharePtr, false);
+        model.setShareNote(sharePtr, QStringLiteral(""));
         QVERIFY(noteSet.wait(3000));
         QCOMPARE(shareIndex.data(ShareModel::NoteEnabledRole).toBool(), false);
 
@@ -852,7 +852,7 @@ private slots:
         model.setShareNote(sharePtr, note);
         QVERIFY(noteSet.wait(3000));
         QCOMPARE(shareIndex.data(ShareModel::NoteEnabledRole).toBool(), true);
-        // The model stores the recently set password.
+        // The model stores the recently set note.
         // We want to present the user with it in the UI while the model is alive
         QCOMPARE(shareIndex.data(ShareModel::NoteRole).toString(), note);
     }


### PR DESCRIPTION
This fixes #7847 by using the [`TextArea`](https://doc.qt.io/qt-6/qml-qtquick-controls-textarea.html) QML control instead of the plain [`TextEdit`](https://doc.qt.io/qt-6/qml-qtquick-textedit.html) for share note field; it's already styled properly as it's part of Qt Quick Controls, **and** it allows for a proper placeholder text!

Also fixed some more icons appearing dark in dark mode.

on the Fluent style the text field is larger as well, indicating that it allows for multi-line text entry:

<table>
<tbody>
<tr>
<td>

 ![Screenshot_20250213_151642](https://github.com/user-attachments/assets/6ed1b0fc-6230-4faf-a296-6d84200b8477)

</td>
<td>

![Screenshot_20250213_151220](https://github.com/user-attachments/assets/9fd5bf4b-ab55-4770-a4e7-507ea1660b6f)

</td>
</tbody>
</table>

