### PR TITLE
fix(msi): ensure the same ProductCode is used for embedded transforms

### DIFF
--- a/admin/win/msi/Nextcloud.wxs
+++ b/admin/win/msi/Nextcloud.wxs
@@ -17,7 +17,7 @@
          But we then should never change the UpgradeCode.
      -->
     <Product Name="$(var.AppName)" Manufacturer="$(var.AppVendor)"
-        Id="*" 
+        Id="$(var.ProductCode)"
         UpgradeCode="$(var.UpgradeCode)"
         Language="1033" Codepage="$(var.codepage)" Version="$(var.VerFull)">
     <Package Id="*" Keywords="Installer" Description="$(var.AppName) $(var.VerDesc)" Manufacturer="$(var.AppVendor)"

--- a/admin/win/msi/make-msi.bat.in
+++ b/admin/win/msi/make-msi.bat.in
@@ -53,6 +53,12 @@ if "%WISUBSTG%" == "" (
   echo :: Did not find WiLangId.vbs ^(environment variable 'WILANGID'^), the resulting MSI will be in English by default
 ))
 
+REM generate a ProductCode to use in the resulting MSI to ensure that the embedded
+REM transforms don't break managed deployments (see #8610)
+REM the uuidgen tool is provided by the Visual Studio CLI tools
+for /f %%i in ('uuidgen -c') do set PRODUCTCODE=%%i
+echo/
+echo :: Using ProductCode=%PRODUCTCODE%
 
 echo/
 echo :: Harvesting files for MSI
@@ -101,7 +107,7 @@ exit 0
   set codepage=%~1
 
   echo :: Compiling MSI project for codepage !codepage!
-  "%WIX%\bin\candle.exe" -dcodepage=!codepage! -dPlatform=%BuildArch% -arch %BuildArch% -dHarvestAppDir="%HarvestAppDir%" -ext WixUtilExtension NCMsiHelper.wxs WinShellExt.wxs collect.wxs Nextcloud.wxs RegistryCleanupCustomAction.wxs
+  "%WIX%\bin\candle.exe" -dcodepage=!codepage! -dProductCode=%PRODUCTCODE% -dPlatform=%BuildArch% -arch %BuildArch% -dHarvestAppDir="%HarvestAppDir%" -ext WixUtilExtension NCMsiHelper.wxs WinShellExt.wxs collect.wxs Nextcloud.wxs RegistryCleanupCustomAction.wxs
   if %ERRORLEVEL% neq 0 exit %ERRORLEVEL%
   echo/
 


### PR DESCRIPTION
Using `"*"` will result in a different GUID with each invocation of the linker (`light.exe`), which can break automated installations when a localised version of the installer was loaded.

Resolves #8610 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
