### PR TITLE
fix(shell_integration/macOS/FileProviderExt): Ensure user agent matches desktop client core

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
@@ -96,7 +96,11 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
     }
 
     @objc func setupDomainAccount(
-        user: String, userId: String, serverUrl: String, password: String
+        user: String,
+        userId: String,
+        serverUrl: String,
+        password: String,
+        userAgent: String = "Nextcloud-macOS/FileProviderExt"
     ) {
         let account = Account(user: user, id: userId, serverUrl: serverUrl, password: password)
         guard account != ncAccount else { return }
@@ -108,7 +112,7 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
                 user: user,
                 userId: userId,
                 password: password,
-                userAgent: "Nextcloud-macOS/FileProviderExt",
+                userAgent: userAgent,
                 nextcloudVersion: 25,
                 groupIdentifier: ""
             )

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderSocketLineProcessor.swift
@@ -37,14 +37,21 @@ class FileProviderSocketLineProcessor: NSObject, LineProcessor {
             delegate.removeAccountConfig()
         } else if command == "ACCOUNT_DETAILS" {
             guard let accountDetailsSubsequence = splitLine.last else { return }
-            let splitAccountDetails = accountDetailsSubsequence.split(separator: "~", maxSplits: 3)
+            let splitAccountDetails = accountDetailsSubsequence.split(separator: "~", maxSplits: 4)
 
-            let user = String(splitAccountDetails[0])
-            let userId = String(splitAccountDetails[1])
-            let serverUrl = String(splitAccountDetails[2])
-            let password = String(splitAccountDetails[3])
+            let userAgent = String(splitAccountDetails[0])
+            let user = String(splitAccountDetails[1])
+            let userId = String(splitAccountDetails[2])
+            let serverUrl = String(splitAccountDetails[3])
+            let password = String(splitAccountDetails[4])
 
-            delegate.setupDomainAccount(user: user, userId: userId, serverUrl: serverUrl, password: password)
+            delegate.setupDomainAccount(
+                user: user,
+                userId: userId,
+                serverUrl: serverUrl,
+                password: password,
+                userAgent: userAgent
+            )
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -14,7 +14,8 @@
 - (void)configureAccountWithUser:(NSString *)user
                           userId:(NSString *)userId
                        serverUrl:(NSString *)serverUrl
-                        password:(NSString *)password;
+                        password:(NSString *)password
+                       userAgent:(NSString *)userAgent;
 - (void)removeAccountConfig;
 - (void)createDebugLogStringWithCompletionHandler:(void(^)(NSString *debugLogString, NSError *error))completionHandler;
 - (void)getFastEnumerationStateWithCompletionHandler:(void(^)(BOOL enabled, BOOL set))completionHandler;

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
@@ -39,15 +39,21 @@ class ClientCommunicationService: NSObject, NSFileProviderServiceSource, NSXPCLi
         completionHandler(accountUserId, nil)
     }
 
-    func configureAccount(withUser user: String,
-                          userId: String,
-                          serverUrl: String,
-                          password: String) {
+    func configureAccount(
+        withUser user: String,
+        userId: String,
+        serverUrl: String,
+        password: String,
+        userAgent: String
+    ) {
         Logger.desktopClientConnection.info("Received configure account information over client communication service")
-        self.fpExtension.setupDomainAccount(user: user,
-                                            userId: userId,
-                                            serverUrl: serverUrl,
-                                            password: password)
+        self.fpExtension.setupDomainAccount(
+            user: user,
+            userId: userId,
+            serverUrl: serverUrl,
+            password: password,
+            userAgent: userAgent
+        )
     }
 
     func removeAccountConfig() {

--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -9,6 +9,7 @@
 #include <QLoggingCategory>
 
 #include "accountmanager.h"
+#include "common/utility.h"
 #include "fileproviderdomainmanager.h"
 
 namespace OCC {
@@ -228,6 +229,7 @@ void FileProviderSocketController::sendAccountDetails() const
 
     // We cannot use colons as separators here due to "https://" in the url
     const auto message = QString(QStringLiteral("ACCOUNT_DETAILS:") +
+                                 Utility::userAgentString() + "~" +
                                  accountUser + "~" +
                                  accountUserId + "~" +
                                  accountUrl + "~" +

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "common/utility.h"
 #include "fileproviderxpc.h"
 
 #include <QLoggingCategory>
@@ -60,12 +61,14 @@ void FileProviderXPC::authenticateExtension(const QString &extensionAccountId) c
     NSString *const userId = account->davUser().toNSString();
     NSString *const serverUrl = account->url().toString().toNSString();
     NSString *const password = credentials->password().toNSString();
+    NSString *const userAgent = QString::fromUtf8(Utility::userAgentString()).toNSString();
 
     const auto clientCommService = (NSObject<ClientCommunicationProtocol> *)_clientCommServices.value(extensionAccountId);
     [clientCommService configureAccountWithUser:user
                                          userId:userId
                                       serverUrl:serverUrl
-                                       password:password];
+                                       password:password
+                                      userAgent:userAgent];
 }
 
 void FileProviderXPC::unauthenticateExtension(const QString &extensionAccountId) const


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
