### PR TITLE
use standard way to find the checkum type and really send it to server

### DIFF
--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -204,7 +204,7 @@ void BulkPropagatorJob::doStartUpload(SyncFileItemPtr item,
 
     const auto remotePath = propagator()->fullRemotePath(fileToUpload._file);
 
-    currentHeaders["X-File-MD5"] = transmissionChecksumHeader;
+    currentHeaders[checkSumHeaderC] = transmissionChecksumHeader;
 
     BulkUploadItem newUploadFile{propagator()->account(), item, fileToUpload,
                 remotePath, fileToUpload._path,
@@ -295,7 +295,7 @@ void BulkPropagatorJob::slotComputeTransmissionChecksum(SyncFileItemPtr item,
 {
     // Compute the transmission checksum.
     const auto computeChecksum = new ComputeChecksum(this);
-    const auto checksumType = uploadChecksumEnabled() ? "MD5" : "";
+    const auto checksumType = uploadChecksumEnabled() ? propagator()->account()->capabilities().preferredUploadChecksumType() : "";
     computeChecksum->setChecksumType(checksumType);
 
     connect(computeChecksum, &ComputeChecksum::done, this, [this, item, fileToUpload] (const QByteArray &contentChecksumType, const QByteArray &contentChecksum) {


### PR DESCRIPTION
will fix missing checksum for bulk upload

will ensure consistent behavior between bulk upload, plain old upload and chunked upload

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
