### PR TITLE
Removed user option for trash deletion

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderDomainDefaults.swift
@@ -14,6 +14,9 @@ struct FileProviderDomainDefaults {
     /// > Warning: Do not change the raw values of these keys, as they are used in UserDefaults. Any change would make the already stored value inaccessible and be like a reset.
     ///
     private enum ConfigKey: String {
+        ///
+        /// Obsolete and kept only for documentation to avoid future collisions.
+        ///
         case trashDeletionEnabled
         case user
         case userId
@@ -85,29 +88,6 @@ struct FileProviderDomainDefaults {
     }
 
     ///
-    /// Whether trash deletion is enabled or not.
-    ///
-    var trashDeletionEnabled: Bool {
-        get {
-            let identifier = self.identifier.rawValue
-
-            if let value = internalConfig[ConfigKey.trashDeletionEnabled.rawValue] as? Bool {
-                logger.debug("Returning existing value \"\(value)\" for \"trashDeletionEnabled\" for file provider domain \"\(identifier)\".")
-                return value
-            } else {
-                return false
-            }
-        }
-
-        set {
-            let identifier = self.identifier.rawValue
-
-            logger.error("Setting value \"\(newValue)\" for \"trashDeletionEnabled\" for file provider domain \"\(identifier)\".")
-            internalConfig[ConfigKey.trashDeletionEnabled.rawValue] = newValue
-        }
-    }
-
-    ///
     /// The user name associated with the domain.
     ///
     var user: String? {
@@ -166,9 +146,4 @@ struct FileProviderDomainDefaults {
             }
         }
     }
-
-    ///
-    /// Whether a value for `trashDeletionEnabled` has been explicitly set.
-    ///
-    lazy var trashDeletionSet = internalConfig[ConfigKey.trashDeletionEnabled.rawValue] != nil
 }

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -445,14 +445,6 @@ import OSLog
             }
             
             logger.debug("Found item for identifier.", [.item: identifier, .name: item.filename])
-
-            guard config.trashDeletionEnabled || item.parentItemIdentifier != .trashContainer else {
-                logger.info("System requested deletion of item in trash, but deleting trash items is disabled. item: \(item.filename)")
-                removeSyncAction(actionId)
-                completionHandler(NSError.fileProviderErrorForRejectedDeletion(of: item))
-                return
-            }
-            
             let error = await item.delete(domain: domain, ignoredFiles: ignoredFiles, dbManager: dbManager)
             
             if error != nil {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -21,8 +21,6 @@
                         password:(NSString *)password
                        userAgent:(NSString *)userAgent;
 - (void)removeAccountConfig;
-- (void)getTrashDeletionEnabledStateWithCompletionHandler:(void(^)(BOOL enabled, BOOL set))completionHandler;
-- (void)setTrashDeletionEnabled:(BOOL)enabled;
 - (void)setIgnoreList:(NSArray<NSString *> *)ignoreList;
 
 @end

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationService.swift
@@ -63,17 +63,6 @@ class ClientCommunicationService: NSObject, NSFileProviderServiceSource, NSXPCLi
         self.fpExtension.removeAccountConfig()
     }
 
-    func getTrashDeletionEnabledState(completionHandler: @escaping (Bool, Bool) -> Void) {
-        let enabled = fpExtension.config.trashDeletionEnabled
-        let set = fpExtension.config.trashDeletionSet
-        completionHandler(enabled, set)
-    }
-
-    func setTrashDeletionEnabled(_ enabled: Bool) {
-        fpExtension.config.trashDeletionEnabled = enabled
-        logger.info("Trash deletion setting changed to: \(enabled)")
-    }
-
     func setIgnoreList(_ ignoreList: [String]) {
         self.fpExtension.ignoredFiles = IgnoredFilesMatcher(ignoreList: ignoreList)
         logger.info("Ignore list updated.")

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -35,15 +35,12 @@ public:
     [[nodiscard]] Q_INVOKABLE float localStorageUsageGbForAccount(const QString &userIdAtHost) const;
     [[nodiscard]] unsigned long long remoteStorageUsageForAccount(const QString &userIdAtHost) const;
     [[nodiscard]] Q_INVOKABLE float remoteStorageUsageGbForAccount(const QString &userIdAtHost) const;
-    [[nodiscard]] Q_INVOKABLE bool trashDeletionEnabledForAccount(const QString &userIdAtHost) const;
-    [[nodiscard]] Q_INVOKABLE bool trashDeletionSetForAccount(const QString &userIdAtHost) const;
 
     [[nodiscard]] Q_INVOKABLE QAbstractListModel *materialisedItemsModelForAccount(const QString &userIdAtHost);
     [[nodiscard]] Q_INVOKABLE FileProviderDomainSyncStatus *domainSyncStatusForAccount(const QString &userIdAtHost) const;
 
 public slots:
     void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled, const bool showInformationDialog = true);
