### PR TITLE
Revert "gui: do not allow MainWindow to be resized"

### DIFF
--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -43,16 +43,7 @@ ApplicationWindow {
 
     readonly property int maxMenuHeight: Style.trayWindowHeight - Style.trayWindowHeaderHeight - 2 * Style.trayWindowBorderWidth
 
-    Component.onCompleted: {
-        Systray.forceWindowInit(trayWindow)
-        if (Systray.useNormalWindow) {
-            return;
-        }
-
-        // do not allow this window to be resized when it's frameless
-        this.minimumWidth = this.maximumWidth = this.width
-        this.minimumHeight = this.maximumHeight = this.height
-    }
+    Component.onCompleted: Systray.forceWindowInit(trayWindow)
 
     // Close tray window when focus is lost (e.g. click somewhere else on the screen)
     onActiveChanged: {


### PR DESCRIPTION
This reverts commit 0963856a941e85881cc82b254585fc76bf5b3aa0.

turns out it's fine on Sonoma, whereas it breaks on Sequoia (the window now gets stuck below the menubar) -- maybe I'll open up a QTBUG later if I can reproduce this with a minimal example

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
