### PR TITLE
fix: size sync folders panel to contents

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -45,6 +45,7 @@
 #include <QListWidgetItem>
 #include <QMessageBox>
 #include <QAction>
+#include <QAbstractScrollArea>
 #include <QSizePolicy>
 #include <QVBoxLayout>
 #include <QTreeView>
@@ -188,10 +189,10 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     _ui->tabWidget->setStyleSheet(QStringLiteral(
         "QTabWidget { background: transparent; }"
         "QTabWidget::pane { background: palette(alternate-base); border: none; }"
-        "QWidget#standardSyncTab, QWidget#connectionSettingsTab, QWidget#fileProviderPanelContents {"
+        "QWidget#syncFoldersPanelContents, QWidget#connectionSettingsTab, QWidget#fileProviderPanelContents {"
         " background: palette(alternate-base); }"));
-    _ui->standardSyncTab->setAutoFillBackground(true);
-    _ui->standardSyncTab->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->syncFoldersPanelContents->setAutoFillBackground(true);
+    _ui->syncFoldersPanelContents->setAttribute(Qt::WA_StyledBackground, true);
     _ui->fileProviderPanelContents->setAutoFillBackground(true);
     _ui->fileProviderPanelContents->setAttribute(Qt::WA_StyledBackground, true);
     _ui->connectionSettingsTab->setAutoFillBackground(true);
@@ -206,6 +207,7 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     _ui->_folderList->setStyleSheet(QStringLiteral("QTreeView { background: palette(alternate-base); }"));
     _ui->_folderList->setItemDelegate(delegate);
     _ui->_folderList->setModel(_model);
+    _ui->_folderList->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     _ui->_folderList->setMinimumWidth(300);
 
     new ToolTipUpdater(_ui->_folderList);
@@ -263,6 +265,12 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     refreshSelectiveSyncStatus();
     connect(_model, &QAbstractItemModel::rowsInserted,
         this, &AccountSettings::refreshSelectiveSyncStatus);
+    connect(_model, &QAbstractItemModel::rowsInserted,
+        _ui->_folderList, &QWidget::updateGeometry);
+    connect(_model, &QAbstractItemModel::rowsRemoved,
+        _ui->_folderList, &QWidget::updateGeometry);
+    connect(_model, &QAbstractItemModel::modelReset,
+        _ui->_folderList, &QWidget::updateGeometry);
 
     auto *syncNowAction = new QAction(this);
     syncNowAction->setShortcut(QKeySequence(Qt::Key_F6));

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -15,7 +15,8 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
   <rowstretch>
-    <number>0</number> 
+    <number>0</number>
+    <number>0</number>
     <number>0</number>
     <number>1</number>
    </rowstretch>
@@ -198,6 +199,210 @@
     </widget>
    </item>
    <item row="2" column="0">
+    <widget class="QFrame" name="syncFoldersPanel">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <layout class="QVBoxLayout" name="syncFoldersPanelLayout">
+      <item>
+       <widget class="QLabel" name="syncFoldersPanelTitle">
+        <property name="text">
+         <string>Sync folders</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="syncFoldersPanelContents" native="true">
+        <layout class="QVBoxLayout" name="syncFoldersLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="OCC::FolderStatusView" name="_folderList">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="contextMenuPolicy">
+            <enum>Qt::CustomContextMenu</enum>
+           </property>
+           <property name="autoFillBackground">
+            <bool>false</bool>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="animated">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="selectiveSyncStatus" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_3">
+              <item>
+               <widget class="QLabel" name="selectiveSyncLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>Unchecked folders will be &lt;b&gt;removed&lt;/b&gt; from your local file system and will not be synchronized to this computer anymore</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QWidget" name="selectiveSyncButtons" native="true">
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="selectiveSyncCancel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Cancel</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="selectiveSyncApply">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Apply</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="bigFolderUi" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="selectiveSyncNotification">
+              <property name="styleSheet">
+               <string notr="true">color: red</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="bigFolderSyncAll">
+                <property name="text">
+                 <string>Synchronize all</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="bigFolderSyncNone">
+                <property name="text">
+                 <string>Synchronize none</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="bigFolderApply">
+                <property name="text">
+                 <string>Apply manual changes</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QFrame" name="accountTabsPanel">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
@@ -223,200 +428,11 @@
         <property name="currentIndex">
          <number>0</number>
         </property>
