### PR TITLE
Improve FolderStatusModel tests

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,7 +1,7 @@
 set( MIRALL_VERSION_MAJOR 3 )
-set( MIRALL_VERSION_MINOR 15 )
+set( MIRALL_VERSION_MINOR 16 )
 set( MIRALL_VERSION_PATCH 50 )
-set( MIRALL_VERSION_YEAR  2024 )
+set( MIRALL_VERSION_YEAR  2025 )
 set( MIRALL_SOVERSION 0 )
 
 # Minimum supported server version according to https://docs.nextcloud.com/server/latest/admin_manual/release_schedule.html

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -100,7 +100,6 @@ void FolderStatusModel::setAccountState(const AccountState *accountState)
     }
 
     endResetModel();
-    // TODO: maybe we need to analyze the previous state of _dirty before signal emitting?
     emit dirtyChanged();
 
     // Automatically fetch the subfolders to prevent showing the expansion chevron if there are no subfolders
@@ -396,8 +395,6 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
                 }
             }
         }
-        // TODO: think about that maybe better to introduce a separate setter for [_dirty] var with emitting of signal if changed
-        // TODO: maybe we need to analyze the previous state of _dirty before signal emitting?
         _dirty = true;
         emit dirtyChanged();
         emit dataChanged(index, index, QVector<int>() << role);

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -421,23 +421,17 @@ int FolderStatusModel::rowCount(const QModelIndex &parent) const
         }
         return _folders.count() + 1; // +1 for the "add folder" button
     }
