### PR TITLE
macOS File Provider Fix: Allow Insecure HTTP Connections

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -92,5 +92,10 @@
     </array>
     <key>NCFPKAppGroupIdentifier</key>
     <string>@DEVELOPMENT_TEAM@.@APPLICATION_REV_DOMAIN@</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleIcons</key>
 	<dict>
 		<key>CFBundlePrimaryIcon</key>

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Info.plist
@@ -2,14 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIcons</key>
-    <dict>
-        <key>CFBundlePrimaryIcon</key>
-        <dict>
-            <key>CFBundleSymbolName</key>
-            <string>cloud</string>
-        </dict>
-    </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleSymbolName</key>
+			<string>cloud</string>
+		</dict>
+	</dict>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleDisplayName</key>

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
I do not know why but for whatever reason suddenly the built client did not connect to `http://localhost:8080` anymore and the debugger output complained about the app transport security. I am familiar with this topic since years because of  iOS. I thought we had that explicit approval already set up in the desktop client because it used to work. Anyway, now I have added it to the `Info.plist` of the app and extensions to ensure insecure HTTP connections are possible because it is important for the product overall, especially for self-hosted servers or private networks.