### PR TITLE
[stable-3.16] gui/wizard: Integrate macOS VFS (File Provider) configuration into account wizard

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -41,11 +41,13 @@ public:
 signals:
     void domainSetupComplete();
 
+public slots:
+    void addFileProviderDomainForAccount(const OCC::AccountState * const accountState);
+
 private slots:
     void setupFileProviderDomains();
     void updateFileProviderDomains();
 
-    void addFileProviderDomainForAccount(const OCC::AccountState * const accountState);
     void removeFileProviderDomainForAccount(const OCC::AccountState * const accountState);
     void disconnectFileProviderDomainForAccount(const OCC::AccountState * const accountState, const QString &reason);
     void reconnectFileProviderDomainForAccount(const OCC::AccountState * const accountState);

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -511,8 +511,6 @@ void FileProviderDomainManager::start()
 
     setupFileProviderDomains();
 
-    connect(AccountManager::instance(), &AccountManager::accountAdded,
-            this, &FileProviderDomainManager::addFileProviderDomainForAccount);
     // If an account is deleted from the client, accountSyncConnectionRemoved will be
     // emitted first. So we treat accountRemoved as only being relevant to client
     // shutdowns.

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -692,6 +692,11 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
 #ifdef BUILD_FILE_PROVIDER_MODULE
         if (Mac::FileProvider::fileProviderAvailable()) {
             Mac::FileProvider::instance()->domainManager()->addFileProviderDomainForAccount(account);
+            _ocWizard->appendToConfigurationLog(
+                tr("<font color=\"green\"><b>File Provider-based account %1 successfully created!</b></font>").arg(account->account()->userIdAtHostWithPort()));
+            _ocWizard->done(result);
+            emit ownCloudWizardDone(result);
+            return;
         }
 #endif
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -689,6 +689,12 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
         // is changed.
         auto account = applyAccountChanges();
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+        if (Mac::FileProvider::fileProviderAvailable()) {
+            Mac::FileProvider::instance()->domainManager()->addFileProviderDomainForAccount(account);
+        }
+#endif
+
         QString localFolder = FolderDefinition::prepareLocalPath(_ocWizard->localFolder());
 
         bool startFromScratch = _ocWizard->field("OCSyncFromScratch").toBool();
@@ -698,9 +704,11 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
             folderDefinition.localPath = localFolder;
             folderDefinition.targetPath = FolderDefinition::prepareTargetPath(_remoteFolder);
             folderDefinition.ignoreHiddenFiles = folderMan->ignoreHiddenFiles();
+#ifndef BUILD_FILE_PROVIDER_MODULE
             if (_ocWizard->useVirtualFileSync()) {
                 folderDefinition.virtualFilesMode = bestAvailableVfsMode();
             }
+#endif
             if (folderMan->navigationPaneHelper().showInExplorerNavigationPane())
                 folderDefinition.navigationPaneClsid = QUuid::createUuid();
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -696,6 +696,14 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
                 tr("<font color=\"green\"><b>File Provider-based account %1 successfully created!</b></font>").arg(account->account()->userIdAtHostWithPort()));
             _ocWizard->done(result);
             emit ownCloudWizardDone(result);
