### PR TITLE
List only locally deleted Items in Trash

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -139,21 +139,15 @@ import OSLog
         }
 
         let progress = Progress()
+        
         Task {
             progress.totalUnitCount = 1
-            if let item = await Item.storedItem(
-                identifier: identifier,
-                account: ncAccount,
-                remoteInterface: ncKit,
-                dbManager: dbManager,
-                log: log
-            ) {
+
+            if let item = await Item.storedItem(identifier: identifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log) {
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
             } else {
-                completionHandler(
-                    nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier)
-                )
+                completionHandler(nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier))
             }
         }
         return progress

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
+        "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
+        "version" : "5.11.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nextcloud/NextcloudFileProviderKit.git",
       "state" : {
-        "revision" : "3ff19ffdda3361ec3446266aa757653a8b272898",
-        "version" : "3.2.11"
+        "revision" : "6340c62b8d7c7c5099c8e6122f5c90594bb60cdc",
+        "version" : "3.2.13"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nextcloud/NextcloudKit",
       "state" : {
-        "revision" : "67f3cf59a5e6ae11c061815a05197e2b2cbcb3ad",
-        "version" : "7.2.2"
+        "revision" : "8ac6f9e08d112b51a9b7a7189fa144009a6f382d",
+        "version" : "7.2.3"
       }
     },
     {

--- a/src/gui/macOS/fileproviderdomainmanager_mac.mm
+++ b/src/gui/macOS/fileproviderdomainmanager_mac.mm
@@ -347,6 +347,13 @@ public:
             NSFileProviderDomain * const fileProviderDomain = [[NSFileProviderDomain alloc] initWithIdentifier:domainId.toNSString()
                                                                                                    displayName:domainDisplayName.toNSString()];
 
+            if (@available(macOS 13.0, *)) {
+                // supportsSyncingTrash is only available on macOS 13 and later.
+                // The trash is a server feature of which the availability can change any time.
+                // Its availability is checked on demand by the file provider extension itself.
+                fileProviderDomain.supportsSyncingTrash = YES;
+            }
+
             [NSFileProviderManager addDomain:fileProviderDomain completionHandler:^(NSError * const error) {
                 if(error) {
                     qCWarning(lcMacFileProviderDomainManager) << "Error adding file provider domain: "


### PR DESCRIPTION
This is the solution for the imminent maintenance release and will be brought to `master` in a different pull request. Due to the recent integration of the NextcloudFileProviderKit package from an external into this repository, this is a bit more complicated.

Reducing the trash integration to items deleted only on the local device makes it feel more natural by ruling out side effects we have a lot of complaints about. For example: When emptying the local trash on macOS, probably no-one expects to also purge everything from the trash on the Nextcloud server, including files from shared folders or even deleted by other users who might want to restore those later.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
