### PR TITLE
fix(get/file): avoid failing to download files under 20 MiB

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -29,6 +29,8 @@
 
 namespace OCC {
 
+static constexpr auto CustomDecompressedSafetyCheckThreshold = 20 * 1024 * 1024;
+
 Q_LOGGING_CATEGORY(lcGetJob, "nextcloud.sync.networkjob.get", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcPropagateDownload, "nextcloud.sync.propagator.download", QtInfoMsg)
 
@@ -114,6 +116,7 @@ void GETFileJob::start()
     }
 
     req.setPriority(QNetworkRequest::LowPriority); // Long downloads must not block non-propagation jobs.
+    req.setDecompressedSafetyCheckThreshold(CustomDecompressedSafetyCheckThreshold);
 
     if (_directDownloadUrl.isEmpty()) {
         sendRequest("GET", makeDavUrl(path()), req);


### PR DESCRIPTION
if a file that uncompresses to a file size under 10 MiB, Qt will allow it

for files with an higher size, they must not have higher compression ratio than what Qt network stack expect

https://doc.qt.io/qt-6/qnetworkrequest.html#setDecompressedSafetyCheckThreshold

we will use a 2 times bigger threshold

Close https://github.com/nextcloud/desktop/issues/7470
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
