### PR TITLE
fix(shell_integration/macOS/FileProviderExt): Correctly build NSFileProviderErrors

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -122,7 +122,9 @@ import OSLog
         ) {
             completionHandler(item, nil)
         } else {
-            completionHandler(nil, NSFileProviderError(.noSuchItem))
+            completionHandler(
+                nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier)
+            )
         }
         return Progress()
     }
@@ -188,7 +190,11 @@ import OSLog
                 as item not found.
                 """
             )
-            completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
+            completionHandler(
+                nil,
+                nil,
+                NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemIdentifier)
+            )
             insertErrorAction(actionId)
             return Progress()
         }
@@ -335,7 +341,12 @@ import OSLog
                 "Not modifying item: \(ocId, privacy: .public) as item not found."
             )
             insertErrorAction(actionId)
-            completionHandler(item, [], false, NSFileProviderError(.noSuchItem))
+            completionHandler(
+                item,
+                [],
+                false,
+                NSError.fileProviderErrorForNonExistentItem(withIdentifier: item.itemIdentifier)
+            )
             return Progress()
         }
 
@@ -404,7 +415,9 @@ import OSLog
                 "Not deleting item \(identifier.rawValue, privacy: .public), item not found"
             )
             insertErrorAction(actionId)
-            completionHandler(NSFileProviderError(.noSuchItem))
+            completionHandler(
+                NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier)
+            )
             return Progress()
         }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
