### PR TITLE
feat: split user status tray menu

### DIFF
--- a/src/gui/UserStatusSelector.qml
+++ b/src/gui/UserStatusSelector.qml
@@ -17,12 +17,16 @@ ColumnLayout {
     id: rootLayout
     spacing: Style.standardSpacing * 2
     property NC.UserStatusSelectorModel userStatusSelectorModel
+    property bool showOnlineStatusSection: true
+    property bool showStatusMessageSection: true
 
     ColumnLayout {
         id: statusButtonsLayout
 
         Layout.fillWidth: true
         spacing: Style.smallSpacing
+        visible: rootLayout.showOnlineStatusSection
+        Layout.preferredHeight: visible ? implicitHeight : 0
 
         EnforcedPlainTextLabel {
             Layout.fillWidth: true
@@ -107,6 +111,8 @@ ColumnLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
         spacing: Style.smallSpacing
+        visible: rootLayout.showStatusMessageSection
+        Layout.preferredHeight: visible ? implicitHeight : 0
 
         EnforcedPlainTextLabel {
             Layout.fillWidth: true

--- a/src/gui/UserStatusSelectorPage.qml
+++ b/src/gui/UserStatusSelectorPage.qml
@@ -15,6 +15,8 @@ Page {
     signal finished
 
     property int userIndex: -1
+    property bool showOnlineStatusSection: true
+    property bool showStatusMessageSection: true
     property NC.UserStatusSelectorModel model: NC.UserStatusSelectorModel {
         userIndex: page.userIndex
         onFinished: page.finished()
@@ -31,5 +33,7 @@ Page {
         id: userStatusSelector
         userStatusSelectorModel: model
         spacing: Style.standardSpacing
+        showOnlineStatusSection: page.showOnlineStatusSection
+        showStatusMessageSection: page.showStatusMessageSection
     }
 }

--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -72,8 +72,8 @@ Button {
                 UserLine {
                     id: instantiatedUserLine
                     width: parent.width
-                    onShowUserStatusSelector: {
-                        userStatusDrawer.openUserStatusDrawer(model.index);
+                    onShowUserStatusSelector: function(idx, showOnlineStatusSection, showStatusMessageSection) {
+                        userStatusDrawer.openUserStatusDrawer(idx, showOnlineStatusSection, showStatusMessageSection);
                         accountMenu.close();
                     }
                     onClicked: UserModel.currentUserId = model.index;

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -138,10 +138,14 @@ ApplicationWindow {
         }
 
         property int userIndex: 0
+        property bool showOnlineStatusSection: true
+        property bool showStatusMessageSection: true
 
-        function openUserStatusDrawer(index) {
+        function openUserStatusDrawer(index, onlineStatusSection, statusMessageSection) {
             console.log(`About to show dialog for user with index ${index}`);
             userIndex = index;
+            showOnlineStatusSection = onlineStatusSection;
+            showStatusMessageSection = statusMessageSection;
             open();
         }
 
@@ -152,6 +156,8 @@ ApplicationWindow {
             sourceComponent: UserStatusSelectorPage {
                 anchors.fill: parent
                 userIndex: userStatusDrawer.userIndex
+                showOnlineStatusSection: userStatusDrawer.showOnlineStatusSection
+                showStatusMessageSection: userStatusDrawer.showStatusMessageSection
                 onFinished: userStatusDrawer.close()
             }
         }

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -15,7 +15,7 @@ import com.nextcloud.desktopclient
 AbstractButton {
     id: userLine
 
-    signal showUserStatusSelector(int id)
+    signal showUserStatusSelector(int id, bool showOnlineStatusSection, bool showStatusMessageSection)
 
 
     Accessible.role: Accessible.MenuItem
@@ -135,10 +135,19 @@ AbstractButton {
                 MenuItem {
                     visible: model.isConnected && model.serverHasUserStatus
                     height: visible ? implicitHeight : 0
-                    text: qsTr("Set status")
+                    text: qsTr("Online status")
                     font.pixelSize: Style.topLinePixelSize
                     hoverEnabled: true
-                    onClicked: showUserStatusSelector(index)
+                    onClicked: showUserStatusSelector(index, true, false)
+               }
+
+                MenuItem {
+                    visible: model.isConnected && model.serverHasUserStatus
+                    height: visible ? implicitHeight : 0
+                    text: qsTr("Status message")
+                    font.pixelSize: Style.topLinePixelSize
+                    hoverEnabled: true
+                    onClicked: showUserStatusSelector(index, false, true)
                }
 
                 MenuItem {


### PR DESCRIPTION
Separate the status selector and the status message