### PR TITLE
feat(mac-crafter): retry code-signing attempts

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Codesign.swift
@@ -46,9 +46,17 @@ func isExecutable(_ path: String) throws -> Bool {
 func codesign(identity: String, path: String, options: String = defaultCodesignOptions) throws {
     print("Code-signing \(path)...")
     let command = "codesign -s \"\(identity)\" \(options) \"\(path)\""
-    guard shell(command) == 0 else {
-        throw CodeSigningError.failedToCodeSign("Failed to code-sign \(path).")
+    for _ in 1...5 {
+        guard shell(command) == 0 else {
+            print("Code-signing failed, retrying ...")
+            continue
+        }
+
+        // code signing was successful
+        return
     }
+
+    throw CodeSigningError.failedToCodeSign("Failed to code-sign \(path).")
 }
 
 func recursivelyCodesign(


### PR DESCRIPTION
This step sometimes fails with an error such as: "A timestamp was expected but was not found.".  Any code-signing errors will result in the notarisation step to fail.

Apparently this might be due to intermittent network issues.  Let's just retry codesigning a couple of times in the case it fails ...

See also: https://developer.apple.com/documentation/security/resolving-common-notarization-issues#Include-a-secure-timestamp

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
