### PR TITLE
chore(chunk-upload): always sent the total size header

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -368,6 +368,7 @@ void PropagateUploadFileNG::startNextChunk()
     QMap<QByteArray, QByteArray> headers;
     headers["OC-Chunk-Offset"] = QByteArray::number(_sent);
     headers["Destination"] = destinationHeader();
+    headers[QByteArrayLiteral("OC-Total-Length")] = QByteArray::number(fileSize);
 
     _sent += _currentChunkSize;
     const auto url = chunkUrl(_currentChunk);


### PR DESCRIPTION
as documented here
https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/chunking.html#uploading-chunks

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
