### PR TITLE
chore(log): try to print the file name of the crash log

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -282,6 +282,7 @@ void Logger::dumpCrashLog()
             out << _crashLog[(_crashLogIndex + i) % CrashLogSize] << QLatin1Char('\n');
         }
     }
+    qDebug() << "crash log written in" << logFile.fileName();
 }
 
 void Logger::enterNextLogFileNoLock(const QString &baseFileName, LogType type)


### PR DESCRIPTION
should make it easier to discover when needed

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
