### PR TITLE
Improve configuration-related e2ee wording

### DIFF
--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -116,14 +116,14 @@ private slots:
 
 private slots:
     void displayMnemonic(const QString &mnemonic);
-    void disableEncryptionForAccount(const OCC::AccountPtr &account) const;
+    void forgetEncryptionOnDeviceForAccount(const OCC::AccountPtr &account) const;
     void migrateCertificateForAccount(const OCC::AccountPtr &account);
     void showConnectionLabel(const QString &message, QStringList errors = QStringList());
     void openIgnoredFilesDialog(const QString & absFolderPath);
     void customizeStyle();
 
-    void initializeE2eEncryption();
-    void resetE2eEncryption();
+    void setupE2eEncryption();
+    void forgetE2eEncryption();
     void checkClientSideEncryptionState();
     void removeActionFromEncryptionMessage(const QString &actionId);
 
@@ -131,7 +131,7 @@ private:
     bool event(QEvent *) override;
     QAction *addActionToEncryptionMessage(const QString &actionTitle, const QString &actionId);
 
-    void initializeE2eEncryptionSettingsMessage();
+    void setupE2eEncryptionMessage();
 
     /// Returns the alias of the selected folder, empty string if none
     [[nodiscard]] QString selectedFolderAlias() const;


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

I am a new user to Nextcloud. I would consider myself a power-user,  but I got totally thrown under a bus by the e2e configuration AND the misleading wording in the UI. Specifically, the UI uses the "enabled", "supported", "activated", "set up", "start", "reset", etc. in an inconsequential, often interchangable way. It's all over the place and makes it really hard to understand what is going on in the UI, as well as in the code itself.

I also noticed the iOS client mixes the verbiage even more, by also using "activated" and "start":
```
"_e2e_settings_"                    = "End-to-end encryption";
"_e2e_settings_start_"              = "Start end-to-end encryption";
"_e2e_settings_activated_"          = "End-to-end encryption activated";
"_e2e_server_disabled_"             = "End-to-end encryption app disabled on server";
```
I will file a separate PR for this once this one gets cleared for merging.

Moreover, even the code itself confuses the "enabled for account"  with "set up for the device" :

```
void AccountSettings::disableEncryptionForAccount(const AccountPtr &account) const
{
    QMessageBox dialog;
    dialog.setWindowTitle(tr("Disable end-to-end encryption"));
    dialog.setText(tr("Disable end-to-end encryption for %1?").arg(account->davUser()));
    dialog.setInformativeText(tr("Removing end-to-end encryption will remove locally-synced files that are encrypted."
                                 "<br>"
                                 "Encrypted files will remain on the server."));
```
`disableEncryptionForAccount` calls `AccountSettings::resetE2eEncryption()`, which effectively makes the device "forget" the e2ee configuration and the mnemonic, but *does not* change anything on the account itself. In particular, it does not reset the encryption on the account itself, which is a destructive and irreversible action, availble in the web UI:

<img width="868" alt="Screenshot 2025-04-15 at 3 16 17 PM" src="https://github.com/user-attachments/assets/7759c51e-56e7-410d-9155-6273daf714f9" />

As such, this PR establishes that:
- "enabled" should not be used, as it's too broad and generic, and could be applied to too many of contexts.
- "supported" means e2ee is available for the account but haven't been yet set-up (mnemonic wasn't generated). Pertains to account.
- "initialized" means the encryption certificates and a mnemonic have been issued for the account after setting up on a device (a.k.a "client side encryption is available on server"). Pertains to account.
- "set up" means the device knows the mnemonic and synchronizes the encrypted folders. Pertains to device.
  - "forget" is the action opposite to "set up". I was struggling with finding a best word for this. "Reset" is taken and implies more destructive of an action. "Remove" might be mixed up with removing/deleting data. Meanwhile "forget" seems less serious and was also used in places for the related code already.
- "reset" is a destructive action on the account itself, as described by the web UI. Pertains to the account. Not used in the client.

Last, but not least, for the e2e to actually be enabled , a user needs to explicitly enable encryption on *each* subfolder in the synchronized root folder. This goes against all other common/popular software that supports e2e encryption, where you simply assume everything gets encrypted by default. As such, I am confident that the UI should lend itself to the user to help them understand that they need to take an *additional*, explicit action for their files to actually get encrypted, which is why after properly setting up the encryption, the message box in the Settings now reads `Remember to **Encrypt** a folder to end-to-end encrypt any new files added to it.`


