### PR TITLE
Implement more prominent quota warning

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -287,6 +287,7 @@ bool AccountManager::restoreFromLegacySettings()
     configFile.setPromptDeleteFiles(settings->value(ConfigFile::promptDeleteC, configFile.promptDeleteFiles()).toBool());
     configFile.setShowCallNotifications(settings->value(ConfigFile::showCallNotificationsC, configFile.showCallNotifications()).toBool());
     configFile.setShowChatNotifications(settings->value(ConfigFile::showChatNotificationsC, configFile.showChatNotifications()).toBool());
+    configFile.setShowQuotaWarningNotifications(settings->value(ConfigFile::showQuotaWarningNotificationsC, configFile.showQuotaWarningNotifications()).toBool());
     configFile.setShowInExplorerNavigationPane(settings->value(ConfigFile::showInExplorerNavigationPaneC, configFile.showInExplorerNavigationPane()).toBool());
     ClientProxy().saveProxyConfigurationFromSettings(*settings);
     configFile.setUseUploadLimit(settings->value(ConfigFile::useUploadLimitC, configFile.useUploadLimit()).toInt());

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -195,6 +195,9 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         this, &GeneralSettings::slotToggleCallNotifications);
     _ui->callNotificationsCheckBox->setToolTip(tr("Show call notification dialogs."));
 
+    connect(_ui->quotaWarningNotificationsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleQuotaWarningNotifications);
+    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Receive notification when storage usage exceeds 80/90/95 percent"));
+
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 
     // Rename 'Explorer' appropriately on non-Windows
@@ -298,6 +301,8 @@ void GeneralSettings::loadMiscSettings()
     _ui->chatNotificationsCheckBox->setChecked(cfgFile.showChatNotifications());
     _ui->callNotificationsCheckBox->setEnabled(cfgFile.optionalServerNotifications());
     _ui->callNotificationsCheckBox->setChecked(cfgFile.showCallNotifications());
+    _ui->quotaWarningNotificationsCheckBox->setEnabled(cfgFile.optionalServerNotifications());
+    _ui->quotaWarningNotificationsCheckBox->setChecked(cfgFile.showQuotaWarningNotifications());
     _ui->showInExplorerNavigationPaneCheckBox->setChecked(cfgFile.showInExplorerNavigationPane());
     _ui->newExternalStorage->setChecked(cfgFile.confirmExternalStorage());
     _ui->monoIconsCheckBox->setChecked(cfgFile.monoIcons());
@@ -592,6 +597,12 @@ void GeneralSettings::slotToggleCallNotifications(bool enable)
 {
     ConfigFile cfgFile;
     cfgFile.setShowCallNotifications(enable);
+}
+
+void GeneralSettings::slotToggleQuotaWarningNotifications(bool enable)
+{
+    ConfigFile cfgFile;
+    cfgFile.setShowQuotaWarningNotifications(enable);
 }
 
 void GeneralSettings::slotShowInExplorerNavigationPane(bool checked)

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -196,7 +196,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     _ui->callNotificationsCheckBox->setToolTip(tr("Show call notification dialogs."));
 
     connect(_ui->quotaWarningNotificationsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleQuotaWarningNotifications);
-    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Receive notification when storage usage exceeds 80/90/95 percent"));
+    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Show notification when quota usage exceeds 80%"));
 
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -196,7 +196,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
     _ui->callNotificationsCheckBox->setToolTip(tr("Show call notification dialogs."));
 
     connect(_ui->quotaWarningNotificationsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleQuotaWarningNotifications);
-    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Show notification when quota usage exceeds 80%"));
+    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Show notification when quota usage exceeds 80%."));
 
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -195,9 +195,6 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         this, &GeneralSettings::slotToggleCallNotifications);
     _ui->callNotificationsCheckBox->setToolTip(tr("Show call notification dialogs."));
 
