### PR TITLE
Corrected plural forms handling in messages

### DIFF
--- a/src/gui/macOS/fileprovidereditlocallyjob.cpp
+++ b/src/gui/macOS/fileprovidereditlocallyjob.cpp
@@ -45,7 +45,7 @@ void FileProviderEditLocallyJob::start()
 
     const auto relPathSplit = _relPath.split(QLatin1Char('/'));
     if (relPathSplit.isEmpty()) {
-        showError(tr("Could not find a file for local editing."
+        showError(tr("Could not find a file for local editing. "
                      "Make sure its path is valid and it is synced locally."), _relPath);
         return;
     }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -174,7 +174,7 @@ void User::showDesktopNotification(const Activity &activity)
 
 void User::showDesktopNotification(const ActivityList &activityList)
 {
-    const auto subject = tr("%n notification(s)", "", activityList.count());
+    const auto subject = tr("%1 notifications").arg(activityList.count());
     const auto notificationId = -static_cast<int>(qHash(subject));
 
     if (!canShowNotification(notificationId)) {

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -174,7 +174,7 @@ void User::showDesktopNotification(const Activity &activity)
 
 void User::showDesktopNotification(const ActivityList &activityList)
 {
-    const auto subject = tr("%1 notifications").arg(activityList.count());
+    const auto subject = tr("%n notification(s)", "", activityList.count());
     const auto notificationId = -static_cast<int>(qHash(subject));
 
     if (!canShowNotification(notificationId)) {


### PR DESCRIPTION
Corrected the way the plural forms was being handled according to the Qt documentation for better translations:
https://doc.qt.io/qt-6/i18n-source-translation.html