### PR TITLE
feat(macOS): Add trash sync toggle for FileProvider virtual files

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderDomainDefaults.swift
@@ -14,7 +14,6 @@ struct FileProviderDomainDefaults {
     /// > Warning: Do not change the raw values of these keys, as they are used in UserDefaults. Any change would make the already stored value inaccessible and be like a reset.
     ///
     private enum ConfigKey: String {
-        case trashDeletionEnabled
         case user
         case userId
         case serverUrl
@@ -85,29 +84,6 @@ struct FileProviderDomainDefaults {
     }
 
     ///
-    /// Whether trash deletion is enabled or not.
-    ///
-    var trashDeletionEnabled: Bool {
-        get {
-            let identifier = self.identifier.rawValue
-
-            if let value = internalConfig[ConfigKey.trashDeletionEnabled.rawValue] as? Bool {
-                logger.debug("Returning existing value \"\(value)\" for \"trashDeletionEnabled\" for file provider domain \"\(identifier)\".")
-                return value
-            } else {
-                return false
-            }
-        }
-
-        set {
-            let identifier = self.identifier.rawValue
-
-            logger.error("Setting value \"\(newValue)\" for \"trashDeletionEnabled\" for file provider domain \"\(identifier)\".")
-            internalConfig[ConfigKey.trashDeletionEnabled.rawValue] = newValue
-        }
-    }
-
-    ///
     /// The user name associated with the domain.
     ///
     var user: String? {
@@ -166,9 +142,4 @@ struct FileProviderDomainDefaults {
             }
         }
     }
-
-    ///
-    /// Whether a value for `trashDeletionEnabled` has been explicitly set.
-    ///
-    lazy var trashDeletionSet = internalConfig[ConfigKey.trashDeletionEnabled.rawValue] != nil
 }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -452,13 +452,6 @@ import OSLog
             
             logger.debug("Found item for identifier.", [.item: identifier, .name: item.filename])
 
-            guard config.trashDeletionEnabled || item.parentItemIdentifier != .trashContainer else {
-                logger.info("System requested deletion of item in trash, but deleting trash items is disabled. item: \(item.filename)")
-                removeSyncAction(actionId)
-                completionHandler(NSError.fileProviderErrorForRejectedDeletion(of: item))
-                return
-            }
-            
             let error = await item.delete(domain: domain, ignoredFiles: ignoredFiles, dbManager: dbManager)
             
             if error != nil {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -21,8 +21,6 @@
                         password:(NSString *)password
                        userAgent:(NSString *)userAgent;
 - (void)removeAccountConfig;
-- (void)getTrashDeletionEnabledStateWithCompletionHandler:(void(^)(BOOL enabled, BOOL set))completionHandler;
-- (void)setTrashDeletionEnabled:(BOOL)enabled;
 - (void)setIgnoreList:(NSArray<NSString *> *)ignoreList;
 
 @end

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
@@ -63,17 +63,6 @@ class ClientCommunicationService: NSObject, NSFileProviderServiceSource, NSXPCLi
         self.fpExtension.removeAccountConfig()
     }
 
-    func getTrashDeletionEnabledState(completionHandler: @escaping (Bool, Bool) -> Void) {
-        let enabled = fpExtension.config.trashDeletionEnabled
-        let set = fpExtension.config.trashDeletionSet
-        completionHandler(enabled, set)
-    }
-
-    func setTrashDeletionEnabled(_ enabled: Bool) {
-        fpExtension.config.trashDeletionEnabled = enabled
-        logger.info("Trash deletion setting changed to: \(enabled)")
-    }
-
     func setIgnoreList(_ ignoreList: [String]) {
         self.fpExtension.ignoredFiles = IgnoredFilesMatcher(ignoreList: ignoreList)
         logger.info("Ignore list updated.")

--- a/src/gui/macOS/fileprovider.h
+++ b/src/gui/macOS/fileprovider.h
@@ -36,6 +36,7 @@ public:
 
 private slots:
     void configureXPC();
+    void onDomainReconfigurationFailed(const QString &accountId, const QString &errorMessage);
 
 private:
     std::unique_ptr<FileProviderDomainManager> _domainManager;

--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -31,6 +31,7 @@ public:
 
 signals:
     void domainSetupComplete();
+    void domainReconfigurationFailed(const QString &accountId, const QString &errorMessage);
 
 public slots:
     void addFileProviderDomainForAccount(const OCC::AccountState * const accountState);
@@ -42,6 +43,7 @@ private slots:
     void removeFileProviderDomainForAccount(const OCC::AccountState * const accountState);
     void disconnectFileProviderDomainForAccount(const OCC::AccountState * const accountState, const QString &reason);
     void reconnectFileProviderDomainForAccount(const OCC::AccountState * const accountState);
+    void reconfigureFileProviderDomainForAccount(const QString &accountId);
 
     void signalEnumeratorChanged(const OCC::Account * const account);
     void slotAccountStateChanged(const OCC::AccountState * const accountState);

--- a/src/gui/macOS/fileprovidereditlocallyjob_mac.mm
+++ b/src/gui/macOS/fileprovidereditlocallyjob_mac.mm
@@ -32,18 +32,21 @@ void FileProviderEditLocallyJob::openFileProviderFile(const QString &ocId)
     const auto userId = _accountState->account()->userIdAtHostWithPort();
     const auto ncDomainManager = FileProvider::instance()->domainManager();
     const auto voidDomain = ncDomainManager->domainForAccount(_accountState.data());
-    
+
     NSFileProviderDomain *const domain = (NSFileProviderDomain *)voidDomain;
     if (domain == nil) {
         qCWarning(lcFileProviderEditLocallyMacJob) << "Could not get domain for account:" << userId;
         emit notAvailable();
+        return;
     }
 
     NSFileProviderManager *const manager = [NSFileProviderManager managerForDomain:domain]; 
+    [domain release];  // Balance retain from domainForAccount
     if (manager == nil) {
         qCWarning(lcFileProviderEditLocallyMacJob) << "Could not get file provider manager"
                                                       "for domain of account:" << userId;;
         emit notAvailable();
+        return;
     }
 
     [manager retain];

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -29,17 +29,16 @@ public:
 
     [[nodiscard]] QStringList vfsEnabledAccounts() const;
     [[nodiscard]] Q_INVOKABLE bool vfsEnabledForAccount(const QString &userIdAtHost) const;
-    [[nodiscard]] Q_INVOKABLE bool trashDeletionEnabledForAccount(const QString &userIdAtHost) const;
-    [[nodiscard]] Q_INVOKABLE bool trashDeletionSetForAccount(const QString &userIdAtHost) const;
+    [[nodiscard]] Q_INVOKABLE bool trashSyncEnabledForAccount(const QString &userIdAtHost) const;
+    [[nodiscard]] Q_INVOKABLE bool trashSyncSupported() const;
 
 public slots:
     void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled, const bool showInformationDialog = true);
