### PR TITLE
fix(gui/macOS): Add required availability checks around typeAndCreator access for NSFileProviderItem wrapper

### DIFF
--- a/src/gui/macOS/fileprovideritemmetadata_mac.mm
+++ b/src/gui/macOS/fileprovideritemmetadata_mac.mm
@@ -72,8 +72,10 @@ FileProviderItemMetadata FileProviderItemMetadata::fromNSFileProviderItem(const 
     metadata._capabilities = bridgedNsFileProviderItem.capabilities;
     metadata._fileSystemFlags = bridgedNsFileProviderItem.fileSystemFlags;
     metadata._childItemCount = bridgedNsFileProviderItem.childItemCount.unsignedIntegerValue;
-    metadata._typeOsCode = bridgedNsFileProviderItem.typeAndCreator.type;
-    metadata._creatorOsCode = bridgedNsFileProviderItem.typeAndCreator.creator;
+    if (@available(macOS 12.0, *)) {
+        metadata._typeOsCode = bridgedNsFileProviderItem.typeAndCreator.type;
+        metadata._creatorOsCode = bridgedNsFileProviderItem.typeAndCreator.creator;
+    }
     metadata._documentSize = bridgedNsFileProviderItem.documentSize.unsignedLongLongValue;
     metadata._mostRecentVersionDownloaded = bridgedNsFileProviderItem.mostRecentVersionDownloaded;
     metadata._uploading = bridgedNsFileProviderItem.uploading;


### PR DESCRIPTION
Fixes compilation warnings

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
