### PR TITLE
don't remove "needs info" label from maintainers

### DIFF
--- a/.github/workflows/needsinfohelper.yaml
+++ b/.github/workflows/needsinfohelper.yaml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
-        if: ${{ ! startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') && ! startsWith(github.event.comment.body, 'This bug report did not receive an update in the last 4 weeks.')}}
+        if: |
+          !startsWith(github.event.comment.body, 'This issue has been marked as "needs info" 4 weeks ago.') &&
+            !startsWith(github.event.comment.body, 'This bug report did not receive an update in the last 4 weeks.') &&
+            !contains(fromJSON('["camilasan", "claucambra", "mgallien", "nilsding", "Rello"]'), github.event.comment.user.login)
         with:
           labels: 'needs info'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
just taking care some small annoyance I noticed during issue triaging, sometimes I'm faster adding the label before the workflow runs through... I hope this works as expected ;-)

- replaces syntax to yaml multi-line, apparently `${{ ... }}` was only needed because the expression starts with a `!`
- since GitHub workflows only have literals for booleans, null, number, and string, we need to use `fromJSON` in order to create an array as per the example given in the docs for `contains`

see also:
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-matching-an-array-of-strings
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
