### PR TITLE
fix(win32): try to set ACLs without propagating them

### DIFF
--- a/src/common/filesystembase.h
+++ b/src/common/filesystembase.h
@@ -175,7 +175,7 @@ namespace FileSystem {
     std::filesystem::perms OCSYNC_EXPORT filePermissionsWin(const QString &filename);
     void OCSYNC_EXPORT setFilePermissionsWin(const QString &filename, const std::filesystem::perms &perms);
 
-    bool OCSYNC_EXPORT setAclPermission(const QString &path, FileSystem::FolderPermissions permissions, bool applyAlsoToFiles);
+    bool OCSYNC_EXPORT setAclPermission(const QString &path, FileSystem::FolderPermissions permissions);
 #endif
 
     /**

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -372,7 +372,7 @@ bool FileSystem::setFolderPermissions(const QString &path,
     // current read-only folder ACL needs to be removed from files also when making a folder read-write
     // we currently have a too limited set of authorization for files when applying the restrictive ACL for folders on the child files
     setFileReadOnly(path, permissions == FileSystem::FolderPermissions::ReadOnly);
-    setAclPermission(path, permissions, permissions == FileSystem::FolderPermissions::ReadWrite ? true : false);
+    setAclPermission(path, permissions);
 
     permissionsDidChange = true;
 #else


### PR DESCRIPTION
apparently `SetFileSecurity` did not propagate ACLs, unlike its "new" replacement `SetSecurityInfo`/`SetNamedSecurityInfo`.

[`SetSecurityInfo` should not perform the propagation if the handle is opened with an access mask value of `MAXIMUM_ALLOWED`](https://learn.microsoft.com/en-us/windows/win32/api/aclapi/nf-aclapi-setsecurityinfo#:~:text=MAXIMUM_ALLOWED), so let's give that a try.

also removed the restriction on the FILE_WRITE_ATTRIBUTES permission so that `FileSystem::setFileReadOnly` has an easier time modifying the basic attribute

<!-- ...all of that trouble just to have correct file permissions on paths longer than 260 characters, which not even Notepad (now with ✨Copilot✨) can deal with. -->


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
