### PR TITLE
fix(l10n): Don't sync xcstrings for now

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -13,15 +13,3 @@ file_filter = nextcloud.client-desktop/<lang>_translation.desktop
 source_file = mirall.desktop.in
 source_lang = en
 type        = DESKTOP
-
-[o:nextcloud:p:nextcloud:r:client-fileprovider]
-file_filter            = shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Localizable.xcstrings
-source_file            = shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Localizable.xcstrings
-source_lang            = en
-type                   = XCSTRINGS
-
-[o:nextcloud:p:nextcloud:r:client-fileproviderui]
-file_filter            = shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Localizable.xcstrings
-source_file            = shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Localizable.xcstrings
-source_lang            = en
-type                   = XCSTRINGS


### PR DESCRIPTION
See 
- https://github.com/nextcloud/swiftnextcloudui/issues/3
- https://github.com/nextcloud/docker-ci/issues/809

For now the resources have been locked to prevent translators from wasting time by re-translating all the time, but that breaks the normal sync of the desktop client:

```
# Pushing source files

nextcloud.client - Uploading file
nextcloud.client-desktop - Uploading file
nextcloud.client-fileprovider - Uploading file
nextcloud.client-fileproviderui - Uploading file
nextcloud.client-fileprovider - 409, conflict: This action cannot be performed..
nextcloud.client-fileproviderui - 409, conflict: This action cannot be perform..
nextcloud.client-desktop - Done
nextcloud.client - Done

ERR
```

So for now I suggest to remove the resources from the sync, so the other translations at least still sync.