### PR TITLE
fix(macOS): Fix prompting of user for permission to access "other" apps' data

### DIFF
--- a/admin/osx/CMakeLists.txt
+++ b/admin/osx/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} COMPONENTS Core REQUIRED)
 configure_file(create_mac.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/create_mac.sh)
+configure_file(macosx.entitlements.cmake ${CMAKE_CURRENT_BINARY_DIR}/macosx.entitlements)
 configure_file(macosx.pkgproj.cmake ${CMAKE_CURRENT_BINARY_DIR}/macosx.pkgproj)
 configure_file(pre_install.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/pre_install.sh)
 configure_file(post_install.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/post_install.sh)

--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -90,7 +90,9 @@ func saveCodesignEntitlements(target: String, path: String) throws {
 }
 
 func codesignClientAppBundle(
-    at clientAppDir: String, withCodeSignIdentity codeSignIdentity: String
+    at clientAppDir: String,
+    withCodeSignIdentity codeSignIdentity: String,
+    usingEntitlements entitlementsPath: String? = nil
 ) throws {
     print("Code-signing Nextcloud Desktop Client libraries, frameworks and plugins...")
 
@@ -180,5 +182,13 @@ func codesignClientAppBundle(
     let mainExecutableName = String(appName.dropLast(".app".count))
     let mainExecutablePath = "\(binariesDir)/\(mainExecutableName)"
     try recursivelyCodesign(path: binariesDir, identity: codeSignIdentity, skip: [mainExecutablePath])
-    try codesign(identity: codeSignIdentity, path: mainExecutablePath)
+
+    var mainExecutableCodesignOptions = defaultCodesignOptions
+    if let entitlementsPath {
+        mainExecutableCodesignOptions =
+            "--timestamp --force --verbose=4 --options runtime --entitlements \"\(entitlementsPath)\""
+    }
+    try codesign(
+        identity: codeSignIdentity, path: mainExecutablePath, options: mainExecutableCodesignOptions
+    )
 }

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -277,11 +277,19 @@ struct Codesign: ParsableCommand {
     @Option(name: [.short, .long], help: "Code signing identity for desktop client and libs.")
     var codeSignIdentity: String
 
+    @Option(name: [.short, .long], help: "Entitlements to apply to the app bundle.")
+    var entitlementsPath: String?
+
     mutating func run() throws {
         let absolutePath = appBundlePath.hasPrefix("/")
             ? appBundlePath
             : "\(FileManager.default.currentDirectoryPath)/\(appBundlePath)"
-        try codesignClientAppBundle(at: absolutePath, withCodeSignIdentity: codeSignIdentity)
+
+        try codesignClientAppBundle(
+            at: absolutePath,
+            withCodeSignIdentity: codeSignIdentity,
+            usingEntitlements: entitlementsPath
+        )
     }
 }
 

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -235,7 +235,12 @@ struct Build: ParsableCommand {
         let clientAppDir = "\(clientBuildDir)/image-\(buildType)-master/\(appName).app"
         if let codeSignIdentity {
             print("Code-signing Nextcloud Desktop Client libraries and frameworks...")
-            try codesignClientAppBundle(at: clientAppDir, withCodeSignIdentity: codeSignIdentity)
+            let entitlementsPath = "\(clientBuildDir)/work/build/admin/osx/macosx.entitlements"
+            try codesignClientAppBundle(
+                at: clientAppDir,
+                withCodeSignIdentity: codeSignIdentity,
+                usingEntitlements: entitlementsPath
+            )
         }
 
         print("Placing Nextcloud Desktop Client in \(productPath)...")

--- a/admin/osx/macosx.entitlements.cmake
+++ b/admin/osx/macosx.entitlements.cmake
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>@SOCKETAPI_TEAM_IDENTIFIER_PREFIX@@APPLICATION_REV_DOMAIN@</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
![access-other-apps-data](https://github.com/user-attachments/assets/4cd3455e-8a33-4db4-83e6-8a63bde0ac2f)

We currently do not code-sign the macOS version of the client with any entitlements. This means the system believes we are accessing another application's group container when creating or accessing the sockets we create for Finder and FileProvider integration within the group container, as we do not provide any entitlements — and by extension, the expected app group entitlement corresponding our group container.

This PR addresses this by generating a valid entitlements file which we apply during codesigning steps in mac-crafter