-    const auto info = infoForIndex(parent);
-    if (!info)
-        return 0;
-    if (info->hasLabel())
-        return 1;
-    return info->_subs.count();
+    if (const auto info = infoForIndex(parent)) {
+        return info->hasLabel() ? 1 : info->_subs.count();
+    }
+    return 0;
 }
 
 FolderStatusModel::ItemType FolderStatusModel::classify(const QModelIndex &index) const
 {
     if (index.isValid()) {
-        if (const auto sub = static_cast<SubFolderInfo *>(index.internalPointer())) {
-            if (sub->hasLabel()) {
-                return FetchLabel;
-            } else {
-                return SubFolder;
-            }
+        if (const auto sub = static_cast<const SubFolderInfo *>(index.internalPointer())) {
+            return sub->hasLabel() ? FetchLabel : SubFolder;
         }
         if (index.row() < _folders.count()) {
             return RootFolder;

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -159,7 +159,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             return true;
         } else if (role == Qt::ToolTipRole) {
             if (_accountState) {
-                if (_accountState && !_accountState->isConnected()) {
+                if (!_accountState->isConnected()) {
                     return tr("You need to be connected to add a folder");
                 }
                 return tr("Click this button to add a folder to synchronize.");
@@ -398,7 +398,7 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
         }
         // TODO: think about that maybe better to introduce a separate setter for [_dirty] var with emitting of signal if changed
         // TODO: maybe we need to analyze the previous state of _dirty before signal emitting?
-        _dirty = true;;
+        _dirty = true;
         emit dirtyChanged();
         emit dataChanged(index, index, QVector<int>() << role);
         return true;

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -447,7 +447,8 @@ FolderStatusModel::SubFolderInfo *FolderStatusModel::infoForIndex(const QModelIn
                 return nullptr;
             }
             return &parentInfo->_subs[index.row()];
-        } else if (index.row() < _folders.size()){
+        }
+        if (index.row() < _folders.size()) {
             return const_cast<SubFolderInfo *>(&_folders[index.row()]);
         }
     }

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -109,7 +109,7 @@ private Q_SLOTS:
     
     void testThatRowClassifyWorksProperly()
     {
-        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel &test) {
             test.setAccountState(accountState);
             QCOMPARE(test.classify({}), FolderStatusModel::ItemType::AddButton);
             QCOMPARE(test.classify(test.index(0)), FolderStatusModel::ItemType::RootFolder);

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -99,7 +99,7 @@ private Q_SLOTS:
     
     void testRowsChildrenConsistency()
     {
-        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel &test) {
             test.setAccountState(accountState);
             QVERIFY2(test.hasChildren({}), "empty index always has children");
             // we assume that folder may contains of some child elements until not yet fetched

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -118,7 +118,7 @@ private Q_SLOTS:
     
     void testSubFoldersInfoForIndices()
     {
-        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel &test) {
             test.setAccountState(accountState);
             QCOMPARE(test.infoForIndex({}), nullptr);
             QVERIFY2(nullptr != test.infoForIndex(test.index(0)), "NULL info for index 0");

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -89,7 +89,7 @@ private Q_SLOTS:
     
     void testModelRowsCount()
     {
-        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel &test) {
             test.setAccountState(accountState);
             // folders count +1 for the "add folder" button if [singleSyncFolder] is true
             const auto expectedRowsCount = Theme::instance()->singleSyncFolder() ? 1 : 2;

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -15,6 +15,7 @@
 #include <QtTest>
 #include <QStandardPaths>
 #include <QAbstractItemModelTester>
+#include <theme.h>
 
 #include "accountstate.h"
 #include "folderman.h"
@@ -29,7 +30,7 @@ using namespace OCC::Utility;
 class TestFolderStatusModel : public QObject
 {
     Q_OBJECT
-
+    static inline constexpr auto _modelTesterMode = QAbstractItemModelTester::FailureReportingMode::QtTest;
     std::unique_ptr<FolderMan> _folderMan;
 
 public:
@@ -44,8 +45,103 @@ private Q_SLOTS:
 
         _folderMan.reset(new FolderMan{});
     }
+    
+    void testThatFolderManHasInstance() {
+        QVERIFY2(nullptr != FolderMan::instance(), "folder manager must not be a NULL");
+    }
+    
+    void testEmptyModelHasOneColumn()
+    {
+        const FolderStatusModel test;
+        QCOMPARE(test.columnCount(), 1);
+    }
+    
+    void testAccountStateIsConnected()
+    {
+        const auto fakeFolder = makeFakeFolder();
+        const FakeAccountState accountState{fakeFolder.account()};
+        QVERIFY2(accountState.isConnected(), "account must be connected");
+    }
+    
+    void testAbilityToAddRemoveAccountFolders()
+    {
+        executeFolderManTest([](const AccountState *accountState, Folder* folder){
+            QVERIFY2(folder, "folder manager was not able to add folder for a given account");
+            QCOMPARE(folder->accountState(), accountState);
+        });
+    }
+    
+    void testModelConsistencyWithFakeFolder()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            QVERIFY2(!test.isDirty(), "model is dirty after set account state");
+        });
+    }
+    
+    void testNewModelEmitDirtyChangedSignalAfterSetAccountState()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            const QSignalSpy dirtySignalSpy{&test, &FolderStatusModel::dirtyChanged};
+            test.setAccountState(accountState);
+            QCOMPARE(dirtySignalSpy.count(), 1);
+        });
+    }
+    
+    void testModelRowsCount()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            // folders count +1 for the "add folder" button if [singleSyncFolder] is true
+            const auto expectedRowsCount = Theme::instance()->singleSyncFolder() ? 1 : 2;
+            QCOMPARE(test.rowCount(), expectedRowsCount);
+        });
+    }
+    
+    void testRowsChildrenConsistency()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            QVERIFY2(test.hasChildren({}), "empty index always has children");
+            // we assume that folder may contains of some child elements until not yet fetched
+            QCOMPARE(test.hasChildren(test.index(0)), !test._folders.front()._fetched);
+        });
+    }
+    
+    void testThatRowClassifyWorksProperly()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            QCOMPARE(test.classify({}), FolderStatusModel::ItemType::AddButton);
+            QCOMPARE(test.classify(test.index(0)), FolderStatusModel::ItemType::RootFolder);
+        });
+    }
+    
+    void testSubFoldersInfoForIndices()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            QCOMPARE(test.infoForIndex({}), nullptr);
+            QVERIFY2(nullptr != test.infoForIndex(test.index(0)), "NULL info for index 0");
+        });
+    }
+    
+    void testThatAppropriateSignalsEmittedIfItemChecked()
+    {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+            test.setAccountState(accountState);
+            // set checked for our single root folder
+            const QSignalSpy dataChangedSignalSpy{&test, &QAbstractItemModel::dataChanged};
+            const QSignalSpy dirtySignalSpy{&test, &FolderStatusModel::dirtyChanged};
+            QVERIFY(test.setData(test.index(0), Qt::CheckState::Checked, Qt::CheckStateRole));
+            QVERIFY2(dataChangedSignalSpy.count() > 0, "make sure the signal [dataChanged] was emitted at least one time");
+            QVERIFY2(dirtySignalSpy.count() > 0, "make sure the signal [dirtyChanged] was emitted at least one time");
+            QVERIFY2(test.isDirty(), "model is not dirty after set checked state for the folder");
+        });
+    }
 
