### PR TITLE
chore: add new codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: GPL-2.0-or-later
-* @camilasan @i2h3 @mgallien @nilsding
+* @Aiiaiiio @camilasan @i2h3 @mgallien @nilsding

--- a/.github/workflows/needsinfohelper.yml
+++ b/.github/workflows/needsinfohelper.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         if: |
           github.event.comment.user.type != 'Bot' &&
-            !contains(fromJSON('["camilasan", "i2h3", "mgallien", "nilsding", "Rello"]'), github.event.comment.user.login)
+            !contains(fromJSON('["Aiiaiiio", "camilasan", "i2h3", "mgallien", "nilsding", "Rello"]'), github.event.comment.user.login)
         with:
           labels: 'needs info'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
~~Draft PR until @Aiiaiiio is added to the GitHub organisation~~

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
