### PR TITLE
Added Package.resolved of NextcloudIntegration project to version control.

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,7 +30,7 @@ SPDX-FileCopyrightText = "2014 ownCloud GmbH"
 SPDX-License-Identifier = "GPL-2.0-or-later"
 
 [[annotations]]
-path = ["admin/osx/mac-crafter/Package.resolved"]
+path = ["admin/osx/mac-crafter/Package.resolved", "shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-2.0-or-later"

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,87 @@
+{
+  "originHash" : "b1fcfe4980e7dccc02e64ff6b1167e865e1b0fd2839c1f05e315987946e210b5",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "nextcloudcapabilitieskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/claucambra/NextcloudCapabilitiesKit.git",
+      "state" : {
+        "revision" : "a680e947d6cc2a1c101335797213e4b7d3b22102",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "nextcloudfileproviderkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nextcloud/NextcloudFileProviderKit.git",
+      "state" : {
+        "branch" : "stable-3.0",
+        "revision" : "4cd885de71516baa6bfb637a5a99fc2b0490e4e4"
+      }
+    },
+    {
+      "identity" : "nextcloudkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nextcloud/NextcloudKit.git",
+      "state" : {
+        "revision" : "8ac6704234f529d09b0651e4d94fdc14f8820333",
+        "version" : "6.0.9"
+      }
+    },
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "15493076ad9fef22c16cc64cbfbf9e5b65c385f9",
+        "version" : "20.1.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "revision" : "bae6c4be7df169fdb047d0ad63f902c1e2665e83",
+        "version" : "20.0.1"
+      }
+    },
+    {
+      "identity" : "suggestionstextfieldkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/claucambra/SuggestionsTextFieldKit.git",
+      "state" : {
+        "revision" : "b8e267d98a2a6e0c915d6284fddb3f265dc33c25",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON",
+      "state" : {
+        "revision" : "af76cf3ef710b6ca5f8c05f3a31307d44a3c5828",
+        "version" : "5.0.2"
+      }
+    },
+    {
+      "identity" : "swiftyxmlparser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yahoojapan/SwiftyXMLParser",
+      "state" : {
+        "revision" : "d7a1d23f04c86c1cd2e8f19247dd15d74e0ea8be",
+        "version" : "5.6.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
The committed file automatically generated on dependency resolution of the NextcloudIntegration project of the desktop client which contains the macOS system extensions. You can compare it to the `package-lock.json` of NPM or `composer.lock` of PHP Composer.

It is official recommendation to commit such files to version control for top-level projects like our desktop client is, it is not just a library meant to be consumed by other projects.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
