### PR TITLE
fix(appimage): move VFS plugins to AppDir

### DIFF
--- a/admin/linux/build-appimage.sh
+++ b/admin/linux/build-appimage.sh
@@ -49,9 +49,9 @@ cd /app
 
 [ -d usr/lib/x86_64-linux-gnu ] && mv usr/lib/x86_64-linux-gnu/* usr/lib/
 
-mkdir usr/plugins
-mv usr/lib64/*sync_vfs_suffix.so usr/plugins || mv usr/lib/*sync_vfs_suffix.so usr/plugins
-mv usr/lib64/*sync_vfs_xattr.so usr/plugins  || mv usr/lib/*sync_vfs_xattr.so usr/plugins
+mkdir -p AppDir/usr/plugins
+mv usr/lib64/*sync_vfs_suffix.so AppDir/usr/plugins || mv usr/lib/*sync_vfs_suffix.so AppDir/usr/plugins
+mv usr/lib64/*sync_vfs_xattr.so  AppDir/usr/plugins || mv usr/lib/*sync_vfs_xattr.so  AppDir/usr/plugins
 
 rm -rf usr/lib/cmake
 rm -rf usr/include


### PR DESCRIPTION
This allows the AppImage build to find and load the experimental VFS plugins, and not crash with:

    [ critical plugins /home/user/src/common/vfs.cpp:250 ]: Could not load plugin: not existent or bad metadata "nextclouddevsync_vfs_suffix"
    [ fatal default /home/user/src/gui/folderman.cpp:326 ]: Could not load plugin
    [1]    72936 IOT instruction (core dumped)  ./nextclouddev-master-x86_64.AppImage

Fixes #7135
Fixes #7194
Fixes #7465

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
