### PR TITLE
do not display encrypt action for external folders

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -601,8 +601,9 @@ void AccountSettings::slotSubfolderContextMenuRequested(const QModelIndex& index
         const auto isEncrypted = info->isEncrypted();
         const auto isParentEncrypted = _model->isAnyAncestorEncrypted(index);
         const auto isTopFolder = index.parent().isValid() && !index.parent().parent().isValid();
+        const auto isExternal = info->_isExternal;
 
-        if (!isEncrypted && !isParentEncrypted && isTopFolder) {
+        if (!isEncrypted && !isParentEncrypted && !isExternal && isTopFolder) {
             ac = menu.addAction(tr("Encrypt"));
             connect(ac, &QAction::triggered, [this, info] { slotMarkSubfolderEncrypted(info); });
         } else {


### PR DESCRIPTION
at least Android doesn't display it for group folders/shares either: https://github.com/nextcloud/android/blob/3f8527ef66f7838d228dd22efffd6a93c918b4f8/app/src/main/java/com/owncloud/android/files/FileMenuFilter.java#L255-L256

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
