### PR TITLE
fix: emoji picker size and emoji tooltips

### DIFF
--- a/src/gui/EmojiPicker.qml
+++ b/src/gui/EmojiPicker.qml
@@ -59,12 +59,9 @@ ColumnLayout {
 
             Rectangle {
                 anchors.bottom: parent.bottom
-
                 width: parent.width
                 height: Style.thickBorderWidth
-
                 visible: ListView.isCurrentItem
-
                 color: palette.dark
             }
 
@@ -82,64 +79,64 @@ ColumnLayout {
         color: palette.dark
     }
 
-    GridView {
-        id: emojiView
+    ScrollView {
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.preferredHeight: metrics.height * 8
         Layout.margins: Style.normalBorderWidth
-
-        cellWidth: metrics.height * 2
-        cellHeight: metrics.height * 2
-
-        boundsBehavior: Flickable.DragOverBounds
         clip: true
 
-        model: emojiModel.model
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
-        delegate: ItemDelegate {
-            id: emojiDelegate
+        GridView {
+            id: emojiView
+            width: parent.width
+            height: parent.height
+            cellWidth: metrics.height * 2
+            cellHeight: metrics.height * 2
+            boundsBehavior: Flickable.DragOverBounds
+            model: emojiModel.model
 
-            width: metrics.height * 2
-            height: metrics.height * 2
+            delegate: ItemDelegate {
+                id: emojiDelegate
+                width: metrics.height * 2
+                height: metrics.height * 2
 
-            background: Rectangle {
-                color: palette.highlight
-                visible: ListView.isCurrentItem || emojiDelegate.highlighted || emojiDelegate.checked || emojiDelegate.down || emojiDelegate.hovered
-                radius: Style.slightlyRoundedButtonRadius
+                background: Rectangle {
+                    color: palette.highlight
+                    visible: ListView.isCurrentItem || emojiDelegate.highlighted || emojiDelegate.checked || emojiDelegate.down || emojiDelegate.hovered
+                    radius: Style.slightlyRoundedButtonRadius
+                }
+
+                contentItem: EnforcedPlainTextLabel {
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    text: modelData === undefined ? "" : modelData.unicode
+                    font.pointSize: Style.defaultFontPtSize + 4
+                }
+
+                ToolTip {
+                    text: modelData === undefined ? "" : modelData.shortname
+                    visible: emojiDelegate.hovered
+                    delay: Qt.styleHints.mousePressAndHoldInterval
+                }
+
+                onClicked: {
+                    chosen(modelData.unicode);
+                    emojiModel.emojiUsed(modelData);
+                }
+
             }
 
-            contentItem: EnforcedPlainTextLabel {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: modelData === undefined ? "" : modelData.unicode
-                font.pointSize: Style.defaultFontPtSize + 4
-            }
-
-            ToolTip {
-                text: modelData === undefined ? "" : modelData.shortname
-                visible: emojiDelegate.hovered
-                delay: Qt.styleHints.mousePressAndHoldInterval
-            }
-
-            onClicked: {
-                chosen(modelData.unicode);
-                emojiModel.emojiUsed(modelData);
+           EnforcedPlainTextLabel {
+                id: placeholderMessage
+                width: parent.width * 0.8
+                anchors.centerIn: parent
+                text: qsTr("No recent emojis")
+                wrapMode: Text.Wrap
+                font.bold: true
+                visible: emojiView.count === 0
             }
         }
-
-        EnforcedPlainTextLabel {
-            id: placeholderMessage
-            width: parent.width * 0.8
-            anchors.centerIn: parent
-            text: qsTr("No recent emojis")
-            wrapMode: Text.Wrap
-            font.bold: true
-            visible: emojiView.count === 0
-        }
-
-        ScrollBar.vertical: ScrollBar {}
-        
     }
-
 }


### PR DESCRIPTION
- size of emojis adjusted
- tooltip enabled
- scrollbar not overlapping emojis anymore

<img width="449" height="181" alt="Bildschirmfoto 2025-09-05 um 15 45 35" src="https://github.com/user-attachments/assets/0d6721f2-a2ca-49fe-8f09-1917a8a8ece9" />
