### PR TITLE
Fix #7009: Remove leftover .msi and msi.log after update

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -26,6 +26,7 @@ const auto updateAvailableC = QStringLiteral("Updater/updateAvailable");
 const auto updateTargetVersionC = QStringLiteral("Updater/updateTargetVersion");
 const auto updateTargetVersionStringC = QStringLiteral("Updater/updateTargetVersionString");
 const auto autoUpdateAttemptedC = QStringLiteral("Updater/autoUpdateAttempted");
+const auto msiLogFileNameC = QStringLiteral("msi.log");
 }
 
 UpdaterScheduler::UpdaterScheduler(QObject *parent)
@@ -222,7 +223,7 @@ void OCUpdater::slotStartInstaller()
             return QDir::toNativeSeparators(path);
         };
 
-        QString msiLogFile = cfg.configPath() + "msi.log";
+        QString msiLogFile = cfg.configPath() + msiLogFileNameC;
         QString command = QStringLiteral("&{msiexec /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
              .arg(preparePathForPowershell(updateFile))
              .arg(preparePathForPowershell(msiLogFile))
@@ -315,7 +316,7 @@ void NSISUpdater::wipeUpdateData()
         }
     }
     // Also try to remove the msi log file (created when running msiexec)
-    QString msiLogFileName = cfg.configPath() + "msi.log";
+    QString msiLogFileName = cfg.configPath() + msiLogFileNameC;
     if (QFile::remove(msiLogFileName)) {
         qCInfo(lcUpdater) << "Removed msi log file:" << msiLogFileName;
     } else {

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -316,7 +316,7 @@ void NSISUpdater::wipeUpdateData()
         }
     }
     // Also try to remove the msi log file (created when running msiexec)
-    QString msiLogFileName = cfg.configPath() + msiLogFileNameC;
+    const auto msiLogFileName = QString{cfg.configPath() + msiLogFileNameC};
     if (QFile::remove(msiLogFileName)) {
         qCInfo(lcUpdater) << "Removed msi log file:" << msiLogFileName;
     } else {

--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -317,10 +317,12 @@ void NSISUpdater::wipeUpdateData()
     }
     // Also try to remove the msi log file (created when running msiexec)
     const auto msiLogFileName = QString{cfg.configPath() + msiLogFileNameC};
-    if (QFile::remove(msiLogFileName)) {
-        qCInfo(lcUpdater) << "Removed msi log file:" << msiLogFileName;
-    } else {
-        qCWarning(lcUpdater) << "Failed to remove msi log file:" << msiLogFileName;
+    if (QFile::exists(msiLogFileName)) {
+        if (QFile::remove(msiLogFileName)) {
+            qCInfo(lcUpdater) << "Removed msi log file:" << msiLogFileName;
+        } else {
+            qCWarning(lcUpdater) << "Failed to remove msi log file:" << msiLogFileName;
+        }
     }
 
     settings.remove(updateAvailableC);


### PR DESCRIPTION
Fixes #7009

Ensure leftover Windows installers (.msi) and the msiexec log (msi.log) are removed after updates,
both for internal updater flow and for externally performed (manual) installs.

## What I changed
- NSISUpdater::wipeUpdateData() now removes update file and msi.log and logs failures.
- handleStartup() will now call wipeUpdateData() if the update was performed externally.

## How to test
1. Case A (internal updater): simulate a download -> run installer via updater -> restart client -> verify .msi and msi.log are removed.
2. Case B (manual install): download .msi to the config path, run it manually to update, start client -> confirm leftover files are removed.
3. Check logs for messages like "Removed updater file" / "Removed msi log file" or warning messages if removal failed.

## Notes
- This is a Windows-only fix targeted at issue #7009.

Fixes #7009