### PR TITLE
UserStatusSelector: set focusPolicy on accept button

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -341,6 +341,7 @@ ColumnLayout {
             Layout.fillHeight: true
             primary: true
             colored: true
+            focusPolicy: Qt.StrongFocus
             text: qsTr("Set status message")
             onClicked: userStatusSelectorModel.setUserStatus()
         }


### PR DESCRIPTION
otherwise the status text won't be set on macOS as the text box never loses its focus

`Qt.StrongFocus` is the default focusPolicy on all platforms except for macOS, there it's `Qt.TabFocus`

the other buttons of the UserStatusSelector don't need that focusPolicy as they do not modify the model from values in the view

see also:
- https://bugreports.qt.io/browse/QTBUG-110295
- https://codebrowser.dev/qt6/qtdeclarative/src/quicktemplates/qquickabstractbutton.cpp.html#_ZN27QQuickAbstractButtonPrivate4initEv

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
