### PR TITLE
fix(upgrade): set the previous client version after the upgrade check.

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -132,10 +132,9 @@ bool Application::configVersionMigration()
     QStringList deleteKeys, ignoreKeys;
     AccountManager::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
     FolderMan::backwardMigrationSettingsKeys(&deleteKeys, &ignoreKeys);
-    configFile.setClientPreviousVersionString(configFile.clientVersionString());
     
     qCDebug(lcApplication) << "Migration is in progress:"  << configFile.isMigrationInProgress();
-    const auto versionChanged = configFile.isUpgrade() || configFile.isDowngrade();
+    const auto versionChanged = configFile.hasVersionChanged();
     if (versionChanged) {
         qCInfo(lcApplication) << "Version changed. Removing updater settings from config.";
         configFile.cleanUpdaterConfiguration();
@@ -205,6 +204,7 @@ bool Application::configVersionMigration()
         }
     }
 
+    configFile.setClientPreviousVersionString(configFile.clientVersionString());
     configFile.setClientVersionString(MIRALL_VERSION_STRING);
     return true;
 }

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -1396,15 +1396,14 @@ bool ConfigFile::isUnbrandedToBrandedMigrationInProgress() const
 
 bool ConfigFile::shouldTryToMigrate() const
 {
-    return !isClientVersionSet() && (isUpgrade() || isDowngrade());
+    return hasVersionChanged() && (isUpgrade() || isDowngrade());
 }
 
-bool ConfigFile::isClientVersionSet() const
+bool ConfigFile::hasVersionChanged() const
 {
-    const auto currentVersion = QVersionNumber::fromString(MIRALL_VERSION_STRING);
-    const auto clientConfigVersion = QVersionNumber::fromString(clientVersionString());
-    const auto isVersionSet = !clientConfigVersion.isNull() && !clientPreviousVersionString().isEmpty();
-    return isVersionSet && clientConfigVersion == currentVersion;
+    const auto currentVersion = QVersionNumber::fromString(MIRALL_VERSION_STRING); //app running
+    const auto clientConfigVersion = QVersionNumber::fromString(clientVersionString()); //config version
+    return clientConfigVersion != currentVersion;
 }
 
 bool ConfigFile::isMigrationInProgress() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -277,7 +277,8 @@ public:
     [[nodiscard]] bool shouldTryUnbrandedToBrandedMigration() const;
     [[nodiscard]] bool isUnbrandedToBrandedMigrationInProgress() const;
     [[nodiscard]] bool shouldTryToMigrate() const;
-    [[nodiscard]] bool isClientVersionSet() const;
+    /// Does the current app has a different version of the config version
+    [[nodiscard]] bool hasVersionChanged() const;
     [[nodiscard]] bool isMigrationInProgress() const;
     [[nodiscard]] MigrationPhase migrationPhase() const;
     void setMigrationPhase(const MigrationPhase phase);


### PR DESCRIPTION
Consider that an empty previous client version is also an upgrade as long as the app running has a different version of the client version saved in the config file.
