### PR TITLE
use our own Craft cache for macOS builds

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -45,9 +45,15 @@ Paths/Python = C:\Python312-x64
 [macos-64-clang]
 General/ABI = macos-64-clang
 
+Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
+Packager/CacheVersion = 25.03-nc
+
 [macos-clang-arm64]
 General/ABI = macos-clang-arm64
 Paths/Python = /Users/runner/hostedtoolcache/Python/3.12.3/arm64
+
+Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
+Packager/CacheVersion = 25.03-nc
 
 [Env]
 CRAFT_CODESIGN_CERTIFICATE =


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
