### PR TITLE
fix: show enterprise update-channel lock notice in settings

### DIFF
--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -439,6 +439,10 @@ void GeneralSettings::slotUpdateInfo()
         connect(_ui->restartButton, &QAbstractButton::clicked, ocupdater, &OCUpdater::slotStartInstaller, Qt::UniqueConnection);
 
         auto status = ocupdater->statusString(OCUpdater::UpdateStatusStringFormat::Html);
+        if (config.serverHasValidSubscription()) {
+            status.append(QStringLiteral("<br/>%1")
+                              .arg(tr("You are connected to at least one enterprise system and cannot change the update channel.")));
+        }
         Theme::replaceLinkColorStringBackgroundAware(status);
 
         _ui->updateStateLabel->setOpenExternalLinks(false);
@@ -454,7 +458,13 @@ void GeneralSettings::slotUpdateInfo()
 #if defined(Q_OS_MACOS) && defined(HAVE_SPARKLE)
     else if (const auto sparkleUpdater = qobject_cast<SparkleUpdater *>(updater)) {
         connect(sparkleUpdater, &SparkleUpdater::statusChanged, this, &GeneralSettings::slotUpdateInfo, Qt::UniqueConnection);
-        _ui->updateStateLabel->setText(sparkleUpdater->statusString());
+        auto status = sparkleUpdater->statusString();
+        if (config.serverHasValidSubscription()) {
+            const auto separator = Qt::mightBeRichText(status) ? QStringLiteral("<br/>") : QStringLiteral("\n");
+            status.append(separator)
+                .append(tr("You are connected to at least one enterprise system and cannot change the update channel."));
+        }
+        _ui->updateStateLabel->setText(status);
         _ui->restartButton->setVisible(false);
 
         const auto updaterState = sparkleUpdater->state();


### PR DESCRIPTION
### Motivation
- Inform users in the General Settings info box that the update channel cannot be changed when connected to enterprise systems so the status reflects the hidden channel selector.

### Description
- Append an enterprise subscription notice to the updater status text in `GeneralSettings::slotUpdateInfo` in `src/gui/generalsettings.cpp` for `OCUpdater` using an HTML line break when the status is HTML. 
- Do the same for `SparkleUpdater`, choosing a separator based on `Qt::mightBeRichText` so the message works for both rich-text and plain-text status strings.
- The appended message is `You are connected to at least one enterprise system and cannot change the update channel.` and is only added when `ConfigFile::serverHasValidSubscription()` is true.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696faf2eb75c833388c50ae48b22b96f)