### PR TITLE
fix(windows): inode property may be missing for some entries: add it

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1394,6 +1394,14 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
                              << "dbEntry._modtime:" << dbEntry._modtime
                              << "localEntry.modtime:" << localEntry.modtime;
             _childModified = true;
+        } else if (!serverModified &&
+                   !noServerEntry &&
+                   dbEntry._fileSize == localEntry.size &&
+                   dbEntry._modtime == localEntry.modtime &&
+                   dbEntry._inode == 0 &&
+                   localEntry.inode > 0) {
+            item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
+            item->_direction = SyncFileItem::Down;
         } else {
             // Local file was changed
             item->_instruction = CSYNC_INSTRUCTION_SYNC;


### PR DESCRIPTION
when syncing in full mode (only local file system and no client DB cache), verifies that inode has a strictly positive value and if not ensure we will update it

Close #9142 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
