### PR TITLE
fix(gui): handle invalid file name edge case on Windows

### DIFF
--- a/src/gui/folder.h
+++ b/src/gui/folder.h
@@ -165,6 +165,14 @@ public:
      */
     [[nodiscard]] QString remotePathTrailingSlash() const;
 
+    /**
+     * Returns the path name of a file in the local canonical path.
+     *
+     * Similar to `QDir(path()).filePath(...)`, except file names like "Z:test"
+     * are treated as relative paths on Windows.
+     */
+    [[nodiscard]] QString filePath(const QString& fileName);
+
     [[nodiscard]] QString fulllRemotePathToPathInSyncJournalDb(const QString &fullRemotePath) const;
 
     void setNavigationPaneClsid(const QUuid &clsid) { _definition.navigationPaneClsid = clsid; }

--- a/src/gui/invalidfilenamedialog.cpp
+++ b/src/gui/invalidfilenamedialog.cpp
@@ -140,7 +140,6 @@ InvalidFilenameDialog::InvalidFilenameDialog(AccountPtr account,
 
     if (_fileLocation == FileLocation::NewLocalFile) {
         allowRenaming();
-        _ui->errorLabel->setText({});
     } else {
         checkIfAllowedToRename();
     }
@@ -223,6 +222,7 @@ void InvalidFilenameDialog::allowRenaming()
     _ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
     _ui->filenameLineEdit->setEnabled(true);
     _ui->filenameLineEdit->selectAll();
+    _ui->errorLabel->setText({});
 
     const auto filePathFileInfo = QFileInfo(_filePath);
     const auto fileName = filePathFileInfo.fileName();

--- a/src/gui/invalidfilenamedialog.cpp
+++ b/src/gui/invalidfilenamedialog.cpp
@@ -83,7 +83,9 @@ InvalidFilenameDialog::InvalidFilenameDialog(AccountPtr account,
     const auto filePathFileInfo = QFileInfo(_filePath);
     _relativeFilePath = filePathFileInfo.path() + QStringLiteral("/");
     _relativeFilePath = _relativeFilePath.replace(folder->path(), QStringLiteral(""));
-    _relativeFilePath = _relativeFilePath.isEmpty() ? QStringLiteral("") : _relativeFilePath + QStringLiteral("/");
+    if (!(_relativeFilePath.isEmpty() || _relativeFilePath.endsWith(QStringLiteral("/")))) {
+        _relativeFilePath += QStringLiteral("/");
+    }
 
     _originalFileName = _relativeFilePath + filePathFileInfo.fileName();
 

--- a/src/gui/invalidfilenamedialog.cpp
+++ b/src/gui/invalidfilenamedialog.cpp
@@ -97,7 +97,7 @@ InvalidFilenameDialog::InvalidFilenameDialog(AccountPtr account,
     switch (invalidMode) {
     case InvalidMode::SystemInvalid:
         _ui->descriptionLabel->setText(tr("The file \"%1\" could not be synced because the name contains characters which are not allowed on this system.").arg(_originalFileName));
-        _ui->explanationLabel->setText(tr("The following characters are not allowed on the system: * \" | & ? , ; : \\ / ~ < > leading/trailing spaces"));
+        _ui->explanationLabel->setText(tr("The following characters are not allowed on the system: \\ / : ? * \"  < > | leading/trailing spaces"));
         break;
     case InvalidMode::ServerInvalid:
         _ui->descriptionLabel->setText(tr("The file \"%1\" could not be synced because the name contains characters which are not allowed on the server.").arg(_originalFileName));

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -694,8 +694,21 @@ void ActivityListModel::slotTriggerDefaultAction(const int activityIndex)
             ? InvalidFilenameDialog::InvalidMode::ServerInvalid
             : InvalidFilenameDialog::InvalidMode::SystemInvalid;
 
+#ifdef Q_OS_WIN
+        // Edge case time!
+        // QDir::filePath checks whether the passed `fileName` is absolute (essentialy by using `!QFileInfo::isRelative()`).
+        // On Windows, if `fileName` starts with a letter followed by a colon (e.g. "A:BCDEF"), it is considered to be an
+        // absolute path.
+        // Since the complete desired path is required by InvalidFilenameDialog, catch that special case here and prefix it ourselves...
+        const auto filePath = activity._file.length() >= 2 && activity._file[1] == ':'
+                              ? folder->path() + activity._file
+                              : folderDir.filePath(activity._file);
+#else
+        const auto filePath = folderDir.filePath(activity._file);
+#endif
+
         _currentInvalidFilenameDialog = new InvalidFilenameDialog(_accountState->account(), folder,
-            folderDir.filePath(activity._file), fileLocation, invalidMode);
+            filePath, fileLocation, invalidMode);
         connect(_currentInvalidFilenameDialog, &InvalidFilenameDialog::accepted, folder, [folder]() {
             folder->scheduleThisFolderSoon();
         });


### PR DESCRIPTION
File names like `"c:blah"` would break the usage of the dialogue, displaying a path like `"c://blah"` instead; whereas file names like `"test:this"` would work.

Apparently `QDir::filePath` checks if the passed file name is an absolute file name using `!QFileInfo::isRelative`, which is the case if the second character in the string is a colon -- probably indicating a drive letter.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
