### PR TITLE
fix(macos): Improve VFS trash behavior and add deletion warning

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderMaterialisedEnumerationObserver.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderMaterialisedEnumerationObserver.swift
@@ -22,7 +22,14 @@ class FileProviderMaterialisedEnumerationObserver: NSObject, NSFileProviderEnume
     }
 
     func didEnumerate(_ updatedItems: [NSFileProviderItemProtocol]) {
-        let updatedItemsIds = Array(updatedItems.map(\.itemIdentifier.rawValue))
+        // Filter out items that are in the trash container to prevent server-trashed
+        // items from appearing in the macOS Trash. Server trash items should only
+        // be managed through the Nextcloud web interface or desktop client.
+        let nonTrashItems = updatedItems.filter { item in
+            item.parentItemIdentifier != .trashContainer
+        }
+
+        let updatedItemsIds = Array(nonTrashItems.map(\.itemIdentifier.rawValue))
 
         for updatedItemsId in updatedItemsIds {
             allEnumeratedItemIds.insert(updatedItemsId)

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -6,6 +6,7 @@
 #include "fileprovidersettingscontroller.h"
 
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QQmlApplicationEngine>
 
 #include "gui/systray.h"
@@ -267,6 +268,25 @@ void FileProviderSettingsController::setTrashDeletionEnabledForAccount(const QSt
         emit trashDeletionEnabledForAccountChanged(userIdAtHost);
         emit trashDeletionSetForAccountChanged(userIdAtHost);
         return;
+    }
+
+    // Show warning dialog when enabling permanent deletion
+    if (setEnabled) {
+        const auto result = QMessageBox::warning(
+            nullptr,
+            tr("Enable permanent file deletion?"),
+            tr("When you delete files from the virtual drive in Finder, they will be permanently deleted from the server.\n\n"
+               "This action cannot be undone. The files will NOT go to the server's trash and cannot be restored.\n\n"
+               "Are you sure you want to enable this feature?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+
+        if (result != QMessageBox::Yes) {
+            // User cancelled, reset UI state
+            emit trashDeletionEnabledForAccountChanged(userIdAtHost);
+            emit trashDeletionSetForAccountChanged(userIdAtHost);
+            return;
+        }
     }
 
     const auto domainId = FileProviderUtils::domainIdentifierForAccountIdentifier(userIdAtHost);

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -55,9 +55,30 @@ Page {
         }
         
         CheckBox {
-            text: qsTr("Allow deletion of items in Trash")
+            id: trashDeletionCheckBox
+            text: qsTr("Permanently delete files when removed from virtual drive")
             checked: root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost)
             onClicked: root.controller.setTrashDeletionEnabledForAccount(root.accountUserIdAtHost, checked)
+
+            Connections {
+                target: root.controller
+                function onTrashDeletionEnabledForAccountChanged(accountUserIdAtHost) {
+                    if (root.accountUserIdAtHost !== accountUserIdAtHost) {
+                        return;
+                    }
+                    trashDeletionCheckBox.checked = root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost);
+                }
+            }
+        }
+
+        EnforcedPlainTextLabel {
+            Layout.fillWidth: true
+            Layout.leftMargin: trashDeletionCheckBox.indicator.width + trashDeletionCheckBox.spacing
+            visible: trashDeletionCheckBox.checked
+            text: qsTr("⚠️ Warning: Deleted files will be permanently removed from the server and cannot be restored!")
+            color: "#cc0000"
+            wrapMode: Text.WordWrap
+            font.italic: true
         }
     }
 }


### PR DESCRIPTION
## Summary
- Filter server-trashed items from macOS Trash to prevent confusion
- Add confirmation dialog when enabling permanent file deletion
- Improve UI with clearer checkbox text and visible warning label

## Test plan
- [ ] Enable VFS for a Nextcloud account on macOS
- [ ] Verify items in server trash don't appear in macOS Trash
- [ ] Toggle "Permanently delete files" and verify warning dialog appears
- [ ] Verify "No" keeps option disabled, "Yes" enables it with red warning