### PR TITLE
fix(asyncimageresponse): fetch remote resources in the same thread as `Account`

### DIFF
--- a/src/gui/tray/asyncimageresponse.h
+++ b/src/gui/tray/asyncimageresponse.h
@@ -8,6 +8,7 @@
 #include <QImage>
 #include <QQuickImageProvider>
 #include <QFileIconProvider>
+#include <QNetworkReply>
 
 class AsyncImageResponse : public QQuickImageResponse
 {
@@ -18,9 +19,7 @@ public:
 
 private:
     void processNextImage();
-
-private slots:
-    void slotProcessNetworkReply();
+    void processNetworkReply(QNetworkReply *reply);
 
     QImage _image;
     QStringList _imagePaths;


### PR DESCRIPTION
With this change some warnings from QObject like these are gone now:

    QObject: Cannot create children for a parent that is in a different thread.

I suspect this might have been causing some "random" crashes during normal usage as well.  QNAMs are supposed to be used from the same thread they were created in, which (as far as I could tell anyway) isn't the case within async image providers...

This change is similar to how the `ImageResponse` class inside `src/gui/tray/usermodel.cpp` fetches a remote resource: https://github.com/nextcloud/desktop/blob/fb20bb281088567a80e3302dbc8573b2b1a21113/src/gui/tray/usermodel.cpp#L1772-L1784

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
