### PR TITLE
fix(unifiedsearch): open file requested via traymenu-searchbar directly and locally 

### DIFF
--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -27,6 +27,7 @@ class ShareTestHelper;
 class EndToEndTestHelper;
 class TestSyncConflictsModel;
 class TestRemoteWipe;
+class TestUnifiedSearchListModel;
 
 namespace OCC {
 
@@ -415,6 +416,7 @@ private:
     friend class ::EndToEndTestHelper;
     friend class ::TestFolderStatusModel;
     friend class ::TestRemoteWipe;
+    friend class ::TestUnifiedSearchListModel;
 };
 
 } // namespace OCC

--- a/src/gui/tray/UnifiedSearchResultListItem.qml
+++ b/src/gui/tray/UnifiedSearchResultListItem.qml
@@ -68,7 +68,7 @@ MouseArea {
         if (isFetchMoreTrigger) {
             unifiedSearchResultMouseArea.fetchMoreTriggerClicked(model.providerId)
         } else {
-            unifiedSearchResultMouseArea.resultClicked(model.providerId, model.resourceUrlRole)
+            unifiedSearchResultMouseArea.resultClicked(model.providerId, model.resourceUrlRole, model.subline, model.resultTitle)
         }
     }
 }

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -331,15 +331,14 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
                                                                                            const QString &title) const
 {
     const QUrlQuery urlQuery{resourceUrl};
-    QString dir = urlQuery.queryItemValue(QStringLiteral("dir"), QUrl::ComponentFormattingOption::FullyDecoded);
-    QString fileName = urlQuery.queryItemValue(QStringLiteral("scrollto"), QUrl::ComponentFormattingOption::FullyDecoded);
+    auto dir = urlQuery.queryItemValue(QStringLiteral("dir"), QUrl::ComponentFormattingOption::FullyDecoded);
+    auto fileName = urlQuery.queryItemValue(QStringLiteral("scrollto"), QUrl::ComponentFormattingOption::FullyDecoded);
 
     if (providerId.contains(QStringLiteral("file"), Qt::CaseInsensitive)){
         if (!_accountState || !_accountState->account()) {
             return;
         }
 
-        QString relativePath;
         // server version above 20
         if (dir.isEmpty() && fileName.isEmpty()) {
             // file is direct child of syncfolder
@@ -353,7 +352,7 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
         // server version 20
             fileName.prepend(QLatin1Char('/'));
         }
-        relativePath = dir + fileName;
+        const auto relativePath = dir + fileName;
 
         const auto localFiles = FolderMan::instance()->findFileInLocalFolders(relativePath, _accountState->account());
         if (!localFiles.isEmpty()) {

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -358,7 +358,7 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
         const QStringList localFiles = FolderMan::instance()->findFileInLocalFolders(relativePath, _accountState->account());
         if (!localFiles.isEmpty()) {
             qCInfo(lcUnifiedSearch) << "Opening file: " << localFiles.constFirst();
-            const bool fileOpenedLocally = QDesktopServices::openUrl(QUrl::fromLocalFile(localFiles.constFirst()));
+            const auto fileOpenedLocally = QDesktopServices::openUrl(QUrl::fromLocalFile(localFiles.constFirst()));
             if (fileOpenedLocally) {
                 return;
             } else {

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -362,8 +362,9 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
             const bool fileOpenedLocally = QDesktopServices::openUrl(QUrl::fromLocalFile(localFiles.constFirst()));
             if (fileOpenedLocally) {
                 return;
+            } else {
+                qCWarning(lcUnifiedSearch) << "Warning: QDesktopServices::openUrl unexpectedly failed to open the file. Opening resourceUrl in web browser is attempted next.";
             }
-            qCWarning(lcUnifiedSearch) << "Warning: QDesktopServices::openUrl unexpectedly failed to open the file. Opening resourceUrl in web browser is attempted next.";
         }
     }
     Utility::openBrowser(resourceUrl);

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -355,7 +355,7 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
         }
         relativePath = dir + fileName;
 
-        const QStringList localFiles = FolderMan::instance()->findFileInLocalFolders(relativePath, _accountState->account());
+        const auto localFiles = FolderMan::instance()->findFileInLocalFolders(relativePath, _accountState->account());
         if (!localFiles.isEmpty()) {
             qCInfo(lcUnifiedSearch) << "Opening file: " << localFiles.constFirst();
             const auto fileOpenedLocally = QDesktopServices::openUrl(QUrl::fromLocalFile(localFiles.constFirst()));

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -335,7 +335,7 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
     QString fileName = urlQuery.queryItemValue(QStringLiteral("scrollto"), QUrl::ComponentFormattingOption::FullyDecoded);
 
     if (providerId.contains(QStringLiteral("file"), Qt::CaseInsensitive)){
-        if (_accountState == nullptr || _accountState->account() == nullptr) {
+        if (!_accountState || !_accountState->account()) {
             return;
         }
 

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -349,9 +349,8 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
                 dir = subline.split(' ', Qt::SkipEmptyParts).last();
                 fileName = QLatin1Char('/') + title;
             }
-        }
+        } else if (dir.length() > 1) {
         // server version 20
-        else if (dir.length() > 1) {
             fileName.prepend(QLatin1Char('/'));
         }
         relativePath = dir + fileName;

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -325,9 +325,10 @@ bool UnifiedSearchResultsListModel::isSearchInProgress() const
 }
 
 
-void UnifiedSearchResultsListModel::resultClicked(
-    const QString &providerId, const QUrl &resourceUrl, const QString &subline, const QString &title
-) const
+void UnifiedSearchResultsListModel::resultClicked(const QString &providerId,
+                                                                                           const QUrl &resourceUrl,
+                                                                                           const QString &subline,
+                                                                                           const QString &title) const
 {
     const QUrlQuery urlQuery{resourceUrl};
     QString dir = urlQuery.queryItemValue(QStringLiteral("dir"), QUrl::ComponentFormattingOption::FullyDecoded);

--- a/src/gui/tray/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/tray/unifiedsearchresultslistmodel.cpp
@@ -344,8 +344,7 @@ void UnifiedSearchResultsListModel::resultClicked(
             // file is direct child of syncfolder
             if (subline.isEmpty()) {
                 dir = title;
-            }
-            else {
+            } else {
                 dir = subline.split(' ', Qt::SkipEmptyParts).last();
                 fileName = QLatin1Char('/') + title;
             }

--- a/src/gui/tray/unifiedsearchresultslistmodel.h
+++ b/src/gui/tray/unifiedsearchresultslistmodel.h
@@ -71,7 +71,7 @@ public:
     [[nodiscard]] QString errorString() const;
     [[nodiscard]] bool waitingForSearchTermEditEnd() const;
 
-    Q_INVOKABLE void resultClicked(const QString &providerId, const QUrl &resourceUrl) const;
+    Q_INVOKABLE void resultClicked(const QString &providerId, const QUrl &resourceUrl, const QString &subline, const QString &title) const;
     Q_INVOKABLE void fetchMoreTriggerClicked(const QString &providerId);
 
     [[nodiscard]] QHash<int, QByteArray> roleNames() const override;

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -575,15 +575,15 @@ private slots:
             const auto type = model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::TypeRole);
 
             if (type == OCC::UnifiedSearchResult::Type::Default) {
-                const QString providerId =
+                const auto providerId =
                     model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::ProviderIdRole)
                         .toString();
 
-                const QString subline = 
+                const auto subline = 
                     model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::SublineRole)
                         .toString();
 
-                const QString title = 
+                const auto title = 
                     model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::TitleRole)
                         .toString();
 

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -697,6 +697,7 @@ private slots:
         resultClickedLocalFile.clear();
 
         // Accountptr is invalid
+        const auto prevAccountState = accountState.data();
         model.reset(new OCC::UnifiedSearchResultsListModel(nullptr));
         modelTester.reset(new QAbstractItemModelTester(model.data()));
         const auto providerIdTestNullptr = "file";
@@ -711,6 +712,9 @@ private slots:
 
         resultClickedBrowser.clear();
         resultClickedLocalFile.clear();
+
+        model.reset(new OCC::UnifiedSearchResultsListModel(prevAccountState));
+        modelTester.reset(new QAbstractItemModelTester(model.data()));
     }
 
     void testSetSearchTermResultsError()

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -581,7 +581,7 @@ private slots:
                 urlForClickedResult = model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::ResourceUrlRole).toString();
 
                 if (!providerId.isEmpty() && !urlForClickedResult.isEmpty()) {
-                    model->resultClicked(providerId, QUrl(urlForClickedResult));
+                    model->resultClicked(providerId, QUrl(urlForClickedResult), "dummyStringNeedToFix", "dummyStringNeedToFix");
                     break;
                 }
             }

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -274,12 +274,12 @@ FakeSearchResultsStorage *FakeSearchResultsStorage::_instance = nullptr;
 
 }
 
