### PR TITLE
fix(network): fall back to unlimited bandwidth in case the legacy global limit is still set

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -1426,7 +1426,14 @@ void Account::setUploadLimitSetting(const AccountNetworkTransferLimitSetting set
         return;
     }
 
-    _uploadLimitSetting = setting;
+    auto targetSetting = setting;
+
+    if (setting == AccountNetworkTransferLimitSetting::LegacyGlobalLimit) {
+        qCInfo(lcAccount) << "Upload limit setting was requested to be set to the legacy global limit, falling back to unlimited";
+        targetSetting = AccountNetworkTransferLimitSetting::NoLimit;
+    }
+
+    _uploadLimitSetting = targetSetting;
     emit uploadLimitSettingChanged();
 }
 
@@ -1440,8 +1447,15 @@ void Account::setDownloadLimitSetting(const AccountNetworkTransferLimitSetting s
     if (setting == _downloadLimitSetting) {
         return;
     }
-    
-    _downloadLimitSetting = setting;
+
+    auto targetSetting = setting;
+
+    if (setting == AccountNetworkTransferLimitSetting::LegacyGlobalLimit) {
+        qCInfo(lcAccount) << "Download limit setting was requested to be set to the legacy global limit, falling back to unlimited";
+        targetSetting = AccountNetworkTransferLimitSetting::NoLimit;
+    }
+
+    _downloadLimitSetting = targetSetting;
     emit downloadLimitSettingChanged();
 }
 

--- a/src/libsync/account.h
+++ b/src/libsync/account.h
@@ -99,6 +99,7 @@ class OWNCLOUDSYNC_EXPORT Account : public QObject
 
 public:
     enum class AccountNetworkTransferLimitSetting {
+        LegacyGlobalLimit = -2, // Until 3.17.0 a value of -2 was interpreted as "Use global network settings", it's now used to fall back to "No limit".  See also GH#8743
         AutoLimit = -1, // Value under 0 is interpreted as auto in general
         NoLimit,
         ManualLimit,

--- a/test/testaccount.cpp
+++ b/test/testaccount.cpp
@@ -69,6 +69,37 @@ private slots:
         QCOMPARE(account->isPublicShareLink(), expectedResult);
         QCOMPARE(account->davUser(), expectedDavUser);
     }
+
+    void testAccount_setLimitSettings_globalNetworkLimitFallback()
+    {
+        using LimitSetting = Account::AccountNetworkTransferLimitSetting;
+        AccountPtr account = Account::create();
+
+        const auto setLimitSettings = [account](const LimitSetting setting) -> void {
+            account->setDownloadLimitSetting(setting);
+            account->setUploadLimitSetting(setting);
+        };
+
+        const auto verifyLimitSettings = [account](const LimitSetting expectedSetting) -> void {
+            QCOMPARE_EQ(expectedSetting, account->downloadLimitSetting());
+            QCOMPARE_EQ(expectedSetting, account->uploadLimitSetting());
+        };
+
+        // the default setting should be NoLimit
+        verifyLimitSettings(LimitSetting::NoLimit);
+
+        // changing it to ManualLimit should succeed
+        setLimitSettings(LimitSetting::ManualLimit);
+        verifyLimitSettings(LimitSetting::ManualLimit);
+
+        // changing it to AutoLimit should succeed
+        setLimitSettings(LimitSetting::AutoLimit);
+        verifyLimitSettings(LimitSetting::AutoLimit);
+
+        // changing it to LegacyGlobalLimit (-2) should fall back to NoLimit
+        setLimitSettings(LimitSetting::LegacyGlobalLimit);
+        verifyLimitSettings(LimitSetting::NoLimit);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestAccount)


### PR DESCRIPTION
`-2` used to mean "Use global limits", which no longer exist since 3.17.0.  As any negative value results in the auto bandwidth limiter to engage, this could result in unexpected slower sync speeds after a client upgrade.

Let's just keep handling that value and assume that we want to use unlimited bandwidth.

Fixes #8743

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
