### PR TITLE
feat(ci): run four tests in parallel

### DIFF
--- a/.github/workflows/linux-clang-compile-tests.yml
+++ b/.github/workflows/linux-clang-compile-tests.yml
@@ -24,4 +24,4 @@ jobs:
           cd build
           useradd -m -s /bin/bash test
           chown -R test:test .
-          su -c 'xvfb-run ctest --output-on-failure' test
+          su -c 'xvfb-run ctest --output-on-failure --parallel 4' test

--- a/.github/workflows/linux-gcc-compile-tests.yml
+++ b/.github/workflows/linux-gcc-compile-tests.yml
@@ -24,4 +24,4 @@ jobs:
           cd build
           useradd -m -s /bin/bash test
           chown -R test:test .
-          su -c 'xvfb-run ctest --output-on-failure' test
+          su -c 'xvfb-run ctest --output-on-failure --parallel 4' test

--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -88,4 +88,4 @@ jobs:
       - name: Run tests
         run: |
           cd ${{ github.workspace }}/${{ inputs.CRAFT_TARGET }}/build/nextcloud-client/work/build
-          ctest --output-on-failure --output-junit testResult.xml
+          ctest --output-on-failure --output-junit testResult.xml --parallel 4

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: windows-2022
     env:
       CRAFT_TARGET: windows-msvc2022_64-cl
-      COBERTURA_COVERAGE_FILE: ${{ github.workspace }}\cobertura_coverage\coverage.xml
       CRAFT_MASTER_LOCATION: ${{ github.workspace }}\CraftMaster
       CRAFT_MASTER_CONFIG: ${{ github.workspace }}\craftmaster.ini
     steps:
@@ -36,28 +35,7 @@ jobs:
           craft craft
           craft --install-deps nextcloud-client
           
-      - name: Cache Install OpenCppCoverage
-        id: cache-install-opencppcoverage
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: C:\Program Files\OpenCppCoverage
-          key: ${{ runner.os }}-cache-install-opencppcoverage
-          
-      - name: Install OpenCppCoverage
-        if: steps.cache-install-opencppcoverage.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          choco install opencppcoverage
-
-      #- name: Cache Install inkscape
-      #  id: cache-install-inkscape
-      #  uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      #  with:
-      #    path: C:\Program Files\inkscape
-      #    key: ${{ runner.os }}-cache-install-inkscape
-
       - name: Install inkscape
-      #  if: steps.cache-install-inkscape.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           choco install inkscape
@@ -65,7 +43,6 @@ jobs:
       - name: Setup PATH
         shell: pwsh
         run: |
-          echo "C:\Program Files\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "${{ github.workspace }}\${{ env.CRAFT_TARGET }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
    
       - name: Compile
@@ -78,7 +55,7 @@ jobs:
           
           craft --src-dir ${{ github.workspace }} nextcloud-client
           
-      - name: Run tests with coverage
+      - name: Run tests
         shell: pwsh
         run: |
           function runTests() {

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
 
               $binFolder = "$buildFolder\bin"
 
-              & ctest --output-on-failure --timeout 300
+              & ctest --output-on-failure --timeout 300 --parallel 4
           }
           
           runTests


### PR DESCRIPTION
Apparently we can run our tests in parallel just fine.  On my local machine this cuts down the runtime from 3 minutes to around 50 seconds with a parallelism of 4:

```sh
% for jobs in `seq 1 17`; do printf "--parallel %2d => " "$jobs" && time (ctest --parallel $jobs > /dev/null 2>&1); done
--parallel  1 => ( ctest --parallel $jobs > /dev/null 2>&1; )  41.42s user 9.14s system 27% cpu 3:05.53 total
--parallel  2 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.55s user 9.16s system 55% cpu 1:33.34 total
--parallel  3 => ( ctest --parallel $jobs > /dev/null 2>&1; )  41.40s user 9.20s system 81% cpu 1:01.79 total
--parallel  4 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.29s user 9.15s system 102% cpu 49.995 total
--parallel  5 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.08s user 8.94s system 102% cpu 49.895 total
--parallel  6 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.51s user 9.33s system 102% cpu 50.590 total
--parallel  7 => ( ctest --parallel $jobs > /dev/null 2>&1; )  43.77s user 9.33s system 105% cpu 50.537 total
--parallel  8 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.89s user 9.10s system 104% cpu 49.761 total
--parallel  9 => ( ctest --parallel $jobs > /dev/null 2>&1; )  42.77s user 9.19s system 104% cpu 49.810 total
--parallel 10 => ( ctest --parallel $jobs > /dev/null 2>&1; )  44.97s user 9.68s system 107% cpu 50.834 total
--parallel 11 => ( ctest --parallel $jobs > /dev/null 2>&1; )  45.87s user 9.93s system 109% cpu 50.889 total
--parallel 12 => ( ctest --parallel $jobs > /dev/null 2>&1; )  45.37s user 9.33s system 107% cpu 50.908 total
--parallel 13 => ( ctest --parallel $jobs > /dev/null 2>&1; )  45.75s user 9.75s system 108% cpu 50.919 total
--parallel 14 => ( ctest --parallel $jobs > /dev/null 2>&1; )  46.53s user 9.82s system 110% cpu 51.099 total
--parallel 15 => ( ctest --parallel $jobs > /dev/null 2>&1; )  46.76s user 9.81s system 110% cpu 51.379 total
--parallel 16 => ( ctest --parallel $jobs > /dev/null 2>&1; )  47.63s user 9.72s system 114% cpu 50.086 total
--parallel 17 => ( ctest --parallel $jobs > /dev/null 2>&1; )  46.05s user 9.23s system 110% cpu 49.938 total
```

Let's see if this applies to the test runs in CI too.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