-    void startModel()
+private:
+    static FakeFolder makeFakeFolder()
     {
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
 
@@ -59,21 +155,51 @@ private Q_SLOTS:
         account->setCapabilities(capabilities);
         account->setCredentials(new FakeCredentials{fakeFolder.networkAccessManager()});
         account->setUrl(QUrl(("owncloud://somehost/owncloud")));
-        auto accountState = FakeAccountState(account);
-        QVERIFY(accountState.isConnected());
-
-        auto folderDef = folderDefinition(fakeFolder.localPath());
-        folderDef.targetPath = "";
-        const auto folder = FolderMan::instance()->addFolder(&accountState, folderDef);
-        QVERIFY(folder);
-
-        FolderStatusModel test;
-        test.setAccountState(&accountState);
-
-        QSKIP("Initial test implementation is known to be broken");
-        QAbstractItemModelTester modeltester(&test);
-
-        test.fetchMore({});
+        return fakeFolder;
+    }
+    
+    static OCC::FolderDefinition makeFolderDefinition(const QString &path) {
+        auto folderDef = folderDefinition(path);
+        folderDef.targetPath.clear();
+        return folderDef;
+    }
+    
+    static OCC::FolderDefinition makeFolderDefinition(const FakeFolder &folder) {
+        return makeFolderDefinition(folder.localPath());
+    }
+    
+    template <typename TestFunctor>
+    static void executeFolderManTest(TestFunctor&& functor)
+    {
+        const auto fakeFolder = makeFakeFolder();
+        const AccountStatePtr accountState{new FakeAccountState{fakeFolder.account()}};
+        const auto folder = FolderMan::instance()->addFolder(accountState.get(),
+                                                             makeFolderDefinition(fakeFolder));
+        try {
+            functor(accountState.get(), folder);
+            // cleanup
+            if (folder) {
+                FolderMan::instance()->removeFolder(folder);
+            }
+        }
+        catch(...) {
+            // cleanup
+            if (folder) {
+                FolderMan::instance()->removeFolder(folder);
+            }
+            throw; // rethrow exception from test framework
+        }
+    }
+    
+    template <typename TestFunctor>
+    static void executeConsistencyModelTest(TestFunctor&& functor)
+    {
+        executeFolderManTest([functor](const AccountState *accountState, Folder*){
+            FolderStatusModel test;
+            QAbstractItemModelTester tester{&test, _modelTesterMode};
+            tester.setUseFetchMore(true);
+            functor(accountState, test);
+        });
     }
 };
 

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -30,7 +30,6 @@ using namespace OCC::Utility;
 class TestFolderStatusModel : public QObject
 {
     Q_OBJECT
-    static inline constexpr auto _modelTesterMode = QAbstractItemModelTester::FailureReportingMode::QtTest;
     std::unique_ptr<FolderMan> _folderMan;
 
 public:
@@ -196,7 +195,7 @@ private:
     {
         executeFolderManTest([functor](const AccountState *accountState, Folder*){
             FolderStatusModel test;
-            QAbstractItemModelTester tester{&test, _modelTesterMode};
+            QAbstractItemModelTester tester{&test, QAbstractItemModelTester::FailureReportingMode::QtTest};
             tester.setUseFetchMore(true);
             functor(accountState, test);
         });

--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -127,7 +127,7 @@ private Q_SLOTS:
     
     void testThatAppropriateSignalsEmittedIfItemChecked()
     {
-        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel& test) {
+        executeConsistencyModelTest([](const AccountState *accountState, FolderStatusModel &test) {
             test.setAccountState(accountState);
             // set checked for our single root folder
             const QSignalSpy dataChangedSignalSpy{&test, &QAbstractItemModel::dataChanged};


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
The task depends on https://github.com/nextcloud/desktop/pull/7842 and should be possible to tackle without deeper knowledge of the desktop client code base. https://github.com/nextcloud/desktop/pull/7842 will give you the code skeleton. 

The task would be to remove the QSKIP macro, fix the code to not fail and if time allows improve the coverage and see how far you get there within a timeframe of 4 hours. 
Any improvement to that coverage would be a win.
