### PR TITLE
fix: alias desktop client import

### DIFF
--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -17,7 +17,7 @@ import "../filedetails/"
 // Custom qml modules are in /theme (and included by resources.qrc)
 import Style
 
-import com.nextcloud.desktopclient
+import com.nextcloud.desktopclient as NC
 
 ApplicationWindow {
     id:         trayWindow


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
