### PR TITLE
fix: Clicking the copy share link button breaks it.

### DIFF
--- a/src/gui/filedetails/ShareDelegate.qml
+++ b/src/gui/filedetails/ShareDelegate.qml
@@ -181,8 +181,7 @@ GridLayout {
 
             text: shareLinkCopied ? qsTr("Copied!") : ""
 
-            icon.source: shareLinkCopied ? "image://svgimage-custom-color/copy.svg/" + palette.brightText :
-                                           "image://svgimage-custom-color/copy.svg/" + palette.buttonText
+            icon.source: "image://svgimage-custom-color/copy.svg/" + palette.buttonText
             icon.width: Style.activityListButtonIconSize
             icon.height: Style.activityListButtonIconSize
             display: shareLinkCopied ? AbstractButton.TextOnly : AbstractButton.IconOnly


### PR DESCRIPTION
Fixes: [https://github.com/nextcloud/desktop/issues/8496](https://github.com/nextcloud/desktop/issues/8496)

<img width="820" height="250" alt="image" src="https://github.com/user-attachments/assets/1d8c9890-5479-4c69-bfd8-3be3f705ef0d" />


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
