### PR TITLE
fix(msi): set the REBOOT property in the MSI

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -36,6 +36,7 @@
     <MajorUpgrade Schedule="afterInstallExecute" AllowDowngrades="yes" />
     <Property Id="REINSTALLMODE" Value="dmus" />
     <Property Id="MSIRMSHUTDOWN" Value="1" />
+    <Property Id="REBOOT" Value="ReallySuppress" />
 
     <Media Id="1" Cabinet="$(var.AppShortName).cab" EmbedCab="yes" />
 


### PR DESCRIPTION
A value of `ReallySuppress` will not display a reboot prompt whenever the `ForceReboot` action was run, or whenever a reboot was scheduled (e.g. by `FilesInUse`).  Apparently this will not reboot the machine on its own either.

`winget` sets this property [in the manifest], and according to reports in issue #5369 this seems to work.

See also: https://learn.microsoft.com/en-us/windows/win32/msi/reboot

[in the manifest]: https://github.com/microsoft/winget-pkgs/blob/0b40904d1480f67d48c6d8e2ac7f27b31aa566c7/manifests/n/Nextcloud/NextcloudDesktop/3.16.5/Nextcloud.NextcloudDesktop.installer.yaml#L16

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
