### PR TITLE
feat: neutral in-app icons

### DIFF
--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -161,7 +161,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
         setTotalFiles(0);
         setSyncStatusString(tr("Offline"));
         setSyncStatusDetailString("");
-        setSyncIcon(Theme::instance()->folderOffline());
+        setSyncIcon(Theme::instance()->offline());
         return;
     }
 
@@ -178,7 +178,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
             setTotalFiles(0);
             setSyncStatusString(tr("All synced!"));
             setSyncStatusDetailString("");
-            setSyncIcon(Theme::instance()->syncStatusOk());
+            setSyncIcon(Theme::instance()->ok());
         }
         break;
     case SyncResult::Error:
@@ -187,7 +187,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
         setTotalFiles(0);
         setSyncStatusString(tr("Some files couldn't be synced!"));
         setSyncStatusDetailString(tr("See below for errors"));
-        setSyncIcon(Theme::instance()->syncStatusError());
+        setSyncIcon(Theme::instance()->error());
         break;
     case SyncResult::SyncRunning:
     case SyncResult::NotYetStarted:
@@ -198,7 +198,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
             setSyncStatusString(tr("Syncing changes"));
         }
         setSyncStatusDetailString("");
-        setSyncIcon(Theme::instance()->syncStatusRunning());
+        setSyncIcon(Theme::instance()->sync());
         break;
     case SyncResult::Paused:
     case SyncResult::SyncAbortRequested:
@@ -206,7 +206,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
         setTotalFiles(0);
         setSyncStatusString(tr("Sync paused"));
         setSyncStatusDetailString("");
-        setSyncIcon(Theme::instance()->syncStatusPause());
+        setSyncIcon(Theme::instance()->pause());
         break;
     case SyncResult::Problem:
     case SyncResult::Undefined:
@@ -214,7 +214,7 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
         setTotalFiles(0);
         setSyncStatusString(tr("Some files could not be synced!"));
         setSyncStatusDetailString(tr("See below for warnings"));
-        setSyncIcon(Theme::instance()->syncStatusWarning());
+        setSyncIcon(Theme::instance()->warning());
         break;
     }
 }

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -203,6 +203,40 @@ QUrl Theme::folderOffline() const
     return imagePathToUrl(themeImagePath("state-offline"));
 }
 
+/*
+ * neutral icons for in-app status
+ */
+
+QUrl Theme::offline() const
+{
+    return imagePathToUrl(themeImagePath("offline"));
+}
+
+QUrl Theme::ok() const
+{
+    return imagePathToUrl(themeImagePath("ok"));
+}
+
+QUrl Theme::error() const
+{
+    return imagePathToUrl(themeImagePath("error"));
+}
+
+QUrl Theme::sync() const
+{
+    return imagePathToUrl(themeImagePath("sync"));
+}
+
+QUrl Theme::pause() const
+{
+    return imagePathToUrl(themeImagePath("pause"));
+}
+
+QUrl Theme::warning() const
+{
+    return imagePathToUrl(themeImagePath("warning"));
+}
+
 QString Theme::version() const
 {
     return MIRALL_VERSION_STRING;

--- a/src/libsync/theme.h
+++ b/src/libsync/theme.h
@@ -173,6 +173,22 @@ public:
     [[nodiscard]] QUrl folderOffline() const;
 
     /**
+     * @brief nneutral icons for in-app status
+     * @return QUrl full path to an icon
+     */
+    [[nodiscard]] QUrl offline() const;
+
+    [[nodiscard]] QUrl ok() const;
+
+    [[nodiscard]] QUrl error() const;
+
+    [[nodiscard]] QUrl sync() const;
+
+    [[nodiscard]] QUrl pause() const;
+
+    [[nodiscard]] QUrl warning() const;
+
+    /**
      * @brief configFileName
      * @return the name of the config file.
      */

--- a/theme.qrc.in
+++ b/theme.qrc.in
@@ -174,7 +174,14 @@
 		<file>theme/colored/user-status-away.svg</file>
 		<file>theme/colored/user-status-busy.svg</file>
 		<file>theme/colored/user-status-dnd.svg</file>
-
+		<file>theme/colored/ok.svg</file>
+		<file>theme/colored/error.svg</file>
+		<file>theme/colored/info.svg</file>
+		<file>theme/colored/offline.svg</file>		
+		<file>theme/colored/pause.svg</file>		
+		<file>theme/colored/warning.svg</file>		
+		<file>theme/colored/sync.svg</file>
+		
 		<!-- black icons -->
 		<file>theme/black/account-group.svg</file>
 		<file>theme/black/activity.svg</file>


### PR DESCRIPTION
The in-app sync status should receive the new neutral icons. no application logos within the app itself

<img width="471" height="118" alt="Bildschirmfoto 2025-09-24 um 15 40 22" src="https://github.com/user-attachments/assets/f2097ea5-db92-4296-b2e8-5a18c3f5c8de" />

https://github.com/nextcloud/desktop/pull/8791