### PR TITLE
Fix #8914

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -457,10 +457,8 @@ import OSLog
         return progress
     }
 
-    func enumerator(
-        for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest
-    ) throws -> NSFileProviderEnumerator {
-        logger.debug("System requested enumerator.", [.item: containerItemIdentifier, .request: request])
+    func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
+        logger.debug("System requested enumerator.", [.item: containerItemIdentifier])
 
         guard let ncAccount else {
             logger.error("Not providing enumerator for container with identifier \(containerItemIdentifier.rawValue) yet as account not set up")


### PR DESCRIPTION
fix(file-provider): Fix #8914 by omitting the faulty NSFileProviderRequest argument on enumerator request.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
