### PR TITLE
fix(syncstatussummary): do not attempt to fetch VFS state for accounts without VFS enabled

### DIFF
--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -15,6 +15,7 @@
 #ifdef BUILD_FILE_PROVIDER_MODULE
 #include "gui/macOS/fileprovider.h"
 #include "gui/macOS/fileprovidersocketserver.h"
+#include "gui/macOS/fileprovidersettingscontroller.h"
 #endif
 
 #include <theme.h>
@@ -433,11 +434,14 @@ void SyncStatusSummary::initSyncState()
     }
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
-    const auto accounts = AccountManager::instance()->accounts();
-    for (const auto &accountState : accounts) {
-        const auto account = accountState->account();
-        onFileProviderDomainSyncStateChanged(account, Mac::FileProvider::instance()->socketServer()->latestReceivedSyncStatusForAccount(account));
-        syncStateFallbackNeeded = false;
+    if (Mac::FileProvider::fileProviderAvailable() && _accountState) {
+        const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(_accountState);
+        if (Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(accountFpId)) {
+            const auto account = _accountState->account();
+            const auto lastKnownSyncState = Mac::FileProvider::instance()->socketServer()->latestReceivedSyncStatusForAccount(account);
+            onFileProviderDomainSyncStateChanged(account, lastKnownSyncState);
+            syncStateFallbackNeeded = false;
+        }
     }
 #endif
 


### PR DESCRIPTION
The socket server won't ever know anything about accounts that are not set up with VFS, resulting in a "Some files could not be synced" warning message.  There is no use in trying to fetch the state in that case.

Since the state of the File Provider is per-account, iterating over all accounts is not necessary either.

Resolves #8683 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
