### PR TITLE
fixed html formatting on encrypted warning message

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -120,6 +120,7 @@ void showEnableE2eeWarningDialog(std::function<void(void)> onAccept)
     const auto messageBox = new QMessageBox;
     messageBox->setAttribute(Qt::WA_DeleteOnClose);
     messageBox->setText(AccountSettings::tr("End-to-end Encryption"));
+    messageBox->setTextFormat(Qt::RichText);
     messageBox->setInformativeText(
         AccountSettings::tr("This will encrypt your folder and all files within it. "
                             "These files will no longer be accessible without your encryption mnemonic key. "


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
