### PR TITLE
fix(checksums): avoid crash on aborted checksum calculation job

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -175,7 +175,10 @@ ComputeChecksum::ComputeChecksum(QObject *parent)
 {
 }
 
-ComputeChecksum::~ComputeChecksum() = default;
+ComputeChecksum::~ComputeChecksum()
+{
+    _checksumCalculator.reset();
+}
 
 void ComputeChecksum::setChecksumType(const QByteArray &type)
 {
@@ -201,6 +204,11 @@ void ComputeChecksum::startImpl(const QString &filePath)
 
     _checksumCalculator.reset(new ChecksumCalculator(filePath, _checksumType));
     _watcher.setFuture(QtConcurrent::run([this]() {
+        if (!_checksumCalculator) {
+            qCDebug(lcChecksums) << "checksumCalculator instance was destroyed before calculation started, returning empty checksum";
+            return QByteArray();
+        }
+
         return _checksumCalculator->calculate();
     }));
 }


### PR DESCRIPTION
In case a propagation job is aborted while it's about to start computing the content checksum in a thread, the thread could still be started and attempting to call `_checksumCalculator->calculate()`.  As the job was aborted the ComputeChecksum instance has already been deleted along with its ChecksumCalculator instance, and the thread ends up calling `calculate()` on an invalid pointer.

I managed to occasionally reproduce this through:

```cpp
auto computeChecksum = new ComputeChecksum();
computeChecksum->setChecksumType("MD5");
computeChecksum->start("/dev/zero");
delete computeChecksum;
```

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
