### PR TITLE
Fix: mac-crafter installs wget on demand.

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Install.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Install.swift
@@ -5,10 +5,24 @@
 
 import Foundation
 
+///
+/// Errors which can occur during installation of a command-line program.
+///
 enum InstallError: Error {
+    ///
+    /// The installation failed in general with the given output provided by the installation command.
+    ///
     case failedToInstall(String)
 }
 
+///
+/// Install a command-line program if not available already.
+///
+/// - Parameters:
+///     - command: The command name which is required.
+///     - installCommand: The installation command to install the command, if it is not yet installed.
+///     - installCommandEnv: Optional environment variables for the installation command.
+///
 func installIfMissing(
     _ command: String,
     _ installCommand: String,

--- a/admin/osx/mac-crafter/Sources/main.swift
+++ b/admin/osx/mac-crafter/Sources/main.swift
@@ -128,6 +128,7 @@ struct Build: ParsableCommand {
             "curl -fsSL \(brewInstallShUrl) | /bin/bash",
             installCommandEnv: ["NONINTERACTIVE": "1"]
         )
+        try installIfMissing("wget", "brew install wget")
         try installIfMissing("inkscape", "brew install inkscape")
         try installIfMissing("python3", "brew install pyenv && pyenv install 3.12.4")
 


### PR DESCRIPTION
wget is used but not automatically installed, if missing.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
