### PR TITLE
Fix Account ↔ Domain Identifier Mapping for Accounts with Port Numbers

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -14,6 +14,7 @@
 #include "config.h"
 #include "fileproviderdomainmanager.h"
 #include "fileprovidersettingscontroller.h"
+#include "fileproviderutils.h"
 
 #include "gui/accountmanager.h"
 #include "libsync/account.h"
@@ -28,54 +29,13 @@ Q_LOGGING_CATEGORY(lcMacFileProviderDomainManager, "nextcloud.gui.macfileprovide
 // are consistent throughout these classes
 namespace {
 
-static constexpr auto bundleExtensions = std::array{
-    QLatin1StringView(".app"),
-    QLatin1StringView(".framework"),
-    QLatin1StringView(".kext"),
-    QLatin1StringView(".plugin"),
-    QLatin1StringView(".docset"),
-    QLatin1StringView(".xpc"),
-    QLatin1StringView(".qlgenerator"),
-    QLatin1StringView(".component"),
-    QLatin1StringView(".saver"),
-    QLatin1StringView(".mdimporter")
-};
-static const QRegularExpression illegalChars("[:/]");
-
-inline bool hasBundleExtension(const QString &domainId)
-{
-    return std::any_of(bundleExtensions.begin(), bundleExtensions.end(), [&domainId](const auto &ext) {
-        return domainId.endsWith(ext);
-    });
-}
-
-inline bool illegalDomainIdentifier(const QString &domainId)
-{
-    return !domainId.isEmpty() && !illegalChars.match(domainId).hasMatch() && hasBundleExtension(domainId);
-}
-
 QString domainIdentifierForAccount(const OCC::Account * const account)
 {
     Q_ASSERT(account);
     auto domainId = account->userIdAtHostWithPort();
     Q_ASSERT(!domainId.isEmpty());
 
-    domainId.replace(illegalChars, "-");
-
-    // Some url domains like .app cause issues on macOS as these are also bundle extensions.
-    // Under the hood, fileproviderd will create a folder for the user to access the files named
-    // after the domain identifier. If the url domain is the same as a bundle extension, Finder
-    // will interpret this folder as a bundle and will not allow the user to access the files.
-    // Here we wrap the dot in the url domain extension to prevent this from happening.
-    for (const auto &ext : bundleExtensions) {
-        if (domainId.endsWith(ext)) {
-            domainId = domainId.left(domainId.length() - ext.length());
-            domainId += "(.)" + ext.right(ext.length() - 1);
-            break;
-        }
-    }
-
-    return domainId;
+    return OCC::Mac::FileProviderUtils::domainIdentifierForUserIdAtHostWithPort(domainId);
 }
 
 inline QString domainIdentifierForAccount(const OCC::AccountPtr account)
@@ -171,7 +131,7 @@ public:
                                                                << accountState->account()->displayName();
                         [domain retain];
 
-                        if (illegalDomainIdentifier(QString::fromNSString(domain.identifier))) {
+                        if (FileProviderUtils::illegalDomainIdentifier(QString::fromNSString(domain.identifier))) {
                             qCWarning(lcMacFileProviderDomainManager) << "Found existing file provider domain with illegal domain identifier:"
                                                                       << domain.identifier
                                                                       << "removing and recreating";

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -4,6 +4,7 @@
  */
 
 #include "fileprovidersettingscontroller.h"
+#include "fileproviderutils.h"
 
 #include <QFileDialog>
 #include <QQmlApplicationEngine>
@@ -234,8 +235,10 @@ private slots:
         qCInfo(lcFileProviderSettingsController) << "Updating domain sync statuses";
         _fileProviderDomainSyncStatuses.clear();
         const auto enabledAccounts = nsEnabledAccounts();
-        for (NSString *const domainIdentifier in enabledAccounts) {
-            const auto qDomainIdentifier = QString::fromNSString(domainIdentifier);
+
+        for (NSString *const enabledAccount in enabledAccounts) {
+            const auto qEnabledAccount = QString::fromNSString(enabledAccount);
+            const auto qDomainIdentifier = FileProviderUtils::domainIdentifierForUserIdAtHostWithPort(qEnabledAccount);
             const auto syncStatus = new FileProviderDomainSyncStatus(qDomainIdentifier, q);
             _fileProviderDomainSyncStatuses.insert(qDomainIdentifier, syncStatus);
         }

--- a/src/gui/macOS/fileproviderutils.h
+++ b/src/gui/macOS/fileproviderutils.h
@@ -32,6 +32,10 @@ namespace Mac {
 
 namespace FileProviderUtils {
 
+bool illegalDomainIdentifier(const QString &domainId);
+
+QString domainIdentifierForUserIdAtHostWithPort(const QString userIdAtHostWithPort);
+
 // Synchronous function to get the domain for a domain identifier
 NSFileProviderDomain *domainForIdentifier(const QString &domainIdentifier);
 

--- a/src/gui/macOS/fileproviderutils_mac.mm
+++ b/src/gui/macOS/fileproviderutils_mac.mm
@@ -6,6 +6,7 @@
 #include "fileproviderutils.h"
 
 #include <QLoggingCategory>
+#include <QRegularExpression>
 #include <QString>
 
 #import <FileProvider/FileProvider.h>
@@ -17,6 +18,58 @@ namespace Mac {
 namespace FileProviderUtils {
 
 Q_LOGGING_CATEGORY(lcMacFileProviderUtils, "nextcloud.gui.macfileproviderutils", QtInfoMsg)
+
+/**
+ * This list is not exhaustive already because third-party apps can define their own proprietary bundle types arbitrarily.
+ * This list only coveers the most common extensions.
+ */
+static constexpr auto bundleExtensions = std::array{
+    QLatin1StringView(".app"),
+    QLatin1StringView(".framework"),
+    QLatin1StringView(".kext"),
+    QLatin1StringView(".plugin"),
+    QLatin1StringView(".docset"),
+    QLatin1StringView(".xpc"),
+    QLatin1StringView(".qlgenerator"),
+    QLatin1StringView(".component"),
+    QLatin1StringView(".saver"),
+    QLatin1StringView(".mdimporter")
+};
+
+static const QRegularExpression illegalChars("[:/]");
+
+inline bool hasBundleExtension(const QString &domainId)
+{
+    return std::any_of(bundleExtensions.begin(), bundleExtensions.end(), [&domainId](const auto &ext) {
+        return domainId.endsWith(ext);
+    });
+}
+
+bool illegalDomainIdentifier(const QString &domainId)
+{
+    return !domainId.isEmpty() && !illegalChars.match(domainId).hasMatch() && hasBundleExtension(domainId);
+}
+
+QString domainIdentifierForUserIdAtHostWithPort(const QString userIdAtHostWithPort)
+{
+    auto domainId = userIdAtHostWithPort;
+    domainId.replace(illegalChars, "-");
+
+    // Some url domains like .app cause issues on macOS as these are also bundle extensions.
+    // Under the hood, fileproviderd will create a folder for the user to access the files named
+    // after the domain identifier. If the url domain is the same as a bundle extension, Finder
+    // will interpret this folder as a bundle and will not allow the user to access the files.
+    // Here we wrap the dot in the url domain extension to prevent this from happening.
+    for (const auto &ext : bundleExtensions) {
+        if (domainId.endsWith(ext)) {
+            domainId = domainId.left(domainId.length() - ext.length());
+            domainId += "(.)" + ext.right(ext.length() - 1);
+            break;
+        }
+    }
+
+    return domainId;
+}
 
 NSFileProviderDomain *domainForIdentifier(const QString &domainIdentifier)
 {

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -309,33 +309,36 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
     if (Mac::FileProvider::fileProviderAvailable()) {
         for (const auto &accountState : AccountManager::instance()->accounts()) {
-            const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(accountState);
-            if (!Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(accountFpId)) {
+            const auto accountId = accountState->account()->userIdAtHostWithPort();
+            const auto domainId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(accountState);
+
+            if (!Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(accountId)) {
                 continue;
             }
+
             allPaused = false;
             const auto fileProvider = Mac::FileProvider::instance();
 
-            if (!fileProvider->xpc()->fileProviderExtReachable(accountFpId)) {
-                problemFileProviderAccounts.append(accountFpId);
+            if (!fileProvider->xpc()->fileProviderExtReachable(domainId)) {
+                problemFileProviderAccounts.append(accountId);
             } else {
                 switch (fileProvider->socketServer()->latestReceivedSyncStatusForAccount(accountState->account())) {
                 case SyncResult::Undefined:
                 case SyncResult::NotYetStarted:
-                    idleFileProviderAccounts.append(accountFpId);
+                    idleFileProviderAccounts.append(accountId);
                     break;
                 case SyncResult::SyncPrepare:
                 case SyncResult::SyncRunning:
                 case SyncResult::SyncAbortRequested:
-                    syncingFileProviderAccounts.append(accountFpId);
+                    syncingFileProviderAccounts.append(accountId);
                     break;
                 case SyncResult::Success:
-                    successFileProviderAccounts.append(accountFpId);
+                    successFileProviderAccounts.append(accountId);
                     break;
                 case SyncResult::Problem:
                 case SyncResult::Error:
                 case SyncResult::SetupError:
-                    problemFileProviderAccounts.append(accountFpId);
+                    problemFileProviderAccounts.append(accountId);
                     break;
                 case SyncResult::Paused: // This is not technically possible with VFS
                     break;


### PR DESCRIPTION
The code is broken in some places when it comes to mapping account identifiers to file provider domain identifiers and vice versa. This only becomes obvious when connecting to servers with explicit port specifications (in example `localhost:8080`). Hence, file provider domains are not recognized correctly and the interprocess communication fails, too.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
