### PR TITLE
feat: remove parameter fileprovider from updater request.

### DIFF
--- a/src/gui/updater/updater.cpp
+++ b/src/gui/updater/updater.cpp
@@ -52,9 +52,6 @@ QUrl Updater::updateUrl()
     if (SparkleUpdater::autoUpdaterAllowed()) {
         urlQuery.addQueryItem(QLatin1String("sparkle"), QLatin1String("true"));
     }
-#ifdef BUILD_FILE_PROVIDER_MODULE
-    urlQuery.addQueryItem(QLatin1String("fileprovider"), QLatin1String("true"));
-#endif
 #endif
 #if defined(Q_OS_WIN)
     urlQuery.addQueryItem(QLatin1String("msi"), QLatin1String("true"));


### PR DESCRIPTION
All macOS clients will update to a version with file provider.


