### PR TITLE
gui: fix dark mode change on Windows 10 with universal style

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -87,6 +87,10 @@ int main(int argc, char **argv)
     if (QOperatingSystemVersion::current().version() < QOperatingSystemVersion::Windows11.version()) {
         qmlStyle = QStringLiteral("Universal");
         widgetsStyle = QStringLiteral("Fusion");
+        if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_UNIVERSAL_THEME")) {
+            // initialise theme with the light/dark mode setting from the OS
+            qputenv("QT_QUICK_CONTROLS_UNIVERSAL_THEME", "System");
+        }
     } else {
         qmlStyle = QStringLiteral("FluentWinUI3");
         widgetsStyle = QStringLiteral("windows11");


### PR DESCRIPTION
The _Universal_ QML style has a theme that uses the colour scheme from the system.  This can be set by either configuring `qtquickcontrols2.conf` or setting the environment variable `QT_QUICK_CONTROLS_UNIVERSAL_THEME=System`.

Unfortunately, due to [QTBUG-128825], setting the theme in the configuration file/environment variable results in the dark/light mode setting only be set during startup, not during runtime.  Not ideal, but still better than not having a broken dark mode theme at all.

Fixes #7991

[QTBUG-128825]: https://bugreports.qt.io/browse/QTBUG-128825

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
