### PR TITLE
fix(macOS): use correct ID for VFS enabled checks

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -309,12 +309,14 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
     if (Mac::FileProvider::fileProviderAvailable()) {
         for (const auto &accountState : AccountManager::instance()->accounts()) {
-            const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(accountState);
-            if (!Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(accountFpId)) {
+            const auto account = accountState->account();
+            const auto userIdAtHostWithPort = account->userIdAtHostWithPort();
+            if (!Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(userIdAtHostWithPort)) {
                 continue;
             }
             allPaused = false;
             const auto fileProvider = Mac::FileProvider::instance();
+            const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(accountState);
 
             if (!fileProvider->xpc()->fileProviderDomainReachable(accountFpId)) {
                 problemFileProviderAccounts.append(accountFpId);

--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -435,9 +435,9 @@ void SyncStatusSummary::initSyncState()
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
     if (Mac::FileProvider::fileProviderAvailable() && _accountState) {
-        const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(_accountState);
-        if (Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(accountFpId)) {
-            const auto account = _accountState->account();
+        const auto account = _accountState->account();
+        const auto userIdAtHostWithPort = account->userIdAtHostWithPort();
+        if (Mac::FileProviderSettingsController::instance()->vfsEnabledForAccount(userIdAtHostWithPort)) {
             const auto lastKnownSyncState = Mac::FileProvider::instance()->socketServer()->latestReceivedSyncStatusForAccount(account);
             onFileProviderDomainSyncStateChanged(account, lastKnownSyncState);
             syncStateFallbackNeeded = false;


### PR DESCRIPTION
This resolves the status of the tray icon being stuck in a "Paused" state (again).

While the file provider domain now uses a UUID internally, the enabledAccounts array stored in the UserDefaults contains the accounts with the username+host+port string.

cc @Rello 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
