### PR TITLE
fix: Neutral sync icon in VFS sync status

### DIFF
--- a/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
+++ b/src/gui/macOS/fileproviderdomainsyncstatus_mac.mm
@@ -254,7 +254,7 @@ void FileProviderDomainSyncStatus::setIcon(const QUrl &icon)
 
 void FileProviderDomainSyncStatus::updateIcon()
 {
-    const auto iconUrl = syncing() ? Theme::instance()->syncStatusRunning() : Theme::instance()->syncStatusOk();
+    const auto iconUrl = syncing() ? Theme::instance()->sync() : Theme::instance()->ok();
     setIcon(iconUrl);
 }
 


### PR DESCRIPTION
The VFS in-app-sync status still shows the themed icon.
the neutral should be shown in all places within the app.

Neutral ones are already available here:
https://github.com/nextcloud/desktop/blob/master/src/libsync/theme.cpp#L206-L238

<img width="881" height="206" alt="Bildschirmfoto 2025-10-20 um 12 29 25" src="https://github.com/user-attachments/assets/f70f0fc8-e130-42eb-b14d-50309a3ab83b" />
