### PR TITLE
fix(ECMAddAppIcon): Avoid warning with cmake >= 4.1

### DIFF
--- a/cmake/modules/ECMAddAppIcon.cmake
+++ b/cmake/modules/ECMAddAppIcon.cmake
@@ -412,7 +412,7 @@ macro(_ecm_add_app_icon_categorize_icons icons type known_sizes)
 
                     if (offset GREATER -1)
                         list(APPEND ${type}_at_${size}px "${icon_full}")
-                    elseif()
+                    else()
                         message(STATUS "not found ${type}_at_${size}px ${icon_full}")
                     endif()
                 endif()


### PR DESCRIPTION
It started to warn about elseif() without a condition [1].

[1] https://gitlab.kitware.com/cmake/cmake/-/commit/74c62a180dccfd2cb7d594474f93e0facccdd60d

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
