### PR TITLE
fix: initialize user list when the first acc is added

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -728,6 +728,11 @@ AccountState *AccountManager::addAccount(const AccountPtr &newAccount)
 
     const auto newAccountState = new AccountState(newAccount);
     addAccountState(newAccountState);
+
+    if (_accounts.size() == 1) {
+        emit(accountListInitialized());
+    }
+
     return newAccountState;
 }
 


### PR DESCRIPTION
Missed one place where the accountListInitialized signal should be emitted in https://github.com/nextcloud/desktop/pull/9061.

Sorry for the inconvenience.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
