### PR TITLE
display reshares in sharing dialog

### DIFF
--- a/src/gui/filedetails/sharemodel.cpp
+++ b/src/gui/filedetails/sharemodel.cpp
@@ -308,6 +308,7 @@ void ShareModel::updateData()
     _placeholderLinkShare.reset(new Share(_accountState->account(),
                                           placeholderLinkShareId,
                                           _accountState->account()->id(),
+                                          _accountState->account()->id(),
                                           _accountState->account()->davDisplayName(),
                                           _sharePath,
                                           Share::TypePlaceholderLink));
@@ -315,12 +316,14 @@ void ShareModel::updateData()
     _internalLinkShare.reset(new Share(_accountState->account(),
                                        internalLinkShareId,
                                        _accountState->account()->id(),
+                                       _accountState->account()->id(),
                                        _accountState->account()->davDisplayName(),
                                        _sharePath,
                                        Share::TypeInternalLink));
 
     _secureFileDropPlaceholderLinkShare.reset(new Share(_accountState->account(),
                                                         secureFileDropPlaceholderLinkShareId,
+                                                        _accountState->account()->id(),
                                                         _accountState->account()->id(),
                                                         _accountState->account()->davDisplayName(),
                                                         _sharePath,
@@ -497,7 +500,7 @@ void ShareModel::slotSharesFetched(const QList<SharePtr> &shares)
     for (const auto &share : shares) {
         if (share.isNull() ||
             share->account().isNull() ||
-            share->getUidOwner() != share->account()->davUser()) {
+            share->getUidFileOwner() != share->account()->davUser()) {
             continue;
         }
 

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -54,7 +54,8 @@ static void updateFolder(const AccountPtr &account, QStringView path)
 
 Share::Share(AccountPtr account,
     const QString &id,
-    const QString &uidowner,
+    const QString &uidOwner,
+    const QString &uidFileOwner,
     const QString &ownerDisplayName,
     const QString &path,
     const ShareType shareType,
@@ -63,7 +64,8 @@ Share::Share(AccountPtr account,
     const ShareePtr shareWith)
     : _account(account)
     , _id(id)
-    , _uidowner(uidowner)
+    , _uidOwner(uidOwner)
+    , _uidFileOwner(uidFileOwner)
     , _ownerDisplayName(ownerDisplayName)
     , _path(path)
     , _shareType(shareType)
@@ -90,7 +92,12 @@ QString Share::getId() const
 
 QString Share::getUidOwner() const
 {
-    return _uidowner;
+    return _uidOwner;
+}
+
+QString Share::getUidFileOwner() const
+{
+    return _uidFileOwner;
 }
 
 QString Share::getOwnerDisplayName() const
@@ -195,7 +202,8 @@ QDate LinkShare::getExpireDate() const
 
 LinkShare::LinkShare(AccountPtr account,
     const QString &id,
-    const QString &uidowner,
+    const QString &uidOwner,
+    const QString &uidFileOwner,
     const QString &ownerDisplayName,
     const QString &path,
     const QString &name,
@@ -207,7 +215,7 @@ LinkShare::LinkShare(AccountPtr account,
     const QString &note,
     const QString &label,
     const bool hideDownload)
-    : Share(account, id, uidowner, ownerDisplayName, path, Share::TypeLink, isPasswordSet, permissions)
+    : Share(account, id, uidOwner, uidFileOwner, ownerDisplayName, path, Share::TypeLink, isPasswordSet, permissions)
     , _name(name)
     , _token(token)
     , _note(note)
@@ -334,7 +342,8 @@ void LinkShare::slotHideDownloadSet(const QJsonDocument &jsonDoc, const QVariant
 
 UserGroupShare::UserGroupShare(AccountPtr account,
     const QString &id,
-    const QString &owner,
+    const QString &uidOwner,
+    const QString &uidFileOwner,
     const QString &ownerDisplayName,
     const QString &path,
     const ShareType shareType,
@@ -343,7 +352,7 @@ UserGroupShare::UserGroupShare(AccountPtr account,
     const ShareePtr shareWith,
     const QDate &expireDate,
     const QString &note)
-    : Share(account, id, owner, ownerDisplayName, path, shareType, isPasswordSet, permissions, shareWith)
+    : Share(account, id, uidOwner, uidFileOwner, ownerDisplayName, path, shareType, isPasswordSet, permissions, shareWith)
     , _note(note)
     , _expireDate(expireDate)
 {
@@ -612,6 +621,7 @@ QSharedPointer<UserGroupShare> ShareManager::parseUserGroupShare(const QJsonObje
     return QSharedPointer<UserGroupShare>(new UserGroupShare(_account,
         data.value("id").toVariant().toString(), // "id" used to be an integer, support both
         data.value("uid_owner").toVariant().toString(),
+        data.value("uid_file_owner").toVariant().toString(),
         data.value("displayname_owner").toVariant().toString(),
         data.value("path").toString(),
         static_cast<Share::ShareType>(data.value("share_type").toInt()),
@@ -652,6 +662,7 @@ QSharedPointer<LinkShare> ShareManager::parseLinkShare(const QJsonObject &data) 
     return QSharedPointer<LinkShare>(new LinkShare(_account,
         data.value("id").toVariant().toString(), // "id" used to be an integer, support both
         data.value("uid_owner").toString(),
+        data.value("uid_file_owner").toString(),
         data.value("displayname_owner").toString(),
         data.value("path").toString(),
         data.value("name").toString(),
@@ -674,6 +685,7 @@ SharePtr ShareManager::parseShare(const QJsonObject &data) const
     return SharePtr(new Share(_account,
         data.value("id").toVariant().toString(), // "id" used to be an integer, support both
         data.value("uid_owner").toVariant().toString(),
+        data.value("uid_file_owner").toVariant().toString(),
         data.value("displayname_owner").toVariant().toString(),
         data.value("path").toString(),
         (Share::ShareType)data.value("share_type").toInt(),

--- a/src/gui/sharemanager.h
+++ b/src/gui/sharemanager.h
@@ -74,7 +74,8 @@ public:
      */
     explicit Share(AccountPtr account,
                    const QString &id,
-                   const QString &owner,
+                   const QString &uidOwner,
+                   const QString &uidFileOwner,
                    const QString &ownerDisplayName,
                    const QString &path,
                    const ShareType shareType,
@@ -98,6 +99,11 @@ public:
      * Get the uid_owner
      */
     [[nodiscard]] QString getUidOwner() const;
+
+    /*
+     * Get the uid_file_owner
+     */
+    [[nodiscard]] QString getUidFileOwner() const;
 
     /*
      * Get the owner display name
@@ -165,7 +171,8 @@ public slots:
 protected:
     AccountPtr _account;
     QString _id;
-    QString _uidowner;
+    QString _uidOwner;
+    QString _uidFileOwner;
     QString _ownerDisplayName;
     QString _path;
     ShareType _shareType;
@@ -207,7 +214,8 @@ class LinkShare : public Share
 public:
     explicit LinkShare(AccountPtr account,
         const QString &id,
-        const QString &uidowner,
+        const QString &uidOwner,
+        const QString &uidFileOwner,
         const QString &ownerDisplayName,
         const QString &path,
         const QString &name,
@@ -338,7 +346,8 @@ class UserGroupShare : public Share
 public:
     UserGroupShare(AccountPtr account,
         const QString &id,
-        const QString &owner,
+        const QString &uidOwner,
+        const QString &uidFileOwner,
         const QString &ownerDisplayName,
         const QString &path,
         const ShareType shareType,


### PR DESCRIPTION
Previously the sharing dialog would only include the shares created by the owner, with this change reshares by others will now be included as well.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
