### PR TITLE
Bugfix/incorrect context menu activation fix #8425

### DIFF
--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1428,7 +1428,7 @@ void SocketApi::command_GET_MENU_ITEMS(const QString &argument, OCC::SocketListe
         };
         for (const auto &file : files) {
             auto fileData = FileData::get(file);
-            auto availability = syncFolder->vfs().availability(fileData.folderRelativePath, Vfs::AvailabilityRecursivity::NotRecursiveAvailability);
+            auto availability = syncFolder->vfs().availability(fileData.folderRelativePath, Vfs::AvailabilityRecursivity::RecursiveAvailability);
             if (!availability) {
                 if (availability.error() == Vfs::AvailabilityError::DbError)
                     availability = VfsItemAvailability::Mixed;


### PR DESCRIPTION
This PR solves https://github.com/nextcloud/desktop/issues/8425

## Note to reviewers

### Context
In the scenario detailed in the bug report the "Free up local space" context menu item is deactivated, because the directory's pin state is online only. The pin state is checked in a non-recursive way, the pin state of sub-items are completely disregarded.

### Solution
To solve this, I check the pin state recursively. This way the result will be "all hydrated", or "mixed" (according to contents) which will activate said context menu item.

### Considerations
This idea might not be the best, because it introduces a performance issue. If the directory has a lot of sub items, the recursive check might take a long time. For this reason I attempted to make the recursive check slightly faster, however this alone won't solve the possible performance issue.
