### PR TITLE
FolderStatusModel: only create a single QFileIconProvider object

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -21,7 +21,6 @@
 #include <account.h>
 #include <theme.h>
 
-#include <QFileIconProvider>
 #include <QVarLengthArray>
 #include <set>
 
@@ -194,7 +193,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
             } else if (subfolderInfo._size > 0 && isAnyAncestorEncrypted(index)) {
                 return QIcon(QLatin1String(":/client/theme/lock-broken.svg"));
             }
-            return QFileIconProvider().icon(subfolderInfo._isExternal ? QFileIconProvider::Network : QFileIconProvider::Folder);
+            return _fileIconProvider.icon(subfolderInfo._isExternal ? QFileIconProvider::Network : QFileIconProvider::Folder);
         }
         case Qt::ForegroundRole:
             if (subfolderInfo._isUndecided || (subfolderInfo._isNonDecryptable && subfolderInfo._checked)) {

--- a/src/gui/folderstatusmodel.h
+++ b/src/gui/folderstatusmodel.h
@@ -21,6 +21,7 @@
 #include <QVector>
 #include <QElapsedTimer>
 #include <QPointer>
+#include <QFileIconProvider>
 
 class QNetworkReply;
 namespace OCC {
@@ -160,6 +161,8 @@ private:
      * See slotShowPendingFetchProgress()
      */
     QMap<QPersistentModelIndex, QElapsedTimer> _fetchingItems;
+
+    QFileIconProvider _fileIconProvider;
 
 signals:
     void dirtyChanged();


### PR DESCRIPTION
otherwise the icons will end up being loaded from the system each time, which on Windows takes quite long (I saw many calls to `shell32.dll!SHDefExtractIcon` during profiling)

Fixes #7372, tested on Win11, Linux, macOS

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
