### PR TITLE
gui/macOS: Fix broken file provider domain progress reporting in settings window

### DIFF
--- a/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
+++ b/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
@@ -57,7 +57,11 @@ public:
         }
     }
 
-    ~MacImplementation() = default;
+    ~MacImplementation()
+    {
+        [_downloadProgressObserver release];
+        [_uploadProgressObserver release];
+    }
 
     void updateDownload(NSProgress *const progress) const
     {

--- a/src/gui/macOS/progressobserver.m
+++ b/src/gui/macOS/progressobserver.m
@@ -21,6 +21,7 @@
     self = [super init];
     if (self) {
         _progress = progress;
+        [_progress retain];
         [_progress addObserver:self forKeyPath:@"totalUnitCount" options:NSKeyValueObservingOptionNew context:nil];
         [_progress addObserver:self forKeyPath:@"completedUnitCount" options:NSKeyValueObservingOptionNew context:nil];
         [_progress addObserver:self forKeyPath:@"cancelled" options:NSKeyValueObservingOptionNew context:nil];
@@ -29,6 +30,18 @@
         [_progress addObserver:self forKeyPath:@"fileCompletedCount" options:NSKeyValueObservingOptionNew context:nil];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [_progress removeObserver:self forKeyPath:@"totalUnitCount"];
+    [_progress removeObserver:self forKeyPath:@"completedUnitCount"];
+    [_progress removeObserver:self forKeyPath:@"cancelled"];
+    [_progress removeObserver:self forKeyPath:@"paused"];
+    [_progress removeObserver:self forKeyPath:@"fileTotalCount"];
+    [_progress removeObserver:self forKeyPath:@"fileCompletedCount"];
+    [_progress release];
+    [super dealloc];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath


### PR DESCRIPTION

https://github.com/user-attachments/assets/3e5992f1-1e65-46f4-8f7d-561b2c799157



<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
