### PR TITLE
fix(ActivityList): attach vertical scrollbar, having minimum width and thumbsize, to the right of the traymenu 

### DIFF
--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -38,8 +38,8 @@ ScrollView {
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
     ScrollBar.vertical.policy: ScrollBar.AlwaysOn
-    ScrollBar.vertical.width: Math.max(ScrollBar.vertical.implicitWidth, controlRoot.width * 0.03)
-    ScrollBar.vertical.minimumSize: 0.05
+    ScrollBar.vertical.width: Math.max(ScrollBar.vertical.implicitWidth, Style.minimumScrollBarWidth)
+    ScrollBar.vertical.minimumSize: Style.minimumScrollBarThumbSize
 
     data: NC.WheelHandler {
         target: controlRoot.contentItem

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -29,10 +29,15 @@ ScrollView {
     signal activityItemClicked(int index)
 
     contentWidth: availableWidth
-    padding: 0
+    leftPadding: 0
+    topPadding: 0
+    bottomPadding: 0
+    rightPadding: ScrollBar.vertical.width
+    
     focus: false
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
     data: NC.WheelHandler {
         target: controlRoot.contentItem

--- a/src/gui/tray/ActivityList.qml
+++ b/src/gui/tray/ActivityList.qml
@@ -38,6 +38,8 @@ ScrollView {
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
     ScrollBar.vertical.policy: ScrollBar.AlwaysOn
+    ScrollBar.vertical.width: Math.max(ScrollBar.vertical.implicitWidth, controlRoot.width * 0.03)
+    ScrollBar.vertical.minimumSize: 0.05
 
     data: NC.WheelHandler {
         target: controlRoot.contentItem

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -70,6 +70,8 @@ QtObject {
 
     property int minActivityHeight: variableSize(32)
 
+    property int minimumScrollBarWidth: 12
+    property real minimumScrollBarThumbSize: 0
     property int currentAccountButtonWidth: 220
     property int currentAccountButtonRadius: 2
     property int currentAccountLabelWidth: 128


### PR DESCRIPTION
This PR aims to resolve the discussion pertaining to issue #5536. Authors are @mike0609king and me. Thanks a lot for the reviews!

**Previously:**

Though most of the original problems mentioned in this thread seem to have been resolved, there appeared to be a remaining dissatisfaction with the usability of the ActivityList's Scrollbar among users. From what we were able to extract from the discussion this mainly stems from the fact that 
- (mainly on windows11) the ScrollBar is quite slim, 
- it's thumb can get really small and
- then also having to hover over this small area for the ScrollBar to appear.

**Changes:**

- The ScrollBar is attached to the right of the traymenu. This resembles the style that can be found in many other desktop applications like webbrowsers, the Windows file explorer,VS Code and Discord. 
- The ScrollBar is given a minimum width, which is approximately the same as in the `Universal` style (windows10 style). 
- The ScrollBar's thumb's minimum size is set to 0.03

Images: 

Windows10: 
<img width="449" height="551" alt="image" src="https://github.com/user-attachments/assets/f227b054-a310-4d9f-b5c1-389d5dd88940" />

Windows11: 
<img width="451" height="573" alt="image" src="https://github.com/user-attachments/assets/6dad3d7f-97e3-4ae2-82ff-509b1f16cf8c" />

We are aware that these changes might not be wanted. However, as described in the beginning, from our understanding this seemed to be a way to improve the user experience. 
Also, the minimum thumb size should already be implicitly implemented as the traymenu should only show a finite number of activities. Still we figured that it would be good to directly set it in order to guarantee for a sufficiently large thumb, independent of the activity list's length. 

In any case it should be possible to close issue #5536 , right? 