### PR TITLE
fix(file-provider): use correct FP domain identifier for sync status check

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -24,7 +24,7 @@ public:
     ~FileProviderDomainManager() override;
 
     static AccountStatePtr accountStateFromFileProviderDomainIdentifier(const QString &domainIdentifier);
-    static QString fileProviderDomainIdentifierFromAccountState(const AccountStatePtr &accountState);
+    QString fileProviderDomainIdentifierFromAccountId(const QString &accountId);
     
     void start();
     void* domainForAccount(const OCC::AccountState * const accountState);

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -308,6 +308,18 @@ public:
         return nil;
     }
 
+    QString fileProviderDomainIdentifierForAccountId(const QString &accountId)
+    {
+        if (@available(macOS 11.0, *)) {
+            if (_registeredDomains.contains(accountId)) {
+                const auto fileProviderDomain = _registeredDomains[accountId];
+                return QString::fromNSString([fileProviderDomain identifier]);
+            }
+        }
+
+        return {};
+    }
+
     void addFileProviderDomain(const AccountState * const accountState)
     {
         if (@available(macOS 11.0, *)) {
@@ -597,6 +609,7 @@ public:
     }
 
 private:
+    //! keys are accountId, i.e. userIdAtHostWithPort
     QHash<QString, NSFileProviderDomain*> _registeredDomains;
 };
 
@@ -806,9 +819,13 @@ AccountStatePtr FileProviderDomainManager::accountStateFromFileProviderDomainIde
     return accountForReceivedDomainIdentifier;
 }
 
-QString FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(const AccountStatePtr &accountState)
+QString FileProviderDomainManager::fileProviderDomainIdentifierFromAccountId(const QString &accountId)
 {
-    return uuidDomainIdentifierForAccount(accountState->account());
+    if (!d || accountId.isEmpty()) {
+        return {};
+    }
+
+    return d->fileProviderDomainIdentifierForAccountId(accountId);
 }
 
 void* FileProviderDomainManager::domainForAccount(const AccountState * const accountState)

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -43,7 +43,9 @@ private slots:
     void slotAccountStateChanged(AccountState::State state) const;
 
 private:
+    //! keys are File Provider domain identifiers
     QHash<QString, void*> _clientCommServices;
+    //! keys are File Provider domain identifiers
     QHash<QString, QDateTime> _unreachableFileProviderDomains;
 };
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -318,7 +318,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
             }
             allPaused = false;
             const auto fileProvider = Mac::FileProvider::instance();
-            const auto accountFpId = Mac::FileProviderDomainManager::fileProviderDomainIdentifierFromAccountState(accountState);
+            const auto accountFpId = fileProvider->domainManager()->fileProviderDomainIdentifierFromAccountId(userIdAtHostWithPort);
             const auto displayName = account->displayName();
             const auto accountTooltipLabel = displayName.isEmpty() ? userIdAtHostWithPort : displayName;
 


### PR DESCRIPTION
also added some docstrings to some `QHash<>`es dealing with account/file provider identifier to keep in mind what key is expected where

Fixes #8990

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
