### PR TITLE
fix: detect upgrade only scenario.

### DIFF
--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -1352,7 +1352,8 @@ bool ConfigFile::isDowngrade() const
 bool ConfigFile::shouldTryUnbrandedToBrandedMigration() const
 {
     return migrationPhase() == ConfigFile::MigrationPhase::SetupFolders
-        && Theme::instance()->appName() != unbrandedAppName;
+        && Theme::instance()->appName() != unbrandedAppName
+        && !discoveredLegacyConfigPath().isEmpty();
 }
 
 bool ConfigFile::isUnbrandedToBrandedMigrationInProgress() const


### PR DESCRIPTION
If no legacy file is found, it means it might be upgrade only.

ℹ️  I am not adding tests here, because to properly test it I need to refactor the migration logic and move it around. 
I am hoping this quick fix can be merged first and then the refactoring/tests work that is happening here in #9191 can be merged/released soon after.

