### PR TITLE
fix(lockFileJobs): avoid accumulating connections about lock jobs

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -753,10 +753,12 @@ void Folder::slotLockedFilesFound(const QSet<QString> &files)
         qCDebug(lcFolder) << "Automatically locking file on server" << remoteFilePath;
         _fileLockSuccess = connect(_accountState->account().data(), &Account::lockFileSuccess, this, [this, remoteFilePath] {
             disconnect(_fileLockSuccess);
+            disconnect(_fileLockFailure);
             qCDebug(lcFolder) << "Locking file succeeded" << remoteFilePath;
             startSync();
         });
         _fileLockFailure = connect(_accountState->account().data(), &Account::lockFileError, this, [this, remoteFilePath](const QString &message) {
+            disconnect(_fileLockSuccess);
             disconnect(_fileLockFailure);
             qCWarning(lcFolder) << "Failed to lock a file:" << remoteFilePath << message;
         });


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
