### PR TITLE
fix(FileProviderExt): do not report syncing state when trying to delete trash items

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -478,6 +478,7 @@ import OSLog
                         item: \(item.filename, privacy: .public)
                     """
                 )
+                removeSyncAction(actionId)
                 completionHandler(NSError.fileProviderErrorForRejectedDeletion(of: item))
                 return
             }


### PR DESCRIPTION
Trying to delete items from the trash with the "Allow deletion of items in Trash" setting unticked would previously result in the sync state being stuck in the "Syncing" state.

Resolves #8560

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
