### PR TITLE
gui/macOS: Remove "advanced settings" section for macOS VFS settings

### DIFF
--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -139,20 +139,6 @@ Page {
                         }
                     }
                 }
-
-                EnforcedPlainTextLabel {
-                    Layout.fillWidth: true
-                    Layout.topMargin: Style.standardSpacing
-                    text: qsTr("Advanced")
-                    font.bold: true
-                    font.pointSize: Style.subheaderFontPtSize
-                    elide: Text.ElideRight
-                }
-
-                Button {
-                    text: qsTr("Signal file provider domain")
-                    onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
-                }
             }
         }
     }

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -79,6 +79,7 @@ Page {
 
                 FileProviderSyncStatus {
                     syncStatus: root.controller.domainSyncStatusForAccount(root.accountUserIdAtHost)
+                    onDomainSignalRequested: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
                 }
 
                 FileProviderFastEnumerationSettings {

--- a/src/gui/macOS/ui/FileProviderSyncStatus.qml
+++ b/src/gui/macOS/ui/FileProviderSyncStatus.qml
@@ -67,8 +67,15 @@ GridLayout {
     }
 
     Button {
+        id: requestSyncButton
         text: qsTr("Request sync")
-        onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
         visible: !root.syncStatus.syncing
+        hoverEnabled: true
+        onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
+
+        ToolTip {
+            visible: requestSyncButton.hovered
+            text: qsTr("Request a sync of changes for the VFS environment. macOS may ignore or delay this request.")
+        }
     }
 }

--- a/src/gui/macOS/ui/FileProviderSyncStatus.qml
+++ b/src/gui/macOS/ui/FileProviderSyncStatus.qml
@@ -73,9 +73,8 @@ GridLayout {
         hoverEnabled: true
         onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
 
-        ToolTip {
-            visible: requestSyncButton.hovered
-            text: qsTr("Request a sync of changes for the VFS environment. macOS may ignore or delay this request.")
-        }
+        ToolTip.visible: hovered
+        ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+        ToolTip.text: qsTr("Request a sync of changes for the VFS environment.\nmacOS may ignore or delay this request.")
     }
 }

--- a/src/gui/macOS/ui/FileProviderSyncStatus.qml
+++ b/src/gui/macOS/ui/FileProviderSyncStatus.qml
@@ -25,6 +25,7 @@ import com.nextcloud.desktopclient 1.0
 GridLayout {
     id: root
 
+    signal domainSignalRequested
     required property var syncStatus
 
     rows: syncStatus.syncing ? 2 : 1
@@ -63,5 +64,11 @@ GridLayout {
         Layout.fillWidth: true
         value: root.syncStatus.fractionCompleted
         visible: root.syncStatus.syncing
+    }
+
+    Button {
+        text: qsTr("Request sync")
+        onClicked: root.controller.signalFileProviderDomain(root.accountUserIdAtHost)
+        visible: !root.syncStatus.syncing
     }
 }


### PR DESCRIPTION
It's not necessary. Space can be saved by simplifying the text for the button and moving it alongside the sync status item

After changes:

<img width="739" alt="Screenshot 2025-02-26 at 11 00 49" src="https://github.com/user-attachments/assets/172b5261-e2d8-4897-b977-3edefb6a2cf6" />

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
