### PR TITLE
fix: activity tray is not refreshed

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -428,7 +428,7 @@ void User::slotRefresh()
     
     if (checkPushNotificationsAreReady()) {
         // we are relying on WebSocket push notifications - ignore refresh attempts from UI
-        slotRefreshActivitiesInitial();
+        slotRefreshActivities();
         _timeSinceLastCheck[_account.data()].invalidate();
         return;
     }
@@ -445,7 +445,7 @@ void User::slotRefresh()
         return;
     }
     if (_account.data() && _account.data()->isConnected()) {
-        slotRefreshActivitiesInitial();
+        slotRefreshActivities();
         slotRefreshNotifications();
         timer.start();
     }


### PR DESCRIPTION
The tray menu is loading the activities from the server only during first startup.
During normal operations, own file activities from the classic sync + notifications are added on the fly - but the server activities are not refreshed.

The used function `slotRefreshActivitiesInitial()` checks for an empty list and works only one time because of that.

the `slotRefreshActivities()` is now used to refresh the activities on every tray opening