### PR TITLE
use specific revision for KDE blueprints that matches the craft cache

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -35,6 +35,7 @@ Packager/CacheDir = ${Variables:Root}\cache
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
 libs/qt6.version = 6.8.2
+craft/craft-blueprints-kde.revision = 8949a63ae62e88983839d0b5fb008e9990e97135
 
 [windows-msvc2022_64-cl]
 Packager/PackageType = NullsoftInstallerPackager


### PR DESCRIPTION


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
