### PR TITLE
fix(gui/SslErrorDialog): implements parsing the Strict-Transport-Security header using QNetworkAccessManager

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -28,6 +28,11 @@ AccessManager::AccessManager(QObject *parent)
     : QNetworkAccessManager(parent)
 {
     setCookieJar(new CookieJar);
+
+    // Enable HSTS (HTTP Strict Transport Security) for all connections
+    enableStrictTransportSecurityStore(true);
+    setStrictTransportSecurityEnabled(true);
+
     connect(this, &QNetworkAccessManager::authenticationRequired, this, [](QNetworkReply *reply, QAuthenticator *authenticator) {
         Q_UNUSED(reply)
 


### PR DESCRIPTION
This commit implements enabling enableStrictTransportSecurityStore and setStrictTransportSecurityEnabled in the AccessManager- provided QNetworkAccessManager.
On first connection, this will make QNetworkAccessManager save the HSTS status of the host in cache if it was enabled by the server. On future connections, this setting is loaded and if the server presents an invalid certificate and the HSTS hint is not expired, the connection fails without showing the dreaded "Cannot connect securely to ..." dialog.

Fix https://github.com/nextcloud/desktop/issues/7166
Replaces https://github.com/nextcloud/desktop/pull/8275

Signed-off-by: François Guerraz <francois@orographic.uk>