-        <widget class="QWidget" name="standardSyncTab">
-         <attribute name="title">
-          <string>Standard file sync</string>
-         </attribute>
-         <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="OCC::FolderStatusView" name="_folderList">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="autoFillBackground">
-             <bool>false</bool>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Shape::NoFrame</enum>
-            </property>
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="animated">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
         <widget class="QWidget" name="connectionSettingsTab">
          <attribute name="title">
           <string>Connection settings</string>
          </attribute>
         </widget>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="selectiveSyncStatus" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_3">
-           <item>
-            <widget class="QLabel" name="selectiveSyncLabel">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Unchecked folders will be &lt;b&gt;removed&lt;/b&gt; from your local file system and will not be synchronized to this computer anymore</string>
-             </property>
-             <property name="textFormat">
-              <enum>Qt::RichText</enum>
-             </property>
-             <property name="wordWrap">
-              <bool>true</bool>
-             </property>
-             <property name="openExternalLinks">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QWidget" name="selectiveSyncButtons" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QPushButton" name="selectiveSyncCancel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Cancel</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="selectiveSyncApply">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Apply</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="bigFolderUi" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="selectiveSyncNotification">
-           <property name="styleSheet">
-            <string notr="true">color: red</string>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="bigFolderSyncAll">
-             <property name="text">
-              <string>Synchronize all</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="bigFolderSyncNone">
-             <property name="text">
-              <string>Synchronize none</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="bigFolderApply">
-             <property name="text">
-              <string>Apply manual changes</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>

--- a/src/gui/folderstatusview.cpp
+++ b/src/gui/folderstatusview.cpp
@@ -6,6 +6,9 @@
 #include "folderstatusview.h"
 #include "folderstatusdelegate.h"
 
+#include <QScrollBar>
+#include <QtGlobal>
+
 namespace OCC {
 
 FolderStatusView::FolderStatusView(QWidget *parent) : QTreeView(parent)
@@ -28,6 +31,28 @@ QRect FolderStatusView::visualRect(const QModelIndex &index) const
         return FolderStatusDelegate::addButtonRect(rect, layoutDirection());
     }
     return rect;
+}
+
+QSize FolderStatusView::sizeHint() const
+{
+    const auto baseHint = QTreeView::sizeHint();
+    if (!model()) {
+        return baseHint;
+    }
+
+    const int rowCount = model()->rowCount();
+    const int rowSizeHint = rowCount > 0 ? sizeHintForRow(0) : -1;
+    const int fallbackRowHeight = fontMetrics().height() + 8;
+    const int rowHeight = rowSizeHint > 0 ? rowSizeHint : fallbackRowHeight;
+    const int visibleRows = qMax(1, rowCount);
+    int height = rowHeight * visibleRows;
+
+    height += frameWidth() * 2;
+    if (horizontalScrollBar()->isVisible()) {
+        height += horizontalScrollBar()->sizeHint().height();
+    }
+
+    return {baseHint.width(), height};
 }
 
 } // namespace OCC

--- a/src/gui/folderstatusview.h
+++ b/src/gui/folderstatusview.h
@@ -23,6 +23,7 @@ public:
 
     [[nodiscard]] QModelIndex indexAt(const QPoint &point) const override;
     [[nodiscard]] QRect visualRect(const QModelIndex &index) const override;
+    [[nodiscard]] QSize sizeHint() const override;
 };
 
 } // namespace OCC


### PR DESCRIPTION
### Motivation
- The sync folders listing consumed a large fixed vertical space even when empty, leading to a big empty box in the settings dialog.
- The folder listing should behave like the other account panels and only request the space it needs and be movable into its own panel for future layout changes.

### Description
- Move the sync folders UI out of the tab and into a dedicated `syncFoldersPanel` in `src/gui/accountsettings.ui` so it sits alongside the account status and file provider panels.
- Make the tree view report a dynamic preferred height by adding `FolderStatusView::sizeHint()` in `src/gui/folderstatusview.{h,cpp}` which computes height from the number of rows, per-row height and scrollbar presence.
- Enable size-to-contents for the view via `_ui->_folderList->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents)` and refresh geometry when the model changes by connecting `rowsInserted`, `rowsRemoved` and `modelReset` to `updateGeometry` in `src/gui/accountsettings.cpp`.
- Update stylesheets to target the new `syncFoldersPanelContents` widget and adjust the grid row stretch in `src/gui/accountsettings.ui` so the layout grows/shrinks correctly.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa40edcf08333abc8472367f678b9)