### PR TITLE
always set a user if we got asked for one

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -36,6 +36,13 @@ AccessManager::AccessManager(QObject *parent)
     : QNetworkAccessManager(parent)
 {
     setCookieJar(new CookieJar);
+    connect(this, &QNetworkAccessManager::authenticationRequired, this, [this](QNetworkReply *reply, QAuthenticator *authenticator) {
+        if (authenticator->user().isEmpty()) {
+            qCWarning(lcAccessManager) << "Server requested authentication and we didn't provide a user, aborting ...";
+            authenticator->setUser(QUuid::createUuid().toString());
+            reply->abort();
+        }
+    });
 }
 
 QByteArray AccessManager::generateRequestId()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
