### PR TITLE
fix(mac-crafter): use AsyncParsableCommand everywhere

### DIFF
--- a/admin/osx/mac-crafter/Sources/Commands/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Codesign.swift
@@ -6,7 +6,7 @@
 import ArgumentParser
 import Foundation
 
-struct Codesign: ParsableCommand {
+struct Codesign: AsyncParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Codesigning script for the client.")
     
     @Argument(help: "Path to the Nextcloud Desktop Client app bundle.")

--- a/admin/osx/mac-crafter/Sources/Commands/CreateDMG.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/CreateDMG.swift
@@ -6,7 +6,7 @@
 import ArgumentParser
 import Foundation
 
-struct CreateDMG: ParsableCommand {
+struct CreateDMG: AsyncParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Create a DMG for the client.")
     
     @Argument(help: "Path to the desktop client app bundle.")

--- a/admin/osx/mac-crafter/Sources/Commands/Package.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Package.swift
@@ -6,7 +6,7 @@
 import ArgumentParser
 import Foundation
 
-struct Package: ParsableCommand {
+struct Package: AsyncParsableCommand {
     static let configuration = CommandConfiguration(abstract: "Packaging script for the client.")
     
     @Option(name: [.short, .long], help: "Architecture.")


### PR DESCRIPTION
For some reason using `ParsableCommand` structs as subcommands of an `AsyncParsableCommand` does not correctly handle all passed CLI arguments.

The behaviour before this commit was as follows:

```
% mac-crafter create-dmg
Error: Missing expected argument '<app-bundle-path>'
Help:  <app-bundle-path>  Path to the desktop client app bundle.
Usage: mac-crafter create-dmg <app-bundle-path> [--product-path <product-path>] [--build-path <build-path>] [--app-name <app-name>] [--apple-id <apple-id>] [--apple-password <apple-password>] [--apple-team-id <apple-team-id>] [--package-signing-id <package-signing-id>] [--sparkle-package-sign-key <sparkle-package-sign-key>]
  See 'mac-crafter create-dmg --help' for more information.

% mac-crafter create-dmg /tmp/Nextcloud.app
OVERVIEW: Create a DMG for the client.

USAGE: mac-crafter create-dmg <app-bundle-path> [--product-path <product-path>] [--build-path <build-path>] [--app-name <app-name>] [--apple-id <apple-id>] [--apple-password <apple-password>] [--apple-team-id <apple-team-id>] [--package-signing-id <package-signing-id>] [--sparkle-package-sign-key <sparkle-package-sign-key>]

ARGUMENTS:
  <app-bundle-path>       Path to the desktop client app bundle.
[...]
```

After changing every command struct to derive from `AsyncParsableCommand`:

```
% mac-crafter create-dmg
Error: Missing expected argument '<app-bundle-path>'
Help:  <app-bundle-path>  Path to the desktop client app bundle.
Usage: mac-crafter create-dmg <app-bundle-path> [--product-path <product-path>] [--build-path <build-path>] [--app-name <app-name>] [--apple-id <apple-id>] [--apple-password <apple-password>] [--apple-team-id <apple-team-id>] [--package-signing-id <package-signing-id>] [--sparkle-package-sign-key <sparkle-package-sign-key>]
  See 'mac-crafter create-dmg --help' for more information.

% mac-crafter create-dmg /tmp/Nextcloud.app
Required command "create-dmg" is missing, installing...
[...]
```

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
