### PR TITLE
feat: checks Qt managed translations for tripple dots instead of elipsis

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -10,7 +10,7 @@ on:
 permissions: read-all
 
 jobs:
-  checkTranslations:
+  checkGermanTranslations:
     runs-on: ubuntu-latest
     
     steps:
@@ -18,3 +18,17 @@ jobs:
       - name: Check German
         run: |
           [[ $(grep "Benötigt keine Übersetzung" translations/client_de.ts -c) -gt 0 ]] && exit 1 || exit 0
+
+  checkTranslations:
+    runs-on: ubuntu-latest
+    container: ghcr.io/nextcloud/continuous-integration-translations-desktop:latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check Elipsis
+        run: |
+          lupdate -no-obsolete src/gui/ src/cmd/ src/common/ $crashreporter src/csync/ src/libsync/ $resources -ts ../ci-client.ts
+          if [ $(grep '\.\.\.' ../ci-client.ts | wc -l) -ne 0 ]; then
+            echo "English source contains three consecutive dots. Unicode … should be used instead"
+            exit -1
+          fi


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
