### PR TITLE
fix(NextcloudDev): add missing template file.

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/.gitignore
+++ b/shell_integration/MacOSX/NextcloudIntegration/.gitignore
@@ -1,1 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 DerivedData
+
+# exception
+!NextcloudDev/Build.xcconfig.template

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Build.xcconfig.template
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Build.xcconfig.template
@@ -1,0 +1,8 @@
+//  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+//
+// The common name of the signing certificate to use for code signing.
+// It must be present in your keychain and a development certificate.
+//
+CODE_SIGN_IDENTITY=


### PR DESCRIPTION
Adjust .gitignore to accept a file with 'build' in the name.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
