### PR TITLE
Enable Log Output in Xcode Console

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -117,7 +117,12 @@ void Logger::doLog(QtMsgType type, const QMessageLogContext &ctx, const QString 
     // write logs to Output window of Visual Studio
     {
         const auto msgW = QStringLiteral("%1\n").arg(msg).toStdWString();
-        OutputDebugString(msgW.c_str());
+        OutputDebugString(msgW.c());
+    }
+#elif defined Q_OS_MAC && defined QT_DEBUG
+    // write logs to Xcode console (stderr)
+    {
+        std::cerr << msg.toStdString() << std::endl;
     }
 #endif
     {


### PR DESCRIPTION
As already present for Visual Studio on Windows, the logging needs a little extra switch for debug builds so their logging output conveniently appears in the Xcode console, too, and not just a logging file or elsewhere. This improves the developer experience in the platform-specific standard development environment.

I extracted this from my personal work in progress feature branch in which several independent things piled up since yesterday morning.