-    connect(_ui->quotaWarningNotificationsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleQuotaWarningNotifications);
-    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Show notification when quota usage exceeds 80%"));
-
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 
     // Rename 'Explorer' appropriately on non-Windows

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -195,6 +195,9 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         this, &GeneralSettings::slotToggleCallNotifications);
     _ui->callNotificationsCheckBox->setToolTip(tr("Show call notification dialogs."));
 
+    connect(_ui->quotaWarningNotificationsCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleQuotaWarningNotifications);
+    _ui->quotaWarningNotificationsCheckBox->setToolTip(tr("Show notification when quota usage exceeds 80%"));
+
     connect(_ui->showInExplorerNavigationPaneCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotShowInExplorerNavigationPane);
 
     // Rename 'Explorer' appropriately on non-Windows

--- a/src/gui/generalsettings.h
+++ b/src/gui/generalsettings.h
@@ -49,6 +49,7 @@ private slots:
     void slotToggleOptionalServerNotifications(bool);
     void slotToggleChatNotifications(bool);
     void slotToggleCallNotifications(bool);
+    void slotToggleQuotaWarningNotifications(bool);
     void slotShowInExplorerNavigationPane(bool);
     void slotIgnoreFilesEditor();
     void slotCreateDebugArchive();

--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -58,6 +58,13 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="quotaWarningNotificationsCheckBox">
+        <property name="text">
+         <string>Show &amp;Quota Warning Notifications</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -63,6 +63,7 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     , _isCurrentUser(isCurrent)
     , _activityModel(new ActivityListModel(_account.data(), this))
     , _unifiedSearchResultsModel(new UnifiedSearchResultsListModel(_account.data(), this))
+    , _userInfo(account.data(), false, true)
 {
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::progressInfo,
         this, &User::slotProgressInfo);
@@ -121,6 +122,9 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
             showDesktopNotification(certificateNeedMigration);
         }
     });
+
+    _userInfo.setActive(true);
+    connect(&_userInfo, &UserInfo::quotaUpdated, this, &User::slotUpdateQuota);
 }
 
 void User::checkNotifiedNotifications()

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -24,12 +24,14 @@
 #include "tray/talkreply.h"
 #include "userstatusconnector.h"
 
+#include <QtCore>
 #include <QDesktopServices>
 #include <QIcon>
 #include <QMessageBox>
 #include <QSvgRenderer>
 #include <QPainter>
 #include <QPushButton>
+#include <QDateTime>
 
 // time span in milliseconds which has to be between two
 // refreshes of the notifications
@@ -61,6 +63,7 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     , _isCurrentUser(isCurrent)
     , _activityModel(new ActivityListModel(_account.data(), this))
     , _unifiedSearchResultsModel(new UnifiedSearchResultsListModel(_account.data(), this))
+    , _userInfo(account.data(), false, true)
 {
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::progressInfo,
         this, &User::slotProgressInfo);
@@ -118,6 +121,9 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
             showDesktopNotification(certificateNeedMigration);
         }
     });
+
+    _userInfo.setActive(true);
+    connect(&_userInfo, &UserInfo::quotaUpdated, this, &User::slotUpdateQuota);
 }
 
 void User::checkNotifiedNotifications()
@@ -1190,6 +1196,36 @@ void User::slotFetchGroupFolders()
 
     const auto groupFolderListJob = _account->account()->sendRequest(QByteArrayLiteral("GET"), groupFolderListUrl, req);
     connect(groupFolderListJob, &SimpleNetworkJob::finishedSignal, this, &User::slotGroupFoldersFetched);
