### PR TITLE
refactor: migration.

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -23,6 +23,7 @@
 #include "accountsetupcommandlinemanager.h"
 #include "folderman.h"
 #include "configfile.h" // ONLY ACCESS THE STATIC FUNCTIONS!
+#include "settings/migration.h"
 #ifdef TOKEN_AUTH_ONLY
 # include "creds/tokencredentials.h"
 #else
@@ -372,13 +373,12 @@ void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
     auto result = false;
 
     auto folderManager = FolderMan::instance();
-    ConfigFile configFile;
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupUsers);
+    Migration::setPhase(Migration::Phase::SetupUsers);
     if (!setupAccountsOnly()) {
         return result;
     }
 
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupFolders);
+    Migration::setPhase(Migration::Phase::SetupFolders);
     const auto foldersListSize = folderManager->setupFolders();
     folderManager->setSyncEnabled(true);
 

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -20,6 +20,7 @@
 #if !DISABLE_ACCOUNT_MIGRATION
 #include "legacyaccountselectiondialog.h"
 #endif
+#include "settings/migration.h"
 
 #include <QSettings>
 #include <QDir>
@@ -344,7 +345,8 @@ bool AccountManager::restoreFromLegacySettings()
     configFile.setDownloadLimit(settings->value(ConfigFile::downloadLimitC, configFile.downloadLimit()).toInt());
 
     // Try to load the single account.
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupUsers);
+    auto migration = configFile.migration();
+    migration.setMigrationPhase(Migration::MigrationPhase::SetupUsers);
     if (!settings->childKeys().isEmpty()) {
         settings->beginGroup(accountsC);
         const auto childGroups = selectedAccountIds.isEmpty() ? settings->childGroups() : selectedAccountIds;
@@ -693,8 +695,9 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     acc->setDownloadLimit(settings.value(networkDownloadLimitC).toInt());
 
     ConfigFile configFile;
+    auto migration = configFile.migration();
     const auto proxyPasswordKey = QString(acc->userIdAtHostWithPort() + networkProxyPasswordKeychainKeySuffixC);
-    const auto appName = configFile.isUnbrandedToBrandedMigrationInProgress() ? ConfigFile::unbrandedAppName 
+    const auto appName = migration.isUnbrandedToBrandedMigration() ? ConfigFile::unbrandedAppName
         : Theme::instance()->appName();
     const auto job = new QKeychain::ReadPasswordJob(appName, this);
     job->setKey(proxyPasswordKey);

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -70,11 +70,6 @@ constexpr auto webflowAuthPrefix = "webflow_";
 
 constexpr auto networkProxyPasswordKeychainKeySuffixC = "_proxy_password";
 
-constexpr auto legacyRelativeConfigLocationC = "/ownCloud/owncloud.cfg";
-constexpr auto legacyCfgFileNameC = "owncloud.cfg";
-
-constexpr auto unbrandedRelativeConfigLocationC = "/Nextcloud/nextcloud.cfg";
-constexpr auto unbrandedCfgFileNameC = "nextcloud.cfg";
 
 // The maximum versions that this client can read
 constexpr auto maxAccountsVersion = 13;

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -499,7 +499,8 @@ void AccountManager::migrateNetworkSettings(const AccountPtr &account, const QSe
     // Override user settings with global (QNetworkProxy::DefaultProxy) settings 
     // if user is set to use global settings
     ConfigFile configFile;
-    if (accountProxyType == QNetworkProxy::DefaultProxy && configFile.isMigrationInProgress()) {
+    Migration migration;
+    if (accountProxyType == QNetworkProxy::DefaultProxy && migration.isInProgress()) {
         accountProxyType = static_cast<QNetworkProxy::ProxyType>(configFile.proxyType());
         accountProxyHost = configFile.proxyHostName();
         accountProxyPort = configFile.proxyPort();

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -86,7 +86,6 @@ constexpr auto serverDesktopEnterpriseUpdateChannelC = "desktopEnterpriseChannel
 constexpr auto generalC = "General";
 }
 
-
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcAccountManager, "nextcloud.gui.account.manager", QtInfoMsg)
@@ -196,110 +195,64 @@ bool AccountManager::restoreFromLegacySettings()
 {
     qCInfo(lcAccountManager) << "Migrate: restoreFromLegacySettings, checking settings group"
                              << Theme::instance()->appName();
-
     // try to open the correctly themed settings
     auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
-
     auto wasLegacyImportDialogDisplayed = false;
-    const auto displayLegacyImportDialog = Theme::instance()->displayLegacyImportDialog();
     QStringList selectedAccountIds;
+    Migration migration;
+    if (const auto legacyData = migration.legacyData(); !legacyData.isNull()) {
+        
+        const auto displayLegacyImportDialog = Theme::instance()->displayLegacyImportDialog();
+       
+        auto oCSettings = std::move(legacyData);
 
-    // if the settings file could not be opened, the childKeys list is empty
-    // then try to load settings from a very old place
-    if (settings->childKeys().isEmpty()) {
-        // Legacy settings used QDesktopServices to get the location for the config folder in 2.4 and before
-        const auto legacy2_4CfgSettingsLocation = QString(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/data"));
-        const auto legacy2_4CfgFileParentFolder = legacy2_4CfgSettingsLocation.left(legacy2_4CfgSettingsLocation.lastIndexOf('/'));
+        oCSettings->beginGroup(QLatin1String(accountsC));
+        const auto childGroups = oCSettings->childGroups();
+        const auto accountsListSize = childGroups.size();
+        oCSettings->endGroup(); // accountsC
 
-        // 2.5+ (rest of 2.x series)
-        const auto legacy2_5CfgSettingsLocation = QStandardPaths::writableLocation(Utility::isWindows() ? QStandardPaths::AppDataLocation : QStandardPaths::AppConfigLocation);
-        const auto legacy2_5CfgFileParentFolder = legacy2_5CfgSettingsLocation.left(legacy2_5CfgSettingsLocation.lastIndexOf('/'));
-
-        // Now try the locations we use today
-        const auto fullLegacyCfgFile = QDir::fromNativeSeparators(settings->fileName());
-        const auto legacyCfgFileParentFolder = fullLegacyCfgFile.left(fullLegacyCfgFile.lastIndexOf('/'));
-        const auto legacyCfgFileGrandParentFolder = legacyCfgFileParentFolder.left(legacyCfgFileParentFolder.lastIndexOf('/'));
-
-        const auto legacyCfgFileNamePath = QString(QStringLiteral("/") + legacyCfgFileNameC);
-        const auto legacyCfgFileRelativePath = QString(legacyRelativeConfigLocationC);
-
-        auto legacyLocations = QVector<QString>{legacy2_4CfgFileParentFolder + legacyCfgFileRelativePath,
-                                                legacy2_5CfgFileParentFolder + legacyCfgFileRelativePath,
-                                                legacyCfgFileParentFolder + legacyCfgFileNamePath,
-                                                legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
-
-        if (Theme::instance()->isBranded()) {
-            const auto unbrandedCfgFileNamePath = QString(QStringLiteral("/") + unbrandedCfgFileNameC);
-            const auto unbrandedCfgFileRelativePath = QString(unbrandedRelativeConfigLocationC);
-            legacyLocations.append({legacyCfgFileParentFolder + unbrandedCfgFileNamePath, legacyCfgFileGrandParentFolder + unbrandedCfgFileRelativePath});
-        }
-
-        for (const auto &configFile : std::as_const(legacyLocations)) {
-            auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
-            if (oCSettings->status() != QSettings::Status::NoError) {
-                qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
-                break;
-            }
-
-            oCSettings->beginGroup(QLatin1String(accountsC));
-            const auto childGroups = oCSettings->childGroups();
-            const auto accountsListSize = childGroups.size();
-            oCSettings->endGroup(); //accountsC
-            if (const QFileInfo configFileInfo(configFile);
-                configFileInfo.exists() && configFileInfo.isReadable()) {
-
-                qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
-                if (!forceLegacyImport() && accountsListSize > 0 && displayLegacyImportDialog) {
-                    wasLegacyImportDialogDisplayed = true;
-                    if (accountsListSize == 1) {
-                        const auto importQuestion =
-                            tr("An account was detected from a legacy desktop client.\n"
-                               "Should the account be imported?");
-                        QMessageBox importMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
-                        importMessageBox.addButton(tr("Import"), QMessageBox::AcceptRole);
-                        const auto skipButton = importMessageBox.addButton(tr("Skip"), QMessageBox::DestructiveRole);
-                        importMessageBox.exec();
-                        if (importMessageBox.clickedButton() == skipButton) {
-                            return false;
-                        }
-                        selectedAccountIds = childGroups;
-                    } else {
-                        QVector<LegacyAccountSelectionDialog::AccountItem> accountsToDisplay;
-                        oCSettings->beginGroup(QLatin1String(accountsC));
-                        for (const auto &accId : childGroups) {
-                            oCSettings->beginGroup(accId);
-                            const auto displayName = oCSettings->value(QLatin1String(displayNameC)).toString();
-                            const auto urlStr = oCSettings->value(QLatin1String(urlC)).toString();
-                            oCSettings->endGroup(); //accId
-                            const auto label = QString("%1 - %2").arg(displayName, urlStr);
-                            accountsToDisplay.push_back({accId, label});
-                        }
-                        oCSettings->endGroup(); //accountsC
-
-                        LegacyAccountSelectionDialog accountSelectionDialog(accountsToDisplay);
-                        if (accountSelectionDialog.exec() != QDialog::Accepted) {
-                            return false;
-                        }
-                        selectedAccountIds = accountSelectionDialog.selectedAccountIds();
-                        if (selectedAccountIds.isEmpty()) {
-                            return false;
-                        }
-                    }
-                } else {
-                    selectedAccountIds = childGroups;
+        qCInfo(lcAccountManager) << "Migrate: checking old config";
+        if (!forceLegacyImport() && displayLegacyImportDialog && accountsListSize > 0) {
+            wasLegacyImportDialogDisplayed = true;
+            if (childGroups.size() == 1) {
+                const auto importQuestion =
+                    tr("An account was detected from a legacy desktop client.\n"
+                        "Should the account be imported?");
+                QMessageBox importMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
+                importMessageBox.addButton(tr("Import"), QMessageBox::AcceptRole);
+                const auto skipButton = importMessageBox.addButton(tr("Skip"), QMessageBox::DestructiveRole);
+                importMessageBox.exec();
+                if (importMessageBox.clickedButton() == skipButton) {
+                    return false;
                 }
-
-                const auto legacyVersion = oCSettings->value(ConfigFile::clientVersionC, {}).toString();
-                ConfigFile().setClientPreviousVersionString(legacyVersion);
-                qCInfo(lcAccountManager) << "Migrating from" << legacyVersion;
-                qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
-                settings = std::move(oCSettings);
-                ConfigFile::setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
-                break;
+                selectedAccountIds = childGroups;
             } else {
-                qCInfo(lcAccountManager) << "Migrate: could not read old config " << configFile;
+                QVector<LegacyAccountSelectionDialog::AccountItem> accountsToDisplay;
+                oCSettings->beginGroup(QLatin1String(accountsC));
+                for (const auto &accId : childGroups) {
+                    oCSettings->beginGroup(accId);
+                    const auto displayName = oCSettings->value(QLatin1String(displayNameC)).toString();
+                    const auto urlStr = oCSettings->value(QLatin1String(urlC)).toString();
+                    oCSettings->endGroup(); // accId
+                    const auto label = QString("%1 - %2").arg(displayName, urlStr);
+                    accountsToDisplay.push_back({accId, label});
+                }
+                oCSettings->endGroup(); // accountsC
+
+                LegacyAccountSelectionDialog accountSelectionDialog(accountsToDisplay);
+                if (accountSelectionDialog.exec() != QDialog::Accepted) {
+                    return false;
+                }
+                selectedAccountIds = accountSelectionDialog.selectedAccountIds();
+                if (selectedAccountIds.isEmpty()) {
+                    return false;
+                }
             }
+        } else {
+            selectedAccountIds = childGroups;
         }
+
+        settings.reset(oCSettings.get());
     }
 
     ConfigFile configFile;
@@ -345,8 +298,7 @@ bool AccountManager::restoreFromLegacySettings()
     configFile.setDownloadLimit(settings->value(ConfigFile::downloadLimitC, configFile.downloadLimit()).toInt());
 
     // Try to load the single account.
-    auto migration = configFile.migration();
-    migration.setMigrationPhase(Migration::MigrationPhase::SetupUsers);
+    migration.setPhase(Migration::Phase::SetupUsers);
     if (!settings->childKeys().isEmpty()) {
         settings->beginGroup(accountsC);
         const auto childGroups = selectedAccountIds.isEmpty() ? settings->childGroups() : selectedAccountIds;
@@ -695,7 +647,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
     acc->setDownloadLimit(settings.value(networkDownloadLimitC).toInt());
 
     ConfigFile configFile;
-    auto migration = configFile.migration();
+    Migration migration;
     const auto proxyPasswordKey = QString(acc->userIdAtHostWithPort() + networkProxyPasswordKeychainKeySuffixC);
     const auto appName = migration.isUnbrandedToBrandedMigration() ? ConfigFile::unbrandedAppName
         : Theme::instance()->appName();

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -20,6 +20,7 @@
 #if !DISABLE_ACCOUNT_MIGRATION
 #include "legacyaccountselectiondialog.h"
 #endif
+#include "settings/migration.h"
 
 #include <QSettings>
 #include <QDir>
@@ -69,11 +70,6 @@ constexpr auto webflowAuthPrefix = "webflow_";
 
 constexpr auto networkProxyPasswordKeychainKeySuffixC = "_proxy_password";
 
-constexpr auto legacyRelativeConfigLocationC = "/ownCloud/owncloud.cfg";
-constexpr auto legacyCfgFileNameC = "owncloud.cfg";
-
-constexpr auto unbrandedRelativeConfigLocationC = "/Nextcloud/nextcloud.cfg";
-constexpr auto unbrandedCfgFileNameC = "nextcloud.cfg";
 
 // The maximum versions that this client can read
 constexpr auto maxAccountsVersion = 13;
@@ -84,7 +80,6 @@ constexpr auto serverDesktopEnterpriseUpdateChannelC = "desktopEnterpriseChannel
 
 constexpr auto generalC = "General";
 }
-
 
 namespace OCC {
 
@@ -195,110 +190,70 @@ bool AccountManager::restoreFromLegacySettings()
 {
     qCInfo(lcAccountManager) << "Migrate: restoreFromLegacySettings, checking settings group"
                              << Theme::instance()->appName();
-
     // try to open the correctly themed settings
     auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
-
     auto wasLegacyImportDialogDisplayed = false;
-    const auto displayLegacyImportDialog = Theme::instance()->displayLegacyImportDialog();
     QStringList selectedAccountIds;
+    if (auto legacyData = Migration::legacyData(); legacyData) {
 
-    // if the settings file could not be opened, the childKeys list is empty
-    // then try to load settings from a very old place
-    if (settings->childKeys().isEmpty()) {
-        // Legacy settings used QDesktopServices to get the location for the config folder in 2.4 and before
-        const auto legacy2_4CfgSettingsLocation = QString(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/data"));
-        const auto legacy2_4CfgFileParentFolder = legacy2_4CfgSettingsLocation.left(legacy2_4CfgSettingsLocation.lastIndexOf('/'));
+        const auto displayLegacyImportDialog = Theme::instance()->displayLegacyImportDialog();
 
-        // 2.5+ (rest of 2.x series)
-        const auto legacy2_5CfgSettingsLocation = QStandardPaths::writableLocation(Utility::isWindows() ? QStandardPaths::AppDataLocation : QStandardPaths::AppConfigLocation);
-        const auto legacy2_5CfgFileParentFolder = legacy2_5CfgSettingsLocation.left(legacy2_5CfgSettingsLocation.lastIndexOf('/'));
+        auto oCSettings = std::move(legacyData);
 
-        // Now try the locations we use today
-        const auto fullLegacyCfgFile = QDir::fromNativeSeparators(settings->fileName());
-        const auto legacyCfgFileParentFolder = fullLegacyCfgFile.left(fullLegacyCfgFile.lastIndexOf('/'));
-        const auto legacyCfgFileGrandParentFolder = legacyCfgFileParentFolder.left(legacyCfgFileParentFolder.lastIndexOf('/'));
+        oCSettings->beginGroup(QLatin1String(accountsC));
+        const auto childGroups = oCSettings->childGroups();
+        const auto accountsListSize = childGroups.size();
+        oCSettings->endGroup(); // accountsC
 
-        const auto legacyCfgFileNamePath = QString(QStringLiteral("/") + legacyCfgFileNameC);
-        const auto legacyCfgFileRelativePath = QString(legacyRelativeConfigLocationC);
-
-        auto legacyLocations = QVector<QString>{legacy2_4CfgFileParentFolder + legacyCfgFileRelativePath,
-                                                legacy2_5CfgFileParentFolder + legacyCfgFileRelativePath,
-                                                legacyCfgFileParentFolder + legacyCfgFileNamePath,
-                                                legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
-
-        if (Theme::instance()->isBranded()) {
-            const auto unbrandedCfgFileNamePath = QString(QStringLiteral("/") + unbrandedCfgFileNameC);
-            const auto unbrandedCfgFileRelativePath = QString(unbrandedRelativeConfigLocationC);
-            legacyLocations.append({legacyCfgFileParentFolder + unbrandedCfgFileNamePath, legacyCfgFileGrandParentFolder + unbrandedCfgFileRelativePath});
-        }
-
-        for (const auto &configFile : std::as_const(legacyLocations)) {
-            auto oCSettings = std::make_unique<QSettings>(configFile, QSettings::IniFormat);
-            if (oCSettings->status() != QSettings::Status::NoError) {
-                qCInfo(lcAccountManager) << "Error reading legacy configuration file" << oCSettings->status();
-                break;
-            }
-
-            oCSettings->beginGroup(QLatin1String(accountsC));
-            const auto childGroups = oCSettings->childGroups();
-            const auto accountsListSize = childGroups.size();
-            oCSettings->endGroup(); //accountsC
-            if (const QFileInfo configFileInfo(configFile);
-                configFileInfo.exists() && configFileInfo.isReadable()) {
-
-                qCInfo(lcAccountManager) << "Migrate: checking old config " << configFile;
-                if (!forceLegacyImport() && accountsListSize > 0 && displayLegacyImportDialog) {
-                    wasLegacyImportDialogDisplayed = true;
-                    if (accountsListSize == 1) {
-                        const auto importQuestion =
-                            tr("An account was detected from a legacy desktop client.\n"
-                               "Should the account be imported?");
-                        QMessageBox importMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
-                        importMessageBox.addButton(tr("Import"), QMessageBox::AcceptRole);
-                        const auto skipButton = importMessageBox.addButton(tr("Skip"), QMessageBox::DestructiveRole);
-                        importMessageBox.exec();
-                        if (importMessageBox.clickedButton() == skipButton) {
-                            return false;
-                        }
-                        selectedAccountIds = childGroups;
-                    } else {
-                        QVector<LegacyAccountSelectionDialog::AccountItem> accountsToDisplay;
-                        oCSettings->beginGroup(QLatin1String(accountsC));
-                        for (const auto &accId : childGroups) {
-                            oCSettings->beginGroup(accId);
-                            const auto displayName = oCSettings->value(QLatin1String(displayNameC)).toString();
-                            const auto urlStr = oCSettings->value(QLatin1String(urlC)).toString();
-                            oCSettings->endGroup(); //accId
-                            const auto label = QString("%1 - %2").arg(displayName, urlStr);
-                            accountsToDisplay.push_back({accId, label});
-                        }
-                        oCSettings->endGroup(); //accountsC
-
-                        LegacyAccountSelectionDialog accountSelectionDialog(accountsToDisplay);
-                        if (accountSelectionDialog.exec() != QDialog::Accepted) {
-                            return false;
-                        }
-                        selectedAccountIds = accountSelectionDialog.selectedAccountIds();
-                        if (selectedAccountIds.isEmpty()) {
-                            return false;
-                        }
-                    }
-                } else {
-                    selectedAccountIds = childGroups;
+        qCInfo(lcAccountManager) << "Migrate: checking old config";
+        if (!forceLegacyImport() && displayLegacyImportDialog && accountsListSize > 0) {
+            wasLegacyImportDialogDisplayed = true;
+            if (accountsListSize == 1) {
+                const auto importQuestion =
+                    tr("An account was detected from a legacy desktop client.\n"
+                        "Should the account be imported?");
+                QMessageBox importMessageBox(QMessageBox::Question, tr("Legacy import"), importQuestion);
+                importMessageBox.addButton(tr("Import"), QMessageBox::AcceptRole);
+                const auto skipButton = importMessageBox.addButton(tr("Skip"), QMessageBox::DestructiveRole);
+                importMessageBox.exec();
+                if (importMessageBox.clickedButton() == skipButton) {
+                    return false;
                 }
-
-                const auto legacyVersion = oCSettings->value(ConfigFile::clientVersionC, {}).toString();
-                ConfigFile().setClientPreviousVersionString(legacyVersion);
-                qCInfo(lcAccountManager) << "Migrating from" << legacyVersion;
-                qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
-                settings = std::move(oCSettings);
-                ConfigFile::setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
-                break;
+                selectedAccountIds = childGroups;
             } else {
-                qCInfo(lcAccountManager) << "Migrate: could not read old config " << configFile;
+                QVector<LegacyAccountSelectionDialog::AccountItem> accountsToDisplay;
+                oCSettings->beginGroup(QLatin1String(accountsC));
+                for (const auto &accId : childGroups) {
+                    oCSettings->beginGroup(accId);
+                    const auto displayName = oCSettings->value(QLatin1String(displayNameC)).toString();
+                    const auto urlStr = oCSettings->value(QLatin1String(urlC)).toString();
+                    oCSettings->endGroup(); // accId
+                    const auto label = QString("%1 - %2").arg(displayName, urlStr);
+                    accountsToDisplay.push_back({accId, label});
+                }
+                oCSettings->endGroup(); // accountsC
+
+                LegacyAccountSelectionDialog accountSelectionDialog(accountsToDisplay);
+                if (accountSelectionDialog.exec() != QDialog::Accepted) {
+                    return false;
+                }
+                selectedAccountIds = accountSelectionDialog.selectedAccountIds();
+                if (selectedAccountIds.isEmpty()) {
+                    return false;
+                }
             }
+        } else {
+            selectedAccountIds = childGroups;
         }
+
+        const QFileInfo legacyConfigInfo(oCSettings->fileName());
+        const auto legacyVersion = oCSettings->value(ConfigFile::clientVersionC).toString();
+        Migration::setDiscoveredLegacyConfigPath(legacyConfigInfo.canonicalPath());
+        ConfigFile().setClientPreviousVersionString(legacyVersion);
+        qCInfo(lcAccountManager) << "Migrating from" << legacyVersion;
+        qCInfo(lcAccountManager) << "Copy settings" << oCSettings->allKeys().join(", ");
+
+        settings = std::move(oCSettings);
     }
 
     ConfigFile configFile;
@@ -344,7 +299,7 @@ bool AccountManager::restoreFromLegacySettings()
     configFile.setDownloadLimit(settings->value(ConfigFile::downloadLimitC, configFile.downloadLimit()).toInt());
 
     // Try to load the single account.
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupUsers);
+    Migration::setPhase(Migration::Phase::SetupUsers);
     if (!settings->childKeys().isEmpty()) {
         settings->beginGroup(accountsC);
         const auto childGroups = selectedAccountIds.isEmpty() ? settings->childGroups() : selectedAccountIds;
@@ -545,7 +500,7 @@ void AccountManager::migrateNetworkSettings(const AccountPtr &account, const QSe
     // Override user settings with global (QNetworkProxy::DefaultProxy) settings 
     // if user is set to use global settings
     ConfigFile configFile;
-    if (accountProxyType == QNetworkProxy::DefaultProxy && configFile.isMigrationInProgress()) {
+    if (accountProxyType == QNetworkProxy::DefaultProxy && Migration::isInProgress()) {
         accountProxyType = static_cast<QNetworkProxy::ProxyType>(configFile.proxyType());
         accountProxyHost = configFile.proxyHostName();
         accountProxyPort = configFile.proxyPort();
@@ -694,7 +649,7 @@ AccountPtr AccountManager::loadAccountHelper(QSettings &settings)
 
     ConfigFile configFile;
     const auto proxyPasswordKey = QString(acc->userIdAtHostWithPort() + networkProxyPasswordKeychainKeySuffixC);
-    const auto appName = configFile.isUnbrandedToBrandedMigrationInProgress() ? ConfigFile::unbrandedAppName 
+    const auto appName = Migration::isUnbrandedToBrandedMigration() ? ConfigFile::unbrandedAppName
         : Theme::instance()->appName();
     const auto job = new QKeychain::ReadPasswordJob(appName, this);
     job->setKey(proxyPasswordKey);

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -17,6 +17,7 @@
 #include "ocsuserstatusconnector.h"
 #include "pushnotifications.h"
 #include "networkjobs.h"
+#include "settings/migration.h"
 
 #include <QSettings>
 #include <QTimer>
@@ -297,9 +298,10 @@ void AccountState::checkConnectivity()
     if (!account()->credentials()->wasFetched()) {
         _waitingForNewCredentials = true;
         ConfigFile configFile;
-        const auto shouldTryUnbrandedToBrandedMigration = configFile.shouldTryUnbrandedToBrandedMigration();
+        auto migration = configFile.migration();
+        const auto shouldTryUnbrandedToBrandedMigration = migration.shouldTryUnbrandedToBrandedMigration();
         qCDebug(lcAccountState) << "shouldTryUnbrandedToBrandedMigration?" << shouldTryUnbrandedToBrandedMigration;
-        qCDebug(lcAccountState) << "migrationPhase?" << configFile.migrationPhase();
+        qCDebug(lcAccountState) << "migrationPhase?" << migration.migrationPhase();
         const auto appName = shouldTryUnbrandedToBrandedMigration ? configFile.unbrandedAppName : "";
         account()->credentials()->fetchFromKeychain(appName);
         return;
@@ -498,8 +500,9 @@ void AccountState::slotCredentialsFetched(AbstractCredentials *)
                            << "attempting to connect";
     _waitingForNewCredentials = false;
     ConfigFile configFile;
-    if (configFile.isMigrationInProgress()) {
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
+    auto migration = configFile.migration();
+    if (migration.isInProgress()) {
+        migration.setMigrationPhase(Migration::MigrationPhase::Done);
     }
     checkConnectivity();
 }

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -298,10 +298,10 @@ void AccountState::checkConnectivity()
     if (!account()->credentials()->wasFetched()) {
         _waitingForNewCredentials = true;
         ConfigFile configFile;
-        auto migration = configFile.migration();
+        Migration migration;
         const auto shouldTryUnbrandedToBrandedMigration = migration.shouldTryUnbrandedToBrandedMigration();
         qCDebug(lcAccountState) << "shouldTryUnbrandedToBrandedMigration?" << shouldTryUnbrandedToBrandedMigration;
-        qCDebug(lcAccountState) << "migrationPhase?" << migration.migrationPhase();
+        qCDebug(lcAccountState) << "migration Phase?" << migration.phase();
         const auto appName = shouldTryUnbrandedToBrandedMigration ? configFile.unbrandedAppName : "";
         account()->credentials()->fetchFromKeychain(appName);
         return;
@@ -500,9 +500,9 @@ void AccountState::slotCredentialsFetched(AbstractCredentials *)
                            << "attempting to connect";
     _waitingForNewCredentials = false;
     ConfigFile configFile;
-    auto migration = configFile.migration();
+    Migration migration;
     if (migration.isInProgress()) {
-        migration.setMigrationPhase(Migration::MigrationPhase::Done);
+        migration.setPhase(Migration::Phase::Done);
     }
     checkConnectivity();
 }

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -17,6 +17,7 @@
 #include "ocsuserstatusconnector.h"
 #include "pushnotifications.h"
 #include "networkjobs.h"
+#include "settings/migration.h"
 
 #include <QSettings>
 #include <QTimer>
@@ -301,9 +302,9 @@ void AccountState::checkConnectivity()
     if (!account()->credentials()->wasFetched()) {
         _waitingForNewCredentials = true;
         ConfigFile configFile;
-        const auto shouldTryUnbrandedToBrandedMigration = configFile.shouldTryUnbrandedToBrandedMigration();
+        const auto shouldTryUnbrandedToBrandedMigration = Migration::shouldTryUnbrandedToBrandedMigration();
         qCDebug(lcAccountState) << "shouldTryUnbrandedToBrandedMigration?" << shouldTryUnbrandedToBrandedMigration;
-        qCDebug(lcAccountState) << "migrationPhase?" << configFile.migrationPhase();
+        qCDebug(lcAccountState) << "migration Phase?" << Migration::phase();
         const auto appName = shouldTryUnbrandedToBrandedMigration ? configFile.unbrandedAppName : "";
         account()->credentials()->fetchFromKeychain(appName);
         return;
@@ -499,9 +500,8 @@ void AccountState::slotCredentialsFetched(AbstractCredentials *)
     qCInfo(lcAccountState) << "Fetched credentials for" << _account->url().toString()
                            << "attempting to connect";
     _waitingForNewCredentials = false;
-    ConfigFile configFile;
-    if (configFile.isMigrationInProgress()) {
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
+    if (Migration::isInProgress()) {
+        Migration::setPhase(Migration::Phase::Done);
     }
     checkConnectivity();
 }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -129,11 +129,11 @@ bool Application::configVersionMigration()
     const auto shouldTryToMigrate = migration.shouldTryToMigrate();
     if (!shouldTryToMigrate) {
         qCInfo(lcApplication) << "This is not an upgrade/downgrade/migration. Proceed to read current application config file.";
-        migration.setMigrationPhase(Migration::MigrationPhase::Done);
+        migration.setPhase(Migration::Phase::Done);
         return false;
     }
 
-    migration.setMigrationPhase(Migration::MigrationPhase::SetupConfigFile);
+    migration.setPhase(Migration::Phase::SetupConfigFile);
     QStringList deleteKeys, ignoreKeys;
     AccountManager::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
     FolderMan::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
@@ -156,9 +156,25 @@ bool Application::configVersionMigration()
     // default is now off to displaying dialog warning user of too many files deletion
     configFile.setPromptDeleteFiles(false);
 
-    // back up all old config files and message the user either for destructive changes,
+    // back up all old config files
+    QStringList backupFilesList;
+    QDir configDir(configFile.configPath());
+    const auto anyConfigFileNameList = configDir.entryInfoList({"*.cfg"}, QDir::Files);
+    for (const auto &oldConfig : anyConfigFileNameList) {
+        const auto oldConfigFileName = oldConfig.fileName();
+        const auto oldConfigFilePath = oldConfig.filePath();
+        const auto newConfigFileName = configFile.configFile();
+        backupFilesList.append(configFile.backup(oldConfigFileName));
+        if (oldConfigFilePath != newConfigFileName) {
+            if (!QFile::rename(oldConfigFilePath, newConfigFileName)) {
+                qCWarning(lcApplication) << "Failed to rename configuration file from" << oldConfigFilePath << "to" << newConfigFileName;
+            }
+        }
+    }
+
+    // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
-    if (const auto backupFilesList = configFile.backupConfigFiles(); configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
+    if (configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
         QMessageBox box(
             QMessageBox::Warning,
             APPLICATION_SHORTNAME,
@@ -168,7 +184,7 @@ bool Application::configVersionMigration()
                "Continuing will mean <b>%2 these settings</b>.<br>"
                "<br>"
                "The current configuration file was already backed up to <i>%3</i>.")
-                .arg((configFile.migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                .arg((Migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
                      deleteKeys.isEmpty()? tr("ignoring") : tr("deleting"),
                      backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);
@@ -558,18 +574,18 @@ void Application::setupAccountsAndFolders()
 {
     _folderManager.reset(new FolderMan);
     ConfigFile configFile;
-    auto migration = configFile.migration();
-    migration.setMigrationPhase(Migration::MigrationPhase::SetupUsers);
+    Migration migration;
+    migration.setPhase(Migration::Phase::SetupUsers);
     const auto accountsRestoreResult = restoreLegacyAccount();
     if (accountsRestoreResult == AccountManager::AccountsNotFound || accountsRestoreResult == AccountManager::AccountsRestoreFailure) {
         qCWarning(lcApplication) << "Migration result: " << accountsRestoreResult;
         qCDebug(lcApplication) << "is migration disabled?" << DISABLE_ACCOUNT_MIGRATION;
         qCWarning(lcApplication) << "No accounts were migrated, prompting user to set up accounts and folders from scratch.";
-        migration.setMigrationPhase(Migration::MigrationPhase::Done);
+        migration.setPhase(Migration::Phase::Done);
         return;
     }
 
-    migration.setMigrationPhase(Migration::MigrationPhase::SetupFolders);
+    migration.setPhase(Migration::Phase::SetupFolders);
     const auto foldersListSize = FolderMan::instance()->setupFolders();
     FolderMan::instance()->setSyncEnabled(true);
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -33,6 +33,7 @@
 #include "common/vfs.h"
 
 #include "config.h"
+#include "settings/migration.h"
 
 #if defined(Q_OS_WIN)
 #include <windows.h>
@@ -124,21 +125,20 @@ namespace {
 bool Application::configVersionMigration()
 {
     ConfigFile configFile;
-    const auto shouldTryToMigrate = configFile.shouldTryToMigrate();
+    Migration migration;
+    const auto shouldTryToMigrate = migration.shouldTryToMigrate();
     if (!shouldTryToMigrate) {
         qCInfo(lcApplication) << "This is not an upgrade/downgrade/migration. Proceed to read current application config file.";
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
+        migration.setMigrationPhase(Migration::MigrationPhase::Done);
         return false;
     }
 
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupConfigFile);
+    migration.setMigrationPhase(Migration::MigrationPhase::SetupConfigFile);
     QStringList deleteKeys, ignoreKeys;
     AccountManager::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
     FolderMan::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
-    configFile.setClientPreviousVersionString(configFile.clientVersionString());
-
-    qCDebug(lcApplication) << "Migration is in progress:"  << configFile.isMigrationInProgress();
-    const auto versionChanged = configFile.hasVersionChanged();
+    qCDebug(lcApplication) << "Migration is in progress:"  << migration.isInProgress();
+    const auto versionChanged = migration.versionChanged();
     if (versionChanged) {
         qCInfo(lcApplication) << "Version changed. Removing updater settings from config.";
         configFile.cleanUpdaterConfiguration();
@@ -184,7 +184,7 @@ bool Application::configVersionMigration()
                "Continuing will mean <b>%2 these settings</b>.<br>"
                "<br>"
                "The current configuration file was already backed up to <i>%3</i>.")
-                .arg((configFile.isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                .arg((Migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
                      deleteKeys.isEmpty()? tr("ignoring") : tr("deleting"),
                      backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);
@@ -574,18 +574,18 @@ void Application::setupAccountsAndFolders()
 {
     _folderManager.reset(new FolderMan);
     ConfigFile configFile;
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupUsers);
+    auto migration = configFile.migration();
+    migration.setMigrationPhase(Migration::MigrationPhase::SetupUsers);
     const auto accountsRestoreResult = restoreLegacyAccount();
     if (accountsRestoreResult == AccountManager::AccountsNotFound || accountsRestoreResult == AccountManager::AccountsRestoreFailure) {
         qCWarning(lcApplication) << "Migration result: " << accountsRestoreResult;
         qCDebug(lcApplication) << "is migration disabled?" << DISABLE_ACCOUNT_MIGRATION;
         qCWarning(lcApplication) << "No accounts were migrated, prompting user to set up accounts and folders from scratch.";
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
-
+        migration.setMigrationPhase(Migration::MigrationPhase::Done);
         return;
     }
 
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupFolders);
+    migration.setMigrationPhase(Migration::MigrationPhase::SetupFolders);
     const auto foldersListSize = FolderMan::instance()->setupFolders();
     FolderMan::instance()->setSyncEnabled(true);
 
@@ -600,6 +600,7 @@ void Application::setupAccountsAndFolders()
     const auto accounts = AccountManager::instance()->accounts();
     const auto accountsListSize = accounts.size();
     if (accountsRestoreResult == AccountManager::AccountsRestoreSuccessFromLegacyVersion
+        && accountsListSize > 0
         && Theme::instance()->displayLegacyImportDialog()
         && !AccountManager::instance()->forceLegacyImport()
         && accountsListSize > 0) {

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -184,7 +184,7 @@ bool Application::configVersionMigration()
                "Continuing will mean <b>%2 these settings</b>.<br>"
                "<br>"
                "The current configuration file was already backed up to <i>%3</i>.")
-                .arg((Migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                .arg((migration.isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
                      deleteKeys.isEmpty()? tr("ignoring") : tr("deleting"),
                      backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -156,25 +156,9 @@ bool Application::configVersionMigration()
     // default is now off to displaying dialog warning user of too many files deletion
     configFile.setPromptDeleteFiles(false);
 
-    // back up all old config files
-    QStringList backupFilesList;
-    QDir configDir(configFile.configPath());
-    const auto anyConfigFileNameList = configDir.entryInfoList({"*.cfg"}, QDir::Files);
-    for (const auto &oldConfig : anyConfigFileNameList) {
-        const auto oldConfigFileName = oldConfig.fileName();
-        const auto oldConfigFilePath = oldConfig.filePath();
-        const auto newConfigFileName = configFile.configFile();
-        backupFilesList.append(configFile.backup(oldConfigFileName));
-        if (oldConfigFilePath != newConfigFileName) {
-            if (!QFile::rename(oldConfigFilePath, newConfigFileName)) {
-                qCWarning(lcApplication) << "Failed to rename configuration file from" << oldConfigFilePath << "to" << newConfigFileName;
-            }
-        }
-    }
-
-    // We want to message the user either for destructive changes,
+    // back up all old config files and message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
-    if (configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
+    if (const auto backupFilesList = configFile.backupConfigFiles(); configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
         QMessageBox box(
             QMessageBox::Warning,
             APPLICATION_SHORTNAME,
@@ -184,7 +168,7 @@ bool Application::configVersionMigration()
                "Continuing will mean <b>%2 these settings</b>.<br>"
                "<br>"
                "The current configuration file was already backed up to <i>%3</i>.")
-                .arg((Migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                .arg((configFile.migration().isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
                      deleteKeys.isEmpty()? tr("ignoring") : tr("deleting"),
                      backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -33,6 +33,7 @@
 #include "common/vfs.h"
 
 #include "config.h"
+#include "settings/migration.h"
 
 #if defined(Q_OS_WIN)
 #include <windows.h>
@@ -143,21 +144,19 @@ namespace {
 bool Application::configVersionMigration()
 {
     ConfigFile configFile;
-    const auto shouldTryToMigrate = configFile.shouldTryToMigrate();
+    const auto shouldTryToMigrate = Migration::shouldTryToMigrate();
     if (!shouldTryToMigrate) {
         qCInfo(lcApplication) << "This is not an upgrade/downgrade/migration. Proceed to read current application config file.";
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
+        Migration::setPhase(Migration::Phase::Done);
         return false;
     }
 
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupConfigFile);
+    Migration::setPhase(Migration::Phase::SetupConfigFile);
     QStringList deleteKeys, ignoreKeys;
     AccountManager::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
     FolderMan::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
-    configFile.setClientPreviousVersionString(configFile.clientVersionString());
-
-    qCDebug(lcApplication) << "Migration is in progress:"  << configFile.isMigrationInProgress();
-    const auto versionChanged = configFile.hasVersionChanged();
+    qCDebug(lcApplication) << "Migration is in progress:"  << Migration::isInProgress();
+    const auto versionChanged = Migration::versionChanged();
     if (versionChanged) {
         qCInfo(lcApplication) << "Version changed. Removing updater settings from config.";
         configFile.cleanUpdaterConfiguration();
@@ -167,29 +166,8 @@ bool Application::configVersionMigration()
         return true;
     }
 
-    // 'Launch on system startup' defaults to true > 3.11.x
-    const auto theme = Theme::instance();
-    configFile.setLaunchOnSystemStartup(configFile.launchOnSystemStartup());
-    Utility::setLaunchOnStartup(theme->appName(), theme->appNameGUI(), configFile.launchOnSystemStartup());
-
-    // default is now off to displaying dialog warning user of too many files deletion
-    configFile.setPromptDeleteFiles(false);
-
-    // back up all old config files
-    QStringList backupFilesList;
-    QDir configDir(configFile.configPath());
-    const auto anyConfigFileNameList = configDir.entryInfoList({"*.cfg"}, QDir::Files);
-    for (const auto &oldConfig : anyConfigFileNameList) {
-        const auto oldConfigFileName = oldConfig.fileName();
-        const auto oldConfigFilePath = oldConfig.filePath();
-        const auto newConfigFileName = configFile.configFile();
-        backupFilesList.append(configFile.backup(oldConfigFileName));
-        if (oldConfigFilePath != newConfigFileName) {
-            if (!QFile::rename(oldConfigFilePath, newConfigFileName)) {
-                qCWarning(lcApplication) << "Failed to rename configuration file from" << oldConfigFilePath << "to" << newConfigFileName;
-            }
-        }
-    }
+    configFile.applyMigrationDefaults();
+    const auto backupFilesList = configFile.backupConfigFiles();
 
     // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
@@ -203,7 +181,7 @@ bool Application::configVersionMigration()
                            "Continuing will mean <b>%2 these settings</b>.<br>"
                            "<br>"
                            "The current configuration file was already backed up to <i>%3</i>.")
-                            .arg((configFile.isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                            .arg((Migration::isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
                                  deleteKeys.isEmpty() ? tr("ignoring") : tr("deleting"),
                                  backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);
@@ -672,18 +650,17 @@ void Application::setupAccountsAndFolders()
 {
     _folderManager = FolderMan::instance();
     ConfigFile configFile;
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupUsers);
+    Migration::setPhase(Migration::Phase::SetupUsers);
     const auto accountsRestoreResult = restoreLegacyAccount();
     if (accountsRestoreResult == AccountManager::AccountsNotFound || accountsRestoreResult == AccountManager::AccountsRestoreFailure) {
         qCWarning(lcApplication) << "Migration result: " << accountsRestoreResult;
         qCDebug(lcApplication) << "is migration disabled?" << DISABLE_ACCOUNT_MIGRATION;
         qCWarning(lcApplication) << "No accounts were migrated, prompting user to set up accounts and folders from scratch.";
-        configFile.setMigrationPhase(ConfigFile::MigrationPhase::Done);
-
+        Migration::setPhase(Migration::Phase::Done);
         return;
     }
 
-    configFile.setMigrationPhase(ConfigFile::MigrationPhase::SetupFolders);
+    Migration::setPhase(Migration::Phase::SetupFolders);
     const auto foldersListSize = FolderMan::instance()->setupFolders();
     FolderMan::instance()->setSyncEnabled(true);
 
@@ -698,9 +675,9 @@ void Application::setupAccountsAndFolders()
     const auto accounts = AccountManager::instance()->accounts();
     const auto accountsListSize = accounts.size();
     if (accountsRestoreResult == AccountManager::AccountsRestoreSuccessFromLegacyVersion
+        && accountsListSize > 0
         && Theme::instance()->displayLegacyImportDialog()
-        && !AccountManager::instance()->forceLegacyImport()
-        && accountsListSize > 0) {
+        && !AccountManager::instance()->forceLegacyImport()) {
         const auto accountsRestoreMessage = accountsListSize > 1
             ? tr("%1 accounts", "number of accounts imported").arg(QString::number(accountsListSize))
             : tr("1 account");

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -21,6 +21,7 @@
 #include <pushnotifications.h>
 #include <syncengine.h>
 #include "updatee2eefolderusersmetadatajob.h"
+#include "settings/migration.h"
 
 #ifdef Q_OS_MACOS
 #include <CoreServices/CoreServices.h>
@@ -432,7 +433,8 @@ int FolderMan::setupFoldersMigration()
     auto configPath = _folderConfigPath;
 
 #if !DISABLE_ACCOUNT_MIGRATION
-    if (const auto legacyConfigPath = ConfigFile::discoveredLegacyConfigPath();!legacyConfigPath.isEmpty()) {
+    Migration migration;
+    if (const auto legacyConfigPath = migration.discoveredLegacyConfigPath(); !legacyConfigPath.isEmpty()) {
         configPath =  legacyConfigPath;
         qCInfo(lcFolderMan) << "Starting folder migration from legacy path:" << legacyConfigPath;
     }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -21,6 +21,7 @@
 #include <pushnotifications.h>
 #include <syncengine.h>
 #include "updatee2eefolderusersmetadatajob.h"
+#include "settings/migration.h"
 
 #ifdef Q_OS_MACOS
 #include <CoreServices/CoreServices.h>
@@ -444,7 +445,7 @@ int FolderMan::setupFoldersMigration()
     auto configPath = _folderConfigPath;
 
 #if !DISABLE_ACCOUNT_MIGRATION
-    if (const auto legacyConfigPath = ConfigFile::discoveredLegacyConfigPath();!legacyConfigPath.isEmpty()) {
+    if (const auto legacyConfigPath = Migration::discoveredLegacyConfigPath(); !legacyConfigPath.isEmpty()) {
         configPath =  legacyConfigPath;
         qCInfo(lcFolderMan) << "Starting folder migration from legacy path:" << legacyConfigPath;
     }

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -29,6 +29,7 @@ class TestSyncConflictsModel;
 class TestRemoteWipe;
 class FolderManTestHelper;
 class TestFileActionsModel;
+class TestMigration;
 
 namespace OCC {
 
@@ -420,6 +421,7 @@ private:
     friend class ::TestRemoteWipe;
     friend class ::FolderManTestHelper;
     friend class ::TestFileActionsModel;
+    friend class ::TestMigration;
 };
 
 } // namespace OCC

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -38,6 +38,7 @@ class SyncResult;
 class SocketApi;
 class LockWatcher;
 class UpdateE2eeFolderUsersMetadataJob;
+class Migration;
 
 /**
  * @brief The FolderMan class

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -30,6 +30,7 @@ class TestRemoteWipe;
 class FolderManTestHelper;
 class TestFileActionsModel;
 class TestBrowserReAuthController;
+class TestMigration;
 
 namespace OCC {
 
@@ -38,6 +39,7 @@ class SyncResult;
 class SocketApi;
 class LockWatcher;
 class UpdateE2eeFolderUsersMetadataJob;
+class Migration;
 
 /**
  * @brief The FolderMan class
@@ -421,6 +423,7 @@ private:
     friend class ::FolderManTestHelper;
     friend class ::TestFileActionsModel;
     friend class ::TestBrowserReAuthController;
+    friend class ::TestMigration;
 };
 
 } // namespace OCC

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -164,6 +164,8 @@ set(libsync_SRCS
     creds/keychainchunk.cpp
     caseclashconflictsolver.h
     caseclashconflictsolver.cpp
+    settings/migration.h
+    settings/migration.cpp
 )
 
 if (WIN32)

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -166,6 +166,8 @@ set(libsync_SRCS
     creds/keychainchunk.cpp
     caseclashconflictsolver.h
     caseclashconflictsolver.cpp
+    settings/migration.h
+    settings/migration.cpp
 )
 
 if (WIN32)

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -14,6 +14,7 @@
 #include "theme.h"
 #include "updatechannel.h"
 #include "version.h"
+#include "settings/migration.h"
 
 #ifndef TOKEN_AUTH_ONLY
 #include <QWidget>
@@ -91,8 +92,6 @@ namespace chrono = std::chrono;
 Q_LOGGING_CATEGORY(lcConfigFile, "nextcloud.sync.configfile", QtInfoMsg)
 
 QString ConfigFile::_confDir = {};
-QString ConfigFile::_discoveredLegacyConfigPath = {};
-ConfigFile::MigrationPhase ConfigFile::_migrationPhase = ConfigFile::MigrationPhase::NotStarted;
 
 static chrono::milliseconds millisecondsValue(const QSettings &setting, const char *key,
     chrono::milliseconds defaultValue)
@@ -330,7 +329,7 @@ void ConfigFile::restoreGeometryHeader(QHeaderView *header)
 QVariant ConfigFile::getPolicySetting(const QString &setting, const QVariant &defaultValue) const
 {
     if (Utility::isWindows()) {
-        const auto appName = isUnbrandedToBrandedMigrationInProgress() ? unbrandedAppName : Theme::instance()->appNameGUI();
+        const auto appName = Migration::isUnbrandedToBrandedMigration() ? unbrandedAppName : Theme::instance()->appNameGUI();
         // check for policies first and return immediately if a value is found.
         QSettings userPolicy(QString::fromLatin1(R"(HKEY_CURRENT_USER\Software\Policies\%1\%2)").arg(APPLICATION_VENDOR, appName),
             QSettings::NativeFormat);
@@ -384,7 +383,9 @@ QString ConfigFile::excludeFile(Scope scope) const
         return ConfigFile::excludeFileFromSystem();
     }
 
-    const auto excludeFilePath = scope == LegacyScope ? discoveredLegacyConfigPath() : configPath();
+    const auto excludeFilePath = scope == LegacyScope
+        ? Migration::discoveredLegacyConfigPath()
+        : configPath();
 
     // prefer sync-exclude.lst, but if it does not exist, check for exclude.lst
     QFileInfo exclFileInfo(excludeFilePath, syncExclFile);
@@ -888,7 +889,7 @@ QVariant ConfigFile::getValue(const QString &param, const QString &group,
     const QVariant &defaultValue) const
 {
     QVariant systemSetting;
-    const auto appName = isUnbrandedToBrandedMigrationInProgress() ? unbrandedAppName : Theme::instance()->appNameGUI();
+    const auto appName = Migration::isUnbrandedToBrandedMigration() ? unbrandedAppName : Theme::instance()->appNameGUI();
     if (Utility::isMac()) {
         QSettings systemSettings(QLatin1String("/Library/Preferences/" APPLICATION_REV_DOMAIN ".plist"), QSettings::NativeFormat);
         if (!group.isEmpty()) {
@@ -1364,20 +1365,6 @@ void ConfigFile::setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles)
     excludedFiles.addExcludeFilePath(userList);
 }
 
-QString ConfigFile::discoveredLegacyConfigPath()
-{
-    return _discoveredLegacyConfigPath;
-}
-
-void ConfigFile::setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath)
-{
-    if (_discoveredLegacyConfigPath == discoveredLegacyConfigPath) {
-        return;
-    }
-
-    _discoveredLegacyConfigPath = discoveredLegacyConfigPath;
-}
-
 void ConfigFile::removeFileProviderDomainMapping()
 {
     QSettings settings(configFile(), QSettings::IniFormat);
@@ -1417,60 +1404,34 @@ void ConfigFile::setMacFileProviderModeEnabled(const bool enabled)
     settings.sync();
 }
 
-bool ConfigFile::isUpgrade() const
+void ConfigFile::applyMigrationDefaults()
 {
-    const auto currentVersion = QVersionNumber::fromString(MIRALL_VERSION_STRING);
-    const auto previousVersion = QVersionNumber::fromString(clientPreviousVersionString());
-    return currentVersion > previousVersion;
+    const auto theme = Theme::instance();
+    // Launch on system startup defaults to true after 3.11.x.
+    setLaunchOnSystemStartup(launchOnSystemStartup());
+    Utility::setLaunchOnStartup(theme->appName(), theme->appNameGUI(), launchOnSystemStartup());
+    // Do not warn about deleting many files by default.
+    setPromptDeleteFiles(false);
 }
 
-bool ConfigFile::isDowngrade() const
+QStringList ConfigFile::backupConfigFiles()
 {
-    const auto currentVersion = QVersionNumber::fromString(MIRALL_VERSION_STRING);
-    const auto previousVersion = QVersionNumber::fromString(clientPreviousVersionString());
-    return previousVersion > currentVersion;
-}
-
-bool ConfigFile::shouldTryUnbrandedToBrandedMigration() const
-{
-    return migrationPhase() == ConfigFile::MigrationPhase::SetupFolders
-        && Theme::instance()->appName() != unbrandedAppName
-        && !discoveredLegacyConfigPath().isEmpty();
-}
-
-bool ConfigFile::isUnbrandedToBrandedMigrationInProgress() const
-{
-    return isMigrationInProgress() && Theme::instance()->appName() != unbrandedAppName;
-}
-
-bool ConfigFile::shouldTryToMigrate() const
-{
-    return hasVersionChanged() && (isUpgrade() || isDowngrade());
-}
-
-bool ConfigFile::hasVersionChanged() const
-{
-    const auto currentVersion = QVersionNumber::fromString(MIRALL_VERSION_STRING); //app running
-    const auto clientConfigVersion = QVersionNumber::fromString(clientVersionString()); //config version
-    return clientConfigVersion != currentVersion;
-}
-
-bool ConfigFile::isMigrationInProgress() const
-{
-    return _migrationPhase != MigrationPhase::NotStarted && _migrationPhase != MigrationPhase::Done;
-}
-
-void ConfigFile::setMigrationPhase(const MigrationPhase phase)
-{
-    // do not rollback
-    if (phase > _migrationPhase) {
-        _migrationPhase = phase;
+    QStringList backupFilesList;
+    QDir configDir(configPath());
+    const auto anyConfigFileNameList = configDir.entryInfoList({"*.cfg"}, QDir::Files);
+    for (const auto &oldConfig : anyConfigFileNameList) {
+        const auto oldConfigFilePath = oldConfig.filePath();
+        const auto newConfigFilePath = configFile();
+        backupFilesList.append(backup(oldConfig.fileName()));
+        if (oldConfigFilePath == newConfigFilePath || QFileInfo::exists(newConfigFilePath)) {
+            continue;
+        }
+        if (!QFile::rename(oldConfigFilePath, newConfigFilePath)) {
+            qCWarning(lcConfigFile) << "Failed to rename configuration file from" << oldConfigFilePath << "to" << newConfigFilePath;
+        }
     }
-}
 
-ConfigFile::MigrationPhase ConfigFile::migrationPhase() const
-{
-    return _migrationPhase;
+    return backupFilesList;
 }
 
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -265,7 +265,6 @@ public:
     [[nodiscard]] bool fileProviderDomainsAppSandboxMigrationCompleted() const;
     void setFileProviderDomainsAppSandboxMigrationCompleted(bool completed);
 
-    [[nodiscard]] static Migration &migration();
     [[nodiscard]] QStringList backupConfigFiles() const;
 
     static constexpr char unbrandedAppName[] = "Nextcloud";
@@ -312,7 +311,6 @@ private:
     using SharedCreds = QSharedPointer<AbstractCredentials>;
 
     static QString _confDir;
-    static Migration _migration;
 };
 }
 #endif // CONFIGFILE_H

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -23,6 +23,7 @@ class ExcludedFiles;
 namespace OCC {
 
 class AbstractCredentials;
+class Migration;
 
 /**
  * @brief The ConfigFile class
@@ -267,25 +268,8 @@ public:
     /// File Provider app sandbox migration flag
     [[nodiscard]] bool fileProviderDomainsAppSandboxMigrationCompleted() const;
     void setFileProviderDomainsAppSandboxMigrationCompleted(bool completed);
+    [[nodiscard]] static Migration &migration();
 
-    /// Helper function for migration/upgrade proccess
-    enum MigrationPhase {
-        NotStarted,
-        SetupConfigFile,
-        SetupUsers,
-        SetupFolders,
-        Done
-    };
-    [[nodiscard]] bool isUpgrade() const;
-    [[nodiscard]] bool isDowngrade() const;
-    [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration() const;
-    [[nodiscard]] bool isUnbrandedToBrandedMigrationInProgress() const;
-    [[nodiscard]] bool shouldTryToMigrate() const;
-    /// Does the current app has a different version of the config version
-    [[nodiscard]] bool hasVersionChanged() const;
-    [[nodiscard]] bool isMigrationInProgress() const;
-    [[nodiscard]] MigrationPhase migrationPhase() const;
-    void setMigrationPhase(const MigrationPhase phase);
     static constexpr char unbrandedAppName[] = "Nextcloud";
     static constexpr char legacyAppName[] = "Owncloud";
 
@@ -331,7 +315,7 @@ private:
 
     static QString _confDir;
     static QString _discoveredLegacyConfigPath;
-    static MigrationPhase _migrationPhase;
+    static Migration _migration;
 };
 }
 #endif // CONFIGFILE_H

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -254,10 +254,6 @@ public:
     /// Add the system and user exclude file path to the ExcludedFiles instance.
     static void setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles);
 
-    /// Set during first time migration of legacy accounts in AccountManager
-    [[nodiscard]] static QString discoveredLegacyConfigPath();
-    static void setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath);
-
     /// File Provider Domain UUID to Account ID mapping
 
     /**
@@ -268,7 +264,9 @@ public:
     /// File Provider app sandbox migration flag
     [[nodiscard]] bool fileProviderDomainsAppSandboxMigrationCompleted() const;
     void setFileProviderDomainsAppSandboxMigrationCompleted(bool completed);
+
     [[nodiscard]] static Migration &migration();
+    [[nodiscard]] QStringList backupConfigFiles() const;
 
     static constexpr char unbrandedAppName[] = "Nextcloud";
     static constexpr char legacyAppName[] = "Owncloud";
@@ -314,7 +312,6 @@ private:
     using SharedCreds = QSharedPointer<AbstractCredentials>;
 
     static QString _confDir;
-    static QString _discoveredLegacyConfigPath;
     static Migration _migration;
 };
 }

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -23,6 +23,7 @@ class ExcludedFiles;
 namespace OCC {
 
 class AbstractCredentials;
+class Migration;
 
 /**
  * @brief The ConfigFile class
@@ -253,10 +254,6 @@ public:
     /// Add the system and user exclude file path to the ExcludedFiles instance.
     static void setupDefaultExcludeFilePaths(ExcludedFiles &excludedFiles);
 
-    /// Set during first time migration of legacy accounts in AccountManager
-    [[nodiscard]] static QString discoveredLegacyConfigPath();
-    static void setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath);
-
     /// File Provider Domain UUID to Account ID mapping
 
     /**
@@ -268,6 +265,9 @@ public:
     [[nodiscard]] bool fileProviderDomainsAppSandboxMigrationCompleted() const;
     void setFileProviderDomainsAppSandboxMigrationCompleted(bool completed);
 
+    [[nodiscard]] QStringList backupConfigFiles();
+    void applyMigrationDefaults();
+
     /// App-level macOS File Provider mode: when enabled, every account gets a file
     /// provider domain and classic sync folders are unavailable (the File Provider
     /// extension and the FinderSync extension cannot run at the same time).
@@ -275,24 +275,6 @@ public:
     [[nodiscard]] bool macFileProviderModeEnabledIsSet() const;
     void setMacFileProviderModeEnabled(bool enabled);
 
-    /// Helper function for migration/upgrade proccess
-    enum MigrationPhase {
-        NotStarted,
-        SetupConfigFile,
-        SetupUsers,
-        SetupFolders,
-        Done
-    };
-    [[nodiscard]] bool isUpgrade() const;
-    [[nodiscard]] bool isDowngrade() const;
-    [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration() const;
-    [[nodiscard]] bool isUnbrandedToBrandedMigrationInProgress() const;
-    [[nodiscard]] bool shouldTryToMigrate() const;
-    /// Does the current app has a different version of the config version
-    [[nodiscard]] bool hasVersionChanged() const;
-    [[nodiscard]] bool isMigrationInProgress() const;
-    [[nodiscard]] MigrationPhase migrationPhase() const;
-    void setMigrationPhase(const MigrationPhase phase);
     static constexpr char unbrandedAppName[] = "Nextcloud";
     static constexpr char legacyAppName[] = "Owncloud";
 
@@ -337,8 +319,6 @@ private:
     using SharedCreds = QSharedPointer<AbstractCredentials>;
 
     static QString _confDir;
-    static QString _discoveredLegacyConfigPath;
-    static MigrationPhase _migrationPhase;
 };
 }
 #endif // CONFIGFILE_H

--- a/src/libsync/settings/MIGRATION.md
+++ b/src/libsync/settings/MIGRATION.md
@@ -1,0 +1,180 @@
+<!--
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+# Configuration migration
+
+`OCC::Migration` (`migration.h` / `migration.cpp`) drives the one time upgrade of a
+client's on disk configuration when the running binary no longer matches the config
+that is already on the machine. It handles three situations:
+
+* **Version change** the config was written by an older or newer client than the one
+  running now (upgrade or downgrade).
+* **Legacy import** an old ownCloud/Nextcloud config exists in one of the historical
+  locations and its accounts should be pulled into the current config.
+* **Unbranded to branded** an unbranded Nextcloud config is adopted by a branded build.
+
+## Design
+
+`Migration` is a static helper, not an object. All of its state is process global and
+lives in static members, so the constructor is deleted (`Migration() = delete;`) and
+every method is static. This mirrors how the migration actually behaves: there is one
+config per process and one migration in flight at a time.
+
+State held between phases:
+
+| Member | Meaning |
+| --- | --- |
+| `_phase` | how far the migration has progressed |
+| `_brandingType` | branding relationship between old and new config |
+| `_upgradeType` | version relationship (upgrade, downgrade, no change) |
+| `_discoveredLegacyConfigPath` | path of the legacy config, once found |
+
+`resetForTesting()` clears all of it and exists only for unit tests.
+
+## Phases
+
+The migration is a monotonic state machine. `setPhase()` only ever moves forward, so a
+later stage can never roll the phase back:
+
+```cpp
+void Migration::setPhase(const Phase phase)
+{
+    if (phase > _phase) {
+        _phase = phase;
+    }
+}
+```
+
+```
+NotStarted -> SetupConfigFile -> SetupUsers -> SetupFolders -> Done
+```
+
+`isInProgress()` is true for any phase between `SetupConfigFile` and `SetupFolders`
+inclusive, i.e. not `NotStarted` and not `Done`.
+
+## Version detection
+
+Two versions are compared:
+
+* `currentVersion()` the running binary, from `MIRALL_VERSION_STRING`.
+* `configVersion()` the version recorded in the config file, from
+  `ConfigFile().clientVersionString()`.
+
+Derived predicates:
+
+| Predicate | Definition |
+| --- | --- |
+| `isUpgrade()` | `currentVersion() > configVersion()` |
+| `isDowngrade()` | `configVersion() > currentVersion()` |
+| `versionChanged()` | `configVersion() != currentVersion()` |
+| `shouldTryToMigrate()` | `versionChanged()` |
+
+`shouldTryToMigrate()` is the single gate the application checks at startup before doing
+any migration work.
+
+## Legacy discovery
+
+`legacyData()` is pure discovery: it looks for a readable legacy config and returns it,
+without mutating any shared state.
+
+* Return type is `std::unique_ptr<QSettings>` (`Migration::LegacyData`). Ownership moves
+  to the caller; there is no stored copy.
+* It probes the historical config locations in order (ownCloud 2.4 layout, 2.5+ layout,
+  the current layout, and, for branded builds, the unbranded Nextcloud paths).
+* The first location that exists and is readable wins; unreadable candidates are skipped
+  with `continue`, not `break`, so a bad entry does not stop the search.
+* A `nullptr` result means no legacy config was found.
+
+Persisting what was discovered happens **after** the user confirms the import, in
+`AccountManager::restoreFromLegacySettings`, not inside `legacyData()`. Only once an
+account is accepted does the caller record the source:
+
+```cpp
+const QFileInfo legacyConfigInfo(oCSettings->fileName());
+Migration::setDiscoveredLegacyConfigPath(legacyConfigInfo.canonicalPath());
+ConfigFile().setClientPreviousVersionString(oCSettings->value(ConfigFile::clientVersionC).toString());
+```
+
+This keeps discovery side effect free: probing for a legacy file never changes the
+config unless the user actually opts in.
+
+## Branding
+
+`brandingType()` records the relationship between the old and new config
+(`UnbrandedToUnbranded`, `UnbrandedToBranded`, `LegacyToUnbranded`, `LegacyToBranded`).
+
+Two predicates drive branded builds adopting an unbranded config:
+
+* `shouldTryUnbrandedToBrandedMigration()` a forward looking check used during
+  `SetupFolders`: we are at that phase, this is a branded build, and a legacy config path
+  was discovered.
+* `isUnbrandedToBrandedMigration()` true while a migration is in progress, a legacy path
+  was discovered, and this is a branded build. `ConfigFile` uses it to read from the
+  unbranded app group so branded builds pick up unbranded settings.
+
+Both require a non empty `_discoveredLegacyConfigPath`, so neither fires on a plain
+version upgrade with no legacy import.
+
+## Key call sites
+
+| Location | Role |
+| --- | --- |
+| `gui/application.cpp` `configVersionMigration` | entry gate; sets `SetupConfigFile`, backs up config, warns the user |
+| `gui/application.cpp` `setupAccountsAndFolders` | advances `SetupUsers` / `SetupFolders` |
+| `gui/accountmanager.cpp` `restoreFromLegacySettings` | consumes `legacyData()`, confirms import, persists discovered path |
+| `gui/folderman.cpp` `setupFolders` | runs folder migration when a legacy path is known |
+| `gui/accountstate.cpp` `slotCredentialsFetched` | marks the migration `Done` |
+| `libsync/configfile.cpp` | reads from the unbranded group during unbranded to branded migration |
+| `cmd/cmd.cpp` | drives the phases for the headless client |
+
+## Testing
+
+`test/testmigration.cpp` covers the state machine and predicates in isolation via
+`resetForTesting()`: phase monotonicity, `isUpgrade` / `isDowngrade` / `versionChanged`,
+`shouldTryToMigrate` across upgrade, downgrade and no change, `isInProgress` per phase,
+and that `legacyData()` leaves `discoveredLegacyConfigPath()` empty (discovery has no side
+effects).
+
+## Flow diagrams
+
+### Migration
+
+The flow reads top down. A `|` is the main path, a `|--` is a branch that leaves it, and
+the tag on the right marks the start and end.
+
+```text
+Application::configVersionMigration                        [start]
+  |-- shouldTryToMigrate == false -------------------> Phase::Done
+  |
+  Phase::SetupConfigFile
+  |   applyMigrationDefaults, backupConfigFiles
+  |   remove incompatible keys, warn user
+  |
+Application::setupAccountsAndFolders
+  |
+  Application::restoreLegacyAccount -> AccountManager::restore
+  |-- accounts already in current config ------------> load accounts
+  |
+  AccountManager::restoreFromLegacySettings
+  |
+  Migration::legacyData
+  |   search legacy config locations
+  |-- no legacy config found ------------------------> return
+  |
+  found and user confirms import
+  |   setDiscoveredLegacyConfigPath
+  |   setClientPreviousVersionString
+  |
+  Phase::SetupUsers
+  |
+  FolderMan::setupFolders
+  |-- legacy path known -> setupFoldersMigration
+  |
+  load folder definitions
+  |
+AccountState::slotCredentialsFetched                       [end]
+  |
+  Phase::Done
+```

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QLoggingCategory>
+
+#include "migration.h"
+#include "theme.h"
+#include "configfile.h"
+#include "version.h"
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcMigration, "nextcloud.settings.migration", QtInfoMsg)
+
+Migration::Migration()
+{
+    _migrationPhase = MigrationPhase::NotStarted;
+    _migrationType = MigrationType::UnbrandedToUnbranded;
+    _versionChangeType = VersionChangeType::NoVersionChange;
+}
+
+QVersionNumber Migration::currentVersion() const
+{
+    return QVersionNumber::fromString(MIRALL_VERSION_STRING);
+}
+
+QVersionNumber Migration::previousVersion() const
+{
+    return QVersionNumber::fromString(ConfigFile().clientPreviousVersionString());
+}
+
+QVersionNumber Migration::configVersion() const
+{
+    return QVersionNumber::fromString(ConfigFile().clientVersionString());
+}
+
+void Migration::setMigrationPhase(const MigrationPhase phase)
+{
+    // do not rollback
+    if (phase > _migrationPhase) {
+        _migrationPhase = phase;
+    }
+}
+
+Migration::MigrationPhase Migration::migrationPhase() const
+{
+    return _migrationPhase;
+}
+
+void Migration::setMigrationType(const MigrationType type)
+{
+    _migrationType = type;
+}
+
+Migration::MigrationType Migration::migrationType() const
+{
+    return _migrationType;
+}
+
+Migration::VersionChangeType Migration::versionChangeType() const
+{
+    return _versionChangeType;
+}
+
+void Migration::setVersionChangeType(const VersionChangeType type)
+{
+    _versionChangeType = type;
+}
+
+bool Migration::isUpgrade()
+{
+    const auto isUpgrade = currentVersion() > previousVersion();
+    if (isUpgrade) {
+        setVersionChangeType(VersionChangeType::Upgrade);
+    }
+    return versionChangeType() == VersionChangeType::Upgrade;
+}
+
+bool Migration::isDowngrade()
+{
+    const auto isDowngrade = previousVersion() > currentVersion();
+    if (isDowngrade) {
+        setVersionChangeType(VersionChangeType::Downgrade);
+    }
+    return versionChangeType() == VersionChangeType::Downgrade;
+}
+
+bool Migration::versionChanged()
+{
+    return isUpgrade() || isDowngrade();
+}
+
+bool Migration::shouldTryUnbrandedToBrandedMigration() const
+{
+    const auto isUnbrandedToBranded = migrationPhase() == Migration::MigrationPhase::SetupFolders
+        && Theme::instance()->appName() != ConfigFile::unbrandedAppName;
+    if (isUnbrandedToBranded) {
+        Migration().setMigrationType(MigrationType::UnbrandedToBranded);
+    }
+    return migrationType() == MigrationType::UnbrandedToBranded;
+}
+
+bool Migration::isUnbrandedToBrandedMigration() const
+{
+    return isInProgress() && migrationType() == MigrationType::UnbrandedToBranded;
+}
+
+bool Migration::shouldTryToMigrate()
+{
+    return !isClientVersionSet() && (isUpgrade() || isDowngrade());
+}
+
+bool Migration::isClientVersionSet() const
+{
+    const auto configVersionNumber = configVersion();
+    const auto previousVersionNumber = previousVersion();
+    return !configVersionNumber.isNull() && !previousVersionNumber.isNull()
+        && configVersionNumber == previousVersionNumber;
+}
+
+bool Migration::isInProgress() const
+{
+    const auto currentPhase = migrationPhase();
+    return currentPhase != MigrationPhase::NotStarted
+        && currentPhase != MigrationPhase::Done;
+}
+
+}

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -26,12 +26,11 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcMigration, "nextcloud.settings.migration", QtInfoMsg)
 
-Migration::Migration()
-{
-    _migrationPhase = MigrationPhase::NotStarted;
-    _migrationType = MigrationType::UnbrandedToUnbranded;
-    _versionChangeType = VersionChangeType::NoVersionChange;
-}
+Migration::Phase Migration::_phase = Phase::NotStarted;;
+Migration::BrandingType Migration::_brandingType = BrandingType::UnbrandedToUnbranded;
+Migration::UpgradeType Migration::_upgradeType = UpgradeType::NoChange;
+QString Migration::_discoveredLegacyConfigPath = {};
+Migration::LegacyData Migration::_legacyData = {};
 
 QVersionNumber Migration::currentVersion() const
 {
@@ -48,55 +47,55 @@ QVersionNumber Migration::configVersion() const
     return QVersionNumber::fromString(ConfigFile().clientVersionString());
 }
 
-void Migration::setMigrationPhase(const MigrationPhase phase)
+void Migration::setPhase(const Phase phase)
 {
     // do not rollback
-    if (phase > _migrationPhase) {
-        _migrationPhase = phase;
+   if (phase > _phase) {
+        _phase = phase;
     }
 }
 
-Migration::MigrationPhase Migration::migrationPhase() const
+Migration::Phase Migration::phase() const
 {
-    return _migrationPhase;
+    return _phase;
 }
 
-void Migration::setMigrationType(const MigrationType type)
+void Migration::setBrandingType(const BrandingType type)
 {
-    _migrationType = type;
+    _brandingType = type;
 }
 
-Migration::MigrationType Migration::migrationType() const
+Migration::BrandingType Migration::brandingType() const
 {
-    return _migrationType;
+    return _brandingType;
 }
 
-Migration::VersionChangeType Migration::versionChangeType() const
+Migration::UpgradeType Migration::upgradeType() const
 {
-    return _versionChangeType;
+    return _upgradeType;
 }
 
-void Migration::setVersionChangeType(const VersionChangeType type)
+void Migration::setUpgradeType(const UpgradeType type)
 {
-    _versionChangeType = type;
+    _upgradeType = type;
 }
 
 bool Migration::isUpgrade()
 {
     const auto isUpgrade = currentVersion() > previousVersion();
     if (isUpgrade) {
-        setVersionChangeType(VersionChangeType::Upgrade);
+        setUpgradeType(UpgradeType::Upgrade);
     }
-    return versionChangeType() == VersionChangeType::Upgrade;
+    return _upgradeType == UpgradeType::Upgrade;
 }
 
 bool Migration::isDowngrade()
 {
     const auto isDowngrade = previousVersion() > currentVersion();
     if (isDowngrade) {
-        setVersionChangeType(VersionChangeType::Downgrade);
+        setUpgradeType(UpgradeType::Downgrade);
     }
-    return versionChangeType() == VersionChangeType::Downgrade;
+    return _upgradeType == UpgradeType::Downgrade;
 }
 
 bool Migration::versionChanged()
@@ -104,21 +103,21 @@ bool Migration::versionChanged()
     return isUpgrade() || isDowngrade();
 }
 
-bool Migration::shouldTryUnbrandedToBrandedMigration() const
+bool Migration::shouldTryUnbrandedToBrandedMigration()
 {
-    const auto isUnbrandedToBranded = migrationPhase() == Migration::MigrationPhase::SetupFolders
+    const auto isUnbrandedToBranded = phase() == Migration::Phase::SetupFolders
         && Theme::instance()->appName() != ConfigFile::unbrandedAppName 
-        && !ConfigFile().discoveredLegacyConfigPath().isEmpty();
+        && !_discoveredLegacyConfigPath.isEmpty();
 
     if (isUnbrandedToBranded) {
-        Migration().setMigrationType(MigrationType::UnbrandedToBranded);
+        setBrandingType(BrandingType::UnbrandedToBranded);
     }
-    return migrationType() == MigrationType::UnbrandedToBranded;
+    return _brandingType == BrandingType::UnbrandedToBranded;
 }
 
 bool Migration::isUnbrandedToBrandedMigration() const
 {
-    return isInProgress() && migrationType() == MigrationType::UnbrandedToBranded;
+    return isInProgress() && brandingType() == BrandingType::UnbrandedToBranded;
 }
 
 bool Migration::shouldTryToMigrate()
@@ -136,9 +135,94 @@ bool Migration::isClientVersionSet() const
 
 bool Migration::isInProgress() const
 {
-    const auto currentPhase = migrationPhase();
-    return currentPhase != MigrationPhase::NotStarted
-        && currentPhase != MigrationPhase::Done;
+    const auto currentPhase = phase();
+    return currentPhase != Phase::NotStarted 
+        && currentPhase != Phase::Done;
+}
+
+Migration::LegacyData Migration::legacyData() const
+{
+    qCInfo(lcMigration) << "Migrate: restoreFromLegacySettings, checking settings group" << Theme::instance()->appName();
+
+    // try to open the correctly themed settings
+    auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
+    LegacyData legacyData;
+
+    // if the settings file could not be opened, the childKeys list is empty
+    // then try to load settings from a very old place
+    if (settings->childKeys().isEmpty()) {
+        // Legacy settings used QDesktopServices to get the location for the config folder in 2.4 and before
+        const auto legacy2_4CfgSettingsLocation = QString(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/data"));
+        const auto legacy2_4CfgFileParentFolder = legacy2_4CfgSettingsLocation.left(legacy2_4CfgSettingsLocation.lastIndexOf('/'));
+
+        // 2.5+ (rest of 2.x series)
+        const auto legacy2_5CfgSettingsLocation =
+            QStandardPaths::writableLocation(Utility::isWindows() ? QStandardPaths::AppDataLocation : QStandardPaths::AppConfigLocation);
+        const auto legacy2_5CfgFileParentFolder = legacy2_5CfgSettingsLocation.left(legacy2_5CfgSettingsLocation.lastIndexOf('/'));
+
+        // Now try the locations we use today
+        const auto fullLegacyCfgFile = QDir::fromNativeSeparators(settings->fileName());
+        const auto legacyCfgFileParentFolder = fullLegacyCfgFile.left(fullLegacyCfgFile.lastIndexOf('/'));
+        const auto legacyCfgFileGrandParentFolder = legacyCfgFileParentFolder.left(legacyCfgFileParentFolder.lastIndexOf('/'));
+
+        const auto legacyCfgFileNamePath = QString(QStringLiteral("/") + legacyCfgFileNameC);
+        const auto legacyCfgFileRelativePath = QString(legacyRelativeConfigLocationC);
+
+        auto legacyLocations = QVector<QString>{legacy2_4CfgFileParentFolder + legacyCfgFileRelativePath,
+                                                legacy2_5CfgFileParentFolder + legacyCfgFileRelativePath,
+                                                legacyCfgFileParentFolder + legacyCfgFileNamePath,
+                                                legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
+
+        if (Theme::instance()->isBranded()) {
+            const auto unbrandedCfgFileNamePath = QString(QStringLiteral("/") + unbrandedCfgFileNameC);
+            const auto unbrandedCfgFileRelativePath = QString(unbrandedRelativeConfigLocationC);
+            legacyLocations.append({legacyCfgFileParentFolder + unbrandedCfgFileNamePath, legacyCfgFileGrandParentFolder + unbrandedCfgFileRelativePath});
+        }
+
+        for (const auto &configFileString : std::as_const(legacyLocations)) {
+            auto oCSettings = std::make_unique<QSettings>(configFileString, QSettings::IniFormat);
+            if (oCSettings->status() != QSettings::Status::NoError) {
+                qCInfo(lcMigration) << "Error reading legacy configuration file" << oCSettings->status();
+                break;
+            }
+
+            if (const QFileInfo configFileInfo(configFileString); configFileInfo.exists() && configFileInfo.isReadable()) {
+                ConfigFile configFile;
+                const auto legacyVersion = oCSettings->value(ConfigFile::clientVersionC, {}).toString();
+                configFile.setClientPreviousVersionString(legacyVersion);
+                qCInfo(lcMigration) << "Migrating from" << legacyVersion;
+                qCInfo(lcMigration) << "Copy settings" << oCSettings->allKeys().join(", ");
+                Migration migration;
+                migration.setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
+                legacyData.reset(oCSettings.get());
+                migration.setLegacyData(legacyData);
+                break;
+            } else {
+                qCInfo(lcMigration) << "Migrate: could not read old config " << configFileString;
+            }
+        }
+    }
+
+    return legacyData;
+}
+
+QString Migration::discoveredLegacyConfigPath() const
+{
+    return _discoveredLegacyConfigPath;
+}
+
+void Migration::setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath)
+{
+    if (_discoveredLegacyConfigPath == discoveredLegacyConfigPath) {
+        return;
+    }
+
+    _discoveredLegacyConfigPath = discoveredLegacyConfigPath;
+}
+
+void Migration::setLegacyData(const LegacyData legacyData)
+{
+    _legacyData = legacyData;
 }
 
 }

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -190,8 +190,8 @@ Migration::LegacyData Migration::legacyData() const
                 ConfigFile configFile;
                 const auto legacyVersion = oCSettings->value(ConfigFile::clientVersionC, {}).toString();
                 configFile.setClientPreviousVersionString(legacyVersion);
-                qCInfo(lcMigration) << "Migrating from" << legacyVersion;
-                qCInfo(lcMigration) << "Copy settings" << oCSettings->allKeys().join(", ");
+                qCInfo(lcMigration) << "Migrating from legacy version" << legacyVersion;
+                qCDebug(lcMigration) << "Copy settings" << oCSettings->allKeys().join(", ");
                 Migration migration;
                 migration.setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
                 legacyData.reset(oCSettings.get());

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -9,6 +9,18 @@
 #include "theme.h"
 #include "configfile.h"
 #include "version.h"
+#include "common/utility.h"
+
+#include <QSettings>
+#include <QDir>
+#include <QStandardPaths>
+
+namespace {
+    constexpr auto legacyCfgFileNameC = "owncloud.cfg";
+    constexpr auto legacyRelativeConfigLocationC = "/ownCloud/owncloud.cfg";
+    constexpr auto unbrandedRelativeConfigLocationC = "/Nextcloud/nextcloud.cfg";
+    constexpr auto unbrandedCfgFileNameC = "nextcloud.cfg";
+}
 
 namespace OCC {
 

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -107,7 +107,9 @@ bool Migration::versionChanged()
 bool Migration::shouldTryUnbrandedToBrandedMigration() const
 {
     const auto isUnbrandedToBranded = migrationPhase() == Migration::MigrationPhase::SetupFolders
-        && Theme::instance()->appName() != ConfigFile::unbrandedAppName;
+        && Theme::instance()->appName() != ConfigFile::unbrandedAppName 
+        && !ConfigFile().discoveredLegacyConfigPath().isEmpty();
+
     if (isUnbrandedToBranded) {
         Migration().setMigrationType(MigrationType::UnbrandedToBranded);
     }

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -26,7 +26,7 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcMigration, "nextcloud.settings.migration", QtInfoMsg)
 
-Migration::Phase Migration::_phase = Phase::NotStarted;;
+Migration::Phase Migration::_phase = Phase::NotStarted;
 Migration::BrandingType Migration::_brandingType = BrandingType::UnbrandedToUnbranded;
 Migration::UpgradeType Migration::_upgradeType = UpgradeType::NoChange;
 QString Migration::_discoveredLegacyConfigPath = {};
@@ -80,25 +80,17 @@ void Migration::setUpgradeType(const UpgradeType type)
     _upgradeType = type;
 }
 
-bool Migration::isUpgrade()
+bool Migration::isUpgrade() const
 {
-    const auto isUpgrade = currentVersion() > previousVersion();
-    if (isUpgrade) {
-        setUpgradeType(UpgradeType::Upgrade);
-    }
-    return _upgradeType == UpgradeType::Upgrade;
+    return currentVersion() > previousVersion();
 }
 
-bool Migration::isDowngrade()
+bool Migration::isDowngrade() const
 {
-    const auto isDowngrade = previousVersion() > currentVersion();
-    if (isDowngrade) {
-        setUpgradeType(UpgradeType::Downgrade);
-    }
-    return _upgradeType == UpgradeType::Downgrade;
+    return previousVersion() > currentVersion();
 }
 
-bool Migration::versionChanged()
+bool Migration::versionChanged() const
 {
     return isUpgrade() || isDowngrade();
 }
@@ -120,7 +112,7 @@ bool Migration::isUnbrandedToBrandedMigration() const
     return isInProgress() && brandingType() == BrandingType::UnbrandedToBranded;
 }
 
-bool Migration::shouldTryToMigrate()
+bool Migration::shouldTryToMigrate() const
 {
     return !isClientVersionSet() && (isUpgrade() || isDowngrade());
 }
@@ -136,8 +128,17 @@ bool Migration::isClientVersionSet() const
 bool Migration::isInProgress() const
 {
     const auto currentPhase = phase();
-    return currentPhase != Phase::NotStarted 
+    return currentPhase != Phase::NotStarted
         && currentPhase != Phase::Done;
+}
+
+void Migration::resetForTesting()
+{
+    _phase = Phase::NotStarted;
+    _brandingType = BrandingType::UnbrandedToUnbranded;
+    _upgradeType = UpgradeType::NoChange;
+    _discoveredLegacyConfigPath = {};
+    _legacyData = {};
 }
 
 Migration::LegacyData Migration::legacyData() const
@@ -192,10 +193,9 @@ Migration::LegacyData Migration::legacyData() const
                 configFile.setClientPreviousVersionString(legacyVersion);
                 qCInfo(lcMigration) << "Migrating from legacy version" << legacyVersion;
                 qCDebug(lcMigration) << "Copy settings" << oCSettings->allKeys().join(", ");
-                Migration migration;
-                migration.setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
-                legacyData.reset(oCSettings.get());
-                migration.setLegacyData(legacyData);
+                setDiscoveredLegacyConfigPath(configFileInfo.canonicalPath());
+                legacyData.reset(oCSettings.release());
+                setLegacyData(legacyData);
                 break;
             } else {
                 qCInfo(lcMigration) << "Migrate: could not read old config " << configFileString;

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -141,7 +141,7 @@ void Migration::resetForTesting()
     _legacyData = {};
 }
 
-Migration::LegacyData Migration::legacyData() const
+Migration::LegacyData Migration::legacyData()
 {
     qCInfo(lcMigration) << "Migrate: restoreFromLegacySettings, checking settings group" << Theme::instance()->appName();
 

--- a/src/libsync/settings/migration.cpp
+++ b/src/libsync/settings/migration.cpp
@@ -1,0 +1,196 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QLoggingCategory>
+
+#include "migration.h"
+#include "theme.h"
+#include "configfile.h"
+#include "version.h"
+#include "common/utility.h"
+
+#include <QSettings>
+#include <QDir>
+#include <QStandardPaths>
+
+namespace {
+    constexpr auto legacyCfgFileNameC = "owncloud.cfg";
+    constexpr auto legacyRelativeConfigLocationC = "/ownCloud/owncloud.cfg";
+    constexpr auto unbrandedRelativeConfigLocationC = "/Nextcloud/nextcloud.cfg";
+    constexpr auto unbrandedCfgFileNameC = "nextcloud.cfg";
+}
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcMigration, "nextcloud.settings.migration", QtInfoMsg)
+
+Migration::Phase Migration::_phase = Phase::NotStarted;
+Migration::BrandingType Migration::_brandingType = BrandingType::UnbrandedToUnbranded;
+Migration::UpgradeType Migration::_upgradeType = UpgradeType::NoChange;
+QString Migration::_discoveredLegacyConfigPath = {};
+
+QVersionNumber Migration::currentVersion()
+{
+    return QVersionNumber::fromString(MIRALL_VERSION_STRING);
+}
+
+QVersionNumber Migration::configVersion()
+{
+    return QVersionNumber::fromString(ConfigFile().clientVersionString());
+}
+
+void Migration::setPhase(const Phase phase)
+{
+    if (phase > _phase) {
+        _phase = phase;
+    }
+}
+
+Migration::Phase Migration::phase()
+{
+    return _phase;
+}
+
+void Migration::setBrandingType(const BrandingType type)
+{
+    _brandingType = type;
+}
+
+Migration::BrandingType Migration::brandingType()
+{
+    return _brandingType;
+}
+
+Migration::UpgradeType Migration::upgradeType()
+{
+    return _upgradeType;
+}
+
+void Migration::setUpgradeType(const UpgradeType type)
+{
+    _upgradeType = type;
+}
+
+bool Migration::isUpgrade()
+{
+    return currentVersion() > configVersion();
+}
+
+bool Migration::isDowngrade()
+{
+    return configVersion() > currentVersion();
+}
+
+bool Migration::versionChanged()
+{
+    return configVersion() != currentVersion();
+}
+
+bool Migration::shouldTryUnbrandedToBrandedMigration()
+{
+    return phase() == Migration::Phase::SetupFolders
+        && Theme::instance()->appName() != ConfigFile::unbrandedAppName
+        && !_discoveredLegacyConfigPath.isEmpty();
+}
+
+bool Migration::isUnbrandedToBrandedMigration()
+{
+    return isInProgress() && !_discoveredLegacyConfigPath.isEmpty() && Theme::instance()->appName() != ConfigFile::unbrandedAppName;
+}
+
+bool Migration::shouldTryToMigrate()
+{
+    return versionChanged();
+}
+
+bool Migration::isInProgress()
+{
+    const auto currentPhase = phase();
+    return currentPhase != Phase::NotStarted
+        && currentPhase != Phase::Done;
+}
+
+void Migration::resetForTesting()
+{
+    _phase = Phase::NotStarted;
+    _brandingType = BrandingType::UnbrandedToUnbranded;
+    _upgradeType = UpgradeType::NoChange;
+    _discoveredLegacyConfigPath = {};
+}
+
+Migration::LegacyData Migration::legacyData()
+{
+    qCInfo(lcMigration) << "Migrate: restoreFromLegacySettings, checking settings group" << Theme::instance()->appName();
+
+    // try to open the correctly themed settings
+    auto settings = ConfigFile::settingsWithGroup(Theme::instance()->appName());
+    LegacyData legacyData;
+
+    // if the settings file could not be opened, the childKeys list is empty
+    // then try to load settings from a very old place
+    if (settings->childKeys().isEmpty()) {
+        // Legacy settings used QDesktopServices to get the location for the config folder in 2.4 and before
+        const auto legacy2_4CfgSettingsLocation = QString(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/data"));
+        const auto legacy2_4CfgFileParentFolder = legacy2_4CfgSettingsLocation.left(legacy2_4CfgSettingsLocation.lastIndexOf('/'));
+
+        // 2.5+ (rest of 2.x series)
+        const auto legacy2_5CfgSettingsLocation =
+            QStandardPaths::writableLocation(Utility::isWindows() ? QStandardPaths::AppDataLocation : QStandardPaths::AppConfigLocation);
+        const auto legacy2_5CfgFileParentFolder = legacy2_5CfgSettingsLocation.left(legacy2_5CfgSettingsLocation.lastIndexOf('/'));
+
+        // Now try the locations we use today
+        const auto fullLegacyCfgFile = QDir::fromNativeSeparators(settings->fileName());
+        const auto legacyCfgFileParentFolder = fullLegacyCfgFile.left(fullLegacyCfgFile.lastIndexOf('/'));
+        const auto legacyCfgFileGrandParentFolder = legacyCfgFileParentFolder.left(legacyCfgFileParentFolder.lastIndexOf('/'));
+
+        const auto legacyCfgFileNamePath = QString(QStringLiteral("/") + legacyCfgFileNameC);
+        const auto legacyCfgFileRelativePath = QString(legacyRelativeConfigLocationC);
+
+        auto legacyLocations = QVector<QString>{legacy2_4CfgFileParentFolder + legacyCfgFileRelativePath,
+                                                legacy2_5CfgFileParentFolder + legacyCfgFileRelativePath,
+                                                legacyCfgFileParentFolder + legacyCfgFileNamePath,
+                                                legacyCfgFileGrandParentFolder + legacyCfgFileRelativePath};
+
+        if (Theme::instance()->isBranded()) {
+            const auto unbrandedCfgFileNamePath = QString(QStringLiteral("/") + unbrandedCfgFileNameC);
+            const auto unbrandedCfgFileRelativePath = QString(unbrandedRelativeConfigLocationC);
+            legacyLocations.append({legacyCfgFileParentFolder + unbrandedCfgFileNamePath, legacyCfgFileGrandParentFolder + unbrandedCfgFileRelativePath});
+        }
+
+        for (const auto &configFileString : std::as_const(legacyLocations)) {
+            auto oCSettings = std::make_unique<QSettings>(configFileString, QSettings::IniFormat);
+            if (oCSettings->status() != QSettings::Status::NoError) {
+                qCInfo(lcMigration) << "Error reading legacy configuration file" << configFileString << oCSettings->status();
+                continue;
+            }
+
+            if (const QFileInfo configFileInfo(configFileString); configFileInfo.exists() && configFileInfo.isReadable()) {
+                qCInfo(lcMigration) << "Discovered legacy config at" << configFileInfo.canonicalPath();
+                legacyData = std::move(oCSettings);
+                break;
+            } else {
+                qCInfo(lcMigration) << "Migrate: could not read old config " << configFileString;
+            }
+        }
+    }
+
+    return legacyData;
+}
+
+QString Migration::discoveredLegacyConfigPath()
+{
+    return _discoveredLegacyConfigPath;
+}
+
+void Migration::setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath)
+{
+    if (_discoveredLegacyConfigPath == discoveredLegacyConfigPath) {
+        return;
+    }
+
+    _discoveredLegacyConfigPath = discoveredLegacyConfigPath;
+}
+
+}

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef MIGRATION_H
+#define MIGRATION_H
+
+#include <QVersionNumber>
+#include "owncloudlib.h"
+
+namespace OCC {
+
+class OWNCLOUDSYNC_EXPORT Migration
+{
+public:
+    Migration();
+
+    enum MigrationPhase {
+        NotStarted,
+        SetupConfigFile,
+        SetupUsers,
+        SetupFolders,
+        Done
+    };
+
+    enum MigrationType {
+        UnbrandedToUnbranded,
+        UnbrandedToBranded,
+        LegacyToUnbranded,
+        LegacyToBranded
+    };
+
+    enum VersionChangeType {
+        NoVersionChange,
+        Upgrade,
+        Downgrade
+    };
+
+    [[nodiscard]] QVersionNumber previousVersion() const;
+    [[nodiscard]] QVersionNumber currentVersion() const;
+    [[nodiscard]] QVersionNumber configVersion() const;
+
+    [[nodiscard]] MigrationPhase migrationPhase() const;
+    [[nodiscard]] MigrationType migrationType() const;
+    [[nodiscard]] VersionChangeType versionChangeType() const;
+
+    void setMigrationPhase(const MigrationPhase phase);
+    void setMigrationType(const MigrationType type);
+    void setVersionChangeType(const VersionChangeType type);
+
+    [[nodiscard]] bool isUpgrade();
+    [[nodiscard]] bool isDowngrade();
+    [[nodiscard]] bool versionChanged();
+    [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration() const;
+    [[nodiscard]] bool isUnbrandedToBrandedMigration() const;
+    [[nodiscard]] bool shouldTryToMigrate();
+    [[nodiscard]] bool isClientVersionSet() const;
+    [[nodiscard]] bool isInProgress() const;
+
+private:
+    MigrationPhase _migrationPhase;
+    MigrationType _migrationType;
+    VersionChangeType _versionChangeType;
+};
+}
+#endif // MIGRATION_H

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -45,6 +45,18 @@ public:
     [[nodiscard]] QVersionNumber currentVersion() const;
     [[nodiscard]] QVersionNumber configVersion() const;
 
+    /**
+     * => Application::configVersionMigration: check existing config
+     *  => no upgrade/downgrade/migration: Migration::Phase::Done
+     *  => need to set config file: Migration::Phase::SetupConfigFile
+     * => Application::setupAccountsAndFolders: Migration::Phase::SetupUsers
+     *   => Application::restoreLegacyAccount
+     *     => AccountManager::restore
+     *       => AccountManager::restoreFromLegacySettings:
+     *         => Migration::legacyData: find legacy config and read its settings using
+     *     => FolderMan::setupFolders: Migration::Phase::SetupFolders
+     * => AccountState::slotCredentialsFetched: Migration::Phase::Done
+     */
     [[nodiscard]] Phase phase() const;
     void setPhase(const Phase phase);
 

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -7,6 +7,8 @@
 #define MIGRATION_H
 
 #include <QVersionNumber>
+#include <QSettings>
+#include <QMap>
 #include "owncloudlib.h"
 
 namespace OCC {
@@ -14,9 +16,9 @@ namespace OCC {
 class OWNCLOUDSYNC_EXPORT Migration
 {
 public:
-    Migration();
+    Migration() { };
 
-    enum MigrationPhase {
+    enum Phase {
         NotStarted,
         SetupConfigFile,
         SetupUsers,
@@ -24,44 +26,56 @@ public:
         Done
     };
 
-    enum MigrationType {
+    enum BrandingType {
         UnbrandedToUnbranded,
         UnbrandedToBranded,
         LegacyToUnbranded,
         LegacyToBranded
     };
 
-    enum VersionChangeType {
-        NoVersionChange,
+    enum UpgradeType {
+        NoChange,
         Upgrade,
         Downgrade
     };
+
+    using LegacyData = QSharedPointer<QSettings>;
 
     [[nodiscard]] QVersionNumber previousVersion() const;
     [[nodiscard]] QVersionNumber currentVersion() const;
     [[nodiscard]] QVersionNumber configVersion() const;
 
-    [[nodiscard]] MigrationPhase migrationPhase() const;
-    [[nodiscard]] MigrationType migrationType() const;
-    [[nodiscard]] VersionChangeType versionChangeType() const;
+    [[nodiscard]] Phase phase() const;
+    void setPhase(const Phase phase);
 
-    void setMigrationPhase(const MigrationPhase phase);
-    void setMigrationType(const MigrationType type);
-    void setVersionChangeType(const VersionChangeType type);
+    [[nodiscard]] BrandingType brandingType() const;
+    void setBrandingType(const BrandingType type);
 
+    [[nodiscard]] UpgradeType upgradeType() const;
+    void setUpgradeType(const UpgradeType type);
+
+    [[nodiscard]] LegacyData legacyData() const;
+    void setLegacyData(const LegacyData legacyData);
+
+    /// Set during first time migration of legacy accounts in AccountManager
+    [[nodiscard]] QString discoveredLegacyConfigPath() const;
+    void setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath);
+   
     [[nodiscard]] bool isUpgrade();
     [[nodiscard]] bool isDowngrade();
     [[nodiscard]] bool versionChanged();
-    [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration() const;
+    [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration();
     [[nodiscard]] bool isUnbrandedToBrandedMigration() const;
     [[nodiscard]] bool shouldTryToMigrate();
     [[nodiscard]] bool isClientVersionSet() const;
     [[nodiscard]] bool isInProgress() const;
 
 private:
-    MigrationPhase _migrationPhase;
-    MigrationType _migrationType;
-    VersionChangeType _versionChangeType;
+    static Phase _phase;
+    static BrandingType _brandingType;
+    static UpgradeType _upgradeType;
+    static QString _discoveredLegacyConfigPath;
+    static LegacyData _legacyData;
 };
 }
 #endif // MIGRATION_H

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -54,6 +54,7 @@ public:
     [[nodiscard]] UpgradeType upgradeType() const;
     void setUpgradeType(const UpgradeType type);
 
+    /// Returns QSettings from a legacy config file
     [[nodiscard]] LegacyData legacyData() const;
     void setLegacyData(const LegacyData legacyData);
 

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -90,7 +90,7 @@ public:
     void setUpgradeType(const UpgradeType type);
 
     /// Returns QSettings from a legacy config file
-    [[nodiscard]] LegacyData legacyData() const;
+    [[nodiscard]] LegacyData legacyData();
     void setLegacyData(const LegacyData legacyData);
 
     /// Set during first time migration of legacy accounts in AccountManager

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -46,16 +46,39 @@ public:
     [[nodiscard]] QVersionNumber configVersion() const;
 
     /**
-     * => Application::configVersionMigration: check existing config
-     *  => no upgrade/downgrade/migration: Migration::Phase::Done
-     *  => need to set config file: Migration::Phase::SetupConfigFile
-     * => Application::setupAccountsAndFolders: Migration::Phase::SetupUsers
-     *   => Application::restoreLegacyAccount
-     *     => AccountManager::restore
-     *       => AccountManager::restoreFromLegacySettings:
-     *         => Migration::legacyData: find legacy config and read its settings using
-     *     => FolderMan::setupFolders: Migration::Phase::SetupFolders
-     * => AccountState::slotCredentialsFetched: Migration::Phase::Done
+     * Application::configVersionMigration                     [start]
+     *   |-- no migration needed ----------------------> Phase::Done
+     *   |
+     *   Phase::SetupConfigFile
+     *   |   backup config files, remove incompatible keys
+     *   |
+     * Application::setupAccountsAndFolders
+     *   |
+     *   Phase::SetupUsers
+     *   |
+     *   Application::restoreLegacyAccount
+     *     |
+     *     AccountManager::restore
+     *       |-- accounts in current config -----------> load accounts
+     *       |
+     *       AccountManager::restoreFromLegacySettings
+     *         |
+     *         Migration::legacyData
+     *           |   search legacy config locations
+     *           |-- no legacy config found -----------> return
+     *           |
+     *           store legacy QSettings + config path
+     *   |
+     *   Phase::SetupFolders
+     *   |
+     *   FolderMan::setupFolders
+     *     |-- legacy path known -> setupFoldersMigration
+     *     |
+     *     load folder definitions
+     *   |
+     * AccountState::slotCredentialsFetched            [end]
+     *   |
+     *   Phase::Done
      */
     [[nodiscard]] Phase phase() const;
     void setPhase(const Phase phase);

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -74,14 +74,17 @@ public:
     [[nodiscard]] QString discoveredLegacyConfigPath() const;
     void setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath);
    
-    [[nodiscard]] bool isUpgrade();
-    [[nodiscard]] bool isDowngrade();
-    [[nodiscard]] bool versionChanged();
+    [[nodiscard]] bool isUpgrade() const;
+    [[nodiscard]] bool isDowngrade() const;
+    [[nodiscard]] bool versionChanged() const;
     [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration();
     [[nodiscard]] bool isUnbrandedToBrandedMigration() const;
-    [[nodiscard]] bool shouldTryToMigrate();
+    [[nodiscard]] bool shouldTryToMigrate() const;
     [[nodiscard]] bool isClientVersionSet() const;
     [[nodiscard]] bool isInProgress() const;
+
+    /// Resets all shared state to initial values. Only intended for use in unit tests.
+    static void resetForTesting();
 
 private:
     static Phase _phase;

--- a/src/libsync/settings/migration.h
+++ b/src/libsync/settings/migration.h
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef MIGRATION_H
+#define MIGRATION_H
+
+#include <QVersionNumber>
+#include <QSettings>
+#include <QMap>
+#include <memory>
+#include "owncloudlib.h"
+
+namespace OCC {
+
+class OWNCLOUDSYNC_EXPORT Migration
+{
+    Q_GADGET
+public:
+    // All state is process global; this class is a collection of static
+    // helpers and is not meant to be instantiated.
+    Migration() = delete;
+
+    enum class Phase {
+        NotStarted,
+        SetupConfigFile,
+        SetupUsers,
+        SetupFolders,
+        Done
+    };
+    Q_ENUM(Phase)
+
+    enum class BrandingType {
+        UnbrandedToUnbranded,
+        UnbrandedToBranded,
+        LegacyToUnbranded,
+        LegacyToBranded
+    };
+    Q_ENUM(BrandingType)
+
+    enum class UpgradeType {
+        NoChange,
+        Upgrade,
+        Downgrade
+    };
+    Q_ENUM(UpgradeType)
+
+    using LegacyData = std::unique_ptr<QSettings>;
+
+    [[nodiscard]] static QVersionNumber currentVersion();
+    [[nodiscard]] static QVersionNumber configVersion();
+
+    /**
+     * Application::configVersionMigration                     [start]
+     *   |-- no migration needed ----------------------> Phase::Done
+     *   |
+     *   Phase::SetupConfigFile
+     *   |   backup config files, remove incompatible keys
+     *   |
+     * Application::setupAccountsAndFolders
+     *   |
+     *   Phase::SetupUsers
+     *   |
+     *   Application::restoreLegacyAccount
+     *     |
+     *     AccountManager::restore
+     *       |-- accounts in current config -----------> load accounts
+     *       |
+     *       AccountManager::restoreFromLegacySettings
+     *         |
+     *         Migration::legacyData
+     *           |   search legacy config locations
+     *           |-- no legacy config found -----------> return
+     *           |
+     *           store legacy QSettings + config path
+     *   |
+     *   Phase::SetupFolders
+     *   |
+     *   FolderMan::setupFolders
+     *     |-- legacy path known -> setupFoldersMigration
+     *     |
+     *     load folder definitions
+     *   |
+     * AccountState::slotCredentialsFetched            [end]
+     *   |
+     *   Phase::Done
+     */
+    [[nodiscard]] static Phase phase();
+    static void setPhase(const Phase phase);
+
+    [[nodiscard]] static BrandingType brandingType();
+    static void setBrandingType(const BrandingType type);
+
+    [[nodiscard]] static UpgradeType upgradeType();
+    static void setUpgradeType(const UpgradeType type);
+
+    /// Returns QSettings from a legacy config file. Ownership is transferred to the caller.
+    [[nodiscard]] static LegacyData legacyData();
+
+    /// Set during first time migration of legacy accounts in AccountManager
+    [[nodiscard]] static QString discoveredLegacyConfigPath();
+    static void setDiscoveredLegacyConfigPath(const QString &discoveredLegacyConfigPath);
+
+    [[nodiscard]] static bool isUpgrade();
+    [[nodiscard]] static bool isDowngrade();
+    [[nodiscard]] static bool versionChanged();
+    [[nodiscard]] static bool shouldTryUnbrandedToBrandedMigration();
+    [[nodiscard]] static bool isUnbrandedToBrandedMigration();
+    [[nodiscard]] static bool shouldTryToMigrate();
+    [[nodiscard]] static bool isInProgress();
+
+    /// Resets all shared state to initial values. Only intended for use in unit tests.
+    static void resetForTesting();
+
+private:
+    static Phase _phase;
+    static BrandingType _brandingType;
+    static UpgradeType _upgradeType;
+    static QString _discoveredLegacyConfigPath;
+};
+}
+#endif // MIGRATION_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -154,6 +154,7 @@ nextcloud_add_test(Account)
 nextcloud_add_test(Folder)
 nextcloud_add_test(FolderMan)
 nextcloud_add_test(RemoteWipe)
+nextcloud_add_test(Migration)
 
 if(NOT BUILD_FILE_PROVIDER_MODULE)
     # the File Provider build crashes this test in CI for some reason

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,7 @@ nextcloud_add_test(Folder)
 nextcloud_add_test(FolderMan)
 nextcloud_add_test(ForceSyncNow)
 nextcloud_add_test(RemoteWipe)
+nextcloud_add_test(Migration)
 
 if(NOT BUILD_FILE_PROVIDER_MODULE)
     # the File Provider build crashes this test in CI for some reason

--- a/test/testmigration.cpp
+++ b/test/testmigration.cpp
@@ -17,6 +17,7 @@
 #include "syncenginetestutils.h"
 #include "testhelper.h"
 #include "version.h"
+#include "settings/migration.h"
 
 using namespace OCC;
 

--- a/test/testmigration.cpp
+++ b/test/testmigration.cpp
@@ -1,0 +1,220 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <qglobal.h>
+#include <QTemporaryDir>
+#include <QtTest>
+#include <QtTest/qtestcase.h>
+
+#include "common/utility.h"
+#include "folderman.h"
+#include "account.h"
+#include "accountstate.h"
+#include "accountmanager.h"
+#include "configfile.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+#include "version.h"
+
+using namespace OCC;
+
+class TestMigration: public QObject
+{
+    Q_OBJECT
+
+    ConfigFile _configFile;
+    QTemporaryDir _temporaryDir;
+    std::unique_ptr<FolderMan> _folderMan;
+
+private:
+    static constexpr char legacyAppName[] = "ownCloud";
+    static constexpr char standardAppName[] = "Nextcloud";
+    static constexpr char brandedAppName[] = "Branded";
+    static constexpr char ocBrandedAppName[] = "branded";
+    static constexpr char legacyAppConfigContent[] = "[General]\n"
+        "clientVersion=5.3.2.15463\n"
+        "issuesWidgetFilter=FatalError, BlacklistedError, Excluded, Message, FilenameReserved\n"
+        "logHttp=false\n"
+        "optionalDesktopNotifications=true\n"
+        "\n"
+        "[Accounts]e\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\davUrl=@Variant(http://oc.de/remote.php/dav/files/admin/)\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\deployed=false\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\displayString=ownCloud\n"
+        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\ignoreHiddenFiles=true\n"
+        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\journalPath=.sync_journal.db\n"
+        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\localPath=/ownCloud/\n"
+        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\paused=false\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\priority=0\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\targetPath=/\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\version=13\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\virtualFilesMode=off\n"
+        "0\\capabilities=@QVariant()\n"
+        "0\\dav_user=admin\n"
+        "0\\default_sync_root=/ownCloud\n"
+        "0\\display-name=admin\n"
+        "0\\http_CredentialVersion=1\n"
+        "0\\http_oauth=false\n"
+        "0\\http_user=admin\n"
+        "0\\supportsSpaces=true\n"
+        "0\\url=http://oc.de/\n"
+        "0\\user=admin\n"
+        "0\\userExplicitlySignedOut=false\n"
+        "0\\uuid=@Variant()\n"
+        "0\\version=13\n"
+        "version=13\n"
+        "\n"
+        "[Credentials]\n"
+        "ownCloud_credentials%oc.de%2ba4b09a-1223-aaaa-abcd-c2df238816d8\\http\\password=true";
+
+private slots:
+    void setupStandardConfigFolder()
+    {
+        QVERIFY(QDir(_temporaryDir.path()).mkpath(standardAppName));
+        const auto standardConfigFolder = QString(_temporaryDir.path() + "/" + standardAppName);
+        _configFile.setConfDir(standardConfigFolder);
+    }
+
+    void setupStandarConfig(const QString &version)
+    {
+        setupStandardConfigFolder();
+        QSettings settings(_configFile.configFile(), QSettings::IniFormat);
+        _configFile.setClientVersionString(version);
+        _configFile.setOptionalServerNotifications(true);
+        _configFile.setShowChatNotifications(true);
+        _configFile.setShowCallNotifications(true);
+        _configFile.setShowInExplorerNavigationPane(true);
+        _configFile.setShowInExplorerNavigationPane(true);
+        _configFile.setRemotePollInterval(std::chrono::milliseconds(1000));
+        _configFile.setAutoUpdateCheck(true, QString());
+        _configFile.setUpdateChannel("beta");
+        _configFile.setOverrideServerUrl("http://example.de");
+        _configFile.setOverrideLocalDir("A");
+        _configFile.setVfsEnabled(true);
+        _configFile.setProxyType(0);
+        _configFile.setVfsEnabled(true);
+        _configFile.setUseUploadLimit(0);
+        _configFile.setUploadLimit(1);
+        _configFile.setUseDownloadLimit(0);
+        _configFile.setUseDownloadLimit(1);
+        _configFile.setNewBigFolderSizeLimit(true, 500);
+        _configFile.setNotifyExistingFoldersOverLimit(true);
+        _configFile.setStopSyncingExistingFoldersOverLimit(true);
+        _configFile.setConfirmExternalStorage(true);
+        _configFile.setMoveToTrash(true);
+        _configFile.setForceLoginV2(true);
+        _configFile.setPromptDeleteFiles(true);
+        _configFile.setDeleteFilesThreshold(1);
+        _configFile.setMonoIcons(true);
+        _configFile.setAutomaticLogDir(true);
+        _configFile.setLogDir(_temporaryDir.path());
+        _configFile.setLogDebug(true);
+        _configFile.setLogExpire(72);
+        _configFile.setLogFlush(true);
+        _configFile.setCertificatePath(_temporaryDir.path());
+        _configFile.setCertificatePasswd("123456");
+        _configFile.setLaunchOnSystemStartup(true);
+        _configFile.setServerHasValidSubscription(true);
+        _configFile.setDesktopEnterpriseChannel("stable");
+        _configFile.setLanguage("pt");
+        settings.sync();
+        QVERIFY(_configFile.exists());
+        QScopedPointer<FakeQNAM> fakeQnam(new FakeQNAM({}));
+        OCC::AccountPtr account = OCC::Account::create();
+        account->setDavUser("user");
+        account->setDavDisplayName("Nextcloud user");
+        // TODO: detangle UI from logic
+        //account->setProxyType(QNetworkProxy::ProxyType::HttpProxy);
+        //account->setProxyUser("proxyuser");
+        account->setDownloadLimit(120);
+        account->setUploadLimit(120);
+        account->setDownloadLimitSetting(OCC::Account::AccountNetworkTransferLimitSetting::ManualLimit);
+        account->setServerVersion("30");
+        account->setCredentials(new FakeCredentials{fakeQnam.data()});
+        account->setUrl(QUrl(("http://example.de")));
+        const auto accountState = OCC::AccountManager::instance()->addAccount(account);
+        OCC::AccountManager::instance()->saveAccount(accountState->account());
+        OCC::FolderDefinition folderDefinition;
+        folderDefinition.localPath = "/standardAppName";
+        folderDefinition.targetPath = "/";
+        folderDefinition.alias = standardAppName;
+        _folderMan.reset({});
+        _folderMan.reset(new FolderMan{});
+        QVERIFY(_folderMan->addFolder(accountState, folderDefinition));
+    }
+
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogFlush(true);
+        OCC::Logger::instance()->setLogDebug(true);
+
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    void testSetPhase()
+    {
+        Migration migration;
+        QCOMPARE(migration.phase(), OCC::Migration::Phase::NotStarted);
+        migration.setPhase(OCC::Migration::Phase::SetupConfigFile);
+        QCOMPARE(migration.phase(), OCC::Migration::Phase::SetupConfigFile);
+        migration.setPhase(OCC::Migration::Phase::SetupUsers);
+        QCOMPARE(migration.phase(), OCC::Migration::Phase::SetupUsers);
+        migration.setPhase(OCC::Migration::Phase::SetupFolders);
+        QCOMPARE(migration.phase(), OCC::Migration::Phase::SetupFolders);
+        migration.setPhase(OCC::Migration::Phase::Done);
+        QCOMPARE(migration.phase(), OCC::Migration::Phase::Done);
+    }
+
+    void testSetUpgradeType()
+    {
+        Migration migration;
+        QCOMPARE(migration.upgradeType(), OCC::Migration::UpgradeType::NoChange);
+        migration.setUpgradeType(OCC::Migration::UpgradeType::Upgrade);
+        QCOMPARE(migration.upgradeType(), OCC::Migration::UpgradeType::Upgrade);
+        migration.setUpgradeType(OCC::Migration::UpgradeType::Downgrade);
+        QCOMPARE(migration.upgradeType(), OCC::Migration::UpgradeType::Downgrade);
+    }
+
+    void testSetBrandingType()
+    {
+        Migration migration;
+        QCOMPARE(migration.brandingType(), OCC::Migration::BrandingType::UnbrandedToUnbranded);
+        migration.setBrandingType(OCC::Migration::BrandingType::LegacyToUnbranded);
+        QCOMPARE(migration.brandingType(), OCC::Migration::BrandingType::LegacyToUnbranded);
+        migration.setBrandingType(OCC::Migration::BrandingType::LegacyToBranded);
+        QCOMPARE(migration.brandingType(), OCC::Migration::BrandingType::LegacyToBranded);
+        migration.setBrandingType(OCC::Migration::BrandingType::UnbrandedToBranded);
+        QCOMPARE(migration.brandingType(), OCC::Migration::BrandingType::UnbrandedToBranded);
+    }
+
+    void testSetDiscoveredLegacyConfigPath()
+    {
+        Migration migration;
+        QCOMPARE(migration.discoveredLegacyConfigPath(), QString());
+        const auto legacyConfigPath = QString("/path/to/legacy/config");
+        migration.setDiscoveredLegacyConfigPath(legacyConfigPath);
+        QCOMPARE(migration.discoveredLegacyConfigPath(), legacyConfigPath);
+    }
+
+    void testUpgrade()
+    {
+        // create Nextcloud config with older version
+        setupStandarConfig("1.0.0");
+        Migration migration;
+        QCOMPARE(migration.isUpgrade(), true);
+
+        // backup old config
+        const auto backupFilesList = _configFile.backupConfigFiles();
+        QCOMPARE_GE(backupFilesList.size(), 1);
+
+        // successfully upgrade to new config
+        const auto afterUpgradeVersionNumber = MIRALL_VERSION_STRING;
+        _configFile.setClientVersionString(afterUpgradeVersionNumber);
+        QCOMPARE(_configFile.clientVersionString(), MIRALL_VERSION_STRING);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestMigration)
+#include "testmigration.moc"

--- a/test/testmigration.cpp
+++ b/test/testmigration.cpp
@@ -154,10 +154,15 @@ private slots:
         QStandardPaths::setTestModeEnabled(true);
     }
 
-    // Reset all static Migration state before every test so tests are independent.
+    // Reset all Migration static state and QSettings config before every test
+    // so tests are fully independent of each other.
     void init()
     {
         Migration::resetForTesting();
+        setupStandardConfigFolder();
+        QSettings settings(_configFile.configFile(), QSettings::IniFormat);
+        settings.clear();
+        settings.sync();
     }
 
     void testSetPhase()
@@ -278,9 +283,8 @@ private slots:
 
     void testIsDowngrade_noSideEffects()
     {
-        // simulate a downgrade: set previous version to a future version
-        setupStandardConfigFolder();
-        _configFile.setClientVersionString("99.0.0");
+        // simulate a downgrade: the previously installed version was newer than the current binary
+        _configFile.setClientPreviousVersionString("99.0.0");
 
         Migration migration;
         QCOMPARE(migration.isDowngrade(), true);

--- a/test/testmigration.cpp
+++ b/test/testmigration.cpp
@@ -40,14 +40,14 @@ private:
         "logHttp=false\n"
         "optionalDesktopNotifications=true\n"
         "\n"
-        "[Accounts]e\n"
+        "[Accounts]\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\davUrl=@Variant(http://oc.de/remote.php/dav/files/admin/)\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\deployed=false\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\displayString=ownCloud\n"
-        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\ignoreHiddenFiles=true\n"
-        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\journalPath=.sync_journal.db\n"
-        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\localPath=/ownCloud/\n"
-        "0\\Folders\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\paused=false\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\ignoreHiddenFiles=true\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\journalPath=.sync_journal.db\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\localPath=/ownCloud/\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\paused=false\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\priority=0\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\targetPath=/\n"
         "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\version=13\n"
@@ -154,6 +154,12 @@ private slots:
         QStandardPaths::setTestModeEnabled(true);
     }
 
+    // Reset all static Migration state before every test so tests are independent.
+    void init()
+    {
+        Migration::resetForTesting();
+    }
+
     void testSetPhase()
     {
         Migration migration;
@@ -214,6 +220,114 @@ private slots:
         const auto afterUpgradeVersionNumber = MIRALL_VERSION_STRING;
         _configFile.setClientVersionString(afterUpgradeVersionNumber);
         QCOMPARE(_configFile.clientVersionString(), MIRALL_VERSION_STRING);
+    }
+
+    void testIsInProgress_notStarted()
+    {
+        Migration migration;
+        QCOMPARE(migration.phase(), Migration::Phase::NotStarted);
+        QCOMPARE(migration.isInProgress(), false);
+    }
+
+    void testIsInProgress_trueForMidPhases()
+    {
+        Migration migration;
+        migration.setPhase(Migration::Phase::SetupConfigFile);
+        QCOMPARE(migration.isInProgress(), true);
+
+        Migration::resetForTesting();
+        migration.setPhase(Migration::Phase::SetupUsers);
+        QCOMPARE(migration.isInProgress(), true);
+
+        Migration::resetForTesting();
+        migration.setPhase(Migration::Phase::SetupFolders);
+        QCOMPARE(migration.isInProgress(), true);
+    }
+
+    void testIsInProgress_falseWhenDone()
+    {
+        Migration migration;
+        migration.setPhase(Migration::Phase::Done);
+        QCOMPARE(migration.isInProgress(), false);
+    }
+
+    void testPhaseRollbackPrevented()
+    {
+        Migration migration;
+        migration.setPhase(Migration::Phase::Done);
+        migration.setPhase(Migration::Phase::SetupUsers);  // attempt rollback
+        QCOMPARE(migration.phase(), Migration::Phase::Done);
+    }
+
+    void testIsUpgrade_noSideEffects()
+    {
+        setupStandarConfig("1.0.0");
+        Migration migration;
+
+        // upgrading: current > previous
+        QCOMPARE(migration.isUpgrade(), true);
+        QCOMPARE(migration.isDowngrade(), false);
+        QCOMPARE(migration.versionChanged(), true);
+
+        // calling isDowngrade after isUpgrade must not corrupt the result
+        QCOMPARE(migration.isUpgrade(), true);
+
+        // upgradeType is not touched by isUpgrade/isDowngrade
+        QCOMPARE(migration.upgradeType(), Migration::UpgradeType::NoChange);
+    }
+
+    void testIsDowngrade_noSideEffects()
+    {
+        // simulate a downgrade: set previous version to a future version
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString("99.0.0");
+
+        Migration migration;
+        QCOMPARE(migration.isDowngrade(), true);
+        QCOMPARE(migration.isUpgrade(), false);
+        QCOMPARE(migration.versionChanged(), true);
+
+        // upgradeType is not touched by isDowngrade
+        QCOMPARE(migration.upgradeType(), Migration::UpgradeType::NoChange);
+    }
+
+    void testVersionUnchanged()
+    {
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(MIRALL_VERSION_STRING);
+        _configFile.setClientPreviousVersionString(MIRALL_VERSION_STRING);
+
+        Migration migration;
+        QCOMPARE(migration.isUpgrade(), false);
+        QCOMPARE(migration.isDowngrade(), false);
+        QCOMPARE(migration.versionChanged(), false);
+    }
+
+    void testShouldTryToMigrate_trueOnUpgrade()
+    {
+        setupStandarConfig("1.0.0");
+        Migration migration;
+        QCOMPARE(migration.shouldTryToMigrate(), true);
+    }
+
+    void testShouldTryToMigrate_falseWhenVersionsMatch()
+    {
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(MIRALL_VERSION_STRING);
+        _configFile.setClientPreviousVersionString(MIRALL_VERSION_STRING);
+
+        Migration migration;
+        QCOMPARE(migration.shouldTryToMigrate(), false);
+    }
+
+    void testStaticStateSharedAcrossInstances()
+    {
+        Migration a;
+        a.setPhase(Migration::Phase::SetupUsers);
+
+        Migration b;
+        QCOMPARE(b.phase(), Migration::Phase::SetupUsers);
+        QCOMPARE(b.isInProgress(), true);
     }
 };
 

--- a/test/testmigration.cpp
+++ b/test/testmigration.cpp
@@ -1,0 +1,381 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <qglobal.h>
+#include <QTemporaryDir>
+#include <QtTest>
+#include <QtTest/qtestcase.h>
+
+#include "common/utility.h"
+#include "folderman.h"
+#include "account.h"
+#include "accountstate.h"
+#include "accountmanager.h"
+#include "configfile.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+#include "version.h"
+#include "settings/migration.h"
+
+using namespace OCC;
+
+class TestMigration: public QObject
+{
+    Q_OBJECT
+
+    ConfigFile _configFile;
+    QTemporaryDir _temporaryDir;
+    std::unique_ptr<FolderMan> _folderMan;
+
+private:
+    static constexpr char standardAppName[] = "Nextcloud";
+    static constexpr char legacyAppConfigContent[] = "[General]\n"
+        "clientVersion=5.3.2.15463\n"
+        "issuesWidgetFilter=FatalError, BlacklistedError, Excluded, Message, FilenameReserved\n"
+        "logHttp=false\n"
+        "optionalDesktopNotifications=true\n"
+        "\n"
+        "[Accounts]\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\davUrl=@Variant(http://oc.de/remote.php/dav/files/admin/)\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\deployed=false\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\displayString=ownCloud\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\ignoreHiddenFiles=true\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\journalPath=.sync_journal.db\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\localPath=/ownCloud/\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\paused=false\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\priority=0\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\targetPath=/\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\version=13\n"
+        "0\\Folders\\2ba4b09a-1223-aaaa-abcd-c2df238816d8\\virtualFilesMode=off\n"
+        "0\\capabilities=@QVariant()\n"
+        "0\\dav_user=admin\n"
+        "0\\default_sync_root=/ownCloud\n"
+        "0\\display-name=admin\n"
+        "0\\http_CredentialVersion=1\n"
+        "0\\http_oauth=false\n"
+        "0\\http_user=admin\n"
+        "0\\supportsSpaces=true\n"
+        "0\\url=http://oc.de/\n"
+        "0\\user=admin\n"
+        "0\\userExplicitlySignedOut=false\n"
+        "0\\uuid=@Variant()\n"
+        "0\\version=13\n"
+        "version=13\n"
+        "\n"
+        "[Credentials]\n"
+        "ownCloud_credentials%oc.de%2ba4b09a-1223-aaaa-abcd-c2df238816d8\\http\\password=true";
+
+private Q_SLOTS:
+    void setupStandardConfigFolder()
+    {
+        QVERIFY(QDir(_temporaryDir.path()).mkpath(standardAppName));
+        const auto standardConfigFolder = QString(_temporaryDir.path() + "/" + standardAppName);
+        _configFile.setConfDir(standardConfigFolder);
+    }
+
+    void setupStandardConfig(const QString &version)
+    {
+        setupStandardConfigFolder();
+        QSettings settings(_configFile.configFile(), QSettings::IniFormat);
+        _configFile.setClientVersionString(version);
+        _configFile.setOptionalServerNotifications(true);
+        _configFile.setShowChatNotifications(true);
+        _configFile.setShowCallNotifications(true);
+        _configFile.setShowInExplorerNavigationPane(true);
+        _configFile.setRemotePollInterval(std::chrono::milliseconds(1000));
+        _configFile.setAutoUpdateCheck(true, QString());
+        _configFile.setUpdateChannel("beta");
+        _configFile.setOverrideServerUrl("http://example.de");
+        _configFile.setOverrideLocalDir("A");
+        _configFile.setVfsEnabled(true);
+        _configFile.setProxyType(0);
+        _configFile.setUseUploadLimit(0);
+        _configFile.setUploadLimit(1);
+        _configFile.setUseDownloadLimit(0);
+        _configFile.setUseDownloadLimit(1);
+        _configFile.setNewBigFolderSizeLimit(true, 500);
+        _configFile.setNotifyExistingFoldersOverLimit(true);
+        _configFile.setStopSyncingExistingFoldersOverLimit(true);
+        _configFile.setConfirmExternalStorage(true);
+        _configFile.setMoveToTrash(true);
+        _configFile.setPromptDeleteFiles(true);
+        _configFile.setDeleteFilesThreshold(1);
+        _configFile.setMonoIcons(true);
+        _configFile.setAutomaticLogDir(true);
+        _configFile.setLogDir(_temporaryDir.path());
+        _configFile.setLogDebug(true);
+        _configFile.setLogExpire(72);
+        _configFile.setLogFlush(true);
+        _configFile.setCertificatePath(_temporaryDir.path());
+        _configFile.setCertificatePasswd("123456");
+        _configFile.setLaunchOnSystemStartup(true);
+        _configFile.setServerHasValidSubscription(true);
+        _configFile.setDesktopEnterpriseChannel("stable");
+        _configFile.setLanguage("pt");
+        settings.sync();
+        QVERIFY(_configFile.exists());
+        QScopedPointer<FakeQNAM> fakeQnam(new FakeQNAM({}));
+        OCC::AccountPtr account = OCC::Account::create();
+        account->setDavUser("user");
+        account->setDavDisplayName("Nextcloud user");
+        // TODO: detangle UI from logic
+        //account->setProxyType(QNetworkProxy::ProxyType::HttpProxy);
+        //account->setProxyUser("proxyuser");
+        account->setDownloadLimit(120);
+        account->setUploadLimit(120);
+        account->setDownloadLimitSetting(OCC::Account::AccountNetworkTransferLimitSetting::ManualLimit);
+        account->setServerVersion("30");
+        account->setCredentials(new FakeCredentials{fakeQnam.data()});
+        account->setUrl(QUrl(("http://example.de")));
+        const auto accountState = OCC::AccountManager::instance()->addAccount(account);
+        OCC::AccountManager::instance()->saveAccount(accountState->account());
+        OCC::FolderDefinition folderDefinition;
+        const auto localFolder = QString(_temporaryDir.path() + "/syncfolder");
+        QVERIFY(QDir().mkpath(localFolder));
+        folderDefinition.localPath = localFolder;
+        folderDefinition.targetPath = "/";
+        folderDefinition.alias = standardAppName;
+        _folderMan.reset(new FolderMan{});
+        QVERIFY(_folderMan->addFolder(accountState, folderDefinition));
+    }
+
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogFlush(true);
+        OCC::Logger::instance()->setLogDebug(true);
+
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    // Reset all Migration static state and QSettings config before every test
+    // so tests are fully independent of each other.
+    void init()
+    {
+        Migration::resetForTesting();
+        setupStandardConfigFolder();
+        QSettings settings(_configFile.configFile(), QSettings::IniFormat);
+        settings.clear();
+        settings.sync();
+    }
+
+    // Release the folders and accounts created by setupStandardConfig so they
+    // do not leak into the AccountManager singleton across tests.
+    void cleanup()
+    {
+        _folderMan.reset();
+        if (const auto accountManager = AccountManager::instance()) {
+            accountManager->shutdown();
+        }
+    }
+
+    void testSetPhase()
+    {
+        QCOMPARE(Migration::phase(), OCC::Migration::Phase::NotStarted);
+        Migration::setPhase(OCC::Migration::Phase::SetupConfigFile);
+        QCOMPARE(Migration::phase(), OCC::Migration::Phase::SetupConfigFile);
+        Migration::setPhase(OCC::Migration::Phase::SetupUsers);
+        QCOMPARE(Migration::phase(), OCC::Migration::Phase::SetupUsers);
+        Migration::setPhase(OCC::Migration::Phase::SetupFolders);
+        QCOMPARE(Migration::phase(), OCC::Migration::Phase::SetupFolders);
+        Migration::setPhase(OCC::Migration::Phase::Done);
+        QCOMPARE(Migration::phase(), OCC::Migration::Phase::Done);
+    }
+
+    void testSetUpgradeType()
+    {
+        QCOMPARE(Migration::upgradeType(), OCC::Migration::UpgradeType::NoChange);
+        Migration::setUpgradeType(OCC::Migration::UpgradeType::Upgrade);
+        QCOMPARE(Migration::upgradeType(), OCC::Migration::UpgradeType::Upgrade);
+        Migration::setUpgradeType(OCC::Migration::UpgradeType::Downgrade);
+        QCOMPARE(Migration::upgradeType(), OCC::Migration::UpgradeType::Downgrade);
+    }
+
+    void testSetBrandingType()
+    {
+        QCOMPARE(Migration::brandingType(), OCC::Migration::BrandingType::UnbrandedToUnbranded);
+        Migration::setBrandingType(OCC::Migration::BrandingType::LegacyToUnbranded);
+        QCOMPARE(Migration::brandingType(), OCC::Migration::BrandingType::LegacyToUnbranded);
+        Migration::setBrandingType(OCC::Migration::BrandingType::LegacyToBranded);
+        QCOMPARE(Migration::brandingType(), OCC::Migration::BrandingType::LegacyToBranded);
+        Migration::setBrandingType(OCC::Migration::BrandingType::UnbrandedToBranded);
+        QCOMPARE(Migration::brandingType(), OCC::Migration::BrandingType::UnbrandedToBranded);
+    }
+
+    void testSetDiscoveredLegacyConfigPath()
+    {
+        QCOMPARE(Migration::discoveredLegacyConfigPath(), QString());
+        const auto legacyConfigPath = QString("/path/to/legacy/config");
+        Migration::setDiscoveredLegacyConfigPath(legacyConfigPath);
+        QCOMPARE(Migration::discoveredLegacyConfigPath(), legacyConfigPath);
+    }
+
+    void testUpgrade()
+    {
+        // create Nextcloud config with older version
+        setupStandardConfig("1.0.0");
+        QCOMPARE(Migration::isUpgrade(), true);
+
+        // backup old config
+        const auto backupFilesList = _configFile.backupConfigFiles();
+        QCOMPARE_GE(backupFilesList.size(), 1);
+
+        // successfully upgrade to new config
+        const auto afterUpgradeVersionNumber = MIRALL_VERSION_STRING;
+        _configFile.setClientVersionString(afterUpgradeVersionNumber);
+        QCOMPARE(_configFile.clientVersionString(), MIRALL_VERSION_STRING);
+        QCOMPARE(Migration::isUpgrade(), false);
+    }
+
+    void testIsInProgress_notStarted()
+    {
+        QCOMPARE(Migration::phase(), Migration::Phase::NotStarted);
+        QCOMPARE(Migration::isInProgress(), false);
+    }
+
+    void testIsInProgress_trueForMidPhases()
+    {
+        Migration::setPhase(Migration::Phase::SetupConfigFile);
+        QCOMPARE(Migration::isInProgress(), true);
+
+        Migration::resetForTesting();
+        Migration::setPhase(Migration::Phase::SetupUsers);
+        QCOMPARE(Migration::isInProgress(), true);
+
+        Migration::resetForTesting();
+        Migration::setPhase(Migration::Phase::SetupFolders);
+        QCOMPARE(Migration::isInProgress(), true);
+    }
+
+    void testIsInProgress_falseWhenDone()
+    {
+        Migration::setPhase(Migration::Phase::Done);
+        QCOMPARE(Migration::isInProgress(), false);
+    }
+
+    void testPhaseRollbackPrevented()
+    {
+        Migration::setPhase(Migration::Phase::Done);
+        Migration::setPhase(Migration::Phase::SetupUsers);  // attempt rollback
+        QCOMPARE(Migration::phase(), Migration::Phase::Done);
+    }
+
+    void testIsUpgrade_noSideEffects()
+    {
+        setupStandardConfig("1.0.0");
+
+        // upgrading: current > previous
+        QCOMPARE(Migration::isUpgrade(), true);
+        QCOMPARE(Migration::isDowngrade(), false);
+        QCOMPARE(Migration::versionChanged(), true);
+
+        // calling isDowngrade after isUpgrade must not corrupt the result
+        QCOMPARE(Migration::isUpgrade(), true);
+
+        // upgradeType is not touched by isUpgrade/isDowngrade
+        QCOMPARE(Migration::upgradeType(), Migration::UpgradeType::NoChange);
+    }
+
+    void testIsDowngrade_noSideEffects()
+    {
+        // simulate a downgrade: the config was written by a newer client than the current binary
+        _configFile.setClientVersionString("99.0.0");
+
+        QCOMPARE(Migration::isDowngrade(), true);
+        QCOMPARE(Migration::isUpgrade(), false);
+        QCOMPARE(Migration::versionChanged(), true);
+
+        // upgradeType is not touched by isDowngrade
+        QCOMPARE(Migration::upgradeType(), Migration::UpgradeType::NoChange);
+    }
+
+    void testVersionUnchanged()
+    {
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(MIRALL_VERSION_STRING);
+        _configFile.setClientPreviousVersionString(MIRALL_VERSION_STRING);
+
+        QCOMPARE(Migration::isUpgrade(), false);
+        QCOMPARE(Migration::isDowngrade(), false);
+        QCOMPARE(Migration::versionChanged(), false);
+    }
+
+    void testShouldTryToMigrate_trueOnUpgrade()
+    {
+        setupStandardConfig("1.0.0");
+        QCOMPARE(Migration::shouldTryToMigrate(), true);
+    }
+
+    void testShouldTryToMigrate_falseWhenVersionsMatch()
+    {
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(MIRALL_VERSION_STRING);
+        _configFile.setClientPreviousVersionString(MIRALL_VERSION_STRING);
+
+        QCOMPARE(Migration::shouldTryToMigrate(), false);
+    }
+
+    void testShouldTryToMigrate_falseWhenConfigMatchesRunningVersion()
+    {
+        // clientVersion already equals the running binary: nothing to migrate,
+        // even though an older previous version is recorded.
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(MIRALL_VERSION_STRING);
+        _configFile.setClientPreviousVersionString(QStringLiteral("1.0.0"));
+
+        QCOMPARE(Migration::shouldTryToMigrate(), false);
+    }
+
+    void testShouldTryToMigrate_trueWhenUpgradingFromMatchingVersions()
+    {
+        // A genuine upgrade in which clientVersion equals clientPreviousVersion
+        // (the previous run settled), so migration must still run.
+        setupStandardConfigFolder();
+        _configFile.setClientVersionString(QStringLiteral("1.0.0"));
+        _configFile.setClientPreviousVersionString(QStringLiteral("1.0.0"));
+
+        QCOMPARE(Migration::shouldTryToMigrate(), true);
+    }
+
+    void testLegacyData_discoversAndParsesConfig()
+    {
+        // No current config keys, so legacyData() searches the legacy locations.
+        setupStandardConfigFolder();
+
+        // Place a legacy owncloud.cfg next to the themed config file.
+        const auto configDir = QFileInfo(_configFile.configFile()).absolutePath();
+        const auto legacyConfigPath = configDir + QStringLiteral("/owncloud.cfg");
+        QFile legacyFile(legacyConfigPath);
+        QVERIFY(legacyFile.open(QIODevice::WriteOnly | QIODevice::Text));
+        legacyFile.write(legacyAppConfigContent);
+        legacyFile.close();
+
+        const auto legacy = Migration::legacyData();
+
+        // Sole ownership is transferred to the caller and the file is parsed.
+        QVERIFY(legacy != nullptr);
+        QCOMPARE(legacy->value(QStringLiteral("clientVersion")).toString(), QStringLiteral("5.3.2.15463"));
+        legacy->beginGroup(QStringLiteral("Accounts"));
+        QVERIFY(legacy->childGroups().contains(QStringLiteral("0")));
+        legacy->endGroup();
+        QVERIFY(Migration::discoveredLegacyConfigPath().isEmpty());
+    }
+
+    void testLegacyData_returnsNullWhenNoLegacyConfig()
+    {
+        setupStandardConfigFolder();
+        // The config dir is shared between tests, so drop any legacy file a
+        // previous test may have written.
+        const auto configDir = QFileInfo(_configFile.configFile()).absolutePath();
+        QFile::remove(configDir + QStringLiteral("/owncloud.cfg"));
+
+        const auto legacy = Migration::legacyData();
+
+        QVERIFY(!legacy);
+        QCOMPARE(Migration::discoveredLegacyConfigPath(), QString());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestMigration)
+#include "testmigration.moc"


### PR DESCRIPTION
## refactor: extract migration into OCC::Migration
Moves client startup migration out of `ConfigFile`, `Application`, `AccountManager`, `AccountState` and `FolderMan` into a dedicated `OCC::Migration` helper under `src/libsync/settings`.

### What changed
- `OCC::Migration` owns the phase, version and legacy discovery logic, as a static only helper.
- `legacyData()` is pure discovery returning an owning `QSettings`; the discovered path is recorded only after the user confirms the import.
- `Application::configVersionMigration` reuses `ConfigFile::backupConfigFiles`.
- Unit tests in `test/testmigration.cpp`.
- Flow documented in `src/libsync/settings/MIGRATION.md`.
