### PR TITLE
fix(file-provider): Sync state for excluded lock files.

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientInterface.swift
@@ -218,12 +218,14 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
         actionsLock.lock()
 
         guard oldActions.isEmpty != syncActions.isEmpty else {
+            logger.debug("Cancelling synchronization state report due to lack of state change.")
             actionsLock.unlock()
             return
         }
 
         let command = "FILE_PROVIDER_DOMAIN_SYNC_STATE_CHANGE"
         var argument: String?
+
         if oldActions.isEmpty, !syncActions.isEmpty {
             argument = "SYNC_STARTED"
         } else if !oldActions.isEmpty, syncActions.isEmpty {
@@ -233,8 +235,13 @@ extension FileProviderExtension: NSFileProviderServicing, ChangeNotificationInte
         
         actionsLock.unlock()
 
-        guard let argument else { return }
-        logger.debug("Reporting sync \(argument)")
+        guard let argument else {
+            logger.error("State argument is nil!")
+            return
+        }
+
+        logger.debug("Reporting synchronization state.", [.name: argument])
+
         let message = command + ":" + argument + "\n"
         socketClient?.sendMessage(message)
     }

--- a/src/gui/macOS/fileprovidersocketcontroller.cpp
+++ b/src/gui/macOS/fileprovidersocketcontroller.cpp
@@ -99,6 +99,7 @@ void FileProviderSocketController::parseReceivedLine(const QString &receivedLine
         reportSyncState("SYNC_FINISHED");
         return;
     } else if (command == "FILE_PROVIDER_DOMAIN_SYNC_STATE_CHANGE") {
+        qCDebug(lcFileProviderSocketController) << "Received FILE_PROVIDER_DOMAIN_SYNC_STATE_CHANGE:" << argument;
         reportSyncState(argument);
         return;
     }


### PR DESCRIPTION
- Added debug logging to file provider extension about its sync actions.
- Added debug logging to file provider extension about its sync state reported to the main app through the socket.
- Added debug logging to the main app about the sync state received from a file provider extension through the socket.
- Updated sync action management to not consider the exclusion of a lock file as an error.