### PR TITLE
Updated NextcloudFileProviderKit Reference

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -25,7 +25,7 @@
       "location" : "https://github.com/nextcloud/NextcloudFileProviderKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "d6cdbc84924bde5eb9d07ce4f6c55b33f82560bc"
+        "revision" : "3e00b22a199ae01d8f70438a854af79e0046b672"
       }
     },
     {


### PR DESCRIPTION
Now pointing to:
https://github.com/nextcloud/nextcloudfileproviderkit/releases/tag/3.1.0

Which contains the updated file provider extension database location to avoid crashes in some use cases due to insufficient permissions within the sandbox.