### PR TITLE
fix(applicationName): ensure correct application name is shown to users

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -43,7 +43,7 @@ ConnectionValidator::ConnectionValidator(AccountStatePtr accountState, const QSt
 void ConnectionValidator::checkServerAndAuth()
 {
     if (!_account) {
-        _errors << tr("No Nextcloud account configured");
+        _errors << tr("No %1 account configured", "The placeholder will be the application name. Please keep it").arg(APPLICATION_NAME);
         reportResult(NotConfigured);
         return;
     }

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -233,7 +233,7 @@ ApplicationWindow {
         color: Style.colorWithoutTransparency(palette.base)
 
         Accessible.role: Accessible.Grouping
-        Accessible.name: qsTr("Desktop main window")
+        Accessible.name: qsTr("Main content")
 
         MouseArea {
             anchors.fill: parent

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -233,7 +233,7 @@ ApplicationWindow {
         color: Style.colorWithoutTransparency(palette.base)
 
         Accessible.role: Accessible.Grouping
-        Accessible.name: qsTr("Nextcloud desktop main dialog")
+        Accessible.name: qsTr("Desktop main window")
 
         MouseArea {
             anchors.fill: parent

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1084,7 +1084,9 @@ QString User::featuredAppIcon() const
 
 QString User::featuredAppAccessibleName() const
 {
-    return isNcAssistantEnabled() ? tr("Open Nextcloud Assistant in browser") : tr("Open Nextcloud Talk in browser");
+    return isNcAssistantEnabled() ?
+        tr("Open %1 Assistant in browser", "The placeholder will be the application name. Please keep it").arg(APPLICATION_NAME) :
+        tr("Open %1 Talk in browser", "The placeholder will be the application name. Please keep it").arg(APPLICATION_NAME);
 }
 
 AccountApp *User::talkApp() const


### PR DESCRIPTION
config.h has a constant for the application name, use this everywhere in user facing messages

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
