### PR TITLE
fix(ui): limit sync folder selection to dirs only

### DIFF
--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -143,7 +143,8 @@ void FolderWizardLocalPath::slotChooseLocalFolder()
 
     QString dir = QFileDialog::getExistingDirectory(this,
         tr("Select the source folder"),
-        sf);
+        sf,
+        QFileDialog::ShowDirsOnly);
     if (!dir.isEmpty()) {
         // set the last directory component name as alias
         _ui.localFolderLineEdit->setText(QDir::toNativeSeparators(dir));


### PR DESCRIPTION
https://doc.qt.io/qt-6/qfiledialog.html#Option-enum

finder currently shows all - there is an option to only show folders


![Bildschirmfoto 2025-05-28 um 15 44 56](https://github.com/user-attachments/assets/056fd275-5c7f-4131-b2c0-80e953b1e936)
