### PR TITLE
Bugfix/allign plus icon

### DIFF
--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -58,7 +58,7 @@ Button {
         closePolicy: Menu.CloseOnPressOutsideParent | Menu.CloseOnEscape
 
         onClosed: {
-            // HACK: reload account Instantiator immediately by restting it - could be done better I guess
+            // HACK: reload account Instantiator immediately by resetting it - could be done better I guess
             // see also onVisibleChanged above
             userLineInstantiator.active = false;
             userLineInstantiator.active = true;
@@ -68,7 +68,7 @@ Button {
             id: userLineInstantiator
             model: UserModel
             delegate: MenuItem {
-                implicitHeight: instantiatedUserLine.height + Style.standardSpacing
+                implicitHeight: instantiatedUserLine.height
                 UserLine {
                     id: instantiatedUserLine
                     width: parent.width
@@ -95,11 +95,17 @@ Button {
             id: addAccountButton
             hoverEnabled: true
             visible: Systray.enableAddAccount
+            implicitHeight: Style.accountAvatarSize
 
             readonly property real addAccountIconSize: Style.accountAvatarSize * Style.smallIconScaleFactor
             readonly property real addAccountHorizontalOffset: (Style.accountAvatarSize - addAccountIconSize) / 2
+            property var iconColor: !addAccountButton.enabled
+                                    ? addAccountButton.palette.mid
+                                    : (addAccountButton.highlighted || addAccountButton.down
+                                        ? addAccountButton.palette.highlightedText
+                                        : addAccountButton.palette.text)
 
-            icon.source: "image://svgimage-custom-color/add.svg/" + palette.windowText
+            icon.source: "image://svgimage-custom-color/add.svg/" + iconColor
             icon.width: addAccountIconSize
             icon.height: addAccountIconSize
             leftPadding: Style.accountIconsMenuMargin + addAccountHorizontalOffset
@@ -125,6 +131,18 @@ Button {
             Accessible.role: Accessible.MenuItem
             Accessible.name: Systray.syncIsPaused ? qsTr("Resume sync for all") : qsTr("Pause sync for all")
             Accessible.onPressAction: syncPauseButton.clicked()
+
+            contentItem: Text {
+                text: parent.text
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: Style.userLineSpacing
+                color: !parent.enabled
+                    ? parent.palette.mid
+                    : (parent.highlighted || parent.down
+                        ? parent.palette.highlightedText
+                        : parent.palette.text)
+            }
         }
 
         MenuItem {
@@ -136,6 +154,18 @@ Button {
             Accessible.role: Accessible.MenuItem
             Accessible.name: text
             Accessible.onPressAction: settingsButton.clicked()
+
+            contentItem: Text {
+                text: parent.text
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: Style.userLineSpacing
+                color: !parent.enabled
+                    ? parent.palette.mid
+                    : (parent.highlighted || parent.down
+                        ? parent.palette.highlightedText
+                        : parent.palette.text)
+            }
         }
 
         MenuItem {
@@ -146,7 +176,19 @@ Button {
             onClicked: Systray.shutdown()
             Accessible.role: Accessible.MenuItem
             Accessible.name: text
-            Accessible.onPressAction: exitButton.clicked() 
+            Accessible.onPressAction: exitButton.clicked()
+
+            contentItem: Text {
+                text: parent.text
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: Style.userLineSpacing
+                color: !parent.enabled
+                    ? parent.palette.mid
+                    : (parent.highlighted || parent.down
+                        ? parent.palette.highlightedText
+                        : parent.palette.text)
+            }
         }
     }
 

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -78,6 +78,12 @@ AbstractButton {
                 elide: Text.ElideRight
                 font.pixelSize: Style.topLinePixelSize
                 font.bold: true
+
+                color: !userLine.parent.enabled
+                    ? userLine.parent.palette.mid
+                    : (userLine.parent.highlighted || userLine.parent.down
+                        ? userLine.parent.palette.highlightedText
+                        : userLine.parent.palette.text)
             }
 
             RowLayout {
@@ -92,6 +98,12 @@ AbstractButton {
                     id: emoji
                     visible: model.statusEmoji !== ""
                     text: statusEmoji
+
+                    color: !userLine.parent.enabled
+                        ? userLine.parent.palette.mid
+                        : (userLine.parent.highlighted || userLine.parent.down
+                            ? userLine.parent.palette.highlightedText
+                            : userLine.parent.palette.text)
                 }
 
                 EnforcedPlainTextLabel {
@@ -101,6 +113,12 @@ AbstractButton {
                     text: statusMessage
                     elide: Text.ElideRight
                     font.pixelSize: Style.subLinePixelSize
+
+                    color: !userLine.parent.enabled
+                        ? userLine.parent.palette.mid
+                        : (userLine.parent.highlighted || userLine.parent.down
+                            ? userLine.parent.palette.highlightedText
+                            : userLine.parent.palette.text)
                 }
             }
 
@@ -112,6 +130,12 @@ AbstractButton {
                 text: server
                 elide: Text.ElideRight
                 font.pixelSize: Style.subLinePixelSize
+
+                color: !userLine.parent.enabled
+                    ? userLine.parent.palette.mid
+                    : (userLine.parent.highlighted || userLine.parent.down
+                        ? userLine.parent.palette.highlightedText
+                        : userLine.parent.palette.text)
             }
         }
 
@@ -127,7 +151,12 @@ AbstractButton {
 
             onClicked: userMoreButtonMenu.visible ? userMoreButtonMenu.close() : userMoreButtonMenu.popup()
 
-            icon.source: "image://svgimage-custom-color/more.svg/" + palette.windowText
+            property var iconColor: !userLine.parent.enabled
+                ? userLine.parent.palette.mid
+                : (!hovered && (userLine.parent.highlighted || userLine.parent.down)
+                    ? userLine.parent.palette.highlightedText
+                    : userLine.parent.palette.text)
+            icon.source: "image://svgimage-custom-color/more.svg/" + iconColor
 
             AutoSizingMenu {
                 id: userMoreButtonMenu


### PR DESCRIPTION
This PR tweaks the looks of the accounts menu menu:

- The + icon for the "Add account" option is aligned with the avatar icons.
- The height of the "Add account" item now equals the height of account lines.
- Spacing is reduced between items.
- The options after the menu separator now have a slight padding on the left.
- The account lines' text color will now change properly when the menu item is highlighted.

Before:

https://github.com/user-attachments/assets/74c6e5ce-e188-4bab-a5d4-5a8e9c809e05

After:

https://github.com/user-attachments/assets/b0ea3f29-daa9-4c8a-92e9-60f77b90df42