+}
+
+void User::slotUpdateQuota(qint64 total, qint64 used)
+{
+    if (total <= 0 || !ConfigFile().showQuotaWarningNotifications()) {
+        return;
+    }
+
+    const auto percent = (double)used / (double)total * 100.0;
+    const auto percentInt = qMin(qRound(percent), 100);
+    qCDebug(lcActivity) << tr("Quota is updated; %1 percent of the total space is used.").arg(QString::number(percentInt));
+
+    int threshold_passed = 0;
+    if (_lastQuotaPercent < 80 && percentInt >= 80) threshold_passed = 80;
+    if (_lastQuotaPercent < 90 && percentInt >= 90) threshold_passed = 90;
+    if (_lastQuotaPercent < 95 && percentInt >= 95) threshold_passed = 95;
+
+    if (threshold_passed > 0) {
+        _activityModel->removeActivityFromActivityList(_lastQuotaActivity);
+
+        const auto localFolderName = getFolder();
+        _lastQuotaActivity._type = Activity::OpenSettingsNotificationType;
+        _lastQuotaActivity._dateTime = QDateTime::fromString(QDateTime::currentDateTime().toString(), Qt::ISODate);
+        _lastQuotaActivity._subject = tr("Quota Warning - %1 percent or more storage in use").arg(QString::number(threshold_passed));
+        _lastQuotaActivity._accName = account()->displayName();
+        _lastQuotaActivity._id = qHash(QDateTime::currentMSecsSinceEpoch());
+        showDesktopNotification(_lastQuotaActivity);
+        _activityModel->addNotificationToActivityList(_lastQuotaActivity);
+    }
+    _lastQuotaPercent = percentInt;
 }
 
 void User::slotGroupFoldersFetched(QNetworkReply *reply)

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -63,7 +63,6 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     , _isCurrentUser(isCurrent)
     , _activityModel(new ActivityListModel(_account.data(), this))
     , _unifiedSearchResultsModel(new UnifiedSearchResultsListModel(_account.data(), this))
-    , _userInfo(account.data(), false, true)
 {
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::progressInfo,
         this, &User::slotProgressInfo);
@@ -86,6 +85,7 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     connect(_account.data(), &AccountState::hasFetchedNavigationApps,
         this, &User::slotRebuildNavigationAppList);
     connect(_account->account().data(), &Account::accountChangedDisplayName, this, &User::nameChanged);
+    connect(_account->account().data(), &Account::rootFolderQuotaChanged, this, &User::slotQuotaChanged);
 
     connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &User::hasLocalFolderChanged);
 
@@ -121,9 +121,6 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
             showDesktopNotification(certificateNeedMigration);
         }
     });
-
-    _userInfo.setActive(true);
-    connect(&_userInfo, &UserInfo::quotaUpdated, this, &User::slotUpdateQuota);
 }
 
 void User::checkNotifiedNotifications()
@@ -1198,13 +1195,14 @@ void User::slotFetchGroupFolders()
     connect(groupFolderListJob, &SimpleNetworkJob::finishedSignal, this, &User::slotGroupFoldersFetched);
 }
 