+
+            QMessageBox::information(nullptr,
+                                     tr("Virtual files enabled"),
+                                     tr("Your account is now syncing with virtual files support. "
+                                        "This means that all your files are online-only by default, "
+                                        "and will be downloaded on-demand when you open them. "
+                                        "You may find your files under the <b>Locations</b> section of the Finder sidebar."));
+
             return;
         }
 #endif

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -83,11 +83,14 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage(OwncloudWizard *wizard)
     connect(_ui.rSyncEverything, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSyncEverythingClicked);
     connect(_ui.rSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
     connect(_ui.rVirtualFileSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotVirtualFileSyncClicked);
-    connect(_ui.rVirtualFileSync, &QRadioButton::toggled, this, [this](bool checked) {
+    connect(_ui.rVirtualFileSync, &QRadioButton::toggled, this, [this](const bool checked) {
         if (checked) {
             _ui.lSelectiveSyncSizeLabel->clear();
             _selectiveSyncBlacklist.clear();
         }
+#ifdef BUILD_FILE_PROVIDER_MODULE
+        updateMacOsFileProviderRelatedViews();
+#endif
     });
     connect(_ui.bSelectiveSync, &QAbstractButton::clicked, this, &OwncloudAdvancedSetupPage::slotSelectiveSyncClicked);
 
@@ -328,10 +331,14 @@ void OwncloudAdvancedSetupPage::updateStatus()
         setResolutionGuiVisible(false);
     }
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    updateMacOsFileProviderRelatedViews();
+#else
     _filePathLabel->setText(QDir::toNativeSeparators(locFolder));
 
     QString lfreeSpaceStr = Utility::octetsToString(availableLocalSpace());
     _ui.lFreeSpace->setText(QString(tr("%1 free space", "%1 gets replaced with the size and a matching unit. Example: 3 MB or 5 GB")).arg(lfreeSpaceStr));
+#endif
 
     _ui.syncModeLabel->setText(t);
     _ui.syncModeLabel->setFixedHeight(_ui.syncModeLabel->sizeHint().height());
@@ -635,6 +642,28 @@ void OwncloudAdvancedSetupPage::setRadioChecked(QRadioButton *radio)
     if (radio != _ui.rVirtualFileSync)
         _ui.rVirtualFileSync->setCheckable(false);
 }
+
+#ifdef BUILD_FILE_PROVIDER_MODULE
+void OwncloudAdvancedSetupPage::updateMacOsFileProviderRelatedViews()
+{
+    if (!Mac::FileProvider::fileProviderAvailable()) {
+        return;
+    }
+
+    const auto freeSpaceHidden = _ui.rVirtualFileSync->isChecked();
+    const auto folderSelectionButtonHidden = _ui.rVirtualFileSync->isChecked();
+    const auto filePathLabelText =
+        _ui.rVirtualFileSync->isChecked() ? tr("In Finder's \"Locations\" sidebar section") : QDir::toNativeSeparators(localFolder());
+    const auto freeSpaceString = freeSpaceHidden ? QString() : Utility::octetsToString(availableLocalSpace());
+    const auto freeSpaceText = freeSpaceHidden ? QString() : QString(tr("%1 free space", "%1 gets replaced with the size and a matching unit. Example: 3 MB or 5 GB")).arg(freeSpaceString);
+
+    _ui.lFreeSpace->setHidden(freeSpaceHidden);
+    _ui.lFreeSpace->setText(freeSpaceText);
+    _ui.pbSelectLocalFolder->setHidden(folderSelectionButtonHidden);
+    _ui.pbSelectLocalFolder->setEnabled(!folderSelectionButtonHidden);
+    _filePathLabel->setText(filePathLabelText);
+}
+#endif
 
 void OwncloudAdvancedSetupPage::styleSyncLogo()
 {

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -35,7 +35,12 @@
 #include "networkjobs.h"
 #include "wizard/owncloudwizard.h"
 
-namespace OCC {
+#ifdef BUILD_FILE_PROVIDER_MODULE
+#include "gui/macOS/fileprovider.h"
+#endif
+
+namespace OCC
+{
 
 OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage(OwncloudWizard *wizard)
     : QWizardPage()
@@ -101,14 +106,22 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage(OwncloudWizard *wizard)
         _ui.confTraillingSizeLabel->hide();
     }
 
-    _ui.rVirtualFileSync->setText(tr("Use &virtual files instead of downloading content immediately %1").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
+    QString vfsExperimentalText = tr("(experimental)");
 
+    if (
 #ifdef Q_OS_WIN
-    if (bestAvailableVfsMode() == Vfs::WindowsCfApi) {
+        bestAvailableVfsMode() == Vfs::WindowsCfApi
+#elif defined(BUILD_FILE_PROVIDER_MODULE)
+        Mac::FileProvider::fileProviderAvailable()
+#else
+        false
+#endif
+    ) {
         _ui.wSyncStrategy->addLayout(_ui.lVirtualFileSync);
         setRadioChecked(_ui.rVirtualFileSync);
+        vfsExperimentalText = "";
     }
-#endif
+    _ui.rVirtualFileSync->setText(tr("Use &virtual files instead of downloading content immediately %1").arg(vfsExperimentalText));
 }
 
 void OwncloudAdvancedSetupPage::setupCustomization()
@@ -142,7 +155,11 @@ void OwncloudAdvancedSetupPage::initializePage()
 {
     WizardCommon::initErrorLabel(_ui.errorLabel);
 
-    if (!Theme::instance()->showVirtualFilesOption() || bestAvailableVfsMode() == Vfs::Off) {
+    if (!Theme::instance()->showVirtualFilesOption()
+#ifndef BUILD_FILE_PROVIDER_MODULE
+        || bestAvailableVfsMode() == Vfs::Off
+#endif
+    ) {
         // If the layout were wrapped in a widget, the auto-grouping of the
         // radio buttons no longer works and there are surprising margins.
         // Just manually hide the button and remove the layout.
@@ -178,7 +195,6 @@ void OwncloudAdvancedSetupPage::initializePage()
     connect(quotaJob, &PropfindJob::result, this, &OwncloudAdvancedSetupPage::slotQuotaRetrieved);
     connect(quotaJob, &PropfindJob::finishedWithError, this, &OwncloudAdvancedSetupPage::slotQuotaRetrievedWithError);
     quotaJob->start();
-
 
     if (Theme::instance()->wizardSelectiveSyncDefaultNothing()) {
         _selectiveSyncBlacklist = QStringList("/");
@@ -260,7 +276,11 @@ void OwncloudAdvancedSetupPage::refreshVirtualFilesAvailibility(const QString &p
         setRadioChecked(_ui.rSyncEverything);
         _ui.rVirtualFileSync->setEnabled(false);
     } else {
-        _ui.rVirtualFileSync->setText(tr("Use &virtual files instead of downloading content immediately %1").arg(bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
+        QString textArg;
+#ifndef BUILD_FILE_PROVIDER_MODULE
+        textArg = bestAvailableVfsMode() == Vfs::WindowsCfApi ? QString() : tr("(experimental)");
+#endif
+        _ui.rVirtualFileSync->setText(tr("Use &virtual files instead of downloading content immediately %1").arg(textArg));
         _ui.rVirtualFileSync->setEnabled(true);
     }
     //

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -413,6 +413,7 @@ bool OwncloudAdvancedSetupPage::isConfirmBigFolderChecked() const
 
 bool OwncloudAdvancedSetupPage::validatePage()
 {
+#ifndef BUILD_FILE_PROVIDER_MODULE
     if (useVirtualFileSync()) {
         const auto availability = Vfs::checkAvailability(localFolder(), bestAvailableVfsMode());
         if (!availability) {
@@ -425,6 +426,7 @@ bool OwncloudAdvancedSetupPage::validatePage()
             return false;
         }
     }
+#endif
 
     if (!_created) {
         setErrorString(QString());

--- a/src/gui/wizard/owncloudadvancedsetuppage.h
+++ b/src/gui/wizard/owncloudadvancedsetuppage.h
@@ -69,6 +69,10 @@ private slots:
 private:
     void setRadioChecked(QRadioButton *radio);
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    void updateMacOsFileProviderRelatedViews();
+#endif
+
     void setupCustomization();
     void updateStatus();
     bool dataChanged();

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -471,6 +471,11 @@ void OwncloudWizard::bringToTop()
 
 void OwncloudWizard::askExperimentalVirtualFilesFeature(QWidget *receiver, const std::function<void(bool enable)> &callback)
 {
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    callback(true);
+    return;
+#endif
+
     const auto bestVfsMode = bestAvailableVfsMode();
     QMessageBox *msgBox = nullptr;
     QPushButton *acceptButton = nullptr;


### PR DESCRIPTION
Manually backport #7875

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
