### PR TITLE
feat(login): use stored credential user ID when authenticating again

### DIFF
--- a/src/gui/creds/flow2auth.cpp
+++ b/src/gui/creds/flow2auth.cpp
@@ -97,11 +97,16 @@ void Flow2Auth::fetchNewToken(const TokenAction action)
         _loginUrl = loginUrl;
 
         if (_account->isUsernamePrefillSupported()) {
-            if (const auto userName = Utility::getCurrentUserName();
-                !userName.isEmpty()) {
-                auto query = QUrlQuery(_loginUrl);
+            constexpr auto setUserNameForLogin = [] (const auto &userName, auto &loginUrl) -> void {
+                auto query = QUrlQuery(loginUrl);
                 query.addQueryItem(QStringLiteral("user"), userName);
-                _loginUrl.setQuery(query);
+                loginUrl.setQuery(query);
+            };
+
+            if (const auto userName = _account->userFromCredentials(); !userName.isEmpty()) {
+                setUserNameForLogin(userName, _loginUrl);
+            } else if (const auto userName = Utility::getCurrentUserName(); !userName.isEmpty()) {
+                setUserNameForLogin(userName, _loginUrl);
             }
         }
 

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -142,6 +142,11 @@ void Account::setDavUser(const QString &newDavUser)
     emit prettyNameChanged();
 }
 
+QString Account::userFromCredentials() const
+{
+    return _credentials ? _credentials->user() : QString{};
+}
+
 #ifndef TOKEN_AUTH_ONLY
 QImage Account::avatar() const
 {

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -120,6 +120,8 @@ public:
     [[nodiscard]] QString davUser() const;
     void setDavUser(const QString &newDavUser);
 
+    [[nodiscard]] QString userFromCredentials() const;
+
     [[nodiscard]] QString davDisplayName() const;
     void setDavDisplayName(const QString &newDisplayName);
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
