### PR TITLE
fix(quota): do not prevent upload when quota info are not available

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -767,8 +767,13 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
     item->_isLivePhoto = serverEntry.isLivePhoto;
     item->_livePhotoFile = serverEntry.livePhotoFile;
 
-    item->_folderQuota.bytesUsed = serverEntry.folderQuota.bytesUsed;
-    item->_folderQuota.bytesAvailable = serverEntry.folderQuota.bytesAvailable;
+    if (serverEntry.isValid()) {
+        item->_folderQuota.bytesUsed = serverEntry.folderQuota.bytesUsed;
+        item->_folderQuota.bytesAvailable = serverEntry.folderQuota.bytesAvailable;
+    } else {
+        item->_folderQuota.bytesUsed = -1;
+        item->_folderQuota.bytesAvailable = -1;
+    }
 
     // Check for missing server data
     {
@@ -1128,6 +1133,14 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     qCDebug(lcDisco) << "File" << item->_file << "- servermodified:" << serverModified
                      << "noServerEntry:" << noServerEntry;
 
+    if (serverEntry.isValid()) {
+        item->_folderQuota.bytesUsed = serverEntry.folderQuota.bytesUsed;
+        item->_folderQuota.bytesAvailable = serverEntry.folderQuota.bytesAvailable;
+    } else {
+        item->_folderQuota.bytesUsed = -1;
+        item->_folderQuota.bytesAvailable = -1;
+    }
+
     // Decay server modifications to UPDATE_METADATA if the local virtual exists
     bool hasLocalVirtual = localEntry.isVirtualFile || (_queryLocal == ParentNotChanged && dbEntry.isVirtualFile());
     bool virtualFileDownload = item->_type == ItemTypeVirtualFileDownload;
@@ -1166,6 +1179,8 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
         if (const auto folderQuota = folderQuotaAvailable(item);item->_size > folderQuota && folderQuota > -1) {
             qCDebug(lcDisco) << "Folder" << item->_file
+                             << "item used:" << item->_folderQuota.bytesUsed
+                             << "item available:" << item->_folderQuota.bytesAvailable
                              << "- quota used: " << serverEntry.folderQuota.bytesUsed
                              << "- quota available: " << serverEntry.folderQuota.bytesAvailable;
             item->_instruction = CSYNC_INSTRUCTION_ERROR;


### PR DESCRIPTION
if we did not query the server info, we have no quota info so do not prevent upload because of no quota info available

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
