### PR TITLE
fix(generalsettings): change remote pollinterval spinBox-minimum from 30 to 5 seconds, to align with configfile

### DIFF
--- a/src/gui/generalsettings.ui
+++ b/src/gui/generalsettings.ui
@@ -221,7 +221,7 @@
          <item>
           <widget class="QSpinBox" name="remotePollIntervalSpinBox">
            <property name="minimum">
-            <number>30</number>
+            <number>5</number>
            </property>
            <property name="maximum">
             <number>999999</number>

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -33,7 +33,7 @@
 #include <QStandardPaths>
 #include <QOperatingSystemVersion>
 
-#define DEFAULT_REMOTE_POLL_INTERVAL 30000 // default remote poll time in milliseconds
+#define DEFAULT_REMOTE_POLL_INTERVAL 30000
 #define DEFAULT_MAX_LOG_LINES 20000
 
 namespace {


### PR DESCRIPTION
This PR adresses issue #8479. I figured the only thing really that had to be done was changing the spinBox minimum from 30 to 5 seconds, as the original poster of the issue had already pointed out. 

The comment behind the macro `DEFAULT_REMOTE_POLL_INTERVAL` in `configfile.cpp` appeared redundant to me, so I removed it. I hope that's alright. 

Thanks for reviewing!
