### PR TITLE
Fix typos in spanish translations

### DIFF
--- a/translations/client_es_CL.ts
+++ b/translations/client_es_CL.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_CO.ts
+++ b/translations/client_es_CO.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_CR.ts
+++ b/translations/client_es_CR.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_DO.ts
+++ b/translations/client_es_DO.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_EC.ts
+++ b/translations/client_es_EC.ts
@@ -2812,7 +2812,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_GT.ts
+++ b/translations/client_es_GT.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_HN.ts
+++ b/translations/client_es_HN.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_MX.ts
+++ b/translations/client_es_MX.ts
@@ -2818,7 +2818,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>

--- a/translations/client_es_SV.ts
+++ b/translations/client_es_SV.ts
@@ -2800,7 +2800,7 @@ For advanced users: this issue might be related to multiple sync database files 
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
         <source>Ask for confirmation before synchronizing external storages</source>
-        <translation>Perdir confirmaci´pón antes de sincronizar almacenamientos externos</translation>
+        <translation>Perdir confirmación antes de sincronizar almacenamientos externos</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
A translation was wrong in all spanish variants
![image](https://github.com/user-attachments/assets/3e5af596-77bf-4a18-b264-a9113a14e5e3)