-    void setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
+    void setTrashSyncEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
 
 signals:
     void vfsEnabledAccountsChanged();
-    void trashDeletionEnabledForAccountChanged(const QString &userIdAtHost);
-    void trashDeletionSetForAccountChanged(const QString &userIdAtHost);
+    void trashSyncEnabledForAccountChanged(const QString &userIdAtHost);
 
 private:
     explicit FileProviderSettingsController(QObject *parent = nullptr);

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -28,8 +28,6 @@ public:
 
     [[nodiscard]] bool fileProviderDomainReachable(const QString &fileProviderDomainIdentifier, bool retry = true, bool reconfigureOnFail = true);
 
-    [[nodiscard]] std::optional<std::pair<bool, bool>> trashDeletionEnabledStateForFileProviderDomain(const QString &fileProviderDomainIdentifier) const;
-
 public slots:
     void connectToFileProviderDomains();
     void authenticateFileProviderDomains();
@@ -37,7 +35,6 @@ public slots:
     void unauthenticateFileProviderDomain(const QString &fileProviderDomainIdentifier) const;
 
     void setIgnoreList() const;
-    void setTrashDeletionEnabledForFileProviderDomain(const QString &fileProviderDomainIdentifier, bool enabled) const;
 
 private slots:
     void slotAccountStateChanged(AccountState::State state) const;

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -53,11 +53,27 @@ Page {
             checked: root.controller.vfsEnabledForAccount(root.accountUserIdAtHost)
             onClicked: root.controller.setVfsEnabledForAccount(root.accountUserIdAtHost, checked)
         }
-        
+
         CheckBox {
-            text: qsTr("Allow deletion of items in Trash")
-            checked: root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost)
-            onClicked: root.controller.setTrashDeletionEnabledForAccount(root.accountUserIdAtHost, checked)
+            id: trashSyncCheckBox
+            visible: root.controller.trashSyncSupported()
+            text: qsTr("Integrate macOS Trash")
+            checked: root.controller.trashSyncEnabledForAccount(root.accountUserIdAtHost)
+            onClicked: root.controller.setTrashSyncEnabledForAccount(root.accountUserIdAtHost, checked)
+
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("When enabled, deleted files go to macOS Trash and server trash is visible.\nWhen disabled, Finder shows 'Delete Immediately' (files still recoverable from server trash).")
+            ToolTip.delay: 500
+
+            Connections {
+                target: root.controller
+                function onTrashSyncEnabledForAccountChanged(accountUserIdAtHost) {
+                    if (root.accountUserIdAtHost !== accountUserIdAtHost) {
+                        return;
+                    }
+                    trashSyncCheckBox.checked = root.controller.trashSyncEnabledForAccount(root.accountUserIdAtHost);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add user-configurable option to enable/disable macOS Trash integration for FileProvider domains
- When enabled: deleted files go to macOS Trash, server trash visible in Finder
- When disabled: Finder shows "Delete Immediately" (files still recoverable from server)

## Changes
- New "Integrate macOS Trash" checkbox in Virtual Files settings (macOS 13.0+)
- Per-account preference stored in NSUserDefaults
- Domain reconfiguration via remove/add cycle (supportsSyncingTrash is read-only after creation)
- Thread-safety improvements for concurrent domain registry access
- Cleanup of unused socket communication code (superseded by XPC)

## Test plan
- [ ] Enable virtual files for an account
- [ ] Toggle "Integrate macOS Trash" option on
- [ ] Delete a file in Finder → verify it appears in macOS Trash
- [ ] Open Trash in Finder → verify server trash contents are visible
- [ ] Toggle option off → verify no crash occurs
- [ ] Delete a file → verify "Delete Immediately" behavior

## Requirements
- macOS 13.0+ (option hidden on earlier versions)
- Virtual files must be enabled for the account