### PR TITLE
Stable 3.17 File Provider Localization

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Localizable.xcstrings
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Localizable.xcstrings
@@ -1,28 +1,1312 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "Allow automatic freeing up space" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatische Freigabe von Speicherplatz erlauben"
+  "sourceLanguage": "en",
+  "strings": {
+    "Allow automatic freeing up space": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السماح بتحرير المساحة تلقائيًا"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povolit automatické uvolňování místa"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillad automatisk frigivelse af plads"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Freigabe von Speicherplatz erlauben"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatische Freigabe von Speicherplatz erlauben"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir liberación automática de espacio"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luba andmeruumi automaatselt vabastada"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baimendu automatikoki tokia libratzea"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser la libération automatique d'espace"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפשר שחרור מקום אוטומטי"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatikus helyfoglalás engedélyezése"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti liberazione automatica spazio"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動容量解放を許可"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 공간 확보 허용"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch ruimte vrijmaken toestaan"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zezwól na automatyczne zwalnianie miejsca"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir liberação automática de espaço"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить автоматическое освобождение пространства"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillåt automatisk frigöring av utrymme"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruhusu kuachilia nafasi kiotomatiki"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik alan boşaltmaya izin ver"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволити автоматичне звільнення місця"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许自动释放空间"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許自動釋放空間"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow automatic freeing up space"
           }
         }
       }
     },
-    "Always keep downloaded" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immer heruntergeladen"
+    "Always keep downloaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "احتفظ بالتنزيل دائماً"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vždy ponechat stažené"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behold altid downloadet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Immer heruntergeladen"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heruntergeladene immer behalten"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantener siempre descargado"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jäta allalaaditu alati alles"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantendu beti deskargatuta"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toujours garder téléchargé"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "שמור תמיד הורדות"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindig tartsd letöltve"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni sempre scaricato"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常にダウンロード済みを保持"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "항상 다운로드 상태 유지"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Altijd gedownload houden"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zawsze zachowaj pobrane"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha sempre baixado"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всегда держать сохранённым"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Behåll alltid nedladdningar"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daima weka iliyopakuliwa"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Her zaman indirilmiş tut"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завжди зберігайте завантажені файли"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始终保持下载"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永遠保持下載"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always keep downloaded"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Localizable.xcstrings
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Localizable.xcstrings
@@ -1,810 +1,21281 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "Account data is unavailable, cannot reload data!" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontodaten sind nicht verfügbar, kann Daten nicht neu laden!"
+  "sourceLanguage": "en",
+  "strings": {
+    "Account data is unavailable, cannot reload data!": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kontodaten sind nicht verfügbar, kann Daten nicht neu laden!"
           }
         }
       }
     },
-    "Allow upload and editing" : {
-      "comment" : "Checkbox title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hochladen und bearbeiten erlauben"
+    "Allow upload and editing": {
+      "comment": "Checkbox title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Cancel" : {
-      "comment" : "Button title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laat oplaai en redigering toe"
           }
-        }
-      }
-    },
-    "Cancel create icon" : {
-      "comment" : "Accessibility description for delete button",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Abbruch"
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Checkmark in a circle" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haken in einem Kreis"
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السّماح بالرفع و التعديل "
           }
-        }
-      }
-    },
-    "Circle share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teamfreigabe (%@)"
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Circle share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Teamfreigabe"
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Close" : {
-      "comment" : "Button title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Communicating with server, locking file…" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommuniziere mit Server, sperre Datei…"
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешаване на качване и редактиране"
           }
-        }
-      }
-    },
-    "Communicating with server, unlocking file…" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kommuniziere mit Server, entsperre Datei…"
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Could not fetch capabilities as account is invalid." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konnte Fähigkeiten nicht laden, weil das Konto ungültig ist!"
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Could not get identifier for item, no shares can be acquired." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konnte Kennung des Elements nicht finden, Freigaben können nicht geladen werden."
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Could not lock unknown item…" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konnte Datei nicht sperren…"
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Could not reload data: %@, will try again." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konnte Daten nicht neu laden: %@, erneuter Versuch."
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povolit nahrávání a úpravy"
           }
-        }
-      }
-    },
-    "Create new share" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neue Freigabe erstellen"
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Delete" : {
-      "comment" : "Button title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Löschen"
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Delete trash icon" : {
-      "comment" : "Accessibility description for image on delete button",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Entleeren des Papierkorbs"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hochladen und bearbeiten erlauben"
           }
-        }
-      }
-    },
-    "Dismiss" : {
-      "comment" : "Button title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Document symbol" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Dokument"
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Email share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail Freigabe"
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Email share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail Freigabe (%@)"
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Email share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für E-Mail Freigabe"
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir la subida y edición"
           }