-    void setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled);
     void resetVfsForAccount(const QString &userIdAtHost);
 
     void createEvictionWindowForAccount(const QString &userIdAtHost);
@@ -55,8 +52,6 @@ signals:
     void localStorageUsageForAccountChanged(const QString &userIdAtHost);
     void remoteStorageUsageForAccountChanged(const QString &userIdAtHost);
     void materialisedItemsForAccountChanged(const QString &userIdAtHost);
-    void trashDeletionEnabledForAccountChanged(const QString &userIdAtHost);
-    void trashDeletionSetForAccountChanged(const QString &userIdAtHost);
 
 private:
     explicit FileProviderSettingsController(QObject *parent = nullptr);

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -379,59 +379,6 @@ void FileProviderSettingsController::setVfsEnabledForAccount(const QString &user
     }
 }
 
-bool FileProviderSettingsController::trashDeletionEnabledForAccount(const QString &userIdAtHost) const
-{
-    const auto xpc = FileProvider::instance()->xpc();
-
-    if (!xpc) {
-        return true;
-    }
-
-    const auto domainId = FileProviderUtils::domainIdentifierForAccountIdentifier(userIdAtHost);
-
-    if (const auto trashDeletionState = xpc->trashDeletionEnabledStateForFileProviderDomain(domainId)) {
-        return trashDeletionState->first;
-    }
-
-    return true;
-}
-
-bool FileProviderSettingsController::trashDeletionSetForAccount(const QString &userIdAtHost) const
-{
-    const auto xpc = FileProvider::instance()->xpc();
-
-    if (!xpc) {
-        return false;
-    }
-
-    const auto domainId = FileProviderUtils::domainIdentifierForAccountIdentifier(userIdAtHost);
-
-    if (const auto state = xpc->trashDeletionEnabledStateForFileProviderDomain(domainId)) {
-        return state->second;
-    }
-
-    return false;
-}
-
-void FileProviderSettingsController::setTrashDeletionEnabledForAccount(const QString &userIdAtHost, const bool setEnabled)
-{
-    const auto xpc = FileProvider::instance()->xpc();
-
-    if (!xpc) {
-        // Reset state of UI elements
-        emit trashDeletionEnabledForAccountChanged(userIdAtHost);
-        emit trashDeletionSetForAccountChanged(userIdAtHost);
-        return;
-    }
-
-    const auto domainId = FileProviderUtils::domainIdentifierForAccountIdentifier(userIdAtHost);
-
-    xpc->setTrashDeletionEnabledForFileProviderDomain(domainId, setEnabled);
-
-    emit trashDeletionEnabledForAccountChanged(userIdAtHost);
-    emit trashDeletionSetForAccountChanged(userIdAtHost);
-}
-
 unsigned long long FileProviderSettingsController::localStorageUsageForAccount(const QString &userIdAtHost) const
 {
     return d->localStorageUsageForAccount(userIdAtHost);

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -28,8 +28,6 @@ public:
 
     [[nodiscard]] bool fileProviderDomainReachable(const QString &fileProviderDomainIdentifier, bool retry = true, bool reconfigureOnFail = true);
 
-    [[nodiscard]] std::optional<std::pair<bool, bool>> trashDeletionEnabledStateForFileProviderDomain(const QString &fileProviderDomainIdentifier) const;
-
 public slots:
     void connectToFileProviderDomains();
     void authenticateFileProviderDomains();
@@ -37,7 +35,6 @@ public slots:
     void unauthenticateFileProviderDomain(const QString &fileProviderDomainIdentifier) const;
 
     void setIgnoreList() const;
-    void setTrashDeletionEnabledForFileProviderDomain(const QString &fileProviderDomainIdentifier, bool enabled) const;
 
 private slots:
     void slotAccountStateChanged(AccountState::State state) const;

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -179,41 +179,6 @@ bool FileProviderXPC::fileProviderDomainReachable(const QString &fileProviderDom
     return response;
 }
 
-std::optional<std::pair<bool, bool>> FileProviderXPC::trashDeletionEnabledStateForFileProviderDomain(const QString &fileProviderDomainIdentifier) const
-{
-    qCInfo(lcFileProviderXPC) << "Checking if fast enumeration is enabled for file provider domain" << fileProviderDomainIdentifier;
-    const auto service = (NSObject<ClientCommunicationProtocol> *)_clientCommServices.value(fileProviderDomainIdentifier);
-
-    if (service == nil) {
-        qCWarning(lcFileProviderXPC) << "Could not get service for file provider domain" << fileProviderDomainIdentifier;
-        return std::nullopt;
-    }
-
-    __block BOOL receivedTrashDeletionEnabled = YES; // What is the value of the setting being used by the extension?
-    __block BOOL receivedTrashDeletionEnabledSet = NO; // Has the setting been set by the user?
-    __block BOOL receivedResponse = NO;
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    [service getTrashDeletionEnabledStateWithCompletionHandler:^(BOOL enabled, BOOL set) {
-        receivedTrashDeletionEnabled = enabled;
-        receivedTrashDeletionEnabledSet = set;
-        receivedResponse = YES;
-        dispatch_semaphore_signal(semaphore);
-    }];
-    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, semaphoreWaitDelta));
-    if (!receivedResponse) {
-        qCWarning(lcFileProviderXPC) << "Did not receive response for fast enumeration state";
-        return std::nullopt;
-    }
-    return std::optional<std::pair<bool, bool>>{{receivedTrashDeletionEnabled, receivedTrashDeletionEnabledSet}};
-}
-
-void FileProviderXPC::setTrashDeletionEnabledForFileProviderDomain(const QString &fileProviderDomainIdentifier, bool enabled) const
-{
-    qCInfo(lcFileProviderXPC) << "Setting trash deletion enabled for file provider domain" << fileProviderDomainIdentifier << "to" << enabled;
-    const auto service = (NSObject<ClientCommunicationProtocol> *)_clientCommServices.value(fileProviderDomainIdentifier);
-    [service setTrashDeletionEnabled:enabled];
-}
-
 void FileProviderXPC::setIgnoreList() const
 {
     ExcludedFiles ignoreList;

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -99,12 +99,6 @@ Page {
                     }
                 }
 
-                CheckBox {
-                    text: qsTr("Allow deletion of items in Trash")
-                    checked: root.controller.trashDeletionEnabledForAccount(root.accountUserIdAtHost)
-                    onClicked: root.controller.setTrashDeletionEnabledForAccount(root.accountUserIdAtHost, checked)
-                }
-
                 Button {
                     text: qsTr("Reset virtual files environment")
                     onPressed: root.controller.resetVfsForAccount(root.accountUserIdAtHost);

--- a/translations/client_en.ts
+++ b/translations/client_en.ts
@@ -329,11 +329,6 @@
     </message>
     <message>
         <location filename="../src/gui/macOS/ui/FileProviderSettings.qml" line="103"/>
-        <source>Allow deletion of items in Trash</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/macOS/ui/FileProviderSettings.qml" line="109"/>
         <source>Reset virtual files environment</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
- Removed XPC APIs for trash state management.
- Removed UserDefaults code about trash state management.
- Removed checkbox from file provider settings tab.
- Removed "Allow deletion of items in Trash" from English translations.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
