### PR TITLE
Include server path to windows explorer shortcut

### DIFF
--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -2,29 +2,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 name: Windows Build and Test
 on:
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-        - info
-        - warning
-        - debug
-      tags:
-        description: 'Test scenario tags'
-        required: false
-        type: boolean
-      environment:
-        description: 'Environment to run tests against'
-        type: environment
-        required: true
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
     name: Windows Build and Test
-    runs-on: self-hosted
+    runs-on: windows-2022
     env:
       CRAFT_TARGET: windows-msvc2022_64-cl
       COBERTURA_COVERAGE_FILE: ${{ github.workspace }}\cobertura_coverage\coverage.xml
@@ -34,7 +17,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-          clean: false
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
@@ -65,6 +47,7 @@ jobs:
         shell: pwsh
         run: |
           choco install opencppcoverage
+
       - name: Cache Install inkscape
         id: cache-install-inkscape
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -77,6 +60,7 @@ jobs:
         shell: pwsh
         run: |
           choco install inkscape
+
       - name: Setup PATH
         shell: pwsh
         run: |
@@ -98,8 +82,11 @@ jobs:
         run: |
           function runTests() {
               $buildFolder = "${{ github.workspace }}\${{ env.CRAFT_TARGET }}\build\nextcloud-client\work\build"
+
               cd $buildFolder
+
               $binFolder = "$buildFolder\bin"
+
               & ctest --output-on-failure --timeout 300
           }
           

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -2,12 +2,29 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 name: Windows Build and Test
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+        - info
+        - warning
+        - debug
+      tags:
+        description: 'Test scenario tags'
+        required: false
+        type: boolean
+      environment:
+        description: 'Environment to run tests against'
+        type: environment
+        required: true
 jobs:
   build:
     name: Windows Build and Test
-    runs-on: windows-2022
+    runs-on: self-hosted
     env:
       CRAFT_TARGET: windows-msvc2022_64-cl
       COBERTURA_COVERAGE_FILE: ${{ github.workspace }}\cobertura_coverage\coverage.xml
@@ -17,6 +34,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          clean: false
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
@@ -47,7 +65,6 @@ jobs:
         shell: pwsh
         run: |
           choco install opencppcoverage
-
       - name: Cache Install inkscape
         id: cache-install-inkscape
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -60,7 +77,6 @@ jobs:
         shell: pwsh
         run: |
           choco install inkscape
-
       - name: Setup PATH
         shell: pwsh
         run: |
@@ -82,11 +98,8 @@ jobs:
         run: |
           function runTests() {
               $buildFolder = "${{ github.workspace }}\${{ env.CRAFT_TARGET }}\build\nextcloud-client\work\build"
-
               cd $buildFolder
-
               $binFolder = "$buildFolder\bin"
-
               & ctest --output-on-failure --timeout 300
           }
           

--- a/src/gui/navigationpanehelper.cpp
+++ b/src/gui/navigationpanehelper.cpp
@@ -102,7 +102,7 @@ void NavigationPaneHelper::updateCloudStorageRegistry()
                 auto title = folder->shortGuiRemotePathOrAppName();
                 // Write the account name in the sidebar only when using more than one account.
                 if (AccountManager::instance()->accounts().size() > 1) {
-                    title = title % " - " % folder->accountState()->account()->displayName();
+                    title = folder->accountState()->account()->shortcutName();
                 }
                 const auto iconPath = QDir::toNativeSeparators(qApp->applicationFilePath());
                 const auto targetFolderPath = QDir::toNativeSeparators(folder->cleanPath());

--- a/src/gui/navigationpanehelper.cpp
+++ b/src/gui/navigationpanehelper.cpp
@@ -102,7 +102,7 @@ void NavigationPaneHelper::updateCloudStorageRegistry()
                 auto title = folder->shortGuiRemotePathOrAppName();
                 // Write the account name in the sidebar only when using more than one account.
                 if (AccountManager::instance()->accounts().size() > 1) {
-                    title = title % " - " % folder->accountState()->account()->prettyName();
+                    title = title % " - " % folder->accountState()->account()->displayName();
                 }
                 const auto iconPath = QDir::toNativeSeparators(qApp->applicationFilePath());
                 const auto targetFolderPath = QDir::toNativeSeparators(folder->cleanPath());

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,14 +181,14 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    auto url = _url.host();
+    auto url_part = _url.host();
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
-        url.append(QLatin1Char(':'));
-        url.append(QString::number(port));
+        url_part.append(QLatin1Char(':'));
+        url_part.append(QString::number(port));
     }
 
-    auto shortcutName = QStringLiteral("%1 - %2").arg(_url.host(), prettyName());
+    auto shortcutName = QStringLiteral("%1 - %2").arg(url_part, prettyName());
 
 
     return shortcutName;

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,7 +181,7 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    const auto url_part = _url.host();
+    const auto url_part = QString(_url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         url_part.append(QLatin1Char(':'));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,7 +181,7 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    auto url_part = _url.host();
+    const auto url_part = _url.host();
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         url_part.append(QLatin1Char(':'));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,7 +181,7 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    const auto url_part = QString(_url.host());
+    const auto url_part = QStringLiteral(_url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         url_part.append(QLatin1Char(':'));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -179,6 +179,18 @@ QString Account::displayName() const
     return displayName;
 }
 
+QString Account::shortcutName() const
+{
+    auto shortcutName = QStringLiteral("%1 - %2").arg(_url.host(), prettyName());
+    const auto port = url().port();
+    if (port > 0 && port != 80 && port != 443) {
+        shortcutName.append(QLatin1Char(':'));
+        shortcutName.append(QString::number(port));
+    }
+
+    return shortcutName;
+}
+
 QString Account::userIdAtHostWithPort() const
 {
     QString dn = QStringLiteral("%1@%2").arg(_davUser, _url.host());

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,7 +181,7 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    auto url_part = QStringLiteral(_url.host());
+    auto url_part = _url.host();
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         url_part.append(QLatin1Char(':'));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,7 +181,7 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    const auto url_part = QStringLiteral(_url.host());
+    auto url_part = QStringLiteral(_url.host());
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
         url_part.append(QLatin1Char(':'));

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -181,12 +181,15 @@ QString Account::displayName() const
 
 QString Account::shortcutName() const
 {
-    auto shortcutName = QStringLiteral("%1 - %2").arg(_url.host(), prettyName());
+    auto url = _url.host();
     const auto port = url().port();
     if (port > 0 && port != 80 && port != 443) {
-        shortcutName.append(QLatin1Char(':'));
-        shortcutName.append(QString::number(port));
+        url.append(QLatin1Char(':'));
+        url.append(QString::number(port));
     }
+
+    auto shortcutName = QStringLiteral("%1 - %2").arg(_url.host(), prettyName());
+
 
     return shortcutName;
 }

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -150,6 +150,9 @@ public:
     /// The name of the account as shown in the toolbar
     [[nodiscard]] QString displayName() const;
 
+    /// The name of the account as shown in the windows shortcut explorer
+    [[nodiscard]] QString shortcutName() const;
+
     /// User id in a form 'user@example.de, optionally port is added (if it is not 80 or 443)
     [[nodiscard]] QString userIdAtHostWithPort() const;
 


### PR DESCRIPTION
Hi,

as mentioned in [#7049 ](https://github.com/nextcloud/desktop/issues/7049), it is not possible to distinguish multiple shortcuts to Nextcloud folders in Windows Explorer when using the same name in the accounts.

I suggest reverting it to the old behavior.

Greetings
Jens