### PR TITLE
fix(ci): Upgrade macOS actions to Sequoia and Xcode 16.2

### DIFF
--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: macOS Build and Test
     timeout-minutes: 60
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
         matrix:
           craft_options: [


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
