### PR TITLE
fix: dismiss notifications.

### DIFF
--- a/src/gui/tray/notificationhandler.cpp
+++ b/src/gui/tray/notificationhandler.cpp
@@ -171,6 +171,15 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
             activity._links.insert(link._primary? 0 : activity._links.size(), link);
         }
 
+        // e.g. announcement
+        if (activity._objectType != "remote_share"_L1 && activity._links.isEmpty()) {
+            ActivityLink link;
+            link._label = tr("Dismiss");
+            link._verb = "DELETE";
+            link._primary = true;
+            activity._links.append(link);
+        }
+
         QUrl url(json.value("link"_L1).toString());
         if (!url.isEmpty()) {
             if (url.host().isEmpty()) {


### PR DESCRIPTION
Fix for https://github.com/nextcloud/desktop/issues/6797 and https://github.com/nextcloud/desktop/issues/8274.

#### Displays the notication with the option to dismiss it:
  <img width="842" height="374" alt="Screenshot 2025-12-10 at 15 46 43" src="https://github.com/user-attachments/assets/f1258440-89ec-4575-8d9c-3c061389f886" />

#### It sends delete action to server, removing the notification from the list:
  <img width="829" height="340" alt="Screenshot 2025-12-10 at 15 48 00" src="https://github.com/user-attachments/assets/9f758982-04b5-4a90-8143-9c6d5acf09f9" />
