### PR TITLE
gui/macOS: Avoid UB in edge cases where there is no matching accountstate for a domain

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -27,6 +27,12 @@
 #include "gui/accountmanager.h"
 #include "libsync/account.h"
 
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcMacFileProviderDomainManager, "nextcloud.gui.macfileproviderdomainmanager", QtInfoMsg)
+
+}
+
 // Ensure that conversion to/from domain identifiers and display names
 // are consistent throughout these classes
 namespace {
@@ -118,7 +124,8 @@ QString accountIdFromDomainId(NSString * const domainId)
             return account->userIdAtHostWithPort();
         }
     }
-    Q_UNREACHABLE();
+    qCWarning(OCC::lcMacFileProviderDomainManager) << "Could not find account id for domain id:" << qDomainId;
+    return {};
 }
 
 API_AVAILABLE(macos(11.0))
@@ -130,8 +137,6 @@ inline QString accountIdFromDomain(NSFileProviderDomain * const domain)
 }
 
 namespace OCC {
-
-Q_LOGGING_CATEGORY(lcMacFileProviderDomainManager, "nextcloud.gui.macfileproviderdomainmanager", QtInfoMsg)
 
 namespace Mac {
 


### PR DESCRIPTION
Do not assume existence of an account for a given domain identifier -- users can modify the config in unexpected ways

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
