### PR TITLE
fix: log - Binding loop detected

### DIFF
--- a/src/gui/tray/UnifiedSearchInputContainer.qml
+++ b/src/gui/tray/UnifiedSearchInputContainer.qml
@@ -22,10 +22,13 @@ TextField {
 
     readonly property int iconInset: Style.smallSpacing
 
+    readonly property real leadingControlWidth: root.isSearchInProgress ? busyIndicator.width : searchIconImage.width
+    readonly property real trailingControlWidth: clearTextButton.visible ? clearTextButton.width : 0
+
     topPadding: topInset
     bottomPadding: bottomInset
-    leftPadding: searchIconImage.width + searchIconImage.x + Style.smallSpacing
-    rightPadding: (width - clearTextButton.x) + Style.smallSpacing
+    leftPadding: iconInset + leadingControlWidth + Style.smallSpacing
+    rightPadding: iconInset + trailingControlWidth + Style.smallSpacing
     verticalAlignment: Qt.AlignVCenter
 
     placeholderText: qsTr("Search files, messages, events …")


### PR DESCRIPTION
> UnifiedSearchInputContainer: Binding loop detected for property "implicitWidth":
qrc:/qt-project.org/imports/QtQuick/NativeStyle/controls/DefaultTextField.qml:16:5
> UnifiedSearchInputContainer: Binding loop detected for property "rightPadding":
qrc:/qml/src/gui/tray/UnifiedSearchInputContainer.qml:28:5
> UnifiedSearchInputContainer: Binding loop detected for property "rightPadding":
qrc:/qml/src/gui/tray/UnifiedSearchInputContainer.qml:28:5
> UnifiedSearchInputContainer: Binding loop detected for property "rightPadding":

Updated the unified search TextField paddings to derive from the leading and trailing control widths, removing the binding loop that stemmed from referencing the field’s own width.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
