### PR TITLE
fix(gui/macOS): Fix default value for File Provider fast sync enablement setting

### DIFF
--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -207,8 +207,8 @@ std::optional<std::pair<bool, bool>> FileProviderXPC::fastEnumerationStateForExt
         return std::nullopt;
     }
 
-    __block BOOL receivedFastEnumerationEnabled; // What is the value of the setting being used by the extension?
-    __block BOOL receivedFastEnumerationSet; // Has the setting been set by the user?
+    __block BOOL receivedFastEnumerationEnabled = YES; // What is the value of the setting being used by the extension?
+    __block BOOL receivedFastEnumerationSet = NO; // Has the setting been set by the user?
     __block BOOL receivedResponse = NO;
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     [service getFastEnumerationStateWithCompletionHandler:^(BOOL enabled, BOOL set) {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
