### PR TITLE
gui/macOS: Use less technical language in FileProvider settings views

### DIFF
--- a/src/gui/macOS/ui/FileProviderEvictionDialog.qml
+++ b/src/gui/macOS/ui/FileProviderEvictionDialog.qml
@@ -33,7 +33,7 @@ ApplicationWindow {
     LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    title: qsTr("Evict materialised files")
+    title: qsTr("Remove local copies")
     color: palette.base
     flags: Qt.Dialog | Qt.WindowStaysOnTopHint
     width: 640
@@ -49,7 +49,7 @@ ApplicationWindow {
             Layout.margins: Style.standardSpacing
 
             EnforcedPlainTextLabel {
-                text: qsTr("Materialised items")
+                text: qsTr("Local copies")
                 font.bold: true
                 font.pointSize: Style.headerFontPtSize
                 Layout.fillWidth: true

--- a/src/gui/macOS/ui/FileProviderStorageInfo.qml
+++ b/src/gui/macOS/ui/FileProviderStorageInfo.qml
@@ -56,7 +56,7 @@ GridLayout {
         Layout.row: 0
         Layout.column: 2
         Layout.alignment: Layout.AlignRight | Layout.AlignVCenter
-        text: qsTr("Evict local copies …")
+        text: qsTr("Free up space …")
         onPressed: root.evictDialogRequested()
     }
 


### PR DESCRIPTION

<img width="723" alt="Screenshot 2025-03-27 at 13 22 25" src="https://github.com/user-attachments/assets/b8f4cac7-cde3-4294-b987-e670a8d0378a" />
<img width="752" alt="Screenshot 2025-03-27 at 13 23 35" src="https://github.com/user-attachments/assets/1adef97a-d76d-4d96-89b7-fbbf2c346ef7" />


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
