### PR TITLE
fix(account): do not consider URLs with a trailing slash as public links

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -557,7 +557,7 @@ void Account::setSslErrorHandler(AbstractSslErrorHandler *handler)
 
 void Account::setUrl(const QUrl &url)
 {
-    const QRegularExpression discoverPublicLinks(R"(((https|http)://[^/]*).*/s/([^/]*))");
+    const QRegularExpression discoverPublicLinks(R"(((https|http)://[^/]*).*/s/([^/]*)$)");
     const auto isPublicLink = discoverPublicLinks.match(url.toString());
     if (isPublicLink.hasMatch()) {
         _url = QUrl::fromUserInput(isPublicLink.captured(1));

--- a/test/testaccount.cpp
+++ b/test/testaccount.cpp
@@ -40,6 +40,35 @@ private slots:
         AccountPtr account = Account::create();
         [[maybe_unused]] const auto davPath = account->davPath();
     }
+
+    void testAccount_isPublicShareLink_data()
+    {
+        QTest::addColumn<QString>("url");
+        QTest::addColumn<bool>("expectedResult");
+        QTest::addColumn<QString>("expectedDavUser");
+
+        QTest::newRow("plain URL") << "https://example.com" << false << "";
+        QTest::newRow("plain URL, trailing slash") << "https://example.com/" << false << "";
+        QTest::newRow("share link") << "https://example.com/s/rPZLaTKfWct37Nd" << true << "rPZLaTKfWct37Nd";
+        QTest::newRow("share link, trailing slash") << "https://example.com/s/rPZLaTKfWct37Nd/" << false << "";
+        QTest::newRow("subpath containing /s/ (looks like share link)") << "https://example.com/s/nextcloud" << true << "nextcloud";
+        QTest::newRow("subpath containing /s/, trailing slash") << "https://example.com/s/nextcloud/" << false << "";
+        QTest::newRow("subpath containing /s/, share link") << "https://example.com/s/nextcloud/s/rPZLaTKfWct37Nd" << true << "rPZLaTKfWct37Nd";
+        QTest::newRow("subpath containing /s/, share link, trailing slash") << "https://example.com/s/nextcloud/s/rPZLaTKfWct37Nd/" << false << "";
+    }
+
+    void testAccount_isPublicShareLink()
+    {
+        AccountPtr account = Account::create();
+
+        QFETCH(QString, url);
+        QFETCH(bool, expectedResult);
+        QFETCH(QString, expectedDavUser);
+
+        account->setUrl(QUrl{url});
+        QCOMPARE(account->isPublicShareLink(), expectedResult);
+        QCOMPARE(account->davUser(), expectedDavUser);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestAccount)


### PR DESCRIPTION
Resolves #8929

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
