### PR TITLE
Increased default limit of free space and critical free space

### DIFF
--- a/doc/envvars.rst
+++ b/doc/envvars.rst
@@ -4,8 +4,8 @@ The environment variables are:
 
 - `OWNCLOUD_CHUNK_SIZE` (default: 5242880; 5 MiB) – Specifies the chunk size of uploaded files in bytes. Increasing this value may help with synchronization problems in certain configurations.  
 - `OWNCLOUD_TIMEOUT` (default: 300 s) – The timeout for network connections in seconds.
-- `OWNCLOUD_CRITICAL_FREE_SPACE_BYTES` (default: 50\*1000\*1000 bytes) - The minimum disk space needed for operation. A fatal error is raised if less free space is available. 
-- `OWNCLOUD_FREE_SPACE_BYTES` (default: 250\*1000\*1000 bytes) - Downloads that would reduce the free space below this value are skipped. More information available under the "Low Disk Space" section. 
+- `OWNCLOUD_CRITICAL_FREE_SPACE_BYTES` (default: 512\*1000\*1000 bytes) - The minimum disk space needed for operation. A fatal error is raised if less free space is available. 
+- `OWNCLOUD_FREE_SPACE_BYTES` (default: 1000\*1000\*1000 bytes) - Downloads that would reduce the free space below this value are skipped. More information available under the "Low Disk Space" section. 
 - `OWNCLOUD_MAX_PARALLEL` (default: 6) - Maximum number of parallel jobs. 
 - `OWNCLOUD_BLACKLIST_TIME_MIN` (default: 25 s) - Minimum timeout for blacklisted files.
 - `OWNCLOUD_BLACKLIST_TIME_MAX` (default: 24\*60\*60 s; one day) - Maximum timeout for blacklisted files.

--- a/doc/lowdiskspace.rst
+++ b/doc/lowdiskspace.rst
@@ -1,5 +1,5 @@
 When disk space is low the Nextcloud Client will be unable to synchronize all files. This section describes its behavior in a low disk space situation as well as the options that influence it.
 
-1. Synchronization of a folder aborts entirely if the remaining disk space falls below 50 MB. This threshold can be adjusted with the ``OWNCLOUD_CRITICAL_FREE_SPACE_BYTES`` environment variable.
+1. Synchronization of a folder aborts entirely if the remaining disk space falls below 512 MB. This threshold can be adjusted with the ``OWNCLOUD_CRITICAL_FREE_SPACE_BYTES`` environment variable.
 
-2. Downloads that would reduce the free disk space below 250 MB will be skipped or aborted. The download will be retried regularly and other synchronization is unaffected. This threshold can be adjusted with the ``OWNCLOUD_FREE_SPACE_BYTES`` environment variable.
+2. Downloads that would reduce the free disk space below 1 GB will be skipped or aborted. The download will be retried regularly and other synchronization is unaffected. This threshold can be adjusted with the ``OWNCLOUD_FREE_SPACE_BYTES`` environment variable.

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -57,7 +57,7 @@ Q_LOGGING_CATEGORY(lcCleanupPolls, "nextcloud.sync.propagator.cleanuppolls", QtI
 
 qint64 criticalFreeSpaceLimit()
 {
-    qint64 value = 50 * 1000 * 1000LL;
+    qint64 value = 512 * 1000 * 1000LL;
 
     static bool hasEnv = false;
     static qint64 env = qgetenv("OWNCLOUD_CRITICAL_FREE_SPACE_BYTES").toLongLong(&hasEnv);
@@ -70,7 +70,7 @@ qint64 criticalFreeSpaceLimit()
 
 qint64 freeSpaceLimit()
 {
-    qint64 value = 250 * 1000 * 1000LL;
+    qint64 value = 1000 * 1000 * 1000LL;
 
     static bool hasEnv = false;
     static qint64 env = qgetenv("OWNCLOUD_FREE_SPACE_BYTES").toLongLong(&hasEnv);


### PR DESCRIPTION
Changed critical free space to 512MB and free space to 1GB. Also updated the relevant documentation with the changes.
Should solve issue #3398 