### PR TITLE
fix: do not fetch user info twice during start of the client

### DIFF
--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -277,8 +277,6 @@ void ConnectionValidator::slotCapabilitiesRecieved(const QJsonDocument &json)
         slotUserFetched(nullptr);
         return;
     }
-
-    fetchUser();
 }
 
 void ConnectionValidator::fetchUser()


### PR DESCRIPTION
will avoid double inits of many things including the end to end encryption

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
