### PR TITLE
chore: always produces systemd service and install it when possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,15 +360,24 @@ elseif(BUILD_CLIENT)
     configure_file(sync-exclude.lst bin/sync-exclude.lst COPYONLY)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND BUILD_CLIENT)
+if(LINUX AND BUILD_CLIENT)
+    set(bindir ${CMAKE_INSTALL_FULL_BINDIR})
+    configure_file(systemd/nextcloud-desktop.service.in "${CMAKE_CURRENT_BINARY_DIR}/${LINUX_APPLICATION_ID}.service")
+
+    pkg_check_modules(SYSTEMD systemd IMPORTED_TARGET)
+    set_package_properties(systemd PROPERTIES
+        DESCRIPTION "Systemd development files needed to install user service"
+        TYPE OPTIONAL
+    )
     pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd "systemd_user_unit_dir")
     if (SYSTEMD_USER_UNIT_DIR)
+        message(STATUS "Systemd development files found. Enable installing systemd user service.")
         option(INSTALL_SYSTEMD "Install systemd user service" ON)
         if(INSTALL_SYSTEMD)
-            set(bindir ${CMAKE_INSTALL_FULL_BINDIR})
-            configure_file(systemd/nextcloud-desktop.service.in "${CMAKE_CURRENT_BINARY_DIR}/${LINUX_APPLICATION_ID}.service")
             install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${LINUX_APPLICATION_ID}.service" DESTINATION "${SYSTEMD_USER_UNIT_DIR}")
         endif()
+    else()
+        message(STATUS "Systemd development files not found. Not installing systemd user service.")
     endif()
 endif()
 


### PR DESCRIPTION
if possible we detect systemd and enable install of the user service

try to improve user feedback when configure is run such that people may be able to figure out what is hapenning

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
