### PR TITLE
fix(windows): ensure proper path conversion on Windows

### DIFF
--- a/src/csync/std/c_time.cpp
+++ b/src/csync/std/c_time.cpp
@@ -52,7 +52,8 @@ int c_utimes(const QString &uri, const time_t time)
     FILETIME filetime;
     HANDLE hFile = nullptr;
 
-    const auto wuri = reinterpret_cast<const wchar_t *>(OCC::FileSystem::longWinPath(uri).utf16());
+    const auto longPathUri = OCC::FileSystem::longWinPath(uri);
+    const auto wuri = reinterpret_cast<const wchar_t *>(longPathUri.utf16());
 
     UnixTimeToFiletime(time, &filetime);
 


### PR DESCRIPTION
ensure we properly convert any file paths to a long path form as necessary on Windows

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
