### PR TITLE
fix(needsinfohelper): use correct not-equals operator in expression

### DIFF
--- a/.github/workflows/needsinfohelper.yml
+++ b/.github/workflows/needsinfohelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         if: |
-          github.event.comment.user.type !== "Bot" &&
+          github.event.comment.user.type != "Bot" &&
             !contains(fromJSON('["camilasan", "i2h3", "mgallien", "nilsding", "Rello"]'), github.event.comment.user.login)
         with:
           labels: 'needs info'


### PR DESCRIPTION
I forgot that these aren't JavaScript expressions...

https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#operators

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
