### PR TITLE
fix(wizard): avoid creating useless folders when setting up a VFS connection on Mac

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -479,6 +479,14 @@ bool OwncloudSetupWizard::checkDowngradeAdvised(QNetworkReply *reply)
 
 void OwncloudSetupWizard::slotCreateLocalAndRemoteFolders(const QString &localFolder, const QString &remoteFolder)
 {
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    if (Mac::FileProvider::fileProviderAvailable() && _ocWizard->useVirtualFileSync()) {
+        qCInfo(lcWizard) << "Not creating local/remote folders as because macOS File Provider uses its own sync root";
+        finalizeSetup(true);
+        return;
+    }
+#endif
+
     qCInfo(lcWizard) << "Setup local sync folder for new oC connection " << localFolder;
     const QDir fi(localFolder);
 


### PR DESCRIPTION


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
