### PR TITLE
Implement signing for Sparkle Installer and Autoupdate

### DIFF
--- a/admin/osx/mac-crafter/Sources/Utils/Signer.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Signer.swift
@@ -160,6 +160,42 @@ enum Signer: Signing {
     }
 
     ///
+    /// Find and sign the Sparkle Installer inside the Sparkle framework.
+    ///
+    /// This needs explicit treatment because codesign does not automatically sign it when signing the upstream framework bundle.
+    ///
+    private static func signSparkleInstaller(in bundle: URL, with codeSignIdentity: String) async {
+        let location = bundle
+            .appendingPathComponent("Contents")
+            .appendingPathComponent("Frameworks")
+            .appendingPathComponent("Sparkle.framework")
+            .appendingPathComponent("Versions")
+            .appendingPathComponent("B")
+            .appendingPathComponent("XPCServices")
+            .appendingPathComponent("Installer")
+            .appendingPathExtension("xpc")
+
+        await sign(at: location, with: codeSignIdentity, entitlements: nil)
+    }
+    
+    ///
+    /// Find and sign the Sparkle autoupdate inside the Sparkle framework.
+    ///
+    /// This needs explicit treatment because codesign does not automatically sign it when signing the upstream framework bundle.
+    ///
+    private static func signSparkleAutoupdate(in bundle: URL, with codeSignIdentity: String) async {
+        let location = bundle
+            .appendingPathComponent("Contents")
+            .appendingPathComponent("Frameworks")
+            .appendingPathComponent("Sparkle.framework")
+            .appendingPathComponent("Versions")
+            .appendingPathComponent("B")
+            .appendingPathComponent("Autoupdate")
+
+        await sign(at: location, with: codeSignIdentity, entitlements: nil)
+    }
+
+    ///
     /// Find and sign the Sparkle updater app inside the Sparkle framework.
     ///
     /// This needs explicit treatment because codesign does not automatically sign it when signing the upstream framework bundle.
@@ -234,6 +270,8 @@ enum Signer: Signing {
         await signQtWebEngineProcessApp(in: location, with: codeSignIdentity)
         await signSparkleDownloader(in: location, with: codeSignIdentity)
         await signSparkleUpdaterApp(in: location, with: codeSignIdentity)
+        await signSparkleInstaller(in: location, with: codeSignIdentity)
+        await signSparkleAutoupdate(in: location, with: codeSignIdentity)
 
         let frameworksInsideMainBundle = try findFrameworks(at: location)
 


### PR DESCRIPTION
Added functions to sign Sparkle Installer and Autoupdate within the Sparkle framework.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
