### PR TITLE
revert to QFile::remove to remove single files

### DIFF
--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -26,7 +26,6 @@
 #include <QFile>
 #include <QCoreApplication>
 
-#include <filesystem>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -541,34 +540,14 @@ bool FileSystem::remove(const QString &fileName, QString *errorString)
     // allow that.
     setFileReadOnly(fileName, false);
 #endif
-
-    try {
-        if (!std::filesystem::remove(std::filesystem::path{fileName.toStdWString()})) {
-            if (errorString) {
-                *errorString = QObject::tr("File is already deleted");
-            }
-            qCWarning(lcFileSystem()) << "File is already deleted" << fileName;
-            return false;
-        }
-        qCInfo(lcFileSystem()) << "delete" << fileName;
-    }
-    catch (const std::filesystem::filesystem_error &e)
-    {
+    QFile f(fileName);
+    if (!f.remove()) {
         if (errorString) {
-            *errorString = QString::fromLatin1(e.what());
+            *errorString = f.errorString();
         }
-        qCWarning(lcFileSystem()) << e.what() << fileName;
+        qCWarning(lcFileSystem()) << f.errorString() << fileName;
         return false;
     }
-    catch (...)
-    {
-        if (errorString) {
-            *errorString = QObject::tr("Error deleting the file");
-        }
-        qCWarning(lcFileSystem()) << "Error deleting the file" << fileName;
-        return false;
-    }
-
     return true;
 }
 

--- a/src/common/filesystembase.cpp
+++ b/src/common/filesystembase.cpp
@@ -540,6 +540,11 @@ bool FileSystem::remove(const QString &fileName, QString *errorString)
     // allow that.
     setFileReadOnly(fileName, false);
 #endif
+    const auto deletedFileInfo = QFileInfo{fileName};
+    if (!deletedFileInfo.exists()) {
+        qCWarning(lcFileSystem()) << fileName << "has been already deleted";
+    }
+
     QFile f(fileName);
     if (!f.remove()) {
         if (errorString) {


### PR DESCRIPTION
revert to QFile::remove to remove a single file

still use std::filesystem::remove to remove a single empty folder
QDir::rmdir does not provide any error message when failing to delete a folder