-        }
-      }
-    },
-    "Enter a new password" : {
-      "comment" : "Text field placeholder",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein neues Passwort eingeben"
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Error creating: %@" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Erstellen: %@"
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir cargar y editar"
           }
-        }
-      }
-    },
-    "Error fetching shares: %@" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Laden der Freigaben: %@"
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Error getting server caps: %@" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Laden der Serverfähigkeiten: %@"
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Expiration date" : {
-      "comment" : "Checkbox title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ablaufdatum"
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Failed to get details from File Provider Extension. Retrying." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Laden der Details von der Finder Erweiterung. Erneuter Versuch."
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Federated cloud share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Föderierte Cloudfreigabe"
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir carga y edición"
           }
-        }
-      }
-    },
-    "Federated cloud share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Föderierte Freigabe (%@)"
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Federated cloud share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Föderierte Freigabe"
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "File \"%@\" locked!" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei „%@“ wurde gesperrt!"
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir la carga y edición"
           }
-        }
-      }
-    },
-    "File \"%@\" unlocked!" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei „%@“ wurde entsperrt!"
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Free up space" : {
-      "comment" : "Context menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherplatz freigeben"
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Group share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gruppenfreigabe"
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Group share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gruppenfreigabe (%@)"
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Group share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Gruppenfreigabe"
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Hide download" : {
-      "comment" : "Checkbox title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloadoption verstecken"
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Internal link share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für interne Freigabe"
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Internal share (requires access to file)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interne Freigabe (erfordert Dateizugriff)"
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luba üleslaadimine ja muutmine"
           }
-        }
-      }
-    },
-    "Last modified: %@" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuletzt geändert: %@"
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onartu igo eta editatzea"
           }
-        }
-      }
-    },
-    "Lock file" : {
-      "comment" : "Context menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei sperren"
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Locking file \"%@\"…" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sperre Datei „%@“…"
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "NextcloudKit instance or account is unavailable, cannot fetch shares!" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NextcloudKit Instanz oder Konto nicht verfügbar, Freigaben können nicht geladen werden!"
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "No item URL, cannot reload data!" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Datei-URL, kann Daten nicht neu laden!"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autoriser le téléversement et l'édition"
           }
-        }
-      }
-    },
-    "Note for the recipient" : {
-      "comment" : "Checkbox title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notiz für Empfänger"
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ceadaigh uaslódáil agus eagarthóireacht"
           }
-        }
-      }
-    },
-    "Password protect" : {
-      "comment" : "Checkbox title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passwortschutz"
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Public link has been copied icon" : {
-      "comment" : "Accessibility description for button",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für erfolgtes Kopieren des öffentlichen Links"
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir o envío e a edición"
           }
-        }
-      }
-    },
-    "Public link share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffentliche Linkfreigabe"
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Public link share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für öffentliche Linkfreigabe"
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Save" : {
-      "comment" : "Button title",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speichern"
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Server does not support shares." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Server unterstützt keine Freigaben."
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Share label" : {
-      "comment" : "Text field placeholder",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Freigabename"
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feltöltés és szerkesztés engedélyezése"
           }
-        }
-      }
-    },
-    "Share options" : {
-      "comment" : "Text label; Context menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Freigabeoptionen"
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Share recipient" : {
-      "comment" : "Text field placeholder",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Freigabeempfänger"
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Talk conversation share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talk Konversationsfreigabe"
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Talk conversation share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Talk Konversationsfreigabe (%@)"
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Talk conversation share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Talk Konversationsfreigabe"
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leyfa innsendingu og breytingar"
           }
-        }
-      }
-    },
-    "Team share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Teamfreigabe"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consenti caricamento e modifica"
           }
-        }
-      }
-    },
-    "This file cannot be shared." : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Datei kann nicht freigegeben werden."
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップロードと編集を許可"
           }
-        }
-      }
-    },
-    "Unable to retrieve file metadata…" : {
-      "comment" : "Error message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler beim Laden der Metadaten…"
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Unknown item" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannte Datei"
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
           }
-        }
-      }
-    },
-    "Unknown modification date" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekanntes Änderungsdatum"
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업로드와 수정 허용"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atļaut augšupielādi un labošanu"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволи прикачување и уредување"
           }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillat opplasting og redigering"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uploaden en bewerken toestaan"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zezwalaj na przesyłanie i edytowanie"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permitir uploads e edição"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешить загрузку и редактирование файлов"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Povoliť nahrávanie a úpravy"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволи отпремање и уређивање"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tillåt uppladdning och redigering"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yüklenebilsin ve düzenlenebilsin"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يوللاش ۋە تەھرىرلەشكە يول قويۇڭ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволити завантаження та редагування"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允许上传与编辑"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許上傳及編輯"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "允許上傳與編輯"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allow upload and editing"
