### PR TITLE
 fix(folderstatusdelegate): improve rendering of status icons on HiDPI screens 

### DIFF
--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -156,8 +156,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     auto overallPercent = qvariant_cast<int>(index.data(SyncProgressOverallPercent));
     auto overallString = qvariant_cast<QString>(index.data(SyncProgressOverallString));
     auto itemString = qvariant_cast<QString>(index.data(SyncProgressItemString));
-    auto warningCount = qvariant_cast<int>(index.data(WarningCount));
-    auto syncOngoing = qvariant_cast<bool>(index.data(SyncRunning));
     auto syncEnabled = qvariant_cast<bool>(index.data(FolderAccountConnected));
     auto syncText = qvariant_cast<QString>(index.data(FolderSyncText));
 
@@ -198,21 +196,6 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
         Qt::AlignCenter,
         syncEnabled ? QIcon::Normal : QIcon::Disabled
     );
-
-    // only show the warning icon if the sync is running. Otherwise its
-    // encoded in the status icon.
-    if (warningCount > 0 && syncOngoing) {
-        QRect warnRect;
-        warnRect.setLeft(iconRect.left());
-        warnRect.setTop(iconRect.bottom() - 17);
-        warnRect.setWidth(16);
-        warnRect.setHeight(16);
-
-        QIcon warnIcon(":/client/theme/warning");
-        const auto warnPixmap = warnIcon.pixmap(16, 16, syncEnabled ? QIcon::Normal : QIcon::Disabled);
-        warnRect = QStyle::visualRect(option.direction, option.rect, warnRect);
-        painter->drawPixmap(QPoint(warnRect.left(), warnRect.top()), warnPixmap);
-    }
 
     auto palette = option.palette;
 

--- a/src/gui/folderstatusdelegate.cpp
+++ b/src/gui/folderstatusdelegate.cpp
@@ -190,12 +190,14 @@ void FolderStatusDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     localPathRect.setLeft(nextToIcon);
     remotePathRect.setLeft(nextToIcon);
 
-    const auto iconSize = iconRect.width();
-
     auto optionsButtonVisualRect = optionsButtonRect(option.rect, option.direction);
 
-    const auto statusPixmap = statusIcon.pixmap(iconSize, iconSize, syncEnabled ? QIcon::Normal : QIcon::Disabled);
-    painter->drawPixmap(QStyle::visualRect(option.direction, option.rect, iconRect).left(), iconRect.top(), statusPixmap);
+    statusIcon.paint(
+        painter,
+        QStyle::visualRect(option.direction, option.rect, iconRect),
+        Qt::AlignCenter,
+        syncEnabled ? QIcon::Normal : QIcon::Disabled
+    );
 
     // only show the warning icon if the sync is running. Otherwise its
     // encoded in the status icon.

--- a/src/gui/folderstatusdelegate.h
+++ b/src/gui/folderstatusdelegate.h
@@ -33,9 +33,6 @@ public:
         SyncProgressOverallPercent,
         SyncProgressOverallString,
         SyncProgressItemString,
-        WarningCount,
-        SyncRunning,
-        SyncDate,
 
         AddButton, // 1 = enabled; 2 = disabled
         FolderSyncText,

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -254,10 +254,6 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
         return folder->virtualFilesEnabled() && folder->vfs().mode() != Vfs::Mode::WindowsCfApi
             ? QStringList(tr("Virtual file support is enabled."))
             : QStringList();
-    case FolderStatusDelegate::SyncRunning:
-        return folder->syncResult().status() == SyncResult::SyncRunning;
-    case FolderStatusDelegate::SyncDate:
-        return folder->syncResult().syncTime();
     case FolderStatusDelegate::HeaderRole:
         return folder->shortGuiRemotePathOrAppName();
     case FolderStatusDelegate::FolderAliasRole:
@@ -306,8 +302,6 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
     case FolderStatusDelegate::SyncProgressItemString:
         // e.g. Syncing fileName1, filename2
         return progress._progressString;
-    case FolderStatusDelegate::WarningCount:
-        return progress._warningCount;
     case FolderStatusDelegate::SyncProgressOverallPercent:
         return progress._overallPercent;
     case FolderStatusDelegate::SyncProgressOverallString:
@@ -985,8 +979,7 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
         _isSyncRunningForAwhile = false;
     }
 
-    const QVector<int> roles{ FolderStatusDelegate::SyncProgressItemString, FolderStatusDelegate::WarningCount,
-                             Qt::ToolTipRole };
+    const QVector<int> roles{ FolderStatusDelegate::SyncProgressItemString, Qt::ToolTipRole };
 
     if (progress.status() == ProgressInfo::Discovery) {
         if (!progress._currentDiscoveredRemoteFolder.isEmpty()) {


### PR DESCRIPTION
QIcon can take care of painting and scaling the icon on its own.

Apparently a small warning icon was supposed to be painted over the sync status as well if something occurred during sync.  That never seemed to work however; even after changing that `if` to always evaluate to true, I didn't see any paint events for that one in GammaRay.  I removed that from the paint code and cleaned up some (now-)unused roles from the model as well.




<table><thead>
<tr><th>Before</th><th>After</th>
</thead><tbody>
<tr><td><img width="467" height="419" alt="Folder status view with chunky icons" src="https://github.com/user-attachments/assets/fb5674b7-899f-4765-b5c0-02afef1eeafc" /></td><td><img width="467" height="419" alt="Folder status view with smooth icons" src="https://github.com/user-attachments/assets/770b9f01-36ab-41da-9576-0010f19910fe" /></td></tr>
<tr><th colspan="2">Right-to-left positioning</th></tr>
<tr><td colspan="2"><img width="603" height="439" alt="Folder status view with smooth icons with the right-to-left alignment.  The icon is drawn at the right of the list as expected" src="https://github.com/user-attachments/assets/3499e492-dc82-4b3a-a890-161be37b402f" /></th></tr>
</tbody></table>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
