### PR TITLE
fix(shell_integration/macOS/FileProviderUIExt): Properly mark action as complete when evicting item

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/DocumentActionViewController.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/DocumentActionViewController.swift
@@ -46,7 +46,7 @@ class DocumentActionViewController: FPUIActionExtensionViewController {
             prepare(childViewController: LockViewController(itemIdentifiers, locking: false))
         case "com.nextcloud.desktopclient.FileProviderUIExt.EvictAction":
             evict(itemsWithIdentifiers: itemIdentifiers, inDomain: domain);
-            dismiss(self);
+            extensionContext.completeRequest();
         default:
             return
         }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
