### PR TITLE
fix: Drop Qt6GuiPrivate dependency to fix the build with Qt 6.10

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -6,10 +6,6 @@ find_package(Qt${QT_MAJOR_VERSION} REQUIRED COMPONENTS Widgets Svg Qml Quick Qui
 find_package(KF6Archive REQUIRED)
 find_package(KF6GuiAddons)
 
-if (NOT TARGET Qt::GuiPrivate)
-    message(FATAL_ERROR "Could not find GuiPrivate component of Qt. It might be shipped as a separate package, please check that.")
-endif()
-
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     add_definitions(-DQT_QML_DEBUG)
 endif()
@@ -579,7 +575,6 @@ target_link_libraries(nextcloudCore
   PUBLIC
   Nextcloud::sync
   Qt::Widgets
-  Qt::GuiPrivate
   Qt::Svg
   Qt::Network
   Qt::Xml


### PR DESCRIPTION
Usage of private Qt modules requires a call to

`find_package(Qt6 COMPONENTS FooPrivate)` since 6.10 [1].

[1] https://doc-snapshots.qt.io/qt6-dev/whatsnew610.html#build-system-changes

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
