### PR TITLE
fix(win32): avoid displaying certificate warning on first connection

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -185,11 +185,11 @@ void OwncloudSetupWizard::slotCheckServer(const QUrl &serverURL, const OCC::Wiza
     if (!_ocWizard->_clientSslCertificate.isNull()) {
         sslConfiguration.setLocalCertificate(_ocWizard->_clientSslCertificate);
         sslConfiguration.setPrivateKey(_ocWizard->_clientSslKey);
+        // Merge client side CA with system CA
+        auto ca = sslConfiguration.systemCaCertificates();
+        ca.append(_ocWizard->_clientSslCaCertificates);
+        sslConfiguration.setCaCertificates(ca);
     }
-    // Be sure to merge the CAs
-    auto ca = sslConfiguration.systemCaCertificates();
-    ca.append(_ocWizard->_clientSslCaCertificates);
-    sslConfiguration.setCaCertificates(ca);
     account->setSslConfiguration(sslConfiguration);
 
     // Make sure TCP connections get re-established


### PR DESCRIPTION
Windows fetches unknown but trusted root CAs on demand from Windows Update.  Qt will allow for the on-demand fetching of root CAs until at `setCaCertificates`/`addCaCertificates` was called.

As this is done in the setup wizard for handling client SSL certificates, the `QSslConfiguration::systemCaCertificates` list would not include the newly-fetched certificate just yet.

Fixes #8686

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
