### PR TITLE
feat(gui/macOS): Present explanatory message after enabling macOS VFS for an account

### DIFF
--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -363,6 +363,14 @@ void FileProviderSettingsController::setVfsEnabledForAccount(const QString &user
     const auto enabledAccountsAction = d->setVfsEnabledForAccount(userIdAtHost, setEnabled);
     if (enabledAccountsAction == MacImplementation::VfsAccountsAction::VfsAccountsEnabledChanged) {
         emit vfsEnabledAccountsChanged();
+
+        if (setEnabled) {
+            QMessageBox::information(nullptr,
+                                     tr("macOS virtual files enabled"),
+                                     tr("Virtual files have been enabled for this account.\n"
+                                        "Files are accessible in Finder via an entry under the \"Locations\" section.\n"
+                                        "Please note that on macOS, virtual and classic sync folders are separate.\n"));
+        }
     }
 }
 


### PR DESCRIPTION

<img width="372" alt="Screenshot 2025-05-08 at 12 40 24" src="https://github.com/user-attachments/assets/6b1d76d3-7098-452e-b6e2-05fdfc7d2b93" />


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
