### PR TITLE
fix: implicit hydration will not abort synchronization

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1585,19 +1585,19 @@ void Folder::slotWatcherUnreliable(const QString &message)
 
 void Folder::slotHydrationStarts()
 {
-    // Abort any running full sync run and reschedule
-    if (_engine->isSyncRunning()) {
-        setSilenceErrorsUntilNextSync(true);
-        slotTerminateSync();
-        scheduleThisFolderSoon();
-        // TODO: This sets the sync state to AbortRequested on done, we don't want that
-    }
+    // // Abort any running full sync run and reschedule
+    // if (_engine->isSyncRunning()) {
+    //     setSilenceErrorsUntilNextSync(true);
+    //     slotTerminateSync();
+    //     scheduleThisFolderSoon();
+    //     // TODO: This sets the sync state to AbortRequested on done, we don't want that
+    // }
 
-    // Let everyone know we're syncing
-    _syncResult.reset();
-    _syncResult.setStatus(SyncResult::SyncRunning);
-    emit syncStarted();
-    emit syncStateChange();
+    // // Let everyone know we're syncing
+    // _syncResult.reset();
+    // _syncResult.setStatus(SyncResult::SyncRunning);
+    // emit syncStarted();
+    // emit syncStateChange();
 }
 
 void Folder::slotHydrationDone()


### PR DESCRIPTION
should avoid constant sync/abort loop for people having many files

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
