### PR TITLE
fix(wizard): show VFS option during account setup when using a mac-VFS build

### DIFF
--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -149,11 +149,14 @@ void OwncloudAdvancedSetupPage::initializePage()
 {
     WizardCommon::initErrorLabel(_ui.errorLabel);
 
-    if (Theme::instance()->disableVirtualFilesSyncFolder() || !Theme::instance()->showVirtualFilesOption()
-#ifndef BUILD_FILE_PROVIDER_MODULE
-        || bestAvailableVfsMode() == Vfs::Off
+    if (Theme::instance()->disableVirtualFilesSyncFolder()
+            || !(Theme::instance()->showVirtualFilesOption()
+#ifdef BUILD_FILE_PROVIDER_MODULE
+                 || Mac::FileProvider::fileProviderAvailable()
+#else
+                 && bestAvailableVfsMode() != Vfs::Off
 #endif
-    ) {
+    )) {
         // If the layout were wrapped in a widget, the auto-grouping of the
         // radio buttons no longer works and there are surprising margins.
         // Just manually hide the button and remove the layout.


### PR DESCRIPTION
Resolves #8508

tested with:
- macOS VFS build: option appears
- macOS non-VFS build `showExperimentalOptions=false` and `suffix` plugin present: option does not appear
- macOS non-VFS build `showExperimentalOptions=true` and `suffix` plugin present: option appears
- macOS non-VFS build `showExperimentalOptions=true` and `suffix` plugin absent: option does not appear
- windows, `cfapi` plugin absent: option does not appear
- windows, `cfapi` plugin present: option appears

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
