### PR TITLE
gui: add a "Yes to all" button when resolving multiple conflicts at once

### DIFF
--- a/src/gui/conflictsolver.h
+++ b/src/gui/conflictsolver.h
@@ -17,6 +17,9 @@ class ConflictSolver : public QObject
     Q_OBJECT
     Q_PROPERTY(QString localVersionFilename READ localVersionFilename WRITE setLocalVersionFilename NOTIFY localVersionFilenameChanged)
     Q_PROPERTY(QString remoteVersionFilename READ remoteVersionFilename WRITE setRemoteVersionFilename NOTIFY remoteVersionFilenameChanged)
+    Q_PROPERTY(bool isBulkSolution READ isBulkSolution WRITE setIsBulkSolution NOTIFY isBulkSolutionChanged)
+    Q_PROPERTY(bool yesToAllRequested READ yesToAllRequested WRITE setYesToAllRequested NOTIFY yesToAllRequestedChanged)
+
 public:
     enum Solution {
         KeepLocalVersion,
@@ -29,25 +32,34 @@ public:
 
     [[nodiscard]] QString localVersionFilename() const;
     [[nodiscard]] QString remoteVersionFilename() const;
+    [[nodiscard]] bool isBulkSolution() const;
+    [[nodiscard]] bool yesToAllRequested() const;
 
     bool exec(Solution solution);
 
 public slots:
     void setLocalVersionFilename(const QString &localVersionFilename);
     void setRemoteVersionFilename(const QString &remoteVersionFilename);
+    void setIsBulkSolution(bool isBulkSolution);
+    void setYesToAllRequested(bool yesToAllRequested);
 
 signals:
     void localVersionFilenameChanged();
     void remoteVersionFilenameChanged();
+    void isBulkSolutionChanged();
+    void yesToAllRequestedChanged();
 
 private:
     bool deleteLocalVersion();
     bool renameLocalVersion();
     bool overwriteRemoteVersion();
+    bool confirmDeletion();
 
     QWidget *_parentWidget;
     QString _localVersionFilename;
     QString _remoteVersionFilename;
+    bool _isBulkSolution = false;
+    bool _yesToAllRequested = false;
 };
 
 } // namespace OCC

--- a/src/gui/syncconflictsmodel.cpp
+++ b/src/gui/syncconflictsmodel.cpp
@@ -215,13 +215,19 @@ void SyncConflictsModel::selectAllConflicting(bool selected)
 
 void SyncConflictsModel::applySolution()
 {
-    for(const auto &syncConflict : std::as_const(_conflictData)) {
+    bool yesToAllRequested = false;
+    bool isBulkSolution = _conflictData.size() > 1; // no need to display the "Yes for all" button if only one file is affected
+
+    for (const auto &syncConflict : std::as_const(_conflictData)) {
         if (syncConflict.isValid()) {
             qCInfo(lcSyncConflictsModel) << syncConflict.mExistingFilePath << syncConflict.mConflictingFilePath << syncConflict.solution();
             ConflictSolver solver;
+            solver.setIsBulkSolution(isBulkSolution);
+            solver.setYesToAllRequested(yesToAllRequested);
             solver.setLocalVersionFilename(syncConflict.mConflictingFilePath);
             solver.setRemoteVersionFilename(syncConflict.mExistingFilePath);
             solver.exec(syncConflict.solution());
+            yesToAllRequested = solver.yesToAllRequested();
         }
     }
 }


### PR DESCRIPTION
A quick one for 3.17 :)

<table>
<thead><tr>
<th>(Legacy) QWidget conflict dialog</th>
<th colspan="2">QML-based conflict dialog</th>
</tr><tr>
<th>single file only</th>
<th>single file</th>
<th>multiple files</th>
</tr></thead><tbody><tr>
<td>

![Screenshot_20250319_093101](https://github.com/user-attachments/assets/6b77efb4-3a47-4cb6-b3ec-8d7950e4d83c)

</td><td>

![Screenshot_20250319_093249](https://github.com/user-attachments/assets/fceb85e3-178a-45ca-accf-2bfb1326ebec)

</td><td>

![Screenshot_20250319_093629](https://github.com/user-attachments/assets/dc67af28-8fda-4040-8d2a-548256efca8a)

</td></tr></tbody></table>

Fixes #7446

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
