### PR TITLE
feat(mac-crafter): New logging.

### DIFF
--- a/admin/osx/mac-crafter/README.md
+++ b/admin/osx/mac-crafter/README.md
@@ -2,7 +2,7 @@
   - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: GPL-2.0-or-later
 -->
-# Mac Crafter
+# mac-crafter
 
 mac-crafter is a tool to easily build a fully functional Nextcloud Desktop Client for macOS.
 It automates cloning, configuring, crafting, codesigning, packaging, and even disk image creation of the client.
@@ -57,6 +57,12 @@ Additional preparation is necessary, though.
 5. Define the "PATH" environment variable. You can copy and paste the output of `echo "$PATH"` from a terminal. Otherwise the executable will not inherit your shell environment paths as necessary for Homebrew to work.
 6. Navigate to the "Options" tab.
 7. Enable and define a custom working directory. The root of this Swift package, to be specific. 
+
+## Troubleshooting
+
+mac-crafter has its own simple logging facility which writes to standard output in a terminal environment, the unified logging system of macOS and a log file simultaneously.
+You can stream the log messages in the Console app of macOS by searching for the "mac-crafter" process and "com.nextcloud.mac-crafter" subsystem.
+Alternatively, you can follow the latest log file created in `~/Library/Logs/mac-crafter`.
 
 ## License
 

--- a/admin/osx/mac-crafter/Sources/Log.swift
+++ b/admin/osx/mac-crafter/Sources/Log.swift
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2026 Iva Horn
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import os
+
+///
+/// A simple logging facility for Mac Crafter to abstract terminal output, log file and unified logging system.
+///
+actor Log: Sendable {
+    private static let shared = Log()
+    private let handle: FileHandle?
+    private let logger: Logger
+
+    init() {
+        let manager = FileManager.default
+
+        if let directory = try? manager.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: true).appendingPathComponent("Logs").appendingPathComponent("mac-crafter") {
+                if manager.fileExists(atPath: directory.path) == false {
+                try? manager.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+
+            let file = directory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("log")
+
+            manager.createFile(atPath: file.path, contents: nil)
+            handle = try? FileHandle(forWritingTo: file)
+        } else {
+            handle = nil
+        }
+
+        logger = Logger(subsystem: "com.nextcloud.mac-crafter", category: "")
+    }
+
+    private func log(level: OSLogType, message: String) {
+        guard message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return
+        }
+
+        print(message)
+        logger.log(level: level, "\(message, privacy: .public)")
+
+        guard let handle else {
+            return
+        }
+
+        guard let data = "\(message)\n".data(using: .utf8) else {
+            return
+        }
+
+        try? handle.write(contentsOf: data)
+    }
+
+    ///
+    /// Write an informative message.
+    ///
+    static func info(_ message: String) {
+        Task {
+            await shared.log(level: .info, message: message)
+        }
+    }
+
+    ///
+    /// Write an error message.
+    ///
+    static func error(_ message: String) {
+        Task {
+            await shared.log(level: .error, message: message)
+        }
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/Install.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Install.swift
@@ -29,12 +29,12 @@ func installIfMissing(
     installCommandEnv: [String: String]? = nil
 ) async throws {
     if await commandExists(command) {
-        print("Required command \"\(command)\" already is installed.")
+        Log.info("Required command \"\(command)\" already is installed.")
     } else {
-        print("Required command \"\(command)\" is missing, installing...")
+        Log.info("Required command \"\(command)\" is missing, installing...")
         guard await shell(installCommand, env: installCommandEnv) == 0 else {
             throw InstallError.failedToInstall("Failed to install \"\(command)\"!")
         }
-        print("\"\(command)\" installed.")
+        Log.info("\"\(command)\" installed.")
     }
 }

--- a/admin/osx/mac-crafter/Sources/Utils/Signer.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Signer.swift
@@ -62,7 +62,7 @@ enum Signer: Signing {
                 return true
             }
             
-            print("Found extension bundle: \(item.path)")
+            Log.info("Found extension bundle: \(item.path)")
             return false
         }
         
@@ -86,7 +86,7 @@ enum Signer: Signing {
                 return true
             }
             
-            print("Found framework bundle: \(item.path)")
+            Log.info("Found framework bundle: \(item.path)")
             return false
         }
         
@@ -94,7 +94,7 @@ enum Signer: Signing {
     }
     
     private static func verify(at location: URL) async {
-        print("Verifying: \(location.path)")
+        Log.info("Verifying: \(location.path)")
         await shell("codesign --verify --deep --strict --verbose=2 \"\(location.path)\"")
     }
 
@@ -166,7 +166,7 @@ enum Signer: Signing {
     ///     - codeSignIdentity: The common name of the certificate available in the keychain to use for signing.
     ///
     static func sign(at location: URL, with codeSignIdentity: String, entitlements: URL?) async {
-        print("Signing: \(location.path)")
+        Log.info("Signing: \(location.path)")
 
         var command = [
             "codesign",


### PR DESCRIPTION
- Write log messages to standard output in terminal environment.
- Write log messages to unified logging system of macOS (see Console app of macOS, filter for "mac-crafter" process and "com.nextcloud.mac-crafter" subsystem).
- Write log messages to a log file (located in `~/Library/Logs/mac-crafter`).
- All simultaneously.
- Standard output and errors from child processes launched are captured, too. In example all the KDE Craft output which is run by mac-crafter.