### PR TITLE
ci: use new craft cache for 3.17.x, bump Qt to 6.8.3

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Linux Appimage Package
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.2-1
+    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.3-1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/linux-clang-compile-tests.yml
+++ b/.github/workflows/linux-clang-compile-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Linux Clang compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-6.8.1-2
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-appimage-el8-6.8.3-1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/linux-gcc-compile-tests.yml
+++ b/.github/workflows/linux-gcc-compile-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Linux GCC compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-6.8.1-2
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-appimage-el8-6.8.3-1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -50,9 +50,10 @@ jobs:
         run: |
           git clone -q --depth=1 https://invent.kde.org/ggadinger/craftmaster.git ${{ env.CRAFT_MASTER_LOCATION }}
 
-      - name: Add Nextcloud client blueprints
+      - name: Add required blueprint repositories
         run: |
-          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository https://github.com/nextcloud/desktop-client-blueprints.git
+          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|stable-3.17|"
+          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|bugfix/libp11-use-pkgconf|"
 
       - name: Setup Craft
         run: |

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -31,7 +31,8 @@ jobs:
               if($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
           }
           
-          craft --add-blueprint-repository [git]https://github.com/nextcloud/desktop-client-blueprints.git
+          craft --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|stable-3.17|"
+          craft --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|bugfix/libp11-use-pkgconf|"
           craft craft
           craft --install-deps nextcloud-client
           

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -3,7 +3,7 @@
 [General]
 Branch = master
 # CraftUrl = https://github.com/allexzander/craft.git
-CraftRevision = ec08a9becf7f7749c0d39282561ba5468b80d5e6
+CraftRevision = 894a5d86e6f7417f760c4c4f4cf60abd8d6243b4
 ShallowClone = False
 
 # Variables defined here override the default value
@@ -27,7 +27,8 @@ Compile/UseNinja = True
 ShortPath/Enabled = False
 ShortPath/EnableJunctions = False
 
-Packager/CacheVersion = 25.01
+Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
+Packager/CacheVersion = 3.17
 ContinuousIntegration/Enabled = True
 
 Packager/UseCache = ${Variables:UseCache}
@@ -37,8 +38,8 @@ Packager/CacheDir = ${Variables:Root}\cache
 [BlueprintSettings]
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
-libs/qt6.version = 6.8.2
-craft/craft-blueprints-kde.revision = 8949a63ae62e88983839d0b5fb008e9990e97135
+libs/qt6.version = 6.8.3
+craft/craft-blueprints-kde.revision = stable-3.17
 
 [windows-msvc2022_64-cl]
 Packager/PackageType = NullsoftInstallerPackager
@@ -46,21 +47,12 @@ QtSDK/Compiler = msvc2022_64
 General/ABI = windows-msvc2022_64-cl
 Paths/Python = C:\Python312-x64
 
-Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
-Packager/CacheVersion = 25.03-nc
-
 [macos-64-clang]
 General/ABI = macos-64-clang
-
-Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
-Packager/CacheVersion = 25.03-nc
 
 [macos-clang-arm64]
 General/ABI = macos-clang-arm64
 Paths/Python = /Users/runner/hostedtoolcache/Python/3.12.3/arm64
-
-Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
-Packager/CacheVersion = 25.03-nc
 
 [Env]
 CRAFT_CODESIGN_CERTIFICATE =
@@ -68,4 +60,4 @@ SIGN_PACKAGE = False
 
 [Custom_Variables_for_Brander]
 qtPath = /opt/qt
-dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.2-1
+dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.8.3-1


### PR DESCRIPTION
opened this one as a draft PR to ensure that CI passes...

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
