### PR TITLE
fix: remove "nextcloud" from debug log filenames

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -166,12 +166,12 @@ bool createDebugArchive(const QString &filename)
 #endif
 
     const auto clientParameters = QCoreApplication::arguments().join(' ').toUtf8();
-    zip.prepareWriting("__nextcloud_client_parameters.txt", {}, {}, clientParameters.size());
+    zip.prepareWriting("_client_parameters.txt", {}, {}, clientParameters.size());
     zip.writeData(clientParameters, clientParameters.size());
     zip.finishWriting(clientParameters.size());
 
     const auto buildInfo = QString(OCC::Theme::instance()->aboutInfo() + "\n\n" + OCC::Theme::instance()->aboutDetails()).toUtf8();
-    zip.prepareWriting("__nextcloud_client_buildinfo.txt", {}, {}, buildInfo.size());
+    zip.prepareWriting("_client_buildinfo.txt", {}, {}, buildInfo.size());
     zip.writeData(buildInfo, buildInfo.size());
     zip.finishWriting(buildInfo.size());
     return true;


### PR DESCRIPTION
The first two text files have a hardcoded "nextcloud" also for branded client.
changing to neutral

_client_buildinfo
_client_pramaters

**do we need them at all?**

<img width="272" height="166" alt="Bildschirmfoto 2025-10-20 um 10 25 41" src="https://github.com/user-attachments/assets/7869c7f3-f373-467a-8f4b-b57c3b553431" />
