### PR TITLE
fix(encryption): allow encrypting a new folder if it was synced

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -394,7 +394,7 @@ void AccountSettings::doExpand()
 
 bool AccountSettings::canEncryptOrDecrypt(const FolderStatusModel::SubFolderInfo *info)
 {
-    if (const auto folderSyncStatus = info->_folder->syncResult().status(); folderSyncStatus != SyncResult::Status::Success) {
+    if (const auto folderSyncStatus = info->_folder->syncResult().status(); info->_fileId.isEmpty()) {
         auto message = tr("Please wait for the folder to sync before trying to encrypt it.");
         if (folderSyncStatus == SyncResult::Status::Problem) {
             message = tr("The folder has a minor sync problem. Encryption of this folder will be possible once it has synced successfully");


### PR DESCRIPTION
if the folder has a fileid, it means that it was created on server

most probably we can encrypt it with success

previous code was skiping encryption if some ignored files have been reported (even if it was unrelated to the folder we want to encrypt)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
