### PR TITLE
fix crash within FolderStatusModelTest

### DIFF
--- a/test/testfolderstatusmodel.cpp
+++ b/test/testfolderstatusmodel.cpp
@@ -59,16 +59,16 @@ private Q_SLOTS:
         account->setCapabilities(capabilities);
         account->setCredentials(new FakeCredentials{fakeFolder.networkAccessManager()});
         account->setUrl(QUrl(("owncloud://somehost/owncloud")));
-        auto accountState = FakeAccountState(account);
-        QVERIFY(accountState.isConnected());
+        auto accountState = new FakeAccountState(account);
+        QVERIFY(accountState->isConnected());
 
         auto folderDef = folderDefinition(fakeFolder.localPath());
         folderDef.targetPath = "";
-        const auto folder = FolderMan::instance()->addFolder(&accountState, folderDef);
+        const auto folder = FolderMan::instance()->addFolder(accountState, folderDef);
         QVERIFY(folder);
 
         FolderStatusModel test;
-        test.setAccountState(&accountState);
+        test.setAccountState(accountState);
 
         QSKIP("Initial test implementation is known to be broken");
         QAbstractItemModelTester modeltester(&test);


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