+          }
         }
       }
     },
-    "Unknown share" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannte Freigabe"
+    "Cancel create icon": {
+      "comment": "Accessibility description for delete button",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Abbruch"
           }
         }
       }
     },
-    "Unknown size" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannte Größe"
+    "Checkmark in a circle": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haken in einem Kreis"
           }
         }
       }
     },
-    "Unlock file" : {
-      "comment" : "Context menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei entsperren"
+    "Circle share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teamfreigabe (%@)"
           }
         }
       }
     },
-    "Unlocking file \"%@\"…" : {
-      "comment" : "Text label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entsperre Datei „%@“…"
+    "Circle share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Teamfreigabe"
           }
         }
       }
     },
-    "User share" : {
-      "comment" : "Menu item label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerfreigabe"
+    "Close": {
+      "comment": "Button title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إغلاق"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затвори"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seriñ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanca"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zavřít"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luk"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Κλείσιμο"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermi"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sulge"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Itxi"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بستن"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sulje"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dún"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pechar"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "סגירה"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatvori"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bezárás"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutup"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loka"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chiudi"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫기"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Užverti"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затвори"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lukk"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sluiten"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tampar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamknij"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fechar"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fechar"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Închide"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрыть"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serra"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zatvoriť"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapri"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затвори"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stäng"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ปิด"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapat"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تاقاش"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрити"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        }
+      }
+    },
+    "Communicating with server, locking file…": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kommuniziere mit Server, sperre Datei…"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Communicating with server, locking file…"
+          }
+        }
+      }
+    },
+    "Could not fetch capabilities as account is invalid.": {
+      "comment": "Error message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not fetch capabilities as account is invalid."
+          }
+        }
+      }
+    },
+    "Could not get identifier for item, no shares can be acquired.": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte Kennung des Elements nicht finden, Freigaben können nicht geladen werden."
+          }
+        }
+      }
+    },
+    "Could not lock unknown item…": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte Datei nicht sperren…"
+          }
+        }
+      }
+    },
+    "Could not reload data: %@, will try again.": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konnte Daten nicht neu laden: %@, erneuter Versuch."
+          }
+        }
+      }
+    },
+    "Create new share": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neue Freigabe erstellen"
+          }
+        }
+      }
+    },
+    "Delete trash icon": {
+      "comment": "Accessibility description for image on delete button",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Entleeren des Papierkorbs"
+          }
+        }
+      }
+    },
+    "Dismiss": {
+      "comment": "Button title",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
+          }
+        }
+      }
+    },
+    "Document symbol": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Dokument"
+          }
+        }
+      }
+    },
+    "Email share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail Freigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email share"
+          }
+        }
+      }
+    },
+    "Email share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E-Mail Freigabe (%@)"
+          }
+        }
+      }
+    },
+    "Email share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für E-Mail Freigabe"
+          }
+        }
+      }
+    },
+    "Enter a new password": {
+      "comment": "Text field placeholder",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein neues Passwort eingeben"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new password"
+          }
+        }
+      }
+    },
+    "Error creating: %@": {
+      "comment": "Error message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error creating: %@"
+          }
+        }
+      }
+    },
+    "Error fetching shares: %@": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Laden der Freigaben: %@"
+          }
+        }
+      }
+    },
+    "Error getting server caps: %@": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Laden der Serverfähigkeiten: %@"
+          }
+        }
+      }
+    },
+    "Expiration date": {
+      "comment": "Checkbox title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablaufdatum"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expiration date"
+          }
+        }
+      }
+    },
+    "Failed to get details from File Provider Extension. Retrying.": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler beim Laden der Details von der Finder Erweiterung. Erneuter Versuch."
+          }
+        }
+      }
+    },
+    "Federated cloud share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Föderierte Cloudfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Federated cloud share"
+          }
+        }
+      }
+    },
+    "Federated cloud share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Föderierte Freigabe (%@)"
+          }
+        }
+      }
+    },
+    "Federated cloud share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Föderierte Freigabe"
+          }
+        }
+      }
+    },
+    "File \"%@\" locked!": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei „%@“ wurde gesperrt!"
+          }
+        }
+      }
+    },
+    "Group share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gruppenfreigabe (%@)"
+          }
+        }
+      }
+    },
+    "Group share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Gruppenfreigabe"
+          }
+        }
+      }
+    },
+    "Hide download": {
+      "comment": "Checkbox title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخفاء التنزيل"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скриване на изтеглянето"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skrýt stažení"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Downloadoption verstecken"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar descarga"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar descarga"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar descarga"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Peida allalaadimine"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ezkutuko deskarga"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer le téléchargement"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folaigh íoslódáil"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agochar a descarga"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Letöltés elrejtése"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fela niðurhal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi scaricamento"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロードを隠す"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다운로드 숨기기"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Slėpti atsiuntimą"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paslēpt lejupielādi"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сокриј преземање"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skjul nedlasting"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verberg download"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj pobieranie"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar download"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть закачку"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skryť sťahovanie"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сакриј преузимање"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dölj nedladdning"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İndirme gizlensin"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "چۈشۈرۈشنى يوشۇرۇش"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приховати звантаження"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏下载"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏下載"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏下載"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide download"
+          }
+        }
+      }
+    },
+    "Internal link share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für interne Freigabe"
+          }
+        }
+      }
+    },
+    "Internal share (requires access to file)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interne Freigabe (erfordert Dateizugriff)"
+          }
+        }
+      }
+    },
+    "Last modified: %@": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt geändert: %@"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last modified: %@"
+          }
+        }
+      }
+    },
+    "Locking file \"%@\"…": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sperre Datei „%@“…"
+          }
+        }
+      }
+    },
+    "NextcloudKit instance or account is unavailable, cannot fetch shares!": {
+      "comment": "Error message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NextcloudKit instance or account is unavailable, cannot fetch shares!"
+          }
+        }
+      }
+    },
+    "No item URL, cannot reload data!": {
+      "comment": "Error message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Datei-URL, kann Daten nicht neu laden!"
+          }
+        }
+      }
+    },
+    "Note for the recipient": {
+      "comment": "Checkbox title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notiz für Empfänger"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note for the recipient"
+          }
+        }
+      }
+    },
+    "Public link has been copied icon": {
+      "comment": "Accessibility description for button",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link has been copied icon"
+          }
+        }
+      }
+    },
+    "Public link share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffentliche Linkfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Public link share"
+          }
+        }
+      }
+    },
+    "Public link share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für öffentliche Linkfreigabe"
+          }
+        }
+      }
+    },
+    "Save": {
+      "comment": "Button title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        }
+      }
+    },
+    "Server does not support shares.": {
+      "comment": "Error message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server does not support shares."
+          }
+        }
+      }
+    },
+    "Share label": {
+      "comment": "Text field placeholder",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "علامة رابط المشاركة"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " Споделяне на етикет"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Štítek sdílení"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Freigabename"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta del recurso compartido"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta de uso compartido"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etiqueta del recurso compartido"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jagamise silt"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partekatu etiketa"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Libellé du partage"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comhroinn lipéad"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compartir a etiqueta"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Megosztás címkéje"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merking á sameign"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Condividi etichetta"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有ラベル"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유 이름"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koplietojuma iezīme"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ознака на споделувањето"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Del etikett"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deel label"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udostępnij etykietę"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rótulo do compartilhamento"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Метка общего доступа"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zdieľať značku"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ознака дељења"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delningsetikett"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paylaşım etiketi"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ئورتاقلىشىش بەلگىسى"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ярлик спільного ресурсу"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共享标签"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享標籤"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享標籤"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share label"
+          }
+        }
+      }
+    },
+    "Group share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gruppenfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group share"
+          }
+        }
+      }
+    },
+    "Talk conversation share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk Konversationsfreigabe (%@)"
+          }
+        }
+      }
+    },
+    "Talk conversation share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Talk Konversationsfreigabe"
+          }
+        }
+      }
+    },
+    "Team share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teamfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Team share"
+          }
+        }
+      }
+    },
+    "This file cannot be shared.": {
+      "comment": "Error message",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file cannot be shared."
+          }
+        }
+      }
+    },
+    "Unable to retrieve file metadata…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to retrieve file metadata…"
+          }
+        }
+      }
+    },
+    "Unknown item": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannte Datei"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown item"
+          }
+        }
+      }
+    },
+    "Unknown share": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannte Freigabe"
+          }
+        }
+      }
+    },
+    "Unknown size": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannte Größe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown size"
+          }
+        }
+      }
+    },
+    "Password protect": {
+      "comment": "Checkbox title",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beskerm met 'n wagwoord"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passwortschutz"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proteger con contraseña"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Password protect"
+          }
+        }
+      }
+    },
+    "Share options": {
+      "comment": "Text label; Context menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خيارات المشاركة"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опции за споделяне"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dibaboù rannañ"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcions de compartició"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Možnosti sdílení"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dele muligheder"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Freigabeoptionen"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Επιλογές κοινής χρήσης"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcioj pri kunhavigo"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opciones de compartir"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opciones de uso compartido"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opciones de uso compartido"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jagamise valikud"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partekatze aukerak"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "گزینه‌های هم‌رسانی"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jakamisen valinnat"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Options de partage"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comhroinn roghanna"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcións de compartir"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "אפשרויות שיתוף"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mogućnosti dijeljenja"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Megosztási beállítások"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Valkostir sameigna"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opzioni di condivisione"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有オプション"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공유 옵션"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bendrinimo parinktys"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опции за споделување"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternativer for deling"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deelopties"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcions de partatge"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcje udostępniania"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opções de compartilhamento"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opções de partilha"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Общий доступ…"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sèberos de cumpartzidura"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Možnosti zdieľania"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Možnosti souporabe"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опције дељења"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delningsalternativ"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paylaşım seçenekleri"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ئورتاقلىشىش تاللانمىلىرى"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поділитися"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共享选项"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享選項"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分享選項"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share options"
+          }
+        }
+      }
+    },
+    "Share recipient": {
+      "comment": "Text field placeholder",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Freigabeempfänger"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share recipient"
+          }
+        }
+      }
+    },
+    "Talk conversation share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk Konversationsfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Talk conversation share"
+          }
+        }
+      }
+    },
+    "Unknown modification date": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekanntes Änderungsdatum"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown modification date"
+          }
+        }
+      }
+    },
+    "Unlock file": {
+      "comment": "Context menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح قفل unlock ملف"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отключване на файл"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odemknout soubor"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei entsperren"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Malŝlosi dosieron"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquear archivo"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquear archivo"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquear archivo"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eemalda faili lukustus"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desblokeatu fitxategia"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avaa tiedoston lukitus"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déverrouiller le fichier"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Díghlasáil an comhad"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquear ficheiro"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fájl feloldása"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aflæsa skrá"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sblocca file"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ロックを解除"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 잠금 해제"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrakinti failą"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lås opp filen"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ontgrendel bestand"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odblokuj plik"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desbloquear arquivo"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снять блокировку файла"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odomknúť súbor"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odkleni datoteko"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Откључај фајл"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lås upp fil"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyanın kilidini aç"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ھۆججەتنى ئېچىش"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розблокувати файл"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解锁文件"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解鎖檔案"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解鎖檔案"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlock file"
+          }
+        }
+      }
+    },
+    "Unlocking file \"%@\"…": {
+      "comment": "Text label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entsperre Datei „%@“…"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unlocking file \"%@\"…"
+          }
+        }
+      }
+    },
+    "User share": {
+      "comment": "Menu item label",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "af": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "an": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ast": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "az": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "be": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "bg_BG": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "bn_BD": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "br": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ca": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "cs_CZ": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "cy_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerfreigabe"
+          }
+        },
+        "de_DE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "el": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "en_GB": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "eo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_419": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_AR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_CL": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_CO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_CR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_DO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_EC": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_GT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_HN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_MX": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_NI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_PA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_PE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_PR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_PY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_SV": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "es_UY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "et_EE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "eu": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "fi_FI": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "fo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ga": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "gd": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "gl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "he": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "hi_IN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "hr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "hsb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "hu_HU": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "hy": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ia": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ig": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "is": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ja_JP": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ka": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ka_GE": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "kab": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "kn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "la": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "lb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "lo": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "lt_LT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "lv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "mk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "mn": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "mr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ms_MY": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "my": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "nb_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ne": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "nn_NO": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "oc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ps": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "pt_BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "pt_PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ro": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sc": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "si": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sk_SK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sq": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sr@latin": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "sw": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ta": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "th_TH": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "tk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ug": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "ur_PK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "uz": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "zh_CN": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "zh_HK": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "zh_TW": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
+          }
+        },
+        "zu_ZA": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "User share"
           }
         }
       }
     },
-    "User share (%@)" : {
-      "comment" : "Text label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benutzerfreigabe (%@)"
+    "User share (%@)": {
+      "comment": "Text label",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerfreigabe (%@)"
           }
         }
       }
     },
-    "User share icon" : {
-      "comment" : "Accessibility description for image",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol für Benutzerfreigabe"
+    "User share icon": {
+      "comment": "Accessibility description for image",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symbol für Benutzerfreigabe"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }


### PR DESCRIPTION
I copied the string catalogs from `master` because cherry picking did not work out. This should suffice in this case. `stable-3.17` had an intermediate state of what is on `master` now.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
