### PR TITLE
fix: avoid extra space in sync folders panel

### DIFF
--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -207,6 +207,12 @@
       </item>
       <item>
        <widget class="QWidget" name="syncFoldersPanelContents" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <layout class="QVBoxLayout" name="syncFoldersLayout">
          <property name="leftMargin">
           <number>0</number>
@@ -227,6 +233,9 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QAbstractScrollArea::AdjustToContents</enum>
            </property>
            <property name="contextMenuPolicy">
             <enum>Qt::CustomContextMenu</enum>


### PR DESCRIPTION
### Motivation
- The sync folders panel reserved extra vertical space below the add-folder row because the container and list could expand, so the panel should hug the list contents to remove the gap.

### Description
- Set the `syncFoldersPanelContents` widget vertical `sizePolicy` to `Maximum` and add `sizeAdjustPolicy` = `QAbstractScrollArea::AdjustToContents` for `_folderList` in `src/gui/accountsettings.ui` so the list sizes to its contents and the panel stops expanding.

### Testing
- No automated tests were run for this UI tweak; the UI file was updated and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c6fcaef2c8333b9db03477b59c66e)