### PR TITLE
disable use of bulk upload for small files

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1091,29 +1091,9 @@ Result<Vfs::ConvertToPlaceholderResult, QString> OwncloudPropagator::staticUpdat
 
 bool OwncloudPropagator::isDelayedUploadItem(const SyncFileItemPtr &item) const
 {
-    const auto checkFileShouldBeEncrypted = [this] (const SyncFileItemPtr &item) -> bool {
-        const auto path = item->_file;
-        const auto slashPosition = path.lastIndexOf('/');
-        const auto parentPath = slashPosition >= 0 ? path.left(slashPosition) : QString();
+    Q_UNUSED(item)
 
-        SyncJournalFileRecord parentRec;
-        bool ok = _journal->getFileRecord(parentPath, &parentRec);
-        if (!ok) {
-            return false;
-        }
-
-        const auto accountPtr = account();
-
-        if (!parentRec.isValid() ||
-            !parentRec.isE2eEncrypted()) {
-            return false;
-        }
-
-        return true;
-    };
-
-    return account()->capabilities().bulkUpload() && !_scheduleDelayedTasks && !item->isEncrypted() && _syncOptions.minChunkSize() > item->_size
-        && !isInBulkUploadBlackList(item->_file) && !checkFileShouldBeEncrypted(item);
+    return false;
 }
 
 void OwncloudPropagator::setScheduleDelayedTasks(bool active)

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -150,6 +150,8 @@ private slots:
     }
 
     void testDirUploadWithDelayedAlgorithm() {
+        QSKIP("bulk upload is disabled");
+
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ {"bulkupload", "1.0"} } } });
 
@@ -181,6 +183,8 @@ private slots:
     }
 
     void testDirUploadWithDelayedAlgorithmWithNewChecksum() {
+        QSKIP("bulk upload is disabled");
+
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         fakeFolder.setServerVersion(QStringLiteral("32.0.0"));
         fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ {"bulkupload", "1.0"} } } });
@@ -1009,6 +1013,8 @@ private slots:
      */
     void testErrorsWithBulkUpload()
     {
+        QSKIP("bulk upload is disabled");
+
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
         fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ {"bulkupload", "1.0"} } } });
 
@@ -1104,6 +1110,8 @@ private slots:
      */
     void testNetworkErrorsWithBulkUpload()
     {
+        QSKIP("bulk upload is disabled");
+
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
         fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ {"bulkupload", "1.0"} } } });
 
@@ -1152,6 +1160,8 @@ private slots:
 
     void testNetworkErrorsWithSmallerBatchSizes()
     {
+        QSKIP("bulk upload is disabled");
+
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
         fakeFolder.syncEngine().account()->setCapabilities({ { "dav", QVariantMap{ {"bulkupload", "1.0"} } } });
 
@@ -1477,6 +1487,8 @@ private slots:
 
     void testLocalInvalidMtimeCorrectionBulkUpload()
     {
+        QSKIP("bulk upload is disabled");
+
         const auto INVALID_MTIME = QDateTime::fromSecsSinceEpoch(0);
         const auto RECENT_MTIME = QDateTime::fromSecsSinceEpoch(1743004783); // 2025-03-26T16:59:43+0100
 


### PR DESCRIPTION
With the upcoming release of the desktop client (version 3.16.3), the **bulk upload feature will be temporarily disabled**.

We understand that some of you may rely on this feature, and this decision wasn't made lightly. However, we've encountered ongoing technical issues involving the interaction between the client, server, and underlying systems—including network stack and Qt dependencies—that impact the stability of the feature.

In prioritizing a smoother and more reliable experience for all users, we believe it's best to disable bulk upload for now. The overall benefit of the feature does not currently outweigh the potential for disruption.

If you're unable to update to version 3.16.3 right away, we recommend manually disabling the feature on the server side to avoid any issues:
🔧 [How to disable bulk upload on the server →](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#bulkupload-enabled)

We appreciate your understanding and are continuing to work on improving the experience.