### PR TITLE
fix: align qml value type registration with lowercase names

### DIFF
--- a/src/gui/UserStatusSetStatusView.qml
+++ b/src/gui/UserStatusSetStatusView.qml
@@ -44,57 +44,57 @@ ColumnLayout {
     }
 
     UserStatusSelectorButton {
-        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.UserStatus.Online
+        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.userStatus.Online
         checkable: true
         icon.source: userStatusSelectorModel ? userStatusSelectorModel.onlineIcon : ""
         icon.color: "transparent"
         text: qsTr("Online")
         Layout.fillWidth: true
-        onClicked: handleStatusClick(NC.UserStatus.Online)
+        onClicked: handleStatusClick(NC.userStatus.Online)
     }
 
     UserStatusSelectorButton {
-        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.UserStatus.Away
+        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.userStatus.Away
         checkable: true
         icon.source: userStatusSelectorModel ? userStatusSelectorModel.awayIcon : ""
         icon.color: "transparent"
         text: qsTr("Away")
         Layout.fillWidth: true
-        onClicked: handleStatusClick(NC.UserStatus.Away)
+        onClicked: handleStatusClick(NC.userStatus.Away)
     }
 
     UserStatusSelectorButton {
         visible: userStatusSelectorModel && userStatusSelectorModel.busyStatusSupported
-        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.UserStatus.Busy
+        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.userStatus.Busy
         checkable: true
         icon.source: userStatusSelectorModel ? userStatusSelectorModel.busyIcon : ""
         icon.color: "transparent"
         text: qsTr("Busy")
         Layout.fillWidth: true
-        onClicked: handleStatusClick(NC.UserStatus.Busy)
+        onClicked: handleStatusClick(NC.userStatus.Busy)
     }
 
     UserStatusSelectorButton {
-        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.UserStatus.DoNotDisturb
+        checked: userStatusSelectorModel && userStatusSelectorModel.onlineStatus === NC.userStatus.DoNotDisturb
         checkable: true
         icon.source: userStatusSelectorModel ? userStatusSelectorModel.dndIcon : ""
         icon.color: "transparent"
         text: qsTr("Do not disturb")
         secondaryText: qsTr("Mute all notifications")
         Layout.fillWidth: true
-        onClicked: handleStatusClick(NC.UserStatus.DoNotDisturb)
+        onClicked: handleStatusClick(NC.userStatus.DoNotDisturb)
     }
 
     UserStatusSelectorButton {
-        checked: userStatusSelectorModel && (userStatusSelectorModel.onlineStatus === NC.UserStatus.Invisible
-            || userStatusSelectorModel.onlineStatus === NC.UserStatus.Offline)
+        checked: userStatusSelectorModel && (userStatusSelectorModel.onlineStatus === NC.userStatus.Invisible
+            || userStatusSelectorModel.onlineStatus === NC.userStatus.Offline)
         checkable: true
         icon.source: userStatusSelectorModel ? userStatusSelectorModel.invisibleIcon : ""
         icon.color: "transparent"
         text: qsTr("Invisible")
         secondaryText: qsTr("Appear offline")
         Layout.fillWidth: true
-        onClicked: handleStatusClick(NC.UserStatus.Invisible)
+        onClicked: handleStatusClick(NC.userStatus.Invisible)
     }
 
     Item {

--- a/src/gui/filedetails/ShareeSearchField.qml
+++ b/src/gui/filedetails/ShareeSearchField.qml
@@ -9,6 +9,7 @@ import QtQuick.Layouts
 import QtQuick.Controls
 
 import com.nextcloud.desktopclient
+import com.nextcloud.desktopclient as NC
 import Style
 import "../tray"
 
@@ -189,8 +190,8 @@ TextField {
                 delegate: ShareeDelegate {
                     width: shareeListView.contentItem.width
 
-                    enabled: model.type !== Sharee.LookupServerSearchResults
-                    hoverEnabled: model.type !== Sharee.LookupServerSearchResults
+                    enabled: model.type !== NC.sharee.LookupServerSearchResults
+                    hoverEnabled: model.type !== NC.sharee.LookupServerSearchResults
 
                     function selectSharee() {
                         root.shareeSelected(model.sharee);
@@ -200,7 +201,7 @@ TextField {
                     }
 
                     function selectItem() {
-                        if (model.type === Sharee.LookupServerSearch) {
+                        if (model.type === NC.sharee.LookupServerSearch) {
                             shareeListView.currentIndex = -1
                             root.shareeModel.searchGlobally()
                         } else {

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -136,11 +136,11 @@ ownCloudGui::ownCloudGui(Application *parent)
     qmlRegisterType<SyncConflictsModel>("com.nextcloud.desktopclient", 1, 0, "SyncConflictsModel");
 
     qmlRegisterUncreatableType<QAbstractItemModel>("com.nextcloud.desktopclient", 1, 0, "QAbstractItemModel", "QAbstractItemModel");
-    qmlRegisterUncreatableType<Activity>("com.nextcloud.desktopclient", 1, 0, "Activity", "Activity");
-    qmlRegisterUncreatableType<TalkNotificationData>("com.nextcloud.desktopclient", 1, 0, "TalkNotificationData", "TalkNotificationData");
+    qmlRegisterUncreatableType<Activity>("com.nextcloud.desktopclient", 1, 0, "activity", "Activity");
+    qmlRegisterUncreatableType<TalkNotificationData>("com.nextcloud.desktopclient", 1, 0, "talkNotificationData", "TalkNotificationData");
     qmlRegisterUncreatableType<UnifiedSearchResultsListModel>("com.nextcloud.desktopclient", 1, 0, "UnifiedSearchResultsListModel", "UnifiedSearchResultsListModel");
-    qmlRegisterUncreatableType<UserStatus>("com.nextcloud.desktopclient", 1, 0, "UserStatus", "Access to Status enum");
-    qmlRegisterUncreatableType<Sharee>("com.nextcloud.desktopclient", 1, 0, "Sharee", "Access to Type enum");
+    qmlRegisterUncreatableType<UserStatus>("com.nextcloud.desktopclient", 1, 0, "userStatus", "Access to Status enum");
+    qmlRegisterUncreatableType<Sharee>("com.nextcloud.desktopclient", 1, 0, "sharee", "Access to Type enum");
     qmlRegisterUncreatableType<ClientSideEncryptionTokenSelector>("com.nextcloud.desktopclient", 1, 0, "ClientSideEncryptionTokenSelector", "Access to the certificate selector");
 
     qRegisterMetaType<ActivityListModel *>("ActivityListModel*");

--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -12,6 +12,7 @@ import "../filedetails/"
 
 import Style
 import com.nextcloud.desktopclient
+import com.nextcloud.desktopclient as NC
 
 Button {
     id: root
@@ -246,8 +247,8 @@ Button {
                 id: currentAccountStatusIndicatorBackground
                 visible: UserModel.currentUser && UserModel.currentUser.isConnected
                          && UserModel.currentUser.serverHasUserStatus
-                         && UserModel.currentUser.status !== UserStatus.Invisible
-                         && UserModel.currentUser.status !== UserStatus.Offline
+                         && UserModel.currentUser.status !== NC.userStatus.Invisible
+                         && UserModel.currentUser.status !== NC.userStatus.Offline
                 width: Style.accountAvatarStateIndicatorSize + Style.trayFolderStatusIndicatorSizeOffset
                 height: width
                 color: "white"
@@ -260,8 +261,8 @@ Button {
                 id: currentAccountStatusIndicator
                 visible: UserModel.currentUser && UserModel.currentUser.isConnected
                          && UserModel.currentUser.serverHasUserStatus
-                         && UserModel.currentUser.status !== UserStatus.Invisible
-                         && UserModel.currentUser.status !== UserStatus.Offline
+                         && UserModel.currentUser.status !== NC.userStatus.Invisible
+                         && UserModel.currentUser.status !== NC.userStatus.Offline
                 source: UserModel.currentUser ? UserModel.currentUser.statusIcon : ""
                 cache: false
                 x: currentAccountStatusIndicatorBackground.x + Style.trayFolderStatusIndicatorSizeOffset / 2


### PR DESCRIPTION
> 2025-11-13 13:38:52:689 [ warning qt.qml.typeregistration unknown:0 ]:	Invalid QML element name "Activity"; value type names should begin with a lowercase letter
> 2025-11-13 13:38:52:690 [ warning qt.qml.typeregistration unknown:0 ]:	Invalid QML element name "TalkNotificationData"; value type names should begin with a lowercase letter
> 2025-11-13 13:38:52:690 [ warning qt.qml.typeregistration unknown:0 ]:	Invalid QML element name "UserStatus"; value type names should begin with a lowercase letter
> 2025-11-13 13:38:52:690 [ warning qt.qml.typeregistration unknown:0 ]:	Invalid QML element name "Sharee"; value type names should begin with a lowercase letter

- Registered QML value types with lowercase element names to comply with Qt’s updated validation rules and eliminate the startup warnings.
- Updated QML components to reference the new lowercase enum scopes for user statuses and sharee roles, adding module aliases where required