### PR TITLE
Remove Ubuntu Oracular, add Questing

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -21,7 +21,7 @@ if test "${DRONE_TARGET_BRANCH}" = "stable-2.6"; then
     UBUNTU_DISTRIBUTIONS="bionic focal jammy kinetic"
     DEBIAN_DISTRIBUTIONS="buster stretch testing"
 else
-    UBUNTU_DISTRIBUTIONS="jammy noble oracular plucky"
+    UBUNTU_DISTRIBUTIONS="jammy noble plucky questing"
     DEBIAN_DISTRIBUTIONS="bullseye bookworm testing"
 fi
 


### PR DESCRIPTION
This patch removes Ubuntu Oracular, the support of which has ended, and adds the next release, Questing.