### PR TITLE
feat(wizard): automatically set up macOS-VFS when available

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -703,7 +703,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
         auto account = applyAccountChanges();
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
-        if (Mac::FileProvider::fileProviderAvailable() && _ocWizard->useVirtualFileSync()) {
+        if (_ocWizard->useVirtualFileSyncByDefault()) {
             Mac::FileProvider::instance()->domainManager()->addFileProviderDomainForAccount(account);
             auto const accountId = account->account()->userIdAtHostWithPort();
             // let the user settings know that VFS is enabled

--- a/src/gui/wizard/abstractcredswizardpage.cpp
+++ b/src/gui/wizard/abstractcredswizardpage.cpp
@@ -26,4 +26,21 @@ void AbstractCredentialsWizardPage::cleanupPage()
         }
     }
 }
+
+int AbstractCredentialsWizardPage::nextId() const
+{
+    const auto ocWizard = qobject_cast<OwncloudWizard *>(wizard());
+    Q_ASSERT(ocWizard);
+
+    if (ocWizard->needsToAcceptTermsOfService()) {
+        return WizardCommon::Page_TermsOfService;
+    }
+
+    if (ocWizard->useVirtualFileSyncByDefault()) {
+        return -1;
+    }
+
+    return WizardCommon::Page_AdvancedSetup;
+}
+
 }

--- a/src/gui/wizard/abstractcredswizardpage.h
+++ b/src/gui/wizard/abstractcredswizardpage.h
@@ -21,6 +21,7 @@ class AbstractCredentialsWizardPage : public QWizardPage
 {
 public:
     void cleanupPage() override;
+    [[nodiscard]] int nextId() const override;
     [[nodiscard]] virtual AbstractCredentials *getCredentials() const = 0;
 };
 

--- a/src/gui/wizard/flow2authcredspage.cpp
+++ b/src/gui/wizard/flow2authcredspage.cpp
@@ -92,17 +92,6 @@ void Flow2AuthCredsPage::slotFlow2AuthResult(Flow2Auth::Result r, const QString 
     }
 }
 
-int Flow2AuthCredsPage::nextId() const
-{
-    const auto ocWizard = qobject_cast<OwncloudWizard *>(wizard());
-    Q_ASSERT(ocWizard);
-    if (ocWizard->needsToAcceptTermsOfService()) {
-        return WizardCommon::Page_TermsOfService;
-    }
-
-    return WizardCommon::Page_AdvancedSetup;
-}
-
 void Flow2AuthCredsPage::setConnected()
 {
     auto *ocWizard = qobject_cast<OwncloudWizard *>(wizard());

--- a/src/gui/wizard/flow2authcredspage.h
+++ b/src/gui/wizard/flow2authcredspage.h
@@ -32,7 +32,6 @@ public:
 
     void initializePage() override;
     void cleanupPage() override;
-    [[nodiscard]] int nextId() const override;
     void setConnected();
     [[nodiscard]] bool isComplete() const override;
 

--- a/src/gui/wizard/owncloudhttpcredspage.cpp
+++ b/src/gui/wizard/owncloudhttpcredspage.cpp
@@ -142,17 +142,6 @@ bool OwncloudHttpCredsPage::validatePage()
     return true;
 }
 
-int OwncloudHttpCredsPage::nextId() const
-{
-    const auto ocWizard = qobject_cast<OwncloudWizard *>(wizard());
-    Q_ASSERT(ocWizard);
-    if (ocWizard->needsToAcceptTermsOfService()) {
-        return WizardCommon::Page_TermsOfService;
-    }
-
-    return WizardCommon::Page_AdvancedSetup;
-}
-
 void OwncloudHttpCredsPage::setConnected()
 {
     _connected = true;

--- a/src/gui/wizard/owncloudhttpcredspage.h
+++ b/src/gui/wizard/owncloudhttpcredspage.h
@@ -30,7 +30,6 @@ public:
     void initializePage() override;
     void cleanupPage() override;
     bool validatePage() override;
-    [[nodiscard]] int nextId() const override;
     void setConnected();
     void setErrorString(const QString &err);
 

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -34,6 +34,10 @@
 
 #include <cstdlib>
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+#include "gui/macOS/fileprovider.h"
+#endif
+
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcWizard, "nextcloud.gui.wizard", QtInfoMsg)
@@ -224,6 +228,15 @@ bool OwncloudWizard::isConfirmBigFolderChecked() const
 bool OwncloudWizard::needsToAcceptTermsOfService() const
 {
     return _needsToAcceptTermsOfService;
+}
+
+bool OwncloudWizard::useVirtualFileSyncByDefault() const
+{
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    return Mac::FileProvider::fileProviderAvailable();
+#else
+    return false;
+#endif
 }
 
 QString OwncloudWizard::ocUrl() const

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -62,6 +62,7 @@ public:
     [[nodiscard]] bool useVirtualFileSync() const;
     [[nodiscard]] bool isConfirmBigFolderChecked() const;
     [[nodiscard]] bool needsToAcceptTermsOfService() const;
+    [[nodiscard]] bool useVirtualFileSyncByDefault() const;
 
     void displayError(const QString &, bool retryHTTPonly);
     [[nodiscard]] AbstractCredentials *getCredentials() const;

--- a/src/gui/wizard/termsofservicewizardpage.cpp
+++ b/src/gui/wizard/termsofservicewizardpage.cpp
@@ -54,6 +54,13 @@ void OCC::TermsOfServiceWizardPage::cleanupPage()
 
 int OCC::TermsOfServiceWizardPage::nextId() const
 {
+    const auto ocWizard = qobject_cast<OwncloudWizard *>(wizard());
+    Q_ASSERT(ocWizard);
+
+    if (ocWizard->useVirtualFileSyncByDefault()) {
+        return -1;
+    }
+
     return WizardCommon::Page_AdvancedSetup;
 }
 

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -96,16 +96,6 @@ void WebViewPage::cleanupPage()
     _ocWizard->centerWindow();
 }
 
-int WebViewPage::nextId() const {
-    const auto ocWizard = qobject_cast<OwncloudWizard *>(wizard());
-    Q_ASSERT(ocWizard);
-    if (ocWizard->needsToAcceptTermsOfService()) {
-        return WizardCommon::Page_TermsOfService;
-    }
-
-    return WizardCommon::Page_AdvancedSetup;
-}
-
 bool WebViewPage::isComplete() const {
     return false;
 }

--- a/src/gui/wizard/webviewpage.h
+++ b/src/gui/wizard/webviewpage.h
@@ -23,7 +23,6 @@ public:
 
     void initializePage() override;
     void cleanupPage() override;
-    [[nodiscard]] int nextId() const override;
     [[nodiscard]] bool isComplete() const override;
 
     [[nodiscard]] AbstractCredentials* getCredentials() const override;


### PR DESCRIPTION
In case the macOS FileProvider extension is available, skip the advanced setup page in the account setup wizard and _just™_ set up the FileProvider domain.

## To Do
- decide what to do if classic sync mode is enabled through the config (#8651)
- ensure VFS setup is reliable, #8726 looks really promising with achieving that.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
