### PR TITLE
Enable Xcode Debugger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,11 @@ if (CLANG_TIDY_EXE)
     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} -checks=-*,modernize-use-auto,modernize-use-using,modernize-use-nodiscard,modernize-use-nullptr,modernize-use-override,cppcoreguidelines-pro-type-static-cast-downcast,modernize-use-default-member-init,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-init-variables)
 endif()
 
-set(CMAKE_XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME YES)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME NO)
+else()
+    set(CMAKE_XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME YES)
+endif()
 
 set(BIN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 

--- a/admin/osx/CMakeLists.txt
+++ b/admin/osx/CMakeLists.txt
@@ -13,6 +13,14 @@ else()
 endif()
 
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} COMPONENTS Core REQUIRED)
+
+# Set debug entitlements conditionally based on build type
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(DEBUG_ENTITLEMENTS "\t<key>com.apple.security.get-task-allow</key>\n\t<true/>")
+else()
+    set(DEBUG_ENTITLEMENTS "")
+endif()
+
 configure_file(create_mac.sh.cmake ${CMAKE_CURRENT_BINARY_DIR}/create_mac.sh)
 configure_file(macosx.entitlements.cmake ${CMAKE_CURRENT_BINARY_DIR}/macosx.entitlements)
 configure_file(macosx.pkgproj.cmake ${CMAKE_CURRENT_BINARY_DIR}/macosx.pkgproj)

--- a/admin/osx/macosx.entitlements.cmake
+++ b/admin/osx/macosx.entitlements.cmake
@@ -6,5 +6,6 @@
 	<array>
 		<string>@SOCKETAPI_TEAM_IDENTIFIER_PREFIX@@APPLICATION_REV_DOMAIN@</string>
 	</array>
+@DEBUG_ENTITLEMENTS@
 </dict>
 </plist>


### PR DESCRIPTION
Due to security restrictions, a debugger cannot just attach to any process arbitrarily. Apps must not be hardened and their entitlements explicitly contain an entitlement which allows the retrieval of the task control port of a process.

This enables Xcode to successfully connect to the process of the NextcloudDev build by mac-crafter.

An example Xcode project and appropriate documentation how to leverage this to actually debug the Nextcloud desktop client in Xcode will follow.