### PR TITLE
fix(folderstatusmodel): 32 bit int overflow in current item progress fixed

### DIFF
--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -1017,10 +1017,10 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
     // find the single item to display:  This is going to be the bigger item, or the last completed
     // item if no items are in progress.
     auto curItem = progress._lastCompletedItem;
-    auto curItemProgress = -1; // -1 means finished
-    auto biggerItemSize = 0;
-    auto estimatedUpBw = 0;
-    auto estimatedDownBw = 0;
+    qint64 curItemProgress = -1; // -1 means finished
+    qint64 biggerItemSize = 0;
+    qint64 estimatedUpBw = 0;
+    qint64 estimatedDownBw = 0;
     QStringList filenamesList;
     for (const auto &syncFile : progress._currentItems) {
         if (curItemProgress == -1 || (ProgressInfo::isSizeDependent(syncFile._item)


### PR DESCRIPTION
This PR address issue #8704 . Thanks for the reviews!

**The problem**: The syncing progress for files with at least 2GiB size shows overflown value in the accountsettings dialog, when resyncing. 

**Changes**: Explicit typing to `qint64` instead of using `auto` for the relevant variable(s)

Steps to reproduce: 
1. upload at least one such file in the sync folder (the more files the higher the chance to catch the bug)
2. Close the client
3. delete the `.db` file in the sync folder
4. start the client and go to `settings`

**Images:** 

_Before:_
<img width="607" height="341" alt="image" src="https://github.com/user-attachments/assets/01b3c3fe-5692-4637-82d0-a69c7430c1bc" />

According log: 
<img width="1502" height="38" alt="image" src="https://github.com/user-attachments/assets/4fbeec92-5858-4bc7-a120-50c8f44930a0" />

_After_: 
<img width="425" height="240" alt="imagee" src="https://github.com/user-attachments/assets/0bf4764c-1367-4693-baa3-740f90ad0ff9" />

According log:
<img width="1477" height="23" alt="image" src="https://github.com/user-attachments/assets/555705b3-7f37-4ffe-914d-91a9a2acbb7b" />

I am aware that the project follows the `almost always auto` style, however using auto caused the variable `curItemProgress` to be casted to `int`. The other variables that are declared alongside `curItemProgress` were also casted to `int` even though they were assigned return values of type `qint64` in subsequent lines. Therefore I figured that making sure they are of type `qint64` as well is safer (?). 