-class TestUnifiedSearchListmodel : public QObject
+class TestUnifiedSearchListModel : public QObject
 {
     Q_OBJECT
 
 public:
-    TestUnifiedSearchListmodel() = default;
+    TestUnifiedSearchListModel() = default;
 
     QScopedPointer<FakeQNAM> fakeQnam;
     OCC::AccountPtr account;
@@ -575,13 +575,22 @@ private slots:
             const auto type = model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::TypeRole);
 
             if (type == OCC::UnifiedSearchResult::Type::Default) {
-                const auto providerId =
+                const QString providerId =
                     model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::ProviderIdRole)
                         .toString();
+
+                const QString subline = 
+                    model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::SublineRole)
+                        .toString();
+
+                const QString title = 
+                    model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::TitleRole)
+                        .toString();
+
                 urlForClickedResult = model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::ResourceUrlRole).toString();
 
                 if (!providerId.isEmpty() && !urlForClickedResult.isEmpty()) {
-                    model->resultClicked(providerId, QUrl(urlForClickedResult), "dummyStringNeedToFix", "dummyStringNeedToFix");
+                    model->resultClicked(providerId, QUrl(urlForClickedResult), subline, title);
                     break;
                 }
             }
@@ -632,5 +641,5 @@ private slots:
     }
 };
 
-QTEST_MAIN(TestUnifiedSearchListmodel)
+QTEST_MAIN(TestUnifiedSearchListModel)
 #include "testunifiedsearchlistmodel.moc"


### PR DESCRIPTION
This pull request addresses issue #7814. 

**Previously:** 

Whenever the user searches for and requests a file or folder through the traymenu-searchbar... 

- Nextcloud Server Version 20: ...the containing folder is opened in the local file explorer, instead of the requested file or folder itsself.
- Nextcloud Server Version above 20: ...the requested file or folder is opened, but in the webinterface filesystem application. 

**Change:** 

For any server version using the unified search (20+) the requested file or folder is opened in the local file explorer 

Authors are @mike0609king and me. 

Thanks a lot in advance for review and suggestions!