### PR TITLE
Feat: forward migration at accounts config(issue #9037)

### DIFF
--- a/src/gui/accountmanager.h
+++ b/src/gui/accountmanager.h
@@ -31,6 +31,21 @@ public:
     };
     Q_ENUM (AccountsRestoreResult);
 
+    enum class AccountsVersion {
+        V13 = 13,
+        Min = V13,
+        Max = V13
+    };
+    Q_ENUM (AccountsVersion);
+
+    enum class AccountVersion {
+        V13 = 13,
+        V14,
+        Min = V13,
+        Max = V14
+    };
+    Q_ENUM (AccountVersion);
+
     static AccountManager *instance();
     ~AccountManager() override = default;
 
@@ -83,6 +98,12 @@ public:
      */
     static void backwardMigrationSettingsKeys(QStringList *deleteKeys, QStringList *ignoreKeys);
 
+    /**
+     * Checks the versions of account groups and each account individually
+     * then attempts a soft migration.
+     */
+    static void migrateToActualVersion();
+
 public slots:
     /// Saves account data when adding user, when updating e.g. dav user, not including the credentials
     void saveAccount(const OCC::AccountPtr &newAccountData);
@@ -110,6 +131,9 @@ signals:
     void capabilitiesChanged();
 
 private:
+    static void migrateAccountsSettings(const std::unique_ptr<QSettings> &settings);
+    static void migrateAccountSettings(const std::unique_ptr<QSettings> &settings);
+
     // saving and loading Account to settings
     void saveAccountHelper(const AccountPtr &account, QSettings &settings, bool saveCredentials = true);
     AccountPtr loadAccountHelper(QSettings &settings);

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -198,36 +198,40 @@ void NetworkSettings::saveProxySettings()
 
 void NetworkSettings::saveBWLimitSettings()
 {
+    using NetworkTransferLimitSetting = Account::AccountNetworkTransferLimitSetting;
+
     const auto downloadLimit = _ui->downloadSpinBox->value();
     const auto uploadLimit = _ui->uploadSpinBox->value();
 
-    auto useDownloadLimit = 0;
-    auto useUploadLimit = 0;
+    auto useDownloadLimit = NetworkTransferLimitSetting::NoLimit;
+    auto useUploadLimit = NetworkTransferLimitSetting::NoLimit;
 
     if (_ui->downloadLimitRadioButton->isChecked()) {
-        useDownloadLimit = 1;
+        useDownloadLimit = NetworkTransferLimitSetting::ManualLimit;
     } else if (_ui->noDownloadLimitRadioButton->isChecked()) {
-        useDownloadLimit = 0;
+        useDownloadLimit = NetworkTransferLimitSetting::NoLimit;
     } else if (_ui->autoDownloadLimitRadioButton->isChecked()) {
-        useDownloadLimit = -1;
+        useDownloadLimit = NetworkTransferLimitSetting::AutoLimit;
     } else if (_account) {
-        useDownloadLimit = -2;
+        // Legacy global. See Account::AccountNetworkTransferLimitSetting::LegacyGlobalLimit
+        useDownloadLimit = NetworkTransferLimitSetting::NoLimit;
     }
 
     if (_ui->uploadLimitRadioButton->isChecked()) {
-        useUploadLimit = 1;
+        useUploadLimit = NetworkTransferLimitSetting::ManualLimit;
     } else if (_ui->noUploadLimitRadioButton->isChecked()) {
-        useUploadLimit = 0;
+        useUploadLimit = NetworkTransferLimitSetting::NoLimit;
     } else if (_ui->autoUploadLimitRadioButton->isChecked()) {
-        useUploadLimit = -1;
+        useUploadLimit = NetworkTransferLimitSetting::AutoLimit;
     } else if (_account) {
-        useUploadLimit = -2;
+        // Legacy global. See Account::AccountNetworkTransferLimitSetting::LegacyGlobalLimit
+        useUploadLimit = NetworkTransferLimitSetting::NoLimit;
     }
 
     if (_account) {
-        _account->setDownloadLimitSetting(static_cast<Account::AccountNetworkTransferLimitSetting>(useDownloadLimit));
+        _account->setDownloadLimitSetting(useDownloadLimit);
         _account->setDownloadLimit(downloadLimit);
-        _account->setUploadLimitSetting(static_cast<Account::AccountNetworkTransferLimitSetting>(useUploadLimit));
+        _account->setUploadLimitSetting(useUploadLimit);
         _account->setUploadLimit(uploadLimit);
         AccountManager::instance()->saveAccount(_account);
     }


### PR DESCRIPTION
Issue #9037 requires manipulation with settings only once after app upgrade. I noticed that config migration already exists, but it makes only backward move. In this PR was added forward migration possibility for accounts part of config.

It uses `version` key which already exists in accounts configuration file, so it's just needed to be used in forward way. Every change in config layout could be controlled in `AccountManager::migrateToActualVersion()` function.
Backward migration remained unchanged.

How it works?
Firstly it checks app version string from config. If it was changed, app decides is it upgrade or downgrade. If it's upgrade it checks and perform possible migration actions to higher version of config details. If it's downgrade and config versions are not max, than it will be ignoring or erasing some keys(as it was earlier). Before any change it backups config file and, if enabled, shows warning message.

To resolve the main issue was added checks for `networkUploadLimitSetting` and `networkDownloadLimitSetting` keys in account v14 migration rule.