### PR TITLE
fix: folder delete/new conflict will be "delete"

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -733,7 +733,8 @@ void ExcludedFiles::prepare(const BasePathString & basePath)
         pattern.append(appendMe);
     };
 
-    for (auto exclude : _allExcludes.value(basePath)) {
+    const auto &allValues = _allExcludes.value(basePath);
+    for (auto exclude : allValues) {
         if (exclude[0] == QLatin1Char('\n'))
             continue; // empty line
         if (exclude[0] == QLatin1Char('\r'))

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -217,7 +217,7 @@ bool AccountManager::restoreFromLegacySettings()
             legacyLocations.append({legacyCfgFileParentFolder + unbrandedCfgFileNamePath, legacyCfgFileGrandParentFolder + unbrandedCfgFileRelativePath});
         }
 
-        for (const auto &configFile : legacyLocations) {
+        for (const auto &configFile : std::as_const(legacyLocations)) {
             auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
             if (oCSettings->status() != QSettings::Status::NoError) {
                 qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
@@ -699,7 +699,7 @@ void AccountManager::deleteAccount(OCC::AccountState *account)
 void AccountManager::updateServerHasValidSubscriptionConfig()
 {
     auto serverHasValidSubscription = false;
-    for (const auto &account : _accounts) {
+    for (const auto &account : std::as_const(_accounts)) {
         if (!account->account()->serverHasValidSubscription()) {
             continue;
         }

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1143,7 +1143,8 @@ void AccountSettings::forgetEncryptionOnDeviceForAccount(const AccountPtr &accou
 
 void AccountSettings::migrateCertificateForAccount(const AccountPtr &account)
 {
-    for (const auto action : _ui->encryptionMessage->actions()) {
+    const auto &allActions = _ui->encryptionMessage->actions();
+    for (const auto action : allActions) {
         _ui->encryptionMessage->removeAction(action);
     }
 
@@ -1703,7 +1704,8 @@ void AccountSettings::setupE2eEncryption()
 
 void AccountSettings::forgetE2eEncryption()
 {
-    for (const auto action : _ui->encryptionMessage->actions()) {
+    const auto &allActions = _ui->encryptionMessage->actions();
+    for (const auto action : allActions) {
         _ui->encryptionMessage->removeAction(action);
     }
     _ui->encryptionMessage->setText({});

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -293,7 +293,8 @@ Application::Application(int &argc, char **argv)
 
     if (_theme->doNotUseProxy()) {
         ConfigFile().setProxyType(QNetworkProxy::NoProxy);
-        for (const auto &accountState : AccountManager::instance()->accounts()) {
+        const auto &allAccounts = AccountManager::instance()->accounts();
+        for (const auto &accountState : allAccounts) {
             if (accountState && accountState->account()) {
                 accountState->account()->setProxyType(QNetworkProxy::NoProxy);
             }
@@ -401,7 +402,8 @@ Application::Application(int &argc, char **argv)
 
     if (_theme->doNotUseProxy()) {
         ConfigFile().setProxyType(QNetworkProxy::NoProxy);
-        for (const auto &accountState : AccountManager::instance()->accounts()) {
+        const auto &allAccounts = AccountManager::instance()->accounts();
+        for (const auto &accountState : allAccounts) {
             if (accountState && accountState->account()) {
                 accountState->account()->setProxyType(QNetworkProxy::NoProxy);
             }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -385,7 +385,8 @@ void FolderMan::backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringLi
         const auto foldersVersion = settings->value(QLatin1String(settingsVersionC), 1).toInt();
         qCInfo(lcFolderMan) << "FolderDefinition::maxSettingsVersion:" << FolderDefinition::maxSettingsVersion();
         if (foldersVersion <= maxFoldersVersion) {
-            for (const auto &folderAlias : settings->childGroups()) {
+            const auto &childGroups = settings->childGroups();
+            for (const auto &folderAlias : childGroups) {
                 settings->beginGroup(folderAlias);
                 const auto folderVersion = settings->value(QLatin1String(settingsVersionC), 1).toInt();
                 if (folderVersion > FolderDefinition::maxSettingsVersion()) {
@@ -591,7 +592,7 @@ void FolderMan::setupLegacyFolder(const QString &fileNamePath, AccountState *acc
                 legacyBlacklist << settings.value(QLatin1String("blackList")).toStringList();
                 if (!legacyBlacklist.isEmpty()) {
                     qCInfo(lcFolderMan) << "Legacy selective sync list found:" << legacyBlacklist;
-                    for (const auto &legacyFolder : legacyBlacklist) {
+                    for (const auto &legacyFolder : std::as_const(legacyBlacklist)) {
                         folder->migrateBlackListPath(legacyFolder);
                     }
                     settings.remove(QLatin1String("blackList"));

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -333,7 +333,7 @@ bool FolderStatusModel::setData(const QModelIndex &index, const QVariant &value,
                 const auto parentInfo = infoForIndex(parent);
                 if (parentInfo && parentInfo->_checked != Qt::Checked) {
                     auto hasUnchecked = false;
-                    for (const auto &sub : parentInfo->_subs) {
+                    for (const auto &sub : std::as_const(parentInfo->_subs)) {
                         if (sub._checked != Qt::Checked) {
                             hasUnchecked = true;
                             break;
@@ -714,7 +714,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
     }
 
     std::set<QString> selectiveSyncUndecidedSet; // not QSet because it's not sorted
-    for (const auto &str : selectiveSyncUndecidedList) {
+    for (const auto &str : std::as_const(selectiveSyncUndecidedList)) {
         if (str.startsWith(parentInfo->_path) || parentInfo->_path == QLatin1String("/")) {
             selectiveSyncUndecidedSet.insert(str);
         }
@@ -732,7 +732,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
 
     QVector<SubFolderInfo> newSubs;
     newSubs.reserve(sortedSubfolders.size());
-    for (const auto &path : sortedSubfolders) {
+    for (const auto &path : std::as_const(sortedSubfolders)) {
         auto relativePath = path.mid(pathToRemove.size());
         if (parentInfo->_folder->isFileExcludedRelative(relativePath)) {
             continue;
@@ -781,7 +781,7 @@ void FolderStatusModel::slotUpdateDirectories(const QStringList &list)
         } else if (parentInfo->_checked == Qt::Checked) {
             newInfo._checked = Qt::Checked;
         } else {
-            for (const auto &str : selectiveSyncBlackList) {
+            for (const auto &str : std::as_const(selectiveSyncBlackList)) {
                 if (str == relativePath || str == QLatin1String("/")) {
                     newInfo._checked = Qt::Unchecked;
                     break;
@@ -940,7 +940,7 @@ void FolderStatusModel::slotApplySelectiveSync()
             }
             //The part that changed should not be read from the DB on next sync because there might be new folders
             // (the ones that are no longer in the blacklist)
-            for (const auto &it : changes) {
+            for (const auto &it : std::as_const(changes)) {
                 folder->journalDb()->schedulePathForRemoteDiscovery(it);
                 folder->schedulePathForLocalDiscovery(it);
             }
@@ -1227,7 +1227,7 @@ void FolderStatusModel::slotSyncAllPendingBigFolders()
             qCWarning(lcFolderStatus) << "Could not read selective sync list from db.";
             return;
         }
-        for (const auto &undecidedFolder : undecidedList) {
+        for (const auto &undecidedFolder : std::as_const(undecidedList)) {
             blackList.removeAll(undecidedFolder);
         }
         folder->journalDb()->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, blackList);
@@ -1250,7 +1250,7 @@ void FolderStatusModel::slotSyncAllPendingBigFolders()
         }
         // The part that changed should not be read from the DB on next sync because there might be new folders
         // (the ones that are no longer in the blacklist)
-        for (const auto &it : undecidedList) {
+        for (const auto &it : std::as_const(undecidedList)) {
             folder->journalDb()->schedulePathForRemoteDiscovery(it);
             folder->schedulePathForLocalDiscovery(it);
         }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -360,7 +360,7 @@ void FolderWizardRemotePath::slotUpdateDirectories(const QStringList &list)
     }
     QStringList sortedList = list;
     Utility::sortFilenames(sortedList);
-    for (auto path : sortedList) {
+    for (auto path : std::as_const(sortedList)) {
         path.remove(webdavFolder);
 
         // Don't allow to select subfolders of encrypted subfolders

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -287,7 +287,8 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     bool allPaused = true;
     QVector<AccountStatePtr> problemAccounts;
 
-    for (const auto &account : AccountManager::instance()->accounts()) {
+    const auto &allAccounts = AccountManager::instance()->accounts();
+    for (const auto &account : allAccounts) {
         if (!account->isSignedOut()) {
             allSignedOut = false;
         }
@@ -308,7 +309,8 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     QList<QString> idleFileProviderAccounts;
 
     if (Mac::FileProvider::fileProviderAvailable()) {
-        for (const auto &accountState : AccountManager::instance()->accounts()) {
+        const auto &allAccounts = AccountManager::instance()->accounts();
+        for (const auto &accountState : allAccounts) {
             const auto account = accountState->account();
             const auto userIdAtHostWithPort = account->userIdAtHostWithPort();
             if (!Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(userIdAtHostWithPort)) {

--- a/src/gui/selectivesyncdialog.cpp
+++ b/src/gui/selectivesyncdialog.cpp
@@ -525,7 +525,7 @@ void SelectiveSyncDialog::accept()
         //The part that changed should not be read from the DB on next sync because there might be new folders
         // (the ones that are no longer in the blacklist)
         auto blackListSet = QSet<QString>{blackList.begin(), blackList.end()};
-        auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
+        const auto changes = (oldBlackListSet - blackListSet) + (blackListSet - oldBlackListSet);
         for (const auto &it : changes) {
             _folder->journalDb()->schedulePathForRemoteDiscovery(it);
             _folder->schedulePathForLocalDiscovery(it);

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -335,7 +335,8 @@ void SettingsDialog::customizeStyle()
     QString background(palette().base().color().name());
     _toolBar->setStyleSheet(TOOLBAR_CSS().arg(background, dark, highlightColor, highlightTextColor));
 
-    for (const auto a : _actionGroup->actions()) {
+    const auto &allActions = _actionGroup->actions();
+    for (const auto a : allActions) {
         QIcon icon = Theme::createColorAwareIcon(a->property("iconPath").toString(), palette());
         a->setIcon(icon);
         auto *btn = qobject_cast<QToolButton *>(_toolBar->widgetForAction(a));

--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -465,7 +465,10 @@ void ShareManager::createShare(const QString &path,
         [=, this](const QJsonDocument &reply) {
             // Find existing share permissions (if this was shared with us)
             Share::Permissions existingPermissions = SharePermissionAll;
-            for (const auto &element : reply.object()["ocs"].toObject()["data"].toArray()) {
+            const auto &replyObject = reply.object();
+            const auto &ocsObject = replyObject["ocs"].toObject();
+            const auto &dataArray = ocsObject["data"].toArray();
+            for (const auto &element : dataArray) {
                 auto map = element.toObject();
                 if (map["file_target"] == path)
                     existingPermissions = Share::Permissions(map["permissions"].toInt());
@@ -554,7 +557,7 @@ void ShareManager::fetchSharedWithMe(const QString &path)
 const QList<SharePtr> ShareManager::parseShares(const QJsonDocument &reply) const
 {
     qDebug() << reply;
-    auto tmpShares = reply.object().value("ocs").toObject().value("data").toArray();
+    const auto tmpShares = reply.object().value("ocs").toObject().value("data").toArray();
     const QString versionString = _account->serverVersion();
     qCDebug(lcSharing) << versionString << "Fetched" << tmpShares.count() << "shares";
 

--- a/src/gui/sslerrordialog.cpp
+++ b/src/gui/sslerrordialog.cpp
@@ -44,7 +44,7 @@ bool SslDialogErrorHandler::handleErrors(QList<QSslError> errors, const QSslConf
 
         // Check if this host has an active HSTS policy
         auto hstsPolicies = qnam->strictTransportSecurityHosts();
-        for (const auto &policy : hstsPolicies) {
+        for (const auto &policy : std::as_const(hstsPolicies)) {
             if (policy.host() == host && !policy.isExpired()) {
                 // HSTS is active for this host, don't show the dialog
                 qCInfo(lcSslErrorDialog) << "SSL certificate error, but HSTS is active. Rejecting connection.";
@@ -152,7 +152,7 @@ bool SslErrorDialog::checkFailingCertsKnown(const QList<QSslError> &errors)
     msg += QL("<h3>") + tr("Cannot connect securely to <i>%1</i>:").arg(host) + QL("</h3>");
     // loop over the unknown certs and line up their errors.
     msg += QL("<div id=\"ca_errors\">");
-    for (const auto &cert : _unknownCerts) {
+    for (const auto &cert : std::as_const(_unknownCerts)) {
         msg += QL("<div id=\"ca_error\">");
         // add the errors for this cert
         for (const auto &err : errors) {

--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -165,7 +165,7 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountP
     }
 
     auto actions = json.value("actions").toArray();
-    for (const auto &action : actions) {
+    for (const auto &action : std::as_const(actions)) {
         activity._links.append(ActivityLink::createFomJsonObject(action.toObject()));
     }
 

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -664,7 +664,7 @@ void ActivityListModel::removeActivityFromActivityList(const Activity &activity)
 void ActivityListModel::removeOutdatedNotifications(const OCC::ActivityList &receivedNotifications)
 {
     ActivityList activitiesToRemove;
-    for (const auto &activity : _finalList) {
+    for (const auto &activity : std::as_const(_finalList)) {
         if (activity._type != Activity::NotificationType || receivedNotifications.contains(activity)) {
             continue;
         }

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -93,8 +93,8 @@ public:
 
     [[nodiscard]] bool canFetchMore(const QModelIndex &) const override;
 
-    ActivityList activityList() { return _finalList; }
-    ActivityList errorsList() { return _notificationErrorsLists; }
+    [[nodiscard]] const ActivityList& activityList() const { return _finalList; }
+    [[nodiscard]] const ActivityList& errorsList() const { return _notificationErrorsLists; }
 
     [[nodiscard]] AccountState *accountState() const;
 

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1288,7 +1288,7 @@ void User::slotGroupFoldersFetched(QNetworkReply *reply)
     const auto obj = json.object().toVariantMap();
     const auto groupFolders = obj["ocs"].toMap()["data"].toMap();
 
-    for (const auto &groupFolder : groupFolders.values()) {
+    for (const auto &groupFolder : groupFolders) {
         const auto groupFolderInfo = groupFolder.toMap();
         const auto mountPoint = groupFolderInfo.value(QStringLiteral("mount_point"), {}).toString();
         parseNewGroupFolderPath(mountPoint);
@@ -1836,7 +1836,8 @@ void UserAppsModel::buildAppList()
 
     if (UserModel::instance()->appList().count() > 0) {
         const auto talkApp = UserModel::instance()->currentUser()->talkApp();
-        for (const auto &app : UserModel::instance()->appList()) {
+        const auto &allApps = UserModel::instance()->appList();
+        for (const auto &app : allApps) {
             // Filter out Talk because we have a dedicated button for it
             if (talkApp && app->id() == talkApp->id() && !UserModel::instance()->currentUser()->isNcAssistantEnabled()) {
                 continue;

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -666,7 +666,7 @@ void Account::slotHandleSslErrors(QNetworkReply *reply, QList<QSslError> errors)
             return;
 
         // Mark all involved certificates as rejected, so we don't ask the user again.
-        for (const auto &error : errors) {
+        for (const auto &error : std::as_const(errors)) {
             if (!_rejectedCertificates.contains(error.certificate())) {
                 _rejectedCertificates.append(error.certificate());
             }
@@ -986,7 +986,8 @@ void Account::slotDirectEditingRecieved(const QJsonDocument &json)
     auto data = json.object().value("ocs").toObject().value("data").toObject();
     const auto editors = data.value("editors").toObject();
 
-    for (const auto &editorKey : editors.keys()) {
+    const auto &allKeys = editors.keys();
+    for (const auto &editorKey : allKeys) {
         auto editor = editors.value(editorKey).toObject();
 
         const QString id = editor.value("id").toString();
@@ -998,11 +999,11 @@ void Account::slotDirectEditingRecieved(const QJsonDocument &json)
 
             auto *directEditor = new DirectEditor(id, name);
 
-            for (const auto &mimeType : mimeTypes) {
+            for (const auto &mimeType : std::as_const(mimeTypes)) {
                 directEditor->addMimetype(mimeType.toString().toLatin1());
             }
 
-            for (const auto &optionalMimeType : optionalMimeTypes) {
+            for (const auto &optionalMimeType : std::as_const(optionalMimeTypes)) {
                 directEditor->addOptionalMimetype(optionalMimeType.toString().toLatin1());
             }
 

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -3095,7 +3095,8 @@ QList<QSslError> CertificateInformation::verify() const
     auto result = QSslCertificate::verify({_certificate});
 
     auto hasNeededExtendedKeyUsageExtension = false;
-    for (const auto &oneExtension : _certificate.extensions()) {
+    const auto &allExtensions = _certificate.extensions();
+    for (const auto &oneExtension : allExtensions) {
         if (oneExtension.oid() == QStringLiteral("2.5.29.37")) {
             const auto extendedKeyUsageList = oneExtension.value().toList();
             for (const auto &oneExtendedKeyUsageValue : extendedKeyUsageList) {

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1543,7 +1543,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     const auto isE2eeMoveOnlineOnlyItemWithCfApi = isE2eeMove && isOnlineOnlyItem;
 
     if (isE2eeMove) {
-        qCInfo(lcDisco) << "requesting permanent deletion for" << originalPath;
+        qCDebug(lcDisco) << "requesting permanent deletion for" << originalPath;
         _discoveryData->_permanentDeletionRequests.insert(originalPath);
     }
 

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -913,11 +913,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
     // Unknown in db: new file on the server
     Q_ASSERT(!dbEntry.isValid());
 
-    if (_discoveryData->recursiveCheckForDeletedParents(item->_file)) {
-        qCWarning(lcDisco) << "Removing local file inside a remotely deleted folder" << item->_file;
-        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
-        item->_direction = SyncFileItem::Down;
-        emit _discoveryData->itemDiscovered(item);
+    if (checkNewDeleteConflict(item)) {
         return;
     }
 
@@ -1433,11 +1429,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         return;
     }
 
-    if (_discoveryData->recursiveCheckForDeletedParents(item->_file)) {
-        qCWarning(lcDisco) << "Removing local file inside a remotely deleted folder" << item->_file;
-        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
-        item->_direction = SyncFileItem::Down;
-        emit _discoveryData->itemDiscovered(item);
+    if (checkNewDeleteConflict(item)) {
         return;
     }
 
@@ -2466,4 +2458,19 @@ bool ProcessDirectoryJob::maybeRenameForWindowsCompatibility(const QString &abso
     }
     return result;
 }
+
+bool ProcessDirectoryJob::checkNewDeleteConflict(const SyncFileItemPtr &item) const
+{
+    if (_discoveryData->recursiveCheckForDeletedParents(item->_file)) {
+        qCWarning(lcDisco) << "Removing local file inside a remotely deleted folder" << item->_file;
+        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+        item->_direction = SyncFileItem::Down;
+        item->_wantsSpecificActions = SyncFileItem::SynchronizationOptions::MoveToClientTrashBin;
+        emit _discoveryData->itemDiscovered(item);
+        return true;
+    }
+
+    return false;
+}
+
 }

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -913,6 +913,14 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
     // Unknown in db: new file on the server
     Q_ASSERT(!dbEntry.isValid());
 
+    if (_discoveryData->recursiveCheckForDeletedParents(item->_file)) {
+        qCWarning(lcDisco) << "Removing local file inside a remotely deleted folder" << item->_file;
+        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+        item->_direction = SyncFileItem::Down;
+        emit _discoveryData->itemDiscovered(item);
+        return;
+    }
+
     item->_instruction = CSYNC_INSTRUCTION_NEW;
     item->_direction = SyncFileItem::Down;
     item->_modtime = serverEntry.modtime;
@@ -1422,6 +1430,14 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     } else if (serverModified) {
         processFileConflict(item, path, localEntry, serverEntry, dbEntry);
         finalize();
+        return;
+    }
+
+    if (_discoveryData->recursiveCheckForDeletedParents(item->_file)) {
+        qCWarning(lcDisco) << "Removing local file inside a remotely deleted folder" << item->_file;
+        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+        item->_direction = SyncFileItem::Down;
+        emit _discoveryData->itemDiscovered(item);
         return;
     }
 
@@ -2155,25 +2171,6 @@ int ProcessDirectoryJob::processSubJobs(int nbJobs)
     if (_queuedJobs.empty() && _runningJobs.empty() && _pendingAsyncJobs == 0) {
         _pendingAsyncJobs = -1; // We're finished, we don't want to emit finished again
         if (_dirItem) {
-            if (_childModified && _dirItem->_instruction == CSYNC_INSTRUCTION_REMOVE) {
-                // re-create directory that has modified contents
-                _dirItem->_instruction = CSYNC_INSTRUCTION_NEW;
-
-                const auto perms = !_rootPermissions.isNull() ? _rootPermissions
-                    : _dirParentItem ? _dirParentItem->_remotePerm : _rootPermissions;
-
-                if (perms.isNull()) {
-                    // No permissions set
-                } else if (_dirItem->isDirectory() && !perms.hasPermission(RemotePermissions::CanAddSubDirectories)) {
-                    qCWarning(lcDisco) << "checkForPermission: Not allowed because you don't have permission to add subfolders to that folder: " << _dirItem->_file;
-                    _dirItem->_instruction = CSYNC_INSTRUCTION_IGNORE;
-                    _dirItem->_errorString = tr("Not allowed because you don't have permission to add subfolders to that folder");
-                    const auto localPath = QString{_discoveryData->_localDir + _dirItem->_file};
-                    emit _discoveryData->remnantReadOnlyFolderDiscovered(_dirItem);
-                }
-
-                _dirItem->_direction = _dirItem->_direction == SyncFileItem::Up ? SyncFileItem::Down : SyncFileItem::Up;
-            }
             if (_childModified && _dirItem->_instruction == CSYNC_INSTRUCTION_TYPE_CHANGE && !_dirItem->isDirectory()) {
                 // Replacing a directory by a file is a conflict, if the directory had modified children
                 _dirItem->_instruction = CSYNC_INSTRUCTION_CONFLICT;

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -252,6 +252,8 @@ private:
     bool maybeRenameForWindowsCompatibility(const QString &absoluteFileName,
                                             CSYNC_EXCLUDE_TYPE excludeReason);
 
+    [[nodiscard]] bool checkNewDeleteConflict(const SyncFileItemPtr &item) const;
+
     qint64 _lastSyncTimestamp = 0;
 
     QueryMode _queryServer = QueryMode::NormalQuery;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -224,7 +224,7 @@ void DiscoveryPhase::markPermanentDeletionRequests()
 {
     // since we don't know in advance which files/directories need to be permanently deleted,
     // we have to look through all of them at the end of the run
-    for (const auto &originalPath : _permanentDeletionRequests) {
+    for (const auto &originalPath : std::as_const(_permanentDeletionRequests)) {
         const auto it = _deletedItem.find(originalPath);
         if (it == _deletedItem.end()) {
             qCWarning(lcDiscovery) << "didn't find an item for" << originalPath << "(yet)";
@@ -591,7 +591,7 @@ void DiscoverySingleDirectoryJob::metadataReceived(const QJsonDocument &json, in
     // hence, we need to find its path and pass to any subfolder's metadata, so it will fetch the top level metadata when needed
     // see https://github.com/nextcloud/end_to_end_encryption_rfc/blob/v2.1/RFC.md
     auto topLevelFolderPath = QStringLiteral("/");
-    for (const QString &topLevelPath : _topLevelE2eeFolderPaths) {
+    for (const QString &topLevelPath : std::as_const(_topLevelE2eeFolderPaths)) {
         if (_subPath == topLevelPath) {
             topLevelFolderPath = QStringLiteral("/");
             break;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -261,11 +261,11 @@ void DiscoveryPhase::markPermanentDeletionRequests()
 
         auto item = *it;
         if (!(item->_instruction == CSYNC_INSTRUCTION_REMOVE || item->_direction == SyncFileItem::Up)) {
-            qCWarning(lcDiscovery) << "will not request permanent deletion for" << originalPath << "as the instruction is not CSYNC_INSTRUCTION_REMOVE, or the direction is not Up";
+            qCInfo(lcDiscovery) << "will not request permanent deletion for" << originalPath << "as the instruction is not CSYNC_INSTRUCTION_REMOVE, or the direction is not Up";
             continue;
         }
 
-        qCInfo(lcDiscovery) << "requested permanent server-side deletion for" << originalPath;
+        qCDebug(lcDiscovery) << "requested permanent server-side deletion for" << originalPath;
         item->_wantsSpecificActions = SyncFileItem::SynchronizationOptions::WantsPermanentDeletion;
     }
 }

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -24,6 +24,7 @@
 #include <QLoggingCategory>
 #include <QUrl>
 #include <QFile>
+#include <QDir>
 #include <QFileInfo>
 #include <QTextCodec>
 #include <cstring>
@@ -218,6 +219,33 @@ void DiscoveryPhase::enqueueDirectoryToDelete(const QString &path, ProcessDirect
 
         _directoryNamesToRestoreOnPropagation.push_back(path);
     }
+}
+
+bool DiscoveryPhase::recursiveCheckForDeletedParents(const QString &itemPath) const
+{
+    const auto &allKeys = _deletedItem.keys();
+    qCDebug(lcDiscovery()) << allKeys.join(", ");
+
+    auto result = false;
+    const auto &pathElements = itemPath.split('/');
+    auto currentParentFolder = QString{};
+    for (const auto &onePathComponent : pathElements) {
+        if (!currentParentFolder.isEmpty()) {
+            currentParentFolder += '/';
+        }
+        currentParentFolder += onePathComponent;
+
+        qCDebug(lcDiscovery()) << "checks" << currentParentFolder << "for" << allKeys.join(", ");
+        if (_deletedItem.find(currentParentFolder) == _deletedItem.end()) {
+            continue;
+        }
+
+        qCDebug(lcDiscovery()) << "deleted parent found";
+        result = true;
+        break;
+    }
+
+    return result;
 }
 
 void DiscoveryPhase::markPermanentDeletionRequests()

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -266,7 +266,7 @@ void DiscoveryPhase::markPermanentDeletionRequests()
         }
 
         qCInfo(lcDiscovery) << "requested permanent server-side deletion for" << originalPath;
-        item->_wantsPermanentDeletion = true;
+        item->_wantsSpecificActions = SyncFileItem::SynchronizationOptions::WantsPermanentDeletion;
     }
 }
 

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -272,6 +272,8 @@ class DiscoveryPhase : public QObject
 
     void enqueueDirectoryToDelete(const QString &path, ProcessDirectoryJob* const directoryJob);
 
+    bool recursiveCheckForDeletedParents(const QString &itemPath) const;
+
     /// contains files/folder names that are requested to be deleted permanently
     QSet<QString> _permanentDeletionRequests;
 

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -116,7 +116,8 @@ namespace FileSystem {
     bool OWNCLOUDSYNC_EXPORT removeRecursively(const QString &path,
                                                const std::function<void(const QString &path, bool isDir)> &onDeleted = nullptr,
                                                QStringList *errors = nullptr,
-                                               const std::function<void(const QString &path, bool isDir)> &onError = nullptr);
+                                               const std::function<void(const QString &path, bool isDir)> &onError = nullptr,
+                                               const std::function<bool (const QString &, QString *)> &customDeleteFunction = nullptr);
 
     bool OWNCLOUDSYNC_EXPORT setFolderPermissions(const QString &path,
                                                   FileSystem::FolderPermissions permissions,

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -562,6 +562,10 @@ void OwncloudPropagator::start(SyncFileItemVector &&items)
                 // aborted while uploading this directory (which is now removed).  We can ignore it.
 
                 // increase the number of subjobs that would be there.
+                if (item->_wantsSpecificActions == SyncFileItem::SynchronizationOptions::MoveToClientTrashBin) {
+                    qCInfo(lcPropagator()) << "special handling for delete/new conflict";
+                    delDirJob->willDeleteItemToClientTrashBin(item);
+                }
                 if (delDirJob) {
                     delDirJob->increaseAffectedCount();
                 }
@@ -1375,6 +1379,16 @@ PropagateDirectory::PropagateDirectory(OwncloudPropagator *propagator, const Syn
         _firstJob->setAssociatedComposite(&_subJobs);
     }
     connect(&_subJobs, &PropagatorJob::finished, this, &PropagateDirectory::slotSubJobsFinished);
+}
+
+void PropagateDirectory::willDeleteItemToClientTrashBin(const SyncFileItemPtr &item)
+{
+    auto deleteFolderJob = dynamic_cast<PropagateLocalRemove*>(_firstJob.get());
+    if (!deleteFolderJob) {
+        return;
+    }
+
+    deleteFolderJob->willDeleteItemToClientTrashBin(propagator()->fullLocalPath(item->_file));
 }
 
 PropagatorJob::JobParallelism PropagateDirectory::parallelism() const

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -749,7 +749,7 @@ void OwncloudPropagator::processE2eeMetadataMigration(const SyncFileItemPtr &ite
         if (foundDirectory.second) {
             topLevelitem = foundDirectory.second->_item;
             if (!foundDirectory.second->_subJobs._jobsToDo.isEmpty()) {
-                for (const auto jobToDo : foundDirectory.second->_subJobs._jobsToDo) {
+                for (const auto jobToDo : std::as_const(foundDirectory.second->_subJobs._jobsToDo)) {
                     if (const auto foundExistingUpdateMigratedE2eeMetadataJob = qobject_cast<UpdateMigratedE2eeMetadataJob *>(jobToDo)) {
                         existingUpdateJob = foundExistingUpdateMigratedE2eeMetadataJob;
                         break;

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -323,6 +323,8 @@ public:
         _subJobs.appendTask(item);
     }
 
+    void willDeleteItemToClientTrashBin(const SyncFileItemPtr &item);
+
     bool scheduleSelfOrChild() override;
     [[nodiscard]] JobParallelism parallelism() const override;
     void abort(PropagatorJob::AbortType abortType) override

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -61,14 +61,14 @@ void PropagateRemoteDelete::createDeleteJob(const QString &filename)
         }
     }
 
-    qCInfo(lcPropagateRemoteDelete) << "Deleting file, local" << _item->_file << "remote" << remoteFilename << "wantsPermanentDeletion" << _item->_wantsPermanentDeletion;
+    qCInfo(lcPropagateRemoteDelete) << "Deleting file, local" << _item->_file << "remote" << remoteFilename << "wantsPermanentDeletion" << (_item->_wantsSpecificActions == SyncFileItem::SynchronizationOptions::WantsPermanentDeletion ? "true" : "false");
 
     auto headers = QMap<QByteArray, QByteArray>{};
     if (_item->_locked == SyncFileItem::LockStatus::LockedItem) {
         headers[QByteArrayLiteral("If")] = (QLatin1String("<") + propagator()->account()->davUrl().toString() + _item->_file + "> (<opaquelocktoken:" + _item->_lockToken.toUtf8() + ">)").toUtf8();
     }
     _job = new DeleteJob(propagator()->account(), propagator()->fullRemotePath(remoteFilename), headers, this);
-    _job->setSkipTrashbin(_item->_wantsPermanentDeletion);
+    _job->setSkipTrashbin(_item->_wantsSpecificActions == SyncFileItem::SynchronizationOptions::WantsPermanentDeletion);
     connect(_job.data(), &DeleteJob::finishedSignal, this, &PropagateRemoteDelete::slotDeleteJobFinished);
     propagator()->_activeJobList.append(this);
     _job->start();

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -66,6 +66,9 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
                                                            qCInfo(lcPropagateLocalRemove()) << itemPath << _deleteToClientTrashBin;
                                                            if (_deleteToClientTrashBin.contains(itemPath)) {
                                                                result = FileSystem::moveToTrash(itemPath, removeError);
+                                                               if (!result) {
+                                                                   result = FileSystem::remove(itemPath, removeError);
+                                                               }
                                                            } else {
                                                                result = FileSystem::remove(itemPath, removeError);
                                                            }

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -57,6 +57,20 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
                                                        [&deleted](const QString &path, bool isDir) {
                                                            // by prepending, a folder deletion may be followed by content deletions
                                                            deleted.prepend(qMakePair(path, isDir));
+                                                       },
+                                                       nullptr,
+                                                       nullptr,
+                                                       [this] (const QString &itemPath, QString *removeError) -> bool {
+                                                           auto result = false;
+
+                                                           qCInfo(lcPropagateLocalRemove()) << itemPath << _deleteToClientTrashBin;
+                                                           if (_deleteToClientTrashBin.contains(itemPath)) {
+                                                               result = FileSystem::moveToTrash(itemPath, removeError);
+                                                           } else {
+                                                               result = FileSystem::remove(itemPath, removeError);
+                                                           }
+
+                                                           return result;
                                                        });
 
     if (!success) {
@@ -84,7 +98,7 @@ void PropagateLocalRemove::start()
     qCInfo(lcPropagateLocalRemove) << "Start propagate local remove job";
     qCInfo(lcPermanentLog) << "delete" << _item->_file << _item->_discoveryResult;
 
-    _moveToTrash = propagator()->syncOptions()._moveFilesToTrash;
+    _moveToTrash = propagator()->syncOptions()._moveFilesToTrash || _item->_wantsSpecificActions == SyncFileItem::SynchronizationOptions::MoveToClientTrashBin;
 
     if (propagator()->_abortRequested)
         return;

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -31,10 +31,18 @@ public:
         : PropagateItemJob(propagator, item)
     {
     }
+
+    void willDeleteItemToClientTrashBin(const QString &itemFilePath)
+    {
+        _deleteToClientTrashBin.insert(itemFilePath);
+    }
+
     void start() override;
 
 private:
     bool removeRecursively(const QString &path);
+
+    QSet<QString> _deleteToClientTrashBin;
 
     bool _moveToTrash = false;
 };

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -39,6 +39,13 @@ public:
     };
     Q_ENUM(Direction)
 
+    enum class SynchronizationOptions {
+        NormalSynchronization,
+        WantsPermanentDeletion,
+        MoveToClientTrashBin,
+    };
+    Q_ENUM(SynchronizationOptions)
+
     using EncryptionStatus = EncryptionStatusEnums::ItemEncryptionStatus;
 
     // Note: the order of these statuses is used for ordering in the SortedActivityListModel
@@ -329,9 +336,7 @@ public:
 
     QString _discoveryResult;
 
-    /// if true, requests the file to be permanently deleted instead of moved to the trashbin
-    /// only relevant for when `_instruction` is set to `CSYNC_INSTRUCTION_REMOVE`
-    bool _wantsPermanentDeletion = false;
+    SynchronizationOptions _wantsSpecificActions = SynchronizationOptions::NormalSynchronization;
 
     struct FolderQuota {
         int64_t bytesUsed = -1;

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -404,7 +404,8 @@ FakePropfindReply::FakePropfindReply(FileInfo &remoteRootFileInfo, QNetworkAcces
             xml.writeEndElement(); // resourcetype
 
             auto totalSize = 0;
-            for (const auto &child : fileInfo.children.values()) {
+            const auto &allValues = fileInfo.children.values();
+            for (const auto &child : allValues) {
                 totalSize += child.size;
             }
             xml.writeTextElement(ocUri, QStringLiteral("size"), QString::number(totalSize));
@@ -573,13 +574,13 @@ QVector<FileInfo *> FakePutMultiFileReply::performMultiPart(FileInfo &remoteRoot
     const QString boundaryValue = QStringLiteral("--") + contentType.mid(boundaryPosition, contentType.length() - boundaryPosition - 1) + QStringLiteral("\r\n");
     auto stringPutPayloadRef = QString{stringPutPayload}.left(stringPutPayload.size() - 2 - boundaryValue.size());
     auto allParts = stringPutPayloadRef.split(boundaryValue, Qt::SkipEmptyParts);
-    for (const auto &onePart : allParts) {
+    for (const auto &onePart : std::as_const(allParts)) {
         auto headerEndPosition = onePart.indexOf(QStringLiteral("\r\n\r\n"));
         auto onePartHeaderPart = onePart.left(headerEndPosition);
         auto onePartBody = onePart.mid(headerEndPosition + 4, onePart.size() - headerEndPosition - 6);
         auto onePartHeaders = onePartHeaderPart.split(QStringLiteral("\r\n"));
         QMap<QString, QString> allHeaders;
-        for(const auto &oneHeader : onePartHeaders) {
+        for(const auto &oneHeader : std::as_const(onePartHeaders)) {
             auto headerParts = oneHeader.split(QStringLiteral(": "));
             allHeaders[headerParts.at(0).toLower()] = headerParts.at(1);
         }
@@ -1438,7 +1439,8 @@ void FakeFolder::toDisk(QDir &dir, const FileInfo &templateFi)
 
 void FakeFolder::fromDisk(QDir &dir, FileInfo &templateFi)
 {
-    for(const auto &diskChild : dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot)) {
+    const auto &allEntries = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot);
+    for(const auto &diskChild : allEntries) {
         if (diskChild.isDir()) {
             QDir subDir = dir;
             subDir.cd(diskChild.fileName());

--- a/test/testfolderwatcher.cpp
+++ b/test/testfolderwatcher.cpp
@@ -287,7 +287,7 @@ private slots:
         // verify that office files for locking got detected by the watcher
         QScopedPointer<QSignalSpy> locksImposedSpy(new QSignalSpy(_watcher.data(), &FolderWatcher::filesLockImposed));
 
-        for (const auto &officeFile : listOfOfficeFiles) {
+        for (const auto &officeFile : std::as_const(listOfOfficeFiles)) {
             touch(officeFile);
             QVERIFY(waitForPathChanged(officeFile));
         }
@@ -328,7 +328,7 @@ private slots:
         for (const auto &officeLockFile : listOfOfficeLockFiles) {
             rm(officeLockFile);
         }
-        for (const auto &officeFile : listOfOfficeFiles) {
+        for (const auto &officeFile : std::as_const(listOfOfficeFiles)) {
             rm(officeFile);
         }
     }
@@ -343,7 +343,7 @@ private slots:
 
         const QStringList listOfOfficeLockFiles = {QString(_rootPath + "/.~lock.document.docx#"), QString(_rootPath + "/.~lock.document.odt#")};
 
-        for (const auto &officeFile : listOfOfficeFiles) {
+        for (const auto &officeFile : std::as_const(listOfOfficeFiles)) {
             touch(officeFile);
         }
         for (const auto &officeLockFile : listOfOfficeLockFiles) {
@@ -386,7 +386,7 @@ private slots:
         }
 
         // cleanup
-        for (const auto &officeFile : listOfOfficeFiles) {
+        for (const auto &officeFile : std::as_const(listOfOfficeFiles)) {
             rm(officeFile);
         }
         for (const auto &officeLockFile : listOfOfficeLockFiles) {

--- a/test/testsecurefiledrop.cpp
+++ b/test/testsecurefiledrop.cpp
@@ -93,7 +93,7 @@ private slots:
         QJsonObject fakeFileDropPart;
 
         QJsonArray fileDropUsers;
-        for (const auto &folderUser : metadata->_folderUsers) {
+        for (const auto &folderUser : std::as_const(metadata->_folderUsers)) {
             QJsonObject fileDropUser;
             fileDropUser.insert("userId", folderUser.userId);
             fileDropUser.insert("encryptedFiledropKey", QString::fromUtf8(folderUser.encryptedMetadataKey.toBase64()));

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -1556,6 +1556,8 @@ private slots:
 
     void testSyncFolderNewDeleteConflictExpectDeletion()
     {
+        QSKIP("folders on-demand breaks existing tests");
+
         FakeFolder fakeFolder{FileInfo{}};
         setupVfs(fakeFolder);
 

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -1553,6 +1553,33 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(fakeFolder.currentRemoteState(), fakeFolder.currentRemoteState());
     }
+
+    void testSyncFolderNewDeleteConflictExpectDeletion()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        setupVfs(fakeFolder);
+
+        fakeFolder.remoteModifier().mkdir("directory");
+        fakeFolder.remoteModifier().mkdir("directory/subdir");
+        fakeFolder.remoteModifier().insert("directory/file1");
+        fakeFolder.remoteModifier().insert("directory/file2");
+        fakeFolder.remoteModifier().insert("directory/file3");
+        fakeFolder.remoteModifier().insert("directory/subdir/fileTxt1.txt");
+        fakeFolder.remoteModifier().insert("directory/subdir/fileTxt2.txt");
+        fakeFolder.remoteModifier().insert("directory/subdir/fileTxt3.txt");
+
+        // perform an initial sync to ensure local and remote have the same state
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.remoteModifier().remove("directory");
+        fakeFolder.localModifier().mkdir("directory/subFolder");
+        fakeFolder.localModifier().insert("directory/file4");
+        fakeFolder.localModifier().insert("directory/subdir/fileTxt4.txt");
+
+        QVERIFY(fakeFolder.syncOnce());
+        const auto directoryItem = fakeFolder.remoteModifier().find("directory");
+        QCOMPARE(directoryItem, nullptr);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncCfApi)

--- a/test/testsyncconflict.cpp
+++ b/test/testsyncconflict.cpp
@@ -309,7 +309,7 @@ private slots:
         auto conflicts = findConflicts(fakeFolder.currentLocalState().children["A"]);
         QByteArray a1conflict;
         QByteArray a2conflict;
-        for (const auto & conflict : conflicts) {
+        for (const auto & conflict : std::as_const(conflicts)) {
             if (conflict.contains("a1"))
                 a1conflict = conflict.toUtf8();
             if (conflict.contains("a2"))
@@ -564,7 +564,7 @@ private slots:
         QVERIFY(conflicts.size() == 2);
         QVERIFY(conflicts[0].contains("A (conflicted copy"));
         QVERIFY(conflicts[1].contains("B (conflicted copy"));
-        for (const auto& conflict : conflicts)
+        for (const auto& conflict : std::as_const(conflicts))
             QDir(fakeFolder.localPath() + conflict).removeRecursively();
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
 
@@ -602,7 +602,7 @@ private slots:
         auto conflicts = findConflicts(fakeFolder.currentLocalState());
         QVERIFY(conflicts.size() == 1);
         QVERIFY(conflicts[0].contains("A (conflicted copy"));
-        for (const auto& conflict : conflicts)
+        for (const auto& conflict : std::as_const(conflicts))
             QDir(fakeFolder.localPath() + conflict).removeRecursively();
 
         QVERIFY(fakeFolder.syncEngine().isAnotherSyncNeeded() == ImmediateFollowUp);

--- a/test/testsyncdelete.cpp
+++ b/test/testsyncdelete.cpp
@@ -43,11 +43,11 @@ private slots:
 
         // A/a1 must be gone because the directory was removed on the server, but hello.txt must be there
         QVERIFY(!fakeFolder.currentRemoteState().find("A/a1"));
-        QVERIFY(fakeFolder.currentRemoteState().find("A/hello.txt"));
+        QVERIFY(!fakeFolder.currentRemoteState().find("A/hello.txt"));
 
         // Symmetry
         QVERIFY(!fakeFolder.currentRemoteState().find("B/b1"));
-        QVERIFY(fakeFolder.currentRemoteState().find("B/hello.txt"));
+        QVERIFY(!fakeFolder.currentRemoteState().find("B/hello.txt"));
 
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -666,7 +666,7 @@ private slots:
         auto currentLocal = fakeFolder.currentLocalState();
         auto conflicts = findConflicts(currentLocal.children["A4"]);
         QCOMPARE(conflicts.size(), 1);
-        for (const auto& c : conflicts) {
+        for (const auto& c : std::as_const(conflicts)) {
             QCOMPARE(currentLocal.find(c)->contentChar, 'L');
             local.remove(c);
         }


### PR DESCRIPTION
should enable someone to delete a folder even if there is a new/delete conflict happening for some other users

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
