### PR TITLE
fix(checksums): wait for the checksum to be calculated before deletion

### DIFF
--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -177,7 +177,8 @@ ComputeChecksum::ComputeChecksum(QObject *parent)
 
 ComputeChecksum::~ComputeChecksum()
 {
-    _checksumCalculator.reset();
+    // let the checksum calculation complete before deleting the checksumCalculator instance
+    _watcher.waitForFinished();
 }
 
 void ComputeChecksum::setChecksumType(const QByteArray &type)

--- a/test/testchecksumvalidator.cpp
+++ b/test/testchecksumvalidator.cpp
@@ -225,6 +225,20 @@ private slots:
 #endif
     }
 
+#ifdef Q_OS_LINUX
+    void testDeletingComputeChecksumBeforeCalculationCompletionDoesNotCrash()
+    {
+        // Running this multiple times in a loop makes it easier to run into a crash
+        for (auto i = 0; i < 4096; i++) {
+            auto computeChecksum = new ComputeChecksum();
+            computeChecksum->setChecksumType("MD5");
+            computeChecksum->start("/dev/zero");
+            delete computeChecksum;
+        }
+
+        QVERIFY(true); // no crash occurred
+    }
+#endif
 
     void cleanupTestCase() {
     }


### PR DESCRIPTION
Follow up to #9039.  While the previous fix improved the crash rates, it was still possible for a crash around that area to still occur.

Also added a Linux-only benchmark running my reproduction steps in a loop.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
