### PR TITLE
gui/macOS: Do not log account detail-related messages that were not sent on dead file provider socket

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -113,7 +113,8 @@ void FileProviderSocketController::parseReceivedLine(const QString &receivedLine
 void FileProviderSocketController::sendMessage(const QString &message) const
 {
     if (!_socket) {
-        qCWarning(lcFileProviderSocketController) << "Not sending message on dead file provider socket:" << message;
+        const auto toLog = message.contains("ACCOUNT_DETAILS") ? "ACCOUNT_DETAILS:****" : message;
+        qCWarning(lcFileProviderSocketController) << "Not sending message on dead file provider socket:" << toLog;
         return;
     }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
