### PR TITLE
fix(crash): debug builds would not try to remove a not found job

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1316,9 +1316,11 @@ void PropagatorCompositeJob::slotSubJobFinished(SyncFileItem::Status status)
 
     // Delete the job and remove it from our list of jobs.
     subJob->deleteLater();
-    int i = _runningJobs.indexOf(subJob);
-    Q_ASSERT(i >= 0); // should only happen if this function is called more than once
-    _runningJobs.remove(i);
+    const auto i = _runningJobs.indexOf(subJob);
+    Q_ASSERT(i >= 0 && i < _runningJobs.size()); // should only happen if this function is called more than once
+    if (i >= 0 && i < _runningJobs.size()) {
+        _runningJobs.remove(i);
+    }
 
     // Any sub job error will cause the whole composite to fail. This is important
     // for knowing whether to update the etag in PropagateDirectory, for example.


### PR DESCRIPTION
in release builds we would happily try to remove an element from QList with invalid index (-1) if the job is not found

avoid doing this in release builds and keep teh assert in debug builds

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
