### PR TITLE
fix: Add official PPA as an option of the package type

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -98,6 +98,7 @@ body:
         - "Official Windows MSI"
         - "Official macOS 12+ universal pkg"
         - "Official macOS Virtual files 12+ universal pkg"
+        - "Official PPA"
         - "Community FlatPak"
         - "Community SNAP package"
         - "Distro package manager"


### PR DESCRIPTION
Add missing "Official PPA" to the package type drop-down in the issue ticket.

Also known as: https://launchpad.net/~nextcloud-devs/+archive/ubuntu/client