### PR TITLE
fix(PinState): don't trigger sync when file's PinState changed to Unspecified.

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -652,8 +652,11 @@ void Folder::slotWatchedPathChanged(const QStringView &path, const ChangeReason 
         if (record.isValid()
             && !FileSystem::fileChanged(path.toString(), record._fileSize, record._modtime) && _vfs) {
             spurious = true;
-
             if (auto pinState = _vfs->pinState(relativePath.toString())) {
+                qCDebug(lcFolder) << "PinState for" << relativePath << "is" << *pinState;
+                if (*pinState == PinState::Unspecified) {
+                    spurious = false;
+                }
                 if (*pinState == PinState::AlwaysLocal && record.isVirtualFile()) {
                     spurious = false;
                 }


### PR DESCRIPTION
LibreOffice/Microsoft office might touch the files for unknown reasons,
creating a constant sync state (icon) visible in the parent folder.

This fix excludes PinState changes from a new sync if the trigger
might have been an external application.