### PR TITLE
fix(encryption): remove currently broken certificate hash handling

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -56,7 +56,6 @@ static void fillFileRecordFromGetQuery(SyncJournalFileRecord &rec, SqlQuery &que
     rec._checksumHeader = query.baValue(9);
     rec._e2eMangledName = query.baValue(10);
     rec._e2eEncryptionStatus = static_cast<SyncJournalFileRecord::EncryptionStatus>(query.intValue(11));
-    rec._e2eCertificateFingerprint = query.baValue(12);
     rec._lockstate._locked = query.intValue(13) > 0;
     rec._lockstate._lockOwnerDisplayName = query.stringValue(14);
     rec._lockstate._lockOwnerId = query.stringValue(15);
@@ -1013,7 +1012,7 @@ Result<void, QString> SyncJournalDb::setFileRecord(const SyncJournalFileRecord &
     query->bindValue(16, contentChecksumTypeId);
     query->bindValue(17, record._e2eMangledName);
     query->bindValue(18, static_cast<int>(record._e2eEncryptionStatus));
-    query->bindValue(19, record._e2eCertificateFingerprint);
+    query->bindValue(19, {});
     query->bindValue(20, record._lockstate._locked ? 1 : 0);
     query->bindValue(21, record._lockstate._lockOwnerType);
     query->bindValue(22, record._lockstate._lockOwnerDisplayName);

--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -72,7 +72,6 @@ public:
     QByteArray _checksumHeader;
     QByteArray _e2eMangledName;
     EncryptionStatus _e2eEncryptionStatus = EncryptionStatus::NotEncrypted;
-    QByteArray _e2eCertificateFingerprint;
     SyncJournalFileLockInfo _lockstate;
     bool _isShared = false;
     qint64 _lastShareStateFetchedTimestamp = 0;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -476,11 +476,6 @@ SyncFileItem::EncryptionStatus DiscoverySingleDirectoryJob::requiredEncryptionSt
     return _encryptionStatusRequired;
 }
 
-QByteArray DiscoverySingleDirectoryJob::certificateSha256Fingerprint() const
-{
-    return _e2eCertificateFingerprint;
-}
-
 static void propertyMapToRemoteInfo(const QMap<QString, QString> &map, RemotePermissions::MountedPermissionAlgorithm algorithm, RemoteInfo &result)
 {
     for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
@@ -768,7 +763,6 @@ void DiscoverySingleDirectoryJob::metadataReceived(const QJsonDocument &json, in
         }
         _isFileDropDetected = e2EeFolderMetadata->isFileDropPresent();
         _encryptedMetadataNeedUpdate = e2EeFolderMetadata->encryptedMetadataNeedUpdate();
-        _e2eCertificateFingerprint = e2EeFolderMetadata->certificateSha256Fingerprint();
         _encryptionStatusRequired = EncryptionStatusEnums::fromEndToEndEncryptionApiVersion(_account->capabilities().clientSideEncryptionVersion());
         _encryptionStatusCurrent = e2EeFolderMetadata->existingMetadataEncryptionStatus();
 

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -77,7 +77,6 @@ struct RemoteInfo
     bool _isE2eEncrypted = false;
     bool isFileDropDetected = false;
     QString e2eMangledName;
-    QByteArray e2eCertificateFingerprint;
     bool sharedByMe = false;
 
     [[nodiscard]] bool isValid() const { return !name.isNull(); }
@@ -171,7 +170,6 @@ public:
     void abort();
     [[nodiscard]] bool isFileDropDetected() const;
     [[nodiscard]] bool encryptedMetadataNeedUpdate() const;
-    [[nodiscard]] QByteArray certificateSha256Fingerprint() const;
     [[nodiscard]] SyncFileItem::EncryptionStatus currentEncryptionStatus() const;
     [[nodiscard]] SyncFileItem::EncryptionStatus requiredEncryptionStatus() const;
 
@@ -213,7 +211,6 @@ private:
     bool _isFileDropDetected = false;
     bool _encryptedMetadataNeedUpdate = false;
     SyncFileItem::EncryptionStatus _encryptionStatusRequired = SyncFileItem::EncryptionStatus::NotEncrypted;
-    QByteArray _e2eCertificateFingerprint;
 
     // If set, the discovery will finish with an error
     int64_t _size = 0;

--- a/src/libsync/encryptfolderjob.cpp
+++ b/src/libsync/encryptfolderjob.cpp
@@ -64,7 +64,6 @@ void EncryptFolderJob::slotEncryptionFlagSuccess(const QByteArray &fileId)
         if (_propagator && _item) {
             qCWarning(lcEncryptFolderJob) << "No valid record found in local DB for fileId" << fileId << "going to create it now...";
             _item->_e2eEncryptionStatus = EncryptionStatusEnums::ItemEncryptionStatus::EncryptedMigratedV2_0;
-            _item->_e2eCertificateFingerprint = _account->e2e()->certificateSha256Fingerprint();
             const auto updateResult = _propagator->updateMetadata(*_item.data());
             if (updateResult) {
                 [[maybe_unused]] const auto result = _journal->getFileRecord(currentPath, &rec);
@@ -76,7 +75,6 @@ void EncryptFolderJob::slotEncryptionFlagSuccess(const QByteArray &fileId)
 
     if (rec.isValid() && !rec.isE2eEncrypted()) {
         rec._e2eEncryptionStatus = SyncJournalFileRecord::EncryptionStatus::Encrypted;
-        rec._e2eCertificateFingerprint = _account->e2e()->certificateSha256Fingerprint();
         const auto result = _journal->setFileRecord(rec);
         if (!result) {
             qCWarning(lcEncryptFolderJob) << "Error when setting the file record to the database" << rec._path << result.error();

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -113,8 +113,6 @@ public:
 
     [[nodiscard]] bool encryptedMetadataNeedUpdate() const;
 
-    [[nodiscard]] QByteArray certificateSha256Fingerprint() const;
-
     [[nodiscard]] bool moveFromFileDropToFiles();
 
     // adds a user to have access to this folder (always generates new metadata key)
@@ -151,7 +149,7 @@ private:
 
     [[nodiscard]] QByteArray encryptDataWithPublicKey(const QByteArray &data,
                                                       const CertificateInformation &shareUserCertificate) const;
-    [[nodiscard]] QByteArray decryptDataWithPrivateKey(const QByteArray &data, const QByteArray &certificateFingerprint) const;
+    [[nodiscard]] QByteArray decryptDataWithPrivateKey(const QByteArray &data) const;
 
     [[nodiscard]] QByteArray encryptJsonObject(const QByteArray& obj, const QByteArray pass) const;
     [[nodiscard]] QByteArray decryptJsonObject(const QByteArray& encryptedJsonBlob, const QByteArray& pass) const;
@@ -231,8 +229,6 @@ private:
     QByteArray _metadataSignature;
     // signature from server-side metadata
     QByteArray _initialSignature;
-
-    QByteArray _e2eCertificateFingerprint;
 
     // both files and folders info
     QVector<EncryptedFile> _files;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1520,9 +1520,6 @@ void PropagateDirectory::slotSubJobsFinished(SyncFileItem::Status status)
                 }
             }
             if (!_item->_isAnyCaseClashChild && !_item->_isAnyInvalidCharChild) {
-                if (_item->isEncrypted()) {
-                    _item->_e2eCertificateFingerprint = propagator()->account()->encryptionCertificateFingerprint();
-                }
                 const auto result = propagator()->updateMetadata(*_item);
                 if (!result) {
                     status = _item->_status = SyncFileItem::FatalError;

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1182,7 +1182,6 @@ void PropagateDownloadFile::finalizeDownload()
 {
     if (isEncrypted()) {
         if (_downloadEncryptedHelper->decryptFile(_tmpFile)) {
-            _item->_e2eCertificateFingerprint = propagator()->account()->encryptionCertificateFingerprint();
             downloadFinished();
         } else {
             done(SyncFileItem::NormalError, _downloadEncryptedHelper->errorString(), ErrorCategory::GenericError);

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -254,7 +254,6 @@ void PropagateRemoteMkdir::slotEncryptFolderFinished(int status, EncryptionStatu
     qCDebug(lcPropagateRemoteMkdir) << "Success making the new folder encrypted";
     propagator()->_activeJobList.removeOne(this);
     _item->_e2eEncryptionStatus = encryptionStatus;
-    _item->_e2eCertificateFingerprint = propagator()->account()->encryptionCertificateFingerprint();
     _item->_e2eEncryptionStatusRemote = encryptionStatus;
     if (_item->isEncrypted()) {
         _item->_e2eEncryptionServerCapability = EncryptionStatusEnums::fromEndToEndEncryptionApiVersion(propagator()->account()->capabilities().clientSideEncryptionVersion());

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -820,10 +820,6 @@ void PropagateUploadFileCommon::finalize()
     if (quotaIt != propagator()->_folderQuota.end())
         quotaIt.value() -= _fileToUpload._size;
 
-    if (_item->isEncrypted() && _uploadingEncrypted) {
-        _item->_e2eCertificateFingerprint = propagator()->account()->encryptionCertificateFingerprint();
-    }
-
     // Update the database entry
     const auto result = propagator()->updateMetadata(*_item, Vfs::DatabaseMetadata);
     if (!result) {

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -413,10 +413,6 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
                 }
             }
 
-            if (rec.isE2eEncrypted()) {
-                rec._e2eCertificateFingerprint = _account->encryptionCertificateFingerprint();
-            }
-
             // Updating the db happens on success
             if (!_journal->setFileRecord(rec)) {
                 item->_status = SyncFileItem::Status::NormalError;

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -110,7 +110,6 @@ SyncJournalFileRecord SyncFileItem::toSyncJournalFileRecordWithInode(const QStri
     rec._checksumHeader = _checksumHeader;
     rec._e2eMangledName = _encryptedFileName.toUtf8();
     rec._e2eEncryptionStatus = EncryptionStatusEnums::toDbEncryptionStatus(_e2eEncryptionStatus);
-    rec._e2eCertificateFingerprint = _e2eCertificateFingerprint;
     rec._lockstate._locked = _locked == LockStatus::LockedItem;
     rec._lockstate._lockOwnerDisplayName = _lockOwnerDisplayName;
     rec._lockstate._lockOwnerId = _lockOwnerId;
@@ -151,7 +150,6 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
     item->_encryptedFileName = rec.e2eMangledName();
     item->_e2eEncryptionStatus = EncryptionStatusEnums::fromDbEncryptionStatus(rec._e2eEncryptionStatus);
     item->_e2eEncryptionServerCapability = item->_e2eEncryptionStatus;
-    item->_e2eCertificateFingerprint = rec._e2eCertificateFingerprint;
     item->_locked = rec._lockstate._locked ? LockStatus::LockedItem : LockStatus::UnlockedItem;
     item->_lockOwnerDisplayName = rec._lockstate._lockOwnerDisplayName;
     item->_lockOwnerId = rec._lockstate._lockOwnerId;

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -278,7 +278,6 @@ public:
     EncryptionStatus _e2eEncryptionStatus = EncryptionStatus::NotEncrypted; // The file is E2EE or the content of the directory should be E2EE
     EncryptionStatus _e2eEncryptionServerCapability = EncryptionStatus::NotEncrypted;
     EncryptionStatus _e2eEncryptionStatusRemote = EncryptionStatus::NotEncrypted;
-    QByteArray _e2eCertificateFingerprint;
     quint16 _httpErrorCode = 0;
     RemotePermissions _remotePerm;
     QString _errorString; // Contains a string only in case of error

--- a/src/libsync/updatemigratede2eemetadatajob.cpp
+++ b/src/libsync/updatemigratede2eemetadatajob.cpp
@@ -47,7 +47,6 @@ void UpdateMigratedE2eeMetadataJob::start()
         if (code == 200) {
             _item->_e2eEncryptionStatus = updateMedatadaAndSubfoldersJob->encryptionStatus();
             _item->_e2eEncryptionStatusRemote = updateMedatadaAndSubfoldersJob->encryptionStatus();
-            _item->_e2eCertificateFingerprint = propagator()->account()->encryptionCertificateFingerprint();
             propagator()->updateMetadata(*_item, Vfs::UpdateMetadataType::DatabaseMetadata);
             emit finished(SyncFileItem::Status::Success);
         } else {

--- a/test/testclientsideencryptionv2.cpp
+++ b/test/testclientsideencryptionv2.cpp
@@ -130,7 +130,7 @@ private slots:
             const auto encryptedMetadataKey = QByteArray::fromBase64(folderUserObject.value("encryptedMetadataKey").toString().toUtf8());
 
             if (!encryptedMetadataKey.isEmpty()) {
-                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey, certificate.digest(QCryptographicHash::Sha256));
+                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey);
                 if (decryptedMetadataKey.isEmpty()) {
                     break;
                 }
@@ -269,7 +269,7 @@ private slots:
             const auto encryptedMetadataKey = QByteArray::fromBase64(folderUserObject.value("encryptedMetadataKey").toString().toUtf8());
 
             if (!encryptedMetadataKey.isEmpty()) {
-                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey, certificate.digest(QCryptographicHash::Sha256));
+                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey);
                 if (decryptedMetadataKey.isEmpty()) {
                     break;
                 }
@@ -370,7 +370,7 @@ private slots:
             const auto encryptedMetadataKey = QByteArray::fromBase64(folderUserObject.value("encryptedMetadataKey").toString().toUtf8());
 
             if (!encryptedMetadataKey.isEmpty()) {
-                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey, certificate.digest(QCryptographicHash::Sha256));
+                const auto decryptedMetadataKey = metadata->decryptDataWithPrivateKey(encryptedMetadataKey);
                 if (decryptedMetadataKey.isEmpty()) {
                     break;
                 }


### PR DESCRIPTION
we may not currently properly store certificate hash for encrypted items and later fails to find which public or private key pairs to use

for now, it is better to remove it and ensure we have a reliable way to handle certificate migration

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
