### PR TITLE
Add flatpak support to UNIX `Utility::setLaunchOnStartup`

### DIFF
--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -100,14 +100,16 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName,
         // When running inside an AppImage, we need to set the path to the
         // AppImage instead of the path to the executable
         const QString appImagePath = qEnvironmentVariable("APPIMAGE");
+        const QString flatpakId = qEnvironmentVariable("FLATPAK_ID");
         const bool runningInsideAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
-        const QString executablePath = runningInsideAppImage ? appImagePath : QCoreApplication::applicationFilePath();
+        const bool runningInsideFlatpak = !flatpakId.isNull();
+        const QString executablePath = runningInsideAppImage ? QLatin1String("\"%1\"").arg(appImagePath) : runningInsideFlatpak ? QLatin1String("flatpak run %1").arg(flatpakId) : QLatin1String("\"%1\"").arg(QCoreApplication::applicationFilePath());
 
         QTextStream ts(&iniFile);
         ts << QLatin1String("[Desktop Entry]\n")
            << QLatin1String("Name=") << guiName << QLatin1Char('\n')
            << QLatin1String("GenericName=") << QLatin1String("File Synchronizer\n")
-           << QLatin1String("Exec=\"") << executablePath << "\" --background\n"
+           << QLatin1String("Exec=") << executablePath << " --background\n"
            << QLatin1String("Terminal=") << "false\n"
            << QLatin1String("Icon=") << APPLICATION_ICON_NAME << QLatin1Char('\n')
            << QLatin1String("Categories=") << QLatin1String("Network\n")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
Discussion in https://github.com/flathub/com.nextcloud.desktopclient.nextcloud/pull/225

This PR is the same as what the patch there is. For this to work flatpaks will need permission to acccess `xdg-config/autostart` on the host filesystem. If permission is not granted no autostart file is added.