### PR TITLE
feat(windows/craft): deploy PDB debug symbol files when using craft

### DIFF
--- a/admin/win/msi/collect-transform.xsl.in
+++ b/admin/win/msi/collect-transform.xsl.in
@@ -42,4 +42,8 @@
   <xsl:key name="vc-redist-64-search" match="wix:Component[contains(wix:File/@Source, 'vc_redist.x64.exe')]" use="@Id" />
   <xsl:template match="wix:Component[key('vc-redist-64-search', @Id)]" />
   <xsl:template match="wix:ComponentRef[key('vc-redist-64-search', @Id)]" />
+
+  <xsl:key name="qt6-webengine-core-pdb" match="wix:Component[contains(wix:File/@Source, 'Qt6WebEngineCore.pdb')]" use="@Id" />
+  <xsl:template match="wix:Component[key('qt6-webengine-core-pdb', @Id)]" />
+  <xsl:template match="wix:ComponentRef[key('qt6-webengine-core-pdb', @Id)]" />
 </xsl:stylesheet>


### PR DESCRIPTION
will enable having proper PDB files deployed when using craft to deploy client dependencies on Windows

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
