### PR TITLE
Remove Debian Bullseye, add Trixie

### DIFF
--- a/admin/linux/debian/drone-build.sh
+++ b/admin/linux/debian/drone-build.sh
@@ -22,12 +22,12 @@ if test "${DRONE_TARGET_BRANCH}" = "stable-2.6"; then
     DEBIAN_DISTRIBUTIONS="buster stretch testing"
 else
     UBUNTU_DISTRIBUTIONS="jammy noble plucky questing"
-    DEBIAN_DISTRIBUTIONS="bullseye bookworm testing"
+    DEBIAN_DISTRIBUTIONS="bookworm trixie testing"
 fi
 
 declare -A DIST_TO_OBS=(
-    ["bullseye"]="Debian_11"
     ["bookworm"]="Debian_12"
+    ["trixie"]="Debian_13"
     ["testing"]="Debian_Testing"
 )
 


### PR DESCRIPTION
Debian Trixie was released a few days ago, and this patch adds it to the list of target Debian distributions. Bullseye, the previous oldstable distribution, is removed.
