### PR TITLE
feat(macOS): Add button in settings window to fully reset File Provider-based virtual files

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -90,5 +90,7 @@
             </array>
         </dict>
     </array>
+    <key>NCFPKAppGroupIdentifier</key>
+    <string>@SOCKETAPI_TEAM_IDENTIFIER_PREFIX@@APPLICATION_REV_DOMAIN@</string>
 </dict>
 </plist>

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -44,6 +44,7 @@ public:
 public slots:
     void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
     void setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
+    void resetVfsForAccount(const QString &userIdAtHost);
 
     void createEvictionWindowForAccount(const QString &userIdAtHost);
     void refreshMaterialisedItemsForAccount(const QString &userIdAtHost);

--- a/src/gui/macOS/fileproviderutils.h
+++ b/src/gui/macOS/fileproviderutils.h
@@ -38,6 +38,8 @@ NSFileProviderDomain *domainForIdentifier(const QString &domainIdentifier);
 // Synchronous function to get manager for a domain identifier
 NSFileProviderManager *managerForDomainIdentifier(const QString &domainIdentifier);
 
+QString groupContainerPath();
+
 } // namespace FileProviderUtils
 
 } // namespace Mac

--- a/src/gui/macOS/fileproviderutils_mac.mm
+++ b/src/gui/macOS/fileproviderutils_mac.mm
@@ -78,6 +78,16 @@ NSFileProviderManager *managerForDomainIdentifier(const QString &domainIdentifie
     return manager;
 }
 
+QString groupContainerPath()
+{
+    NSString *const groupId = (NSString *)[NSBundle.mainBundle objectForInfoDictionaryKey:@"NCFPKAppGroupIdentifier"];
+    if (groupId == nil) {
+        qCWarning(lcMacFileProviderUtils) << "No app group identifier found in Info.plist, cannot determine group container path.";
+        return QString();
+    }
+    return QString::fromNSString([NSFileManager.defaultManager containerURLForSecurityApplicationGroupIdentifier:groupId].path);
+}
+
 } // namespace FileProviderUtils
 
 } // namespace Mac

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -104,6 +104,11 @@ Page {
                     checked: root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost)
                     onClicked: root.controller.setTrashDeletionEnabledForAccount(root.accountUserIdAtHost, checked)
                 }
+
+                Button {
+                    text: qsTr("Reset virtual files environment")
+                    onPressed: root.controller.resetVfsForAccount(root.accountUserIdAtHost);
+                }
             }
         }
     }


### PR DESCRIPTION

<img width="777" alt="Screenshot 2025-07-10 at 15 58 18" src="https://github.com/user-attachments/assets/7bac7ca4-d3be-46a8-9701-2148224247a5" />


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
