### PR TITLE
fix(file-provider): report a different error if database is not ready

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -130,7 +130,7 @@ import OSLog
         
         guard let dbManager else {
             logger.error("Not fetching item because database is unavailable.", [.item: identifier])
-            completionHandler(nil, NSFileProviderError(.cannotSynchronize))
+            completionHandler(nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 


### PR DESCRIPTION
As per [the docs for `NSFileProviderReplicatedExtension item(for:request:completionHandler:)`][1], the system will automatically retry calling the method if the error is not one of `.notAuthenticated`, `.serverUnreachable`, or `.noSuchItem`.

From my observations it seems that if the error `.cannotSynchronize` is returned for the root container (i.e.
`NSFileProviderRootContainerItemIdentifier`), the system/file provider framework just ends up deleting the newly created sync directory inside `~/Library/CloudStorage`.  This broke the entry in the Finder sidebar.

After changing the error to `.notAuthenticated` (which is semantically wrong, but alas), I now could disable/enable the File Provider as often as I wanted without the Finder sidebar entry to ever break due to the directory having been removed previously ...  Strange, this.

[1]: https://developer.apple.com/documentation/fileprovider/nsfileproviderreplicatedextension/item(for:request:completionhandler:)#Discussion

----

I discovered this by comparing the logs when setting up the File Provider for the same account.  The logs of such a failed invocation contained the following message, whereas successful ones did not:

```sh
% grep "Not fetching item because database is unavailable." fp-bob-failedinit.jsonl fp-bob-workinginit.jsonl 
fp-bob-failedinit.jsonl:{"category":"FileProviderExtension","date":"2025.10.15 16:09:37.902","details":{"item":"NSFileProviderRootContainerItemIdentifier"},"level":"error","message":"Not fetching item because database is unavailable."}
```

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
