### PR TITLE
fix(ci): use correct parameter for fetching the PRs of a branch

### DIFF
--- a/.github/workflows/linux-appimage-comment.yml
+++ b/.github/workflows/linux-appimage-comment.yml
@@ -24,7 +24,7 @@ jobs:
             const pullRequestsForThisBranch = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.payload.workflow_run.head_repository.owner.login,
               repo: context.payload.workflow_run.head_repository.name,
-              run_id: context.payload.workflow_run.head_branch,
+              commit_sha: context.payload.workflow_run.head_branch,
             });
             const latestPullRequest = pullRequestsForThisBranch.data.sort((a, b) => b.id - a.id)[0];
             if (!latestPullRequest) {


### PR DESCRIPTION
follow-up to #8662

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
