### PR TITLE
gui/tray: Hide resume all menu item when no local sync folders are configured

### DIFF
--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -109,6 +109,9 @@ Systray::Systray()
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, [this]{ showWindow(WindowPosition::Center); });
 #endif
+
+    connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &Systray::slotSyncFoldersChanged);
+    slotSyncFoldersChanged(FolderMan::instance()->map());
 }
 
 void Systray::create()
@@ -490,6 +493,14 @@ void Systray::slotPauseAllFolders()
     setPauseOnAllFoldersHelper(true);
 }
 
+void Systray::slotSyncFoldersChanged(const OCC::Folder::Map &folderMap)
+{
+    if (const auto currentAnySyncFolders = !folderMap.isEmpty(); currentAnySyncFolders != _anySyncFolders) {
+        _anySyncFolders = currentAnySyncFolders;
+        emit anySyncFoldersChanged();
+    }
+}
+
 void Systray::setPauseOnAllFoldersHelper(bool pause)
 {
     // For some reason we get the raw pointer from Folder::accountState()
@@ -608,6 +619,11 @@ void Systray::setSyncIsPaused(const bool syncIsPaused)
         slotUnpauseAllFolders();
     }
     emit syncIsPausedChanged();
+}
+
+bool Systray::anySyncFolders() const
+{
+    return _anySyncFolders;
 }
 
 /********************************************************************************************/

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -69,6 +69,7 @@ class Systray : public QSystemTrayIcon
     Q_PROPERTY(QString windowTitle READ windowTitle CONSTANT)
     Q_PROPERTY(bool useNormalWindow READ useNormalWindow CONSTANT)
     Q_PROPERTY(bool syncIsPaused READ syncIsPaused WRITE setSyncIsPaused NOTIFY syncIsPausedChanged)
+    Q_PROPERTY(bool anySyncFolders READ anySyncFolders NOTIFY anySyncFoldersChanged)
     Q_PROPERTY(bool isOpen READ isOpen WRITE setIsOpen NOTIFY isOpenChanged)
     Q_PROPERTY(bool enableAddAccount READ enableAddAccount CONSTANT)
 
@@ -92,6 +93,7 @@ public:
     Q_REQUIRED_RESULT bool useNormalWindow() const;
 
     Q_REQUIRED_RESULT bool syncIsPaused() const;
+    Q_REQUIRED_RESULT bool anySyncFolders() const;
     Q_REQUIRED_RESULT bool isOpen() const;
 
     [[nodiscard]] bool enableAddAccount() const;
@@ -113,6 +115,7 @@ signals:
     void showErrorMessageDialog(const QString &error);
 
     void syncIsPausedChanged();
+    void anySyncFoldersChanged();
     void isOpenChanged();
 
     void hideSettingsDialog();
@@ -158,6 +161,7 @@ private slots:
     void slotUpdateSyncPausedState();
     void slotUnpauseAllFolders();
     void slotPauseAllFolders();
+    void slotSyncFoldersChanged(const OCC::Folder::Map &foldeMap);
 
 private:
     // Argument allows user to specify a specific dialog to be raised
@@ -183,6 +187,8 @@ private:
 
     bool _isOpen = false;
     bool _syncIsPaused = true;
+    bool _anySyncFolders = false;
+
     std::unique_ptr<QQmlApplicationEngine> _trayEngine;
     QPointer<QMenu> _contextMenu;
     QSharedPointer<QQuickWindow> _trayWindow;

--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -104,8 +104,11 @@ Button {
 
         MenuItem {
             id: syncPauseButton
+            height: Systray.anySyncFolders ? implicitHeight : 0
             font.pixelSize: Style.topLinePixelSize
             hoverEnabled: true
+            enabled: Systray.anySyncFolders
+            visible: Systray.anySyncFolders
             onClicked: Systray.syncIsPaused = !Systray.syncIsPaused
             Accessible.role: Accessible.MenuItem
             Accessible.name: Systray.syncIsPaused ? qsTr("Resume sync for all") : qsTr("Pause sync for all")


### PR DESCRIPTION
<img width="497" alt="Screenshot 2025-03-11 at 16 13 20" src="https://github.com/user-attachments/assets/20c5ce04-0f46-44b1-ab50-9e13fb0d8598" />

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
