### PR TITLE
chore(log): use proper log level when the Qt client side is disconnected

### DIFF
--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -193,7 +193,7 @@ void FileProviderSocketController::sendNotAuthenticated() const
     const auto account = _accountState->account();
     Q_ASSERT(account);
 
-    qCDebug(lcFileProviderSocketController) << "About to send not authenticated message to file provider extension"
+    qCWarning(lcFileProviderSocketController) << "About to send not authenticated message to file provider extension"
                                             << account->displayName();
 
     const auto message = QString(QStringLiteral("ACCOUNT_NOT_AUTHENTICATED"));


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
