### PR TITLE
vfs: fix root folder detection regression 

### DIFF
--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -71,7 +71,7 @@ Result<void, QString> Vfs::checkAvailability(const QString &path, Vfs::Mode mode
 #ifdef Q_OS_WIN
     if (mode == Mode::WindowsCfApi) {
         const auto info = QFileInfo(path);
-        if (QDir(info.canonicalPath()).isRoot()) {
+        if (QDir(info.canonicalFilePath()).isRoot()) {
             return tr("Please choose a different location. %1 is a drive. It doesn't support virtual files.").arg(path);
         }
         if (const auto fileSystemForPath = FileSystem::fileSystemForPath(info.absoluteFilePath());

--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -71,16 +71,17 @@ Result<void, QString> Vfs::checkAvailability(const QString &path, Vfs::Mode mode
 #ifdef Q_OS_WIN
     if (mode == Mode::WindowsCfApi) {
         const auto info = QFileInfo(path);
+        const auto nativePath = QDir::toNativeSeparators(path);
         if (QDir(info.canonicalFilePath()).isRoot()) {
-            return tr("Please choose a different location. %1 is a drive. It doesn't support virtual files.").arg(path);
+            return tr("Please choose a different location. %1 is a drive. It doesn't support virtual files.").arg(nativePath);
         }
         if (const auto fileSystemForPath = FileSystem::fileSystemForPath(info.absoluteFilePath());
             fileSystemForPath != QLatin1String("NTFS")) {
-            return tr("Please choose a different location. %1 isn't a NTFS file system. It doesn't support virtual files.").arg(path);
+            return tr("Please choose a different location. %1 isn't a NTFS file system. It doesn't support virtual files.").arg(nativePath);
         }
         const auto type = GetDriveTypeW(reinterpret_cast<const wchar_t *>(QDir::toNativeSeparators(info.absoluteFilePath().mid(0, 3)).utf16()));
         if (type == DRIVE_REMOTE) {
-            return tr("Please choose a different location. %1 is a network drive. It doesn't support virtual files.").arg(path);
+            return tr("Please choose a different location. %1 is a network drive. It doesn't support virtual files.").arg(nativePath);
         }
     }
 #else


### PR DESCRIPTION
Fixes #7864

this PR also changes the error message to use native `\` separators as it's common on Windows