### PR TITLE
Do not strip get-task-allow entitlement of developer build extensions

### DIFF
--- a/admin/osx/mac-crafter/Sources/Commands/Build.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Build.swift
@@ -274,7 +274,8 @@ struct Build: AsyncParsableCommand {
             try await codesignClientAppBundle(
                 at: clientAppDir,
                 withCodeSignIdentity: codeSignIdentity,
-                usingEntitlements: entitlementsPath
+                usingEntitlements: entitlementsPath,
+                dev: dev
             )
         }
         

--- a/admin/osx/mac-crafter/Sources/Commands/Codesign.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Codesign.swift
@@ -26,7 +26,8 @@ struct Codesign: AsyncParsableCommand {
         try await codesignClientAppBundle(
             at: absolutePath,
             withCodeSignIdentity: codeSignIdentity,
-            usingEntitlements: entitlementsPath
+            usingEntitlements: entitlementsPath,
+            dev: false
         )
     }
 }


### PR DESCRIPTION
This fixes #8495 and came around rather by coincidence while I was going through the mac-crafter code. With this change it becomes possible to attach with the Xcode debugger to the app extension processes of developer builds.