### PR TITLE
feat(shell_integration/macOS/FileProviderExt): Add option to disable deletion of items in Trash

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderConfig.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderConfig.swift
@@ -12,6 +12,7 @@ import Foundation
 struct FileProviderConfig {
     private enum ConfigKey: String {
         case fastEnumerationEnabled = "fastEnumerationEnabled"
+        case trashDeletionEnabled = "trashDeletionEnabled"
     }
 
     let domainIdentifier: NSFileProviderDomainIdentifier
@@ -30,6 +31,11 @@ struct FileProviderConfig {
             let defaults = UserDefaults.standard
             defaults.setValue(newValue, forKey: domainIdentifier.rawValue)
         }
+    }
+
+    var trashDeletionEnabled: Bool {
+        get { internalConfig[ConfigKey.trashDeletionEnabled.rawValue] as? Bool ?? true }
+        set { internalConfig[ConfigKey.trashDeletionEnabled.rawValue] = newValue }
     }
 
     var fastEnumerationEnabled: Bool {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderConfig.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderConfig.swift
@@ -38,6 +38,8 @@ struct FileProviderConfig {
         set { internalConfig[ConfigKey.trashDeletionEnabled.rawValue] = newValue }
     }
 
+    lazy var trashDeletionSet = internalConfig[ConfigKey.trashDeletionEnabled.rawValue] != nil
+
     var fastEnumerationEnabled: Bool {
         get { internalConfig[ConfigKey.fastEnumerationEnabled.rawValue] as? Bool ?? true }
         set { internalConfig[ConfigKey.fastEnumerationEnabled.rawValue] = newValue }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -426,7 +426,7 @@ import OSLog
             Logger.fileProviderExtension.warning(
                 """
                 System requested deletion of item in trash, but deleting trash items is disabled.
-                    item: \(item.filename)
+                    item: \(item.filename, privacy: .public)
                 """
             )
             completionHandler(NSFileProviderError(.deletionRejected))

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -422,6 +422,17 @@ import OSLog
         }
 
         let progress = Progress(totalUnitCount: 1)
+        guard config.trashDeletionEnabled || item.parentItemIdentifier != .trashContainer else {
+            Logger.fileProviderExtension.warning(
+                """
+                System requested deletion of item in trash, but deleting trash items is disabled.
+                    item: \(item.filename)
+                """
+            )
+            completionHandler(NSFileProviderError(.deletionRejected))
+            return progress
+        }
+
         Task {
             let error = await item.delete(dbManager: dbManager)
             if error != nil {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -429,7 +429,7 @@ import OSLog
                     item: \(item.filename, privacy: .public)
                 """
             )
-            completionHandler(NSFileProviderError(.deletionRejected))
+            completionHandler(NSError.fileProviderErrorForRejectedDeletion(of: item))
             return progress
         }
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -20,6 +20,8 @@
 - (void)createDebugLogStringWithCompletionHandler:(void(^)(NSString *debugLogString, NSError *error))completionHandler;
 - (void)getFastEnumerationStateWithCompletionHandler:(void(^)(BOOL enabled, BOOL set))completionHandler;
 - (void)setFastEnumerationEnabled:(BOOL)enabled;
+- (void)getTrashDeletionEnabledStateWithCompletionHandler:(void(^)(BOOL enabled, BOOL set))completionHandler;
+- (void)setTrashDeletionEnabled:(BOOL)enabled;
 
 @end
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
@@ -101,4 +101,17 @@ class ClientCommunicationService: NSObject, NSFileProviderServiceSource, NSXPCLi
             }
         }
     }
+
+    func getTrashDeletionEnabledState(completionHandler: @escaping (Bool, Bool) -> Void) {
+        let enabled = fpExtension.config.trashDeletionEnabled
+        let set = fpExtension.config.trashDeletionSet
+        completionHandler(enabled, set)
+    }
+
+    func setTrashDeletionEnabled(_ enabled: Bool) {
+        fpExtension.config.trashDeletionEnabled = enabled
+        Logger.fileProviderExtension.info(
+            "Trash deletion setting changed to: \(enabled, privacy: .public)"
+        )
+    }
 }

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -37,6 +37,8 @@ public:
     [[nodiscard]] Q_INVOKABLE float remoteStorageUsageGbForAccount(const QString &userIdAtHost) const;
     [[nodiscard]] Q_INVOKABLE bool fastEnumerationEnabledForAccount(const QString &userIdAtHost) const;
     [[nodiscard]] Q_INVOKABLE bool fastEnumerationSetForAccount(const QString &userIdAtHost) const;
+    [[nodiscard]] Q_INVOKABLE bool trashDeletionEnabledForAccount(const QString &userIdAtHost) const;
+    [[nodiscard]] Q_INVOKABLE bool trashDeletionSetForAccount(const QString &userIdAtHost) const;
 
     [[nodiscard]] Q_INVOKABLE QAbstractListModel *materialisedItemsModelForAccount(const QString &userIdAtHost);
     [[nodiscard]] Q_INVOKABLE FileProviderDomainSyncStatus *domainSyncStatusForAccount(const QString &userIdAtHost) const;
@@ -44,6 +46,7 @@ public:
 public slots:
     void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
     void setFastEnumerationEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
+    void setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
 
     void createEvictionWindowForAccount(const QString &userIdAtHost);
     void refreshMaterialisedItemsForAccount(const QString &userIdAtHost);
@@ -57,6 +60,8 @@ signals:
     void materialisedItemsForAccountChanged(const QString &userIdAtHost);
     void fastEnumerationEnabledForAccountChanged(const QString &userIdAtHost);
     void fastEnumerationSetForAccountChanged(const QString &userIdAtHost);
+    void trashDeletionEnabledForAccountChanged(const QString &userIdAtHost);
+    void trashDeletionSetForAccountChanged(const QString &userIdAtHost);
 
 private:
     explicit FileProviderSettingsController(QObject *parent = nullptr);

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -412,6 +412,44 @@ void FileProviderSettingsController::setFastEnumerationEnabledForAccount(const Q
     emit fastEnumerationSetForAccountChanged(userIdAtHost);
 }
 
+bool FileProviderSettingsController::trashDeletionEnabledForAccount(const QString &userIdAtHost) const
+{
+    const auto xpc = FileProvider::instance()->xpc();
+    if (!xpc) {
+        return true;
+    }
+    if (const auto trashDeletionState = xpc->trashDeletionEnabledStateForExtension(userIdAtHost)) {
+        return trashDeletionState->first;
+    }
+    return true;
+}
+
+bool FileProviderSettingsController::trashDeletionSetForAccount(const QString &userIdAtHost) const
+{
+    const auto xpc = FileProvider::instance()->xpc();
+    if (!xpc) {
+        return false;
+    }
+    if (const auto state = xpc->trashDeletionEnabledStateForExtension(userIdAtHost)) {
+        return state->second;
+    }
+    return false;
+}
+
+void FileProviderSettingsController::setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled)
+{
+    const auto xpc = FileProvider::instance()->xpc();
+    if (!xpc) {
+        // Reset state of UI elements
+        emit trashDeletionEnabledForAccountChanged(userIdAtHost);
+        emit trashDeletionSetForAccountChanged(userIdAtHost);
+        return;
+    }
+    xpc->setTrashDeletionEnabledForExtension(userIdAtHost, setEnabled);
+    emit trashDeletionEnabledForAccountChanged(userIdAtHost);
+    emit trashDeletionSetForAccountChanged(userIdAtHost);
+}
+
 unsigned long long FileProviderSettingsController::localStorageUsageForAccount(const QString &userIdAtHost) const
 {
     return d->localStorageUsageForAccount(userIdAtHost);

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -31,6 +31,8 @@ public:
     // Returns enabled and set state of fast enumeration for the given extension
     [[nodiscard]] std::optional<std::pair<bool, bool>> fastEnumerationStateForExtension(const QString &extensionAccountId) const;
 
+    [[nodiscard]] std::optional<std::pair<bool, bool>> trashDeletionEnabledStateForExtension(const QString &extensionAccountId) const;
+
 public slots:
     void connectToExtensions();
     void configureExtensions();
@@ -39,6 +41,7 @@ public slots:
     void createDebugArchiveForExtension(const QString &extensionAccountId, const QString &filename);
 
     void setFastEnumerationEnabledForExtension(const QString &extensionAccountId, bool enabled) const;
+    void setTrashDeletionEnabledForExtension(const QString &extensionAccountId, bool enabled) const;
 
 private slots:
     void slotAccountStateChanged(AccountState::State state) const;

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -131,6 +131,12 @@ Page {
                         }
                     }
                 }
+
+                CheckBox {
+                    text: qsTr("Allow deletion of items in Trash")
+                    checked: root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost)
+                    onClicked: root.controller.setTrashDeletionEnabledForAccount(root.accountUserIdAtHost, checked)
+                }
             }
         }
     }


### PR DESCRIPTION

<img width="723" alt="Screenshot 2025-05-07 at 12 11 48" src="https://github.com/user-attachments/assets/1bf0a5b6-29ee-4339-9f89-c76c231c7966" />


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
