### PR TITLE
perf(activitylistmodel): store conflicts in a separate list

### DIFF
--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -535,7 +535,7 @@ void ActivityListModel::addEntriesToActivityList(const ActivityList &activityLis
     }
     endInsertRows();
 
-    const auto deselectedConflictIt = std::find_if(_finalList.constBegin(), _finalList.constEnd(), [] (const auto activity) {
+    const auto deselectedConflictIt = std::find_if(_finalList.constBegin(), _finalList.constEnd(), [] (const auto &activity) {
         return activity._syncFileItemStatus == SyncFileItem::Conflict;
     });
     const auto conflictsFound = (deselectedConflictIt != _finalList.constEnd());

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -532,15 +532,13 @@ void ActivityListModel::addEntriesToActivityList(const ActivityList &activityLis
     beginInsertRows({}, startRow, startRow + activityList.count() - 1);
     for(const auto &activity : activityList) {
         _finalList.append(activity);
+        if (activity._syncFileItemStatus == SyncFileItem::Conflict) {
+            _conflictsList.push_back(activity);
+        }
     }
     endInsertRows();
 
-    const auto deselectedConflictIt = std::find_if(_finalList.constBegin(), _finalList.constEnd(), [] (const auto &activity) {
-        return activity._syncFileItemStatus == SyncFileItem::Conflict;
-    });
-    const auto conflictsFound = (deselectedConflictIt != _finalList.constEnd());
-
-    setHasSyncConflicts(conflictsFound);
+    setHasSyncConflicts(!_conflictsList.isEmpty());
 }
 
 void ActivityListModel::accountStateHasChanged()
@@ -623,6 +621,10 @@ void ActivityListModel::removeActivityFromActivityList(const Activity &activity)
         beginRemoveRows({}, index, index);
         _finalList.removeAt(index);
         endRemoveRows();
+    }
+
+    if (activity._syncFileItemStatus == SyncFileItem::Conflict) {
+        _conflictsList.removeOne(activity);
     }
 
     if (activity._type != Activity::ActivityType &&
@@ -925,6 +927,7 @@ void ActivityListModel::slotRefreshActivityInitial()
 void ActivityListModel::slotRemoveAccount()
 {
     _finalList.clear();
+    _conflictsList.clear();
     _activityLists.clear();
     _presentedActivities.clear();
     setAndRefreshCurrentlyFetching(false);
@@ -957,15 +960,7 @@ bool ActivityListModel::hasSyncConflicts() const
 
 ActivityList ActivityListModel::allConflicts() const
 {
-    auto result = ActivityList{};
-
-    for(const auto &activity : _finalList) {
-        if (activity._syncFileItemStatus == SyncFileItem::Conflict) {
-            result.push_back(activity);
-        }
-    }
-
-    return result;
+    return _conflictsList;
 }
 
 }

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -183,6 +183,7 @@ private:
     ActivityList _notificationLists;
     ActivityList _listOfIgnoredFiles;
     ActivityList _notificationErrorsLists;
+    ActivityList _conflictsList;
     ActivityList _finalList;
 
     QSet<qint64> _presentedActivities;


### PR DESCRIPTION
Figuring out whether a sync conflict occurred by iterating through the entire activity list each time a new activity was added is really slow, even more so when there already are thousands of previous activities.  
This was especially noticeable during complete initial full syncs involving more than ~10000 files.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
