### PR TITLE
fix(debugArchive): ensure proper path for destination file name

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -699,7 +699,7 @@ void GeneralSettings::slotCreateDebugArchive()
         tr("Zip Archives") + " (*.zip)"
     );
 
-    if (destination.path().isEmpty()) {
+    if (!destination.isLocalFile() || destination.toLocalFile().isEmpty()) {
         return;
     }
 
@@ -719,11 +719,11 @@ void GeneralSettings::slotCreateDebugArchive()
     }
 #endif
 
-    if (createDebugArchive(destination.path())) {
+    if (createDebugArchive(destination.toLocalFile())) {
         QMessageBox::information(
             this,
             tr("Debug Archive Created"),
-            tr("Redact information deemed sensitive before sharing! Debug archive created at %1").arg(destination.toString())
+            tr("Redact information deemed sensitive before sharing! Debug archive created at %1").arg(destination.toLocalFile())
         );
     }
 }


### PR DESCRIPTION
on windows, it is necessary to convert the URL for the destination target for debug archive to a proper local file

hopefully does not break macOS

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
