### PR TITLE
fix(macOS): report `Success` as the initial sync state for VFS

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -96,7 +96,7 @@ void FileProviderSocketController::parseReceivedLine(const QString &receivedLine
         _accountState = FileProviderDomainManager::accountStateFromFileProviderDomainIdentifier(domainIdentifier);
         sendIgnoreList();
         sendAccountDetails();
-        reportSyncState("SYNC_PREPARING");
+        reportSyncState("SYNC_FINISHED");
         return;
     } else if (command == "FILE_PROVIDER_DOMAIN_SYNC_STATE_CHANGE") {
         reportSyncState(argument);


### PR DESCRIPTION
The sync state would be stuck with `SyncPrepare` after VFS was initialised otherwise.  
This resulted in the systray icon displaying the *Syncing* icon when the app is launched until a file got down/uploaded from the configured VFS directory.

I _think_ this broke with ee3ae980a8a41922cb99575682af42592cb37fe7, that commit removed the EnumerationListener which reported the sync state while items were being enumerated.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
