### PR TITLE
gui/macOS: Do not assume accountState will always be valid in socket controller

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -162,7 +162,7 @@ void FileProviderSocketController::requestFileProviderDomainInfo() const
     sendMessage(requestMessage);
 }
 
-void FileProviderSocketController::slotAccountStateChanged(const AccountState::State state)
+void FileProviderSocketController::slotAccountStateChanged(const AccountState::State state) const
 {
     switch(state) {
     case AccountState::Disconnected:
@@ -241,7 +241,7 @@ void FileProviderSocketController::sendAccountDetails() const
     sendMessage(message);
 }
 
-void FileProviderSocketController::reportSyncState(const QString &receivedState)
+void FileProviderSocketController::reportSyncState(const QString &receivedState) const
 {
     if (!accountState()) {
         qCWarning(lcFileProviderSocketController) << "No account state available to report sync state";

--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -206,7 +206,10 @@ void FileProviderSocketController::sendNotAuthenticated() const
 
 void FileProviderSocketController::sendAccountDetails() const
 {
-    Q_ASSERT(_accountState);
+    if (!_accountState) {
+        qCWarning(lcFileProviderSocketController) << "No account state available to send account details, stopping";
+        return;
+    }
     const auto account = _accountState->account();
     Q_ASSERT(account);
 

--- a/src/gui/macOS/fileprovidersocketcontroller.h
+++ b/src/gui/macOS/fileprovidersocketcontroller.h
@@ -47,14 +47,14 @@ private slots:
     void slotSocketDestroyed(const QObject * const object);
     void slotReadyRead();
 
-    void slotAccountStateChanged(const OCC::AccountState::State state);
+    void slotAccountStateChanged(const OCC::AccountState::State state) const;
 
     void parseReceivedLine(const QString &receivedLine);
     void requestFileProviderDomainInfo() const;
     void sendAccountDetails() const;
     void sendNotAuthenticated() const;
 
-    void reportSyncState(const QString &receivedState);
+    void reportSyncState(const QString &receivedState) const;
 
 private:
     QPointer<QLocalSocket> _socket;


### PR DESCRIPTION
Fixes crash on account removal

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
