### PR TITLE
fix(AppImage): fix broken empty web engine rendering

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -51,6 +51,14 @@ void warnSystray()
 
 int main(int argc, char **argv)
 {
+#ifdef Q_OS_LINUX
+    const auto appImagePath = qEnvironmentVariable("APPIMAGE");
+    const auto runningInsideAppImage = !appImagePath.isNull() && QFile::exists(appImagePath);
+    if (runningInsideAppImage) {
+        qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "--disable-gpu-compositing");
+    }
+#endif
+
 #ifdef Q_OS_WIN
     SetDllDirectory(L"");
     qputenv("QML_IMPORT_PATH", (QDir::currentPath() + QStringLiteral("/qml")).toLatin1());


### PR DESCRIPTION
will disable GPU compositing on AppImage due to broken support for graphics drivers in the AppImage and only in the AppImage

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
