### PR TITLE
gui: do not allow MainWindow to be resized

### DIFF
--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -43,7 +43,16 @@ ApplicationWindow {
 
     readonly property int maxMenuHeight: Style.trayWindowHeight - Style.trayWindowHeaderHeight - 2 * Style.trayWindowBorderWidth
 
-    Component.onCompleted: Systray.forceWindowInit(trayWindow)
+    Component.onCompleted: {
+        Systray.forceWindowInit(trayWindow)
+        if (Systray.useNormalWindow) {
+            return;
+        }
+
+        // do not allow this window to be resized when it's frameless
+        this.minimumWidth = this.maximumWidth = this.width
+        this.minimumHeight = this.maximumHeight = this.height
+    }
 
     // Close tray window when focus is lost (e.g. click somewhere else on the screen)
     onActiveChanged: {


### PR DESCRIPTION
previously macOS let you resize the activity window, resulting in strange visual artifacts...

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
