### PR TITLE
fix(gui): resize sharee search results list dependent on required space

### DIFF
--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -152,7 +152,6 @@ TextField {
         id: suggestionsPopup
 
         width: root.width
-        height: 100
         y: root.height
 
         contentItem: ScrollView {
@@ -160,6 +159,11 @@ TextField {
 
             clip: true
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+            ScrollBar.vertical.policy: shareeListView.contentHeight > shareeListView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
+
+            // need to take the popup's padding in account for the max height
+            // remove bottomPadding twice to leave some space between the window border
+            implicitHeight: Math.min(Window.height - parent.y - parent.topPadding - parent.bottomPadding * 2, contentHeight)
 
             ListView {
                 id: shareeListView


### PR DESCRIPTION
Some QtQuick themes don't make it obvious that the search results list is scrollable, leading to a confusing user experience.

With this PR the results list expands to the available space in the window.  In the case the results do not fit the window, a scroll bar will be present as well now.

<table>
<thead>
<tr>
<th>Theme</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<th rowspan="2">Universal</th>
<td>

![before_Universal_few_results](https://github.com/user-attachments/assets/b3661b3f-425f-4de1-9772-b35e7cfa33da)

</td>
<td>

![after_Universal_few_results](https://github.com/user-attachments/assets/9122178e-2d05-440d-a253-e88ba6654e66)

</td>
</tr>
<tr>
<td>

![before_Universal_many_results](https://github.com/user-attachments/assets/c8b27251-3576-4ef8-8f55-25b0b9f4cf1a)

</td>
<td>

![after_Universal_many_results](https://github.com/user-attachments/assets/df94830f-b7ff-4d83-be34-ed65d966392d)

</td>
</tr>
<tr>
<th rowspan="2">FluentWinUI3</th>
<td>

![before_FluentWinUI3_few_results](https://github.com/user-attachments/assets/a7339a83-f025-4566-a388-c10ba59ac882)

</td>
<td>

![after_FluentWinUI3_few_results](https://github.com/user-attachments/assets/cb34dd97-2c39-48d6-bef3-1d2b43734192)

</td>
</tr>
<tr>
<td>

![before_FluentWinUI3_many_results](https://github.com/user-attachments/assets/7ed45887-31ed-4066-91a6-4721158a1443)

</td>
<td>

![after_FluentWinUI3_many_results](https://github.com/user-attachments/assets/231617fa-2f1c-487a-adcc-48fe717247d1)

</td>
</tr>
</tbody>
</table>