### PR TITLE
chore(i18n): Use correct plural syntax

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -174,7 +174,7 @@ void User::showDesktopNotification(const Activity &activity)
 
 void User::showDesktopNotification(const ActivityList &activityList)
 {
-    const auto subject = tr("%n notifications", nullptr, activityList.count());
+    const auto subject = tr("%n notification(s)", nullptr, activityList.count());
     const auto notificationId = -static_cast<int>(qHash(subject));
 
     if (!canShowNotification(notificationId)) {


### PR DESCRIPTION
Reported at Transifex.