### PR TITLE
fix(i18n): Use SI symbol for minute

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -441,10 +441,10 @@ QString Utility::timeAgoInWords(const QDateTime &dt, const QDateTime &from)
                 if (secs < 5) {
                     return QObject::tr("now");
                 } else {
-                    return QObject::tr("1m", "one minute after activity date and time");
+                    return QObject::tr("1min", "one minute after activity date and time");
                 }
             } else {
-                return (QObject::tr("%nm", "delay in minutes after an activity", minutes));
+                return (QObject::tr("%nmin", "delay in minutes after an activity", minutes));
             }
         }
     }

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -164,7 +164,7 @@ private slots:
 
         earlyTS = earlyTS.addSecs(-6);
         s = timeAgoInWords(earlyTS, laterTS );
-        QCOMPARE(s, QLatin1String("1m"));
+        QCOMPARE(s, QLatin1String("1min"));
     }
 
     void testFsCasePreserving()


### PR DESCRIPTION
Discussed in forum (https://help.nextcloud.com/t/heist-1m-einen-monat-oder-eine-minute/230353).

e .g. "5m" is not correct

Corrrect form is "5min"

See https://en.wikipedia.org/wiki/Minute for reference

