### PR TITLE
fix(msi): display non-technical version in installer

### DIFF
--- a/admin/win/msi/OEM.wxi.in
+++ b/admin/win/msi/OEM.wxi.in
@@ -33,7 +33,7 @@
     <?define VerStd = "$(var.VerMajor).$(var.VerMinor).$(var.VerRevision)" ?>
     <?define VerFull = "$(var.VerStd).$(var.VerBuild)" ?>
 
-    <?define VerDesc = "@MIRALL_VERSION_STRING@ (Git revision @GIT_REVISION@)" ?>
+    <?define VerDesc = "@MIRALL_HUMAN_VERSION_STRING@ (Git revision @GIT_REVISION@)" ?>
 
     <!-- MSI upgrade support -->
     <?define UpgradeCode = "@WIN_MSI_UPGRADE_CODE@" ?>


### PR DESCRIPTION
e.g. "3.16.82rc2" -> "3.17.0 rc2"; proper release builds will still read "3.17.0"

| **Before** | **After** |
|-|-|
| <img width="169" height="35" alt="3.16.81rc1 (build 20250730) (Git revision b6773c4)" src="https://github.com/user-attachments/assets/c3bd1b6a-3185-4cf7-a065-3f9cd73bf495" /> | <img width="781" height="611" alt="3.17.0 rc2 (Git revision b39455f)" src="https://github.com/user-attachments/assets/c6d78bc3-8399-4351-b262-9239a30885dc" /> |


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
