### PR TITLE
fix(gui): disable DirectWrite on Win10 versions before 1809

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -76,12 +76,17 @@ int main(int argc, char **argv)
 #if defined Q_OS_MAC
     qmlStyle = QStringLiteral("macOS");
 #elif defined Q_OS_WIN
-    if (QOperatingSystemVersion::current().version() < QOperatingSystemVersion::Windows11.version()) {
+    if (const auto osVersion = QOperatingSystemVersion::current().version(); osVersion < QOperatingSystemVersion::Windows11.version()) {
         qmlStyle = QStringLiteral("Universal");
         widgetsStyle = QStringLiteral("Fusion");
         if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_UNIVERSAL_THEME")) {
             // initialise theme with the light/dark mode setting from the OS
             qputenv("QT_QUICK_CONTROLS_UNIVERSAL_THEME", "System");
+        }
+
+        if (osVersion < QOperatingSystemVersion::Windows10_1809.version() && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+            // for Windows Server 2016 to display text as expected, see #8064
+            qputenv("QT_QPA_PLATFORM", "windows:nodirectwrite");
         }
     } else {
         qmlStyle = QStringLiteral("FluentWinUI3");


### PR DESCRIPTION
Earlier versions of Windows will render each character as a square when DirectWrite is in use.

See also: https://github.com/nextcloud/desktop/issues/8064#issuecomment-2890237591

(passing platform parameters via the command line still seems to work!  tried it with `-platform windows:directwrite` and experienced the same behaviour as before this commit).

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
