### PR TITLE
Fix Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ mkdir <build directory>
 3. Compile:
 ```
 cd <build directory>
-cmake -S <cloned desktop repo> -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=. -DNEXTCLOUD_DEV=ON
+cmake -S <cloned desktop repo> -B build -DCMAKE_PREFIX_PATH=<dependencies> -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=. -DNEXTCLOUD_DEV=ON
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ mkdir <build directory>
 3. Compile:
 ```
 cd <build directory>
-cmake -S <cloned desktop repo> -B build -DCMAKE_INSTALL_PREFIX=<dependencies> -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=. -DNEXTCLOUD_DEV=ON
+cmake -S <cloned desktop repo> -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=. -DNEXTCLOUD_DEV=ON
 ```
 
 > [!TIP]
-> The cmake variabel NEXTCLOUD_DEV allows you to run your own build of the client while developing in parallel with an installed version of the client.
+> The cmake variable NEXTCLOUD_DEV allows you to run your own build of the client while developing in parallel with an installed version of the client.
 
 4. Build it:
 - Windows:


### PR DESCRIPTION
Problem:

Tried to use instructions in README to set up my own environment, but noticed the cmake option -DCMAKE_INSTALL_PREFIX is in here twice. It did not make sense what the <dependencies> folder was supposed to be replaced with, but in terms of running this from the build directory, the second use of the option "." made more sense.

Removed this and it succeeded.
![Screenshot From 2025-03-26 15-42-28](https://github.com/user-attachments/assets/e9e2da97-d778-4317-8340-e67764f080ea)


Solution: 
Remove (invalid) use of cmake option -DCMAKE_INSTALL_PREFIX
Fix small typo :)