### PR TITLE
update AppImage builds to Qt 6.8.2

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     name: Linux Appimage Package
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.1-2
+    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.2-1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -55,4 +55,4 @@ SIGN_PACKAGE = False
 
 [Custom_Variables_for_Brander]
 qtPath = /opt/qt
-dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.1-2
+dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.2-1


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
