### PR TITLE
fix(accountmanager): use defaults from configFile if setting was not present

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -246,18 +246,18 @@ bool AccountManager::restoreFromLegacySettings()
     }
 
     ConfigFile configFile;
-    configFile.setVfsEnabled(settings->value(configFile.isVfsEnabledC, configFile.isVfsEnabled()).toBool());
-    configFile.setLaunchOnSystemStartup(settings->value(configFile.launchOnSystemStartupC, configFile.launchOnSystemStartup()).toBool());
-    configFile.setOptionalServerNotifications(settings->value(configFile.optionalServerNotificationsC, configFile.optionalServerNotifications()).toBool());
-    configFile.setPromptDeleteFiles(settings->value(configFile.promptDeleteC, configFile.promptDeleteFiles()).toBool());
-    configFile.setShowCallNotifications(settings->value(configFile.showCallNotificationsC, configFile.showCallNotifications()).toBool());
-    configFile.setShowChatNotifications(settings->value(configFile.showChatNotificationsC, configFile.showChatNotifications()).toBool());
-    configFile.setShowInExplorerNavigationPane(settings->value(configFile.showInExplorerNavigationPaneC, configFile.showInExplorerNavigationPane()).toBool());
+    configFile.setVfsEnabled(settings->value(ConfigFile::isVfsEnabledC, configFile.isVfsEnabled()).toBool());
+    configFile.setLaunchOnSystemStartup(settings->value(ConfigFile::launchOnSystemStartupC, configFile.launchOnSystemStartup()).toBool());
+    configFile.setOptionalServerNotifications(settings->value(ConfigFile::optionalServerNotificationsC, configFile.optionalServerNotifications()).toBool());
+    configFile.setPromptDeleteFiles(settings->value(ConfigFile::promptDeleteC, configFile.promptDeleteFiles()).toBool());
+    configFile.setShowCallNotifications(settings->value(ConfigFile::showCallNotificationsC, configFile.showCallNotifications()).toBool());
+    configFile.setShowChatNotifications(settings->value(ConfigFile::showChatNotificationsC, configFile.showChatNotifications()).toBool());
+    configFile.setShowInExplorerNavigationPane(settings->value(ConfigFile::showInExplorerNavigationPaneC, configFile.showInExplorerNavigationPane()).toBool());
     ClientProxy().saveProxyConfigurationFromSettings(*settings);
-    configFile.setUseUploadLimit(settings->value(configFile.useUploadLimitC, configFile.useUploadLimit()).toInt());
-    configFile.setUploadLimit(settings->value(configFile.uploadLimitC, configFile.uploadLimit()).toInt());
-    configFile.setUseDownloadLimit(settings->value(configFile.useDownloadLimitC, configFile.useDownloadLimit()).toInt());
-    configFile.setDownloadLimit(settings->value(configFile.downloadLimitC, configFile.downloadLimit()).toInt());
+    configFile.setUseUploadLimit(settings->value(ConfigFile::useUploadLimitC, configFile.useUploadLimit()).toInt());
+    configFile.setUploadLimit(settings->value(ConfigFile::uploadLimitC, configFile.uploadLimit()).toInt());
+    configFile.setUseDownloadLimit(settings->value(ConfigFile::useDownloadLimitC, configFile.useDownloadLimit()).toInt());
+    configFile.setDownloadLimit(settings->value(ConfigFile::downloadLimitC, configFile.downloadLimit()).toInt());
 
     // Try to load the single account.
     if (!settings->childKeys().isEmpty()) {


### PR DESCRIPTION
This prevented e.g. "launchOnSystemStartup" to be set on a fresh installation.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
