### PR TITLE
style(file-provider): improve text displayed when user resets virtual files setup.

### DIFF
--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -213,11 +213,9 @@ void FileProviderSettingsController::setVfsEnabledForAccount(const QString &user
         emit vfsEnabledAccountsChanged();
 
         if (setEnabled && showInformationDialog) {
-            QMessageBox::information(nullptr,
-                                     tr("macOS virtual files enabled"),
-                                     tr("Virtual files have been enabled for this account.\n"
-                                        "Files are accessible in Finder via an entry under the \"Locations\" section.\n"
-                                        "Please note that on macOS, virtual and classic sync folders are separate.\n"));
+            QMessageBox::information(nullptr, tr("Virtual files enabled"),
+                                     tr("Virtual files have been enabled for this account.\n\n"
+                                        "Your files are now accessible in Finder under the \"Locations\" section."));
         }
     }
 }


### PR DESCRIPTION
### before:
<img width="283" height="316" alt="Screenshot 2025-10-16 at 22 59 42" src="https://github.com/user-attachments/assets/cc9caf9a-ac5b-4703-b2f7-2f35c5627fed" />

### after:
<img width="277" height="288" alt="Screenshot 2025-10-16 at 23 31 53" src="https://github.com/user-attachments/assets/34388f8f-081d-4aff-ad34-9ae6ed567bc6" />
