### PR TITLE
fix(gui): remove ignored file notifications from Activity list

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -597,31 +597,6 @@ void ActivityListModel::addErrorToActivityList(const Activity &activity, const E
     }
 }
 
-void ActivityListModel::addIgnoredFileToList(const Activity &newActivity)
-{
-    qCInfo(lcActivity) << "First checking for duplicates then add file to the notification list of ignored files: " << newActivity._file;
-
-    bool duplicate = false;
-    if (_listOfIgnoredFiles.size() == 0) {
-        _notificationIgnoredFiles = newActivity;
-        _notificationIgnoredFiles._subject = tr("Files from the ignore list as well as symbolic links are not synced.");
-        addEntriesToActivityList({_notificationIgnoredFiles});
-        _listOfIgnoredFiles.append(newActivity);
-        return;
-    }
-
-    for (const auto &activity : _listOfIgnoredFiles) {
-        if (activity._file == newActivity._file) {
-            duplicate = true;
-            break;
-        }
-    }
-
-    if (!duplicate) {
-        _notificationIgnoredFiles._message.append(", " + newActivity._file);
-    }
-}
-
 void ActivityListModel::addNotificationToActivityList(const Activity &activity)
 {
     qCDebug(lcActivity) << "Notification successfully added to the notification list: " << activity._subject;

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -131,7 +131,6 @@ public slots:
 
     void addNotificationToActivityList(const OCC::Activity &activity);
     void addErrorToActivityList(const OCC::Activity &activity, const OCC::ActivityListModel::ErrorType type);
-    void addIgnoredFileToList(const OCC::Activity &newActivity);
     void addSyncFileItemToActivityList(const OCC::Activity &activity);
     void removeActivityFromActivityList(int row);
     void removeActivityFromActivityList(const OCC::Activity &activity);

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -869,9 +869,7 @@ void User::processCompletedSyncItem(const Folder *folder, const SyncFileItemPtr 
         activity._subject = item->_errorString;
         activity._id = -static_cast<int>(qHash(activity._subject + activity._message));
 
-        if (item->_status == SyncFileItem::Status::FileIgnored) {
-            _activityModel->addIgnoredFileToList(activity);
-        } else {
+        if (item->_status != SyncFileItem::Status::FileIgnored) {
             // add 'protocol error' to activity list
             if (item->_status == SyncFileItem::Status::FileNameInvalid || item->_status == SyncFileItem::Status::FileNameInvalidOnServer) {
                 ActivityLink buttonActivityLink;

--- a/test/testactivitylistmodel.cpp
+++ b/test/testactivitylistmodel.cpp
@@ -41,7 +41,6 @@ public:
     OCC::Activity testNotificationActivity;
     OCC::Activity testSyncResultErrorActivity;
     OCC::Activity testSyncFileItemActivity;
-    OCC::Activity testFileIgnoredActivity;
 
     static constexpr int searchResultsReplyDelay = 100;
 
@@ -119,7 +118,6 @@ private slots:
         testNotificationActivity = exampleNotificationActivity(accName);
         testSyncResultErrorActivity = exampleSyncResultErrorActivity(accName);
         testSyncFileItemActivity = exampleSyncFileItemActivity(accName, accUrl);
-        testFileIgnoredActivity = exampleFileIgnoredActivity(accName, accUrl);
     };
 
     // Test receiving activity from server
@@ -145,10 +143,6 @@ private slots:
 
     void testAddError() {
         testActivityAdd(&TestingALM::addErrorToActivityList, testSyncResultErrorActivity, OCC::ActivityListModel::ErrorType::SyncError);
-    };
-
-    void testAddIgnoredFile() {
-        testActivityAdd(&TestingALM::addIgnoredFileToList, testFileIgnoredActivity);
     };
 
     // Test removing activity from list
@@ -207,11 +201,8 @@ private slots:
         model->addErrorToActivityList(testSyncResultErrorActivity, OCC::ActivityListModel::ErrorType::SyncError);
         QCOMPARE(model->rowCount(), 52);
 
-        model->addIgnoredFileToList(testFileIgnoredActivity);
-        QCOMPARE(model->rowCount(), 53);
-
         model->addNotificationToActivityList(testNotificationActivity);
-        QCOMPARE(model->rowCount(), 54);
+        QCOMPARE(model->rowCount(), 53);
 
         // Test all rows for things in common
         for (int i = 0; i < model->rowCount(); i++) {

--- a/test/testsortedactivitylistmodel.cpp
+++ b/test/testsortedactivitylistmodel.cpp
@@ -42,7 +42,6 @@ public:
     OCC::Activity testNotificationActivity;
     OCC::Activity testSyncResultErrorActivity;
     OCC::Activity testSyncFileItemActivity;
-    OCC::Activity testFileIgnoredActivity;
 
     QSharedPointer<OCC::SortedActivityListModel> testingSortedALM()
     {
@@ -114,7 +113,6 @@ private slots:
         testNotificationActivity = exampleNotificationActivity(accName);
         testSyncResultErrorActivity = exampleSyncResultErrorActivity(accName);
         testSyncFileItemActivity = exampleSyncFileItemActivity(accName, accUrl);
-        testFileIgnoredActivity = exampleFileIgnoredActivity(accName, accUrl);
     };
 
     void testMatchingRowCounts()
@@ -146,7 +144,6 @@ private slots:
         addActivity(model, &TestingALM::addSyncFileItemToActivityList, testSyncFileItemActivity);
         addActivity(model, &TestingALM::addNotificationToActivityList, testNotificationActivity);
         addActivity(model, &TestingALM::addErrorToActivityList, testSyncResultErrorActivity, OCC::ActivityListModel::ErrorType::SyncError);
-        addActivity(model, &TestingALM::addIgnoredFileToList, testFileIgnoredActivity);
     }
 
     void testSort()
@@ -168,7 +165,6 @@ private slots:
         addActivity(model, &TestingALM::addSyncFileItemToActivityList, testSyncFileItemActivity);
         addActivity(model, &TestingALM::addNotificationToActivityList, testNotificationActivity);
         addActivity(model, &TestingALM::addErrorToActivityList, testSyncResultErrorActivity, OCC::ActivityListModel::ErrorType::SyncError);
-        addActivity(model, &TestingALM::addIgnoredFileToList, testFileIgnoredActivity);
 
         // first let's go through priority activities (interactive ones and those with _fileAction == "security"
         auto i = 0;
@@ -204,15 +200,6 @@ private slots:
 
             QCOMPARE(activity._type, OCC::Activity::SyncFileItemType);
             QCOMPARE(activity._syncFileItemStatus, OCC::SyncFileItem::FatalError);
-        }
-        lasIndex = i;
-
-        // now, let's check if activity is an ignored file
-        for (; i < lasIndex + 1 && i < model->rowCount(); ++i) {
-            const auto index = model->index(i, 0);
-            const auto activity = index.data(OCC::ActivityListModel::ActivityRole).value<OCC::Activity>();
-            QCOMPARE(activity._type, OCC::Activity::SyncFileItemType);
-            QCOMPARE(activity._syncFileItemStatus, OCC::SyncFileItem::FileIgnored);
         }
         lasIndex = i;
 


### PR DESCRIPTION
As discussed internally: these are informative notifications without any need/possibility to act on immediately -- if a file is not synced it will be visible from the shell integration anyway.

An eventual follow-up to this change would be to have a dialogue with an overview of all files that were ignored (including the entry in the ignore list that caused a specific file to be ignored).

Closes #6712 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