-void User::slotUpdateQuota(qint64 total, qint64 used)
+void User::slotQuotaChanged(const int64_t &usedBytes, const int64_t &availableBytes)
 {
+    int64_t total = usedBytes + availableBytes;
     if (total <= 0 || !ConfigFile().showQuotaWarningNotifications()) {
         return;
     }
 
-    const auto percent = (double)used / (double)total * 100.0;
+    const auto percent = (double)usedBytes / (double)total * 100.0;
     const auto percentInt = qMin(qRound(percent), 100);
     qCDebug(lcActivity) << tr("Quota is updated; %1 percent of the total space is used.").arg(QString::number(percentInt));
 
@@ -1224,7 +1222,6 @@ void User::slotUpdateQuota(qint64 total, qint64 used)
     if (threshold_passed > 0) {
         _activityModel->removeActivityFromActivityList(_lastQuotaActivity);
 
-        const auto localFolderName = getFolder();
         _lastQuotaActivity._type = Activity::OpenSettingsNotificationType;
         _lastQuotaActivity._dateTime = QDateTime::fromString(QDateTime::currentDateTime().toString(), Qt::ISODate);
         _lastQuotaActivity._subject = tr("Quota Warning - %1 percent or more storage in use").arg(QString::number(threshold_passed));

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1208,23 +1208,23 @@ void User::slotQuotaChanged(const int64_t &usedBytes, const int64_t &availableBy
 
     int thresholdPassed = 0;
     if (_lastQuotaPercent < 80 && percentInt >= 80) {
-        threshold_passed = 80;
+        thresholdPassed = 80;
     }
 
     if (_lastQuotaPercent < 90 && percentInt >= 90) {
-        threshold_passed = 90;
+        thresholdPassed = 90;
     }
 
     if (_lastQuotaPercent < 95 && percentInt >= 95) {
-        threshold_passed = 95;
+        thresholdPassed = 95;
     }
 
-    if (threshold_passed > 0) {
+    if (thresholdPassed > 0) {
         _activityModel->removeActivityFromActivityList(_lastQuotaActivity);
 
         _lastQuotaActivity._type = Activity::OpenSettingsNotificationType;
         _lastQuotaActivity._dateTime = QDateTime::fromString(QDateTime::currentDateTime().toString(), Qt::ISODate);
-        _lastQuotaActivity._subject = tr("Quota Warning - %1 percent or more storage in use").arg(QString::number(threshold_passed));
+        _lastQuotaActivity._subject = tr("Quota Warning - %1 percent or more storage in use").arg(QString::number(thresholdPassed));
         _lastQuotaActivity._accName = account()->displayName();
         _lastQuotaActivity._id = qHash(QDateTime::currentMSecsSinceEpoch());
         showDesktopNotification(_lastQuotaActivity);

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1209,9 +1209,17 @@ void User::slotUpdateQuota(qint64 total, qint64 used)
     qCDebug(lcActivity) << tr("Quota is updated; %1 percent of the total space is used.").arg(QString::number(percentInt));
 
     int threshold_passed = 0;
-    if (_lastQuotaPercent < 80 && percentInt >= 80) threshold_passed = 80;
-    if (_lastQuotaPercent < 90 && percentInt >= 90) threshold_passed = 90;
-    if (_lastQuotaPercent < 95 && percentInt >= 95) threshold_passed = 95;
+    if (_lastQuotaPercent < 80 && percentInt >= 80) {
+        threshold_passed = 80;
+    }
+
+    if (_lastQuotaPercent < 90 && percentInt >= 90) {
+        threshold_passed = 90;
+    }
+
+    if (_lastQuotaPercent < 95 && percentInt >= 95) {
+        threshold_passed = 95;
+    }
 
     if (threshold_passed > 0) {
         _activityModel->removeActivityFromActivityList(_lastQuotaActivity);

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1206,7 +1206,7 @@ void User::slotQuotaChanged(const int64_t &usedBytes, const int64_t &availableBy
     const auto percentInt = qMin(qRound(percent), 100);
     qCDebug(lcActivity) << tr("Quota is updated; %1 percent of the total space is used.").arg(QString::number(percentInt));
 
-    int threshold_passed = 0;
+    int thresholdPassed = 0;
     if (_lastQuotaPercent < 80 && percentInt >= 80) {
         threshold_passed = 80;
     }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -63,7 +63,6 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
     , _isCurrentUser(isCurrent)
     , _activityModel(new ActivityListModel(_account.data(), this))
     , _unifiedSearchResultsModel(new UnifiedSearchResultsListModel(_account.data(), this))
-    , _userInfo(account.data(), false, true)
 {
     connect(ProgressDispatcher::instance(), &ProgressDispatcher::progressInfo,
         this, &User::slotProgressInfo);
@@ -122,9 +121,6 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
             showDesktopNotification(certificateNeedMigration);
         }
     });
-
-    _userInfo.setActive(true);
-    connect(&_userInfo, &UserInfo::quotaUpdated, this, &User::slotUpdateQuota);
 }
 
 void User::checkNotifiedNotifications()

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -18,6 +18,7 @@
 #include "activitydata.h"
 #include "activitylistmodel.h"
 #include "folderman.h"
+#include "userinfo.h"
 #include "userstatusconnector.h"
 #include "userstatusselectormodel.h"
 #include <chrono>
@@ -153,6 +154,7 @@ public slots:
     void forceSyncNow() const;
     void slotAccountCapabilitiesChangedRefreshGroupFolders();
     void slotFetchGroupFolders();
+    void slotUpdateQuota(qint64 total, qint64 used);
 
 private slots:
     void slotPushNotificationsReady();
@@ -188,6 +190,7 @@ private:
     ActivityListModel *_activityModel;
     UnifiedSearchResultsListModel *_unifiedSearchResultsModel;
     ActivityList _blacklistedNotifications;
+    UserInfo _userInfo;
     
     QVariantList _trayFolderInfos;
 
@@ -206,6 +209,10 @@ private:
     int _lastTalkNotificationsReceivedCount = 0;
 
     bool _isNotificationFetchRunning = false;
+
+    // used for quota warnings
+    int _lastQuotaPercent = 0;
+    Activity _lastQuotaActivity;
 };
 
 class UserModel : public QAbstractListModel

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -154,7 +154,6 @@ public slots:
     void forceSyncNow() const;
     void slotAccountCapabilitiesChangedRefreshGroupFolders();
     void slotFetchGroupFolders();
-    void slotUpdateQuota(qint64 total, qint64 used);
 
 private slots:
     void slotPushNotificationsReady();
@@ -163,6 +162,7 @@ private slots:
     void slotReceivedPushActivity(OCC::Account *account);
     void slotCheckExpiredActivities();
     void slotGroupFoldersFetched(QNetworkReply *reply);
+    void slotQuotaChanged(const int64_t &usedBytes, const int64_t &availableBytes);
     void checkNotifiedNotifications();
     void showDesktopNotification(const QString &title, const QString &message, const long notificationId);
     void showDesktopNotification(const OCC::Activity &activity);
@@ -190,7 +190,6 @@ private:
     ActivityListModel *_activityModel;
     UnifiedSearchResultsListModel *_unifiedSearchResultsModel;
     ActivityList _blacklistedNotifications;
-    UserInfo _userInfo;
     
     QVariantList _trayFolderInfos;
 

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -154,6 +154,7 @@ public slots:
     void forceSyncNow() const;
     void slotAccountCapabilitiesChangedRefreshGroupFolders();
     void slotFetchGroupFolders();
+    void slotUpdateQuota(qint64 total, qint64 used);
 
 private slots:
     void slotPushNotificationsReady();
@@ -190,6 +191,7 @@ private:
     ActivityListModel *_activityModel;
     UnifiedSearchResultsListModel *_unifiedSearchResultsModel;
     ActivityList _blacklistedNotifications;
+    UserInfo _userInfo;
     
     QVariantList _trayFolderInfos;
 

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -154,7 +154,6 @@ public slots:
     void forceSyncNow() const;
     void slotAccountCapabilitiesChangedRefreshGroupFolders();
     void slotFetchGroupFolders();
-    void slotUpdateQuota(qint64 total, qint64 used);
 
 private slots:
     void slotPushNotificationsReady();
@@ -191,7 +190,6 @@ private:
     ActivityListModel *_activityModel;
     UnifiedSearchResultsListModel *_unifiedSearchResultsModel;
     ActivityList _blacklistedNotifications;
-    UserInfo _userInfo;
     
     QVariantList _trayFolderInfos;
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -470,6 +470,7 @@ signals:
     void encryptionCertificateFingerprintChanged();
     void userCertificateNeedsMigrationChanged();
 
+    void rootFolderQuotaChanged(const int64_t &usedBytes, const int64_t &availableBytes);
 protected Q_SLOTS:
     void slotCredentialsFetched();
     void slotCredentialsAsked();

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -216,6 +216,19 @@ void ConfigFile::setShowCallNotifications(bool show)
     settings.sync();
 }
 
+bool ConfigFile::showQuotaWarningNotifications() const
+{
+    const QSettings settings(configFile(), QSettings::IniFormat);
+    return settings.value(showQuotaWarningNotificationsC, true).toBool() && optionalServerNotifications();
+}
+
+void ConfigFile::setShowQuotaWarningNotifications(bool show)
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    settings.setValue(showQuotaWarningNotificationsC, show);
+    settings.sync();
+}
+
 bool ConfigFile::showInExplorerNavigationPane() const
 {
     const bool defaultValue =

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -165,6 +165,9 @@ public:
     [[nodiscard]] bool showCallNotifications() const;
     void setShowCallNotifications(bool show);
 
+    [[nodiscard]] bool showQuotaWarningNotifications() const;
+    void setShowQuotaWarningNotifications(bool show);
+
     [[nodiscard]] bool showInExplorerNavigationPane() const;
     void setShowInExplorerNavigationPane(bool show);
 
@@ -257,6 +260,7 @@ public:
     static constexpr char optionalServerNotificationsC[] = "optionalServerNotifications";
     static constexpr char promptDeleteC[] = "promptDeleteAllFiles";
     static constexpr char showCallNotificationsC[] = "showCallNotifications";
+    static constexpr char showQuotaWarningNotificationsC[] = "showQuotaWarningNotifications";
     static constexpr char showChatNotificationsC[] = "showChatNotifications";
     static constexpr char showInExplorerNavigationPaneC[] = "showInExplorerNavigationPane";
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -2299,6 +2299,10 @@ void ProcessDirectoryJob::setFolderQuota(const FolderQuota &folderQuota)
 {
     _folderQuota.bytesUsed = folderQuota.bytesUsed;
     _folderQuota.bytesAvailable = folderQuota.bytesAvailable;
+
+    if (_currentFolder._original == "") {
+        emit updatedRootFolderQuota(_folderQuota.bytesUsed, _folderQuota.bytesAvailable);
+    }
 }
 
 void ProcessDirectoryJob::startAsyncLocalQuery()

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -2300,7 +2300,7 @@ void ProcessDirectoryJob::setFolderQuota(const FolderQuota &folderQuota)
     _folderQuota.bytesUsed = folderQuota.bytesUsed;
     _folderQuota.bytesAvailable = folderQuota.bytesAvailable;
 
-    if (_currentFolder._original == "") {
+    if (_currentFolder._original.isEmpty()) {
         emit updatedRootFolderQuota(_folderQuota.bytesUsed, _folderQuota.bytesAvailable);
     }
 }

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -305,6 +305,7 @@ signals:
     void finished();
     // The root etag of this directory was fetched
     void etag(const QByteArray &, const QDateTime &time);
+    void updatedRootFolderQuota(const int64_t &bytesUSed, const int64_t &bytesAvailable);
 
 private slots:
     void setFolderQuota(const FolderQuota &folderQuota);

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -305,7 +305,7 @@ signals:
     void finished();
     // The root etag of this directory was fetched
     void etag(const QByteArray &, const QDateTime &time);
-    void updatedRootFolderQuota(const int64_t &bytesUSed, const int64_t &bytesAvailable);
+    void updatedRootFolderQuota(const int64_t &bytesUsed, const int64_t &bytesAvailable);
 
 private slots:
     void setFolderQuota(const FolderQuota &folderQuota);

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -760,6 +760,7 @@ void SyncEngine::startSync()
     
     _discoveryPhase->startJob(discoveryJob);
     connect(discoveryJob, &ProcessDirectoryJob::etag, this, &SyncEngine::slotRootEtagReceived);
+    connect(discoveryJob, &ProcessDirectoryJob::updatedRootFolderQuota, account().data(), &Account::rootFolderQuotaChanged);
     connect(_discoveryPhase.get(), &DiscoveryPhase::addErrorToGui, this, &SyncEngine::addErrorToGui);
 }
 


### PR DESCRIPTION
This pull request addresses issue #892 and implements
- if the storage usage exceeds the threshold of 80, 90 and 95 percent, then a notification will be sent to the user. This notification also appears on the activity list
- configuration to turn quota warnings on and off

This commit been authored by @barisbasar1209 and me.