### PR TITLE
fix(macOS): fix initial VFS activation step

### DIFF
--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] Q_INVOKABLE FileProviderDomainSyncStatus *domainSyncStatusForAccount(const QString &userIdAtHost) const;
 
 public slots:
-    void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
+    void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled, const bool showInformationDialog = true);
     void setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
     void resetVfsForAccount(const QString &userIdAtHost);
 

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -358,13 +358,13 @@ bool FileProviderSettingsController::vfsEnabledForAccount(const QString &userIdA
     return d->vfsEnabledForAccount(userIdAtHost);
 }
 
-void FileProviderSettingsController::setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled)
+void FileProviderSettingsController::setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled, const bool showInformationDialog)
 {
     const auto enabledAccountsAction = d->setVfsEnabledForAccount(userIdAtHost, setEnabled);
     if (enabledAccountsAction == MacImplementation::VfsAccountsAction::VfsAccountsEnabledChanged) {
         emit vfsEnabledAccountsChanged();
 
-        if (setEnabled) {
+        if (setEnabled && showInformationDialog) {
             QMessageBox::information(nullptr,
                                      tr("macOS virtual files enabled"),
                                      tr("Virtual files have been enabled for this account.\n"

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -26,6 +26,7 @@
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
 #include "gui/macOS/fileprovider.h"
+#include "gui/macOS/fileprovidersettingscontroller.h"
 #endif
 
 #include <QAbstractButton>
@@ -680,19 +681,18 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
         auto account = applyAccountChanges();
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
-        if (Mac::FileProvider::fileProviderAvailable()) {
+        if (Mac::FileProvider::fileProviderAvailable() && _ocWizard->useVirtualFileSync()) {
             Mac::FileProvider::instance()->domainManager()->addFileProviderDomainForAccount(account);
+            // let the user settings know that VFS is enabled
+            Mac::FileProviderSettingsController::instance()->setVfsEnabledForAccount(
+                Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(AccountStatePtr(account)),
+                true,
+                false
+            );
             _ocWizard->appendToConfigurationLog(
                 tr("<font color=\"green\"><b>File Provider-based account %1 successfully created!</b></font>").arg(account->account()->userIdAtHostWithPort()));
             _ocWizard->done(result);
             emit ownCloudWizardDone(result);
-
-            QMessageBox::information(nullptr,
-                                     tr("Virtual files enabled"),
-                                     tr("Your account is now syncing with virtual files support. "
-                                        "This means that all your files are online-only by default, "
-                                        "and will be downloaded on-demand when you open them. "
-                                        "You may find your files under the <b>Locations</b> section of the Finder sidebar."));
 
             return;
         }


### PR DESCRIPTION
- only activate VFS for the account if the user chose to do so
- don't display the "VFS is now active" messagebox during account setup
- set VFS enabled in the FileProviderSettingsController, the enabled/disabled state is set in a .plist file (e.g. `~/Library/Preferences/com.nextcloud.desktopclient.plist`) ...

reported in https://github.com/nextcloud/desktop/issues/8508#issuecomment-3156466367

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
