### PR TITLE
fix(FileProviderSyncStatus): disable rotation of status icon

### DIFF
--- a/src/gui/macOS/ui/FileProviderSyncStatus.qml
+++ b/src/gui/macOS/ui/FileProviderSyncStatus.qml
@@ -36,7 +36,7 @@ GridLayout {
         padding: 0
         spacing: 0
         imageSource: root.syncStatus.icon
-        running: root.syncStatus.syncing
+        running: false // avoid rotating the icon when syncing
     }
 
     EnforcedPlainTextLabel {


### PR DESCRIPTION
similar to how it's done in `src/gui/tray/SyncStatus.qml`

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
