### PR TITLE
fix(log): Re-establish connection for systray mono icons

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -374,7 +374,6 @@ Application::Application(int &argc, char **argv)
     }
 
     _theme->setSystrayUseMonoIcons(ConfigFile().monoIcons());
-    connect(_theme, &Theme::systrayUseMonoIconsChanged, _gui, &ownCloudGui::slotComputeOverallSyncStatus);
     connect(this, &Application::systemPaletteChanged,
             _theme, &Theme::systemPaletteHasChanged);
 
@@ -392,6 +391,7 @@ Application::Application(int &argc, char **argv)
     // Setting up the gui class will allow tray notifications for the
     // setup that follows, like folder setup
     _gui = new ownCloudGui(this);
+    connect(_theme, &Theme::systrayUseMonoIconsChanged, _gui, &ownCloudGui::slotComputeOverallSyncStatus);
     if (_showLogWindow) {
         _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
     }


### PR DESCRIPTION
log:
> 2025-11-13 13:38:51:420 [ warning qt.core.qobject.connect unknown:0 ]:	QObject::connect(OCC::NextcloudTheme, Unknown): invalid nullptr parameter

Moved the Theme::systrayUseMonoIconsChanged hookup until after the GUI object is created so Qt no longer warns about connecting NextcloudTheme signals to a null receiver.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
