### PR TITLE
Added plural forms handling correction to notification message

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -174,7 +174,7 @@ void User::showDesktopNotification(const Activity &activity)
 
 void User::showDesktopNotification(const ActivityList &activityList)
 {
-    const auto subject = tr("%n notification(s)", "", activityList.count());
+    const auto subject = tr("%n notifications", nullptr, activityList.count());
     const auto notificationId = -static_cast<int>(qHash(subject));
 
     if (!canShowNotification(notificationId)) {

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -174,7 +174,7 @@ void User::showDesktopNotification(const Activity &activity)
 
 void User::showDesktopNotification(const ActivityList &activityList)
 {
-    const auto subject = tr("%1 notifications").arg(activityList.count());
+    const auto subject = tr("%n notification(s)", "", activityList.count());
     const auto notificationId = -static_cast<int>(qHash(subject));
 
     if (!canShowNotification(notificationId)) {


### PR DESCRIPTION
Corrected the way the plural forms was being handled according to the Qt documentation for better translation:
https://doc.qt.io/qt-6/i18n-source-translation.html
Would fix issue #7887 