### PR TITLE
Added hiding remotePollInterval selector in settings if notify push available

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -659,15 +659,17 @@ void GeneralSettings::slotRemotePollIntervalChanged(int seconds)
     cfgFile.setRemotePollInterval(interval);
 }
 
-void GeneralSettings::updatePollIntervalVisibility() {
+void GeneralSettings::updatePollIntervalVisibility() 
+{
     const auto accounts = AccountManager::instance()->accounts();
-    const auto pushAvailable = std::any_of(accounts.cbegin(), accounts.cend(),
-    [](const AccountStatePtr &accountState) -> bool {
-        if (!accountState)
+    const auto pushAvailable = std::any_of(accounts.cbegin(), accounts.cend(), [](const AccountStatePtr &accountState) -> bool {
+        if (!accountState) {
             return false;
-        AccountPtr accountPtr = accountState->account();
-        if (!accountPtr)
+        }
+        const auto accountPtr = accountState->account();
+        if (!accountPtr) {
             return false;
+        }
         return accountPtr->capabilities().availablePushNotifications().testFlag(PushNotificationType::Files);
     });
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -21,6 +21,7 @@
 #include "owncloudsetupwizard.h"
 #include "accountmanager.h"
 #include "guiutility.h"
+#include "capabilities.h"
 
 #if defined(BUILD_UPDATER)
 #include "updater/updater.h"
@@ -187,12 +188,9 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     , _ui(new Ui::GeneralSettings)
 {
     _ui->setupUi(this);
-    
-    _ui->labelInterval->setText("seconds (if <a href=\"https://github.com/nextcloud/notify_push\">Client Push</a> is unavailable)");
-    _ui->labelInterval->setTextFormat(Qt::RichText);
-    _ui->labelInterval->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    _ui->labelInterval->setOpenExternalLinks(true);
 
+    updatePollIntervalVisibility();
+    
     connect(_ui->serverNotificationsCheckBox, &QAbstractButton::toggled,
         this, &GeneralSettings::slotToggleOptionalServerNotifications);
     _ui->serverNotificationsCheckBox->setToolTip(tr("Server notifications that require attention."));
@@ -330,7 +328,8 @@ void GeneralSettings::loadMiscSettings()
     _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
 
     const auto interval = cfgFile.remotePollInterval(); 
-    _ui->remotePollIntervalSpinBox->setValue(static_cast<int>(interval.count() / 1000));  
+    _ui->remotePollIntervalSpinBox->setValue(static_cast<int>(interval.count() / 1000));
+    updatePollIntervalVisibility(); 
 }
 
 #if defined(BUILD_UPDATER)
@@ -658,6 +657,21 @@ void GeneralSettings::slotRemotePollIntervalChanged(int seconds)
     ConfigFile cfgFile;
     std::chrono::milliseconds interval(seconds * 1000);
     cfgFile.setRemotePollInterval(interval);
+}
+
+void GeneralSettings::updatePollIntervalVisibility() {
+    const auto accounts = AccountManager::instance()->accounts();
+    const auto pushAvailable = std::any_of(accounts.cbegin(), accounts.cend(),
+    [](const AccountStatePtr &accountState) -> bool {
+        if (!accountState)
+            return false;
+        AccountPtr accountPtr = accountState->account();
+        if (!accountPtr)
+            return false;
+        return accountPtr->capabilities().availablePushNotifications().testFlag(PushNotificationType::Files);
+    });
+
+    _ui->horizontalLayoutWidget_remotePollInterval->setVisible(!pushAvailable);
 }
 
 } // namespace OCC

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -60,6 +60,7 @@ private slots:
     void loadMiscSettings();
     void slotShowLegalNotice();
     void slotRemotePollIntervalChanged(int seconds);
+    void updatePollIntervalVisibility();
 #if defined(BUILD_UPDATER)
     void slotUpdateInfo();
     void slotUpdateChannelChanged();

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -198,50 +198,6 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_remotePollInterval">
-        <item>
-         <widget class="QLabel" name="remotePollIntervalLabel">
-          <property name="text">
-           <string>Server poll interval</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="remotePollIntervalSpinBox">
-          <property name="minimum">
-            <number>30</number>
-          </property>
-          <property name="maximum">
-           <number>999999</number>
-          </property>
-          <property name="singleStep">
-           <number>1</number>
-          </property>         
-         </widget>         
-        </item>
-        <item>
-         <widget class="QLabel" name="labelInterval">
-          <property name="text">
-           <string extracomment="Trailing part of &quot;Server poll interval&quot; ">seconds (if Client Push is unavailable)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_remotePollInterval">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
          <widget class="QCheckBox" name="showInExplorerNavigationPaneCheckBox">
@@ -268,6 +224,61 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QWidget" name="horizontalLayoutWidget_remotePollInterval">
+        <layout class="QHBoxLayout" name="horizontalLayout_remotePollInterval">
+         <item>
+          <widget class="QLabel" name="remotePollIntervalLabel">
+           <property name="text">
+            <string>Server poll interval</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="remotePollIntervalSpinBox">
+           <property name="minimum">
+            <number>30</number>
+           </property>
+           <property name="maximum">
+            <number>999999</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelInterval">
+           <property name="text">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;seconds (if &lt;a href=&quot;https://github.com/nextcloud/notify_push&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Client Push&lt;/span&gt;&lt;/a&gt; is unavailable)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::TextFormat::RichText</enum>
+           </property>
+           <property name="openExternalLinks">
+            <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_remotePollInterval">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -251,7 +251,7 @@
          <item>
           <widget class="QLabel" name="labelInterval">
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;seconds (if &lt;a href=&quot;https://github.com/nextcloud/notify_push&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Client Push&lt;/span&gt;&lt;/a&gt; is unavailable)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>seconds (if &lt;a href=&quot;https://github.com/nextcloud/notify_push&quot;&gt;Client Push&lt;/a&gt; is unavailable)</string>
            </property>
            <property name="textFormat">
             <enum>Qt::TextFormat::RichText</enum>
@@ -260,7 +260,7 @@
             <bool>true</bool>
            </property>
            <property name="textInteractionFlags">
-            <set>Qt::TextInteractionFlag::TextBrowserInteraction</set>
+            <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse</set>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Changed the set properties to the designer file and added a way for the remotePollInterval selector to hide in the settings if notify push is available. This is a follow up to #7926 
