### PR TITLE
adds ability to specify user and password via env variables 

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -386,10 +386,10 @@ int main(int argc, char **argv)
         }
     } else {
         if (user.isEmpty()) {
-            user = std::getenv("NC_USER");
+            user = QString::fromUtf8(qgetenv("NC_USER"));
         }
         if (password.isEmpty()) {
-            password = std::getenv("NC_PASSWORD");
+            password = QString::fromUtf8(qgetenv("NC_PASSWORD"));
         }
     }
    


### PR DESCRIPTION
Created this PR so I could solve the code conflict and merge @internet-memme's contribution: https://github.com/nextcloud/desktop/pull/5980

> Proposal for issue https://github.com/nextcloud/desktop/issues/5875
> 
> It adds the ability to specify username and password in '--non-interactive' via $NC_USER and $NC_PASSWORD. This is the last option in the chain of username/password lookups.
> It also updates the documentation accordingly.

documentation changes: https://github.com/nextcloud/documentation/pull/13459