### PR TITLE
fix(activitydata): use parameter validation regex from server

### DIFF
--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -96,8 +96,9 @@ OCC::Activity Activity::fromActivityJson(const QJsonObject &json, const AccountP
     if(richSubjectData.size() > 1) {
         activity._subjectRich = richSubjectData[0].toString();
         auto parameters = richSubjectData[1].toObject();
-        const QRegularExpression subjectRichParameterRe(QStringLiteral("({[a-zA-Z0-9]*})"));
-        const QRegularExpression subjectRichParameterBracesRe(QStringLiteral("[{}]"));
+        // keep the contents inside the {braces} in sync with server's \OCP\RichObjectStrings\IValidator::PLACEHOLDER_REGEX
+        const QRegularExpression subjectRichParameterRe(uR"#(({[A-Za-z][A-Za-z0-9\-_.]+}))#"_s);
+        const QRegularExpression subjectRichParameterBracesRe(u"[{}]"_s);
 
         for (auto i = parameters.begin(); i != parameters.end(); ++i) {
             const auto parameterJsonObject = i.value().toObject();

--- a/test/testactivitydata.cpp
+++ b/test/testactivitydata.cpp
@@ -319,6 +319,70 @@ private slots:
             QCOMPARE(activity._icon, iconExpected);
         }
     }
+
+    void testRichParametersWithDashKeyeee()
+    {
+        QJsonParseError parseError;
+        const auto activityJsonDocument = QJsonDocument::fromJson(
+            // MOC struggles with multiline raw strings (R"()"), so this will have to do ...
+            "{"
+            "  \"activity_id\": 20891,"
+            "  \"app\": \"tables\","
+            "  \"type\": \"tables\","
+            "  \"user\": \"Testuser\","
+            "  \"subject\": \"You have updated cell How to do on row #42 in table Welcome to Nextcloud Tables!\","
+            "  \"subject_rich\": ["
+            "    \"You have updated cell {col-20} on row {row} in table {table}\","
+            "    {"
+            "      \"user\": {"
+            "        \"type\": \"user\","
+            "        \"id\": \"jyrki\","
+            "        \"name\": \"Jyrki\""
+            "      },"
+            "      \"table\": {"
+            "        \"type\": \"highlight\","
+            "        \"id\": \"5\","
+            "        \"name\": \"Welcome to Nextcloud Tables!\","
+            "        \"link\": \"https://nextcloud.local/apps/tables/#/table/5\""
+            "      },"
+            "      \"row\": {"
+            "        \"type\": \"highlight\","
+            "        \"id\": \"42\","
+            "        \"name\": \"#42\","
+            "        \"link\": \"https://nextcloud.local/apps/tables/#/table/5/row/42\""
+            "      },"
+            "      \"col-20\": {"
+            "        \"type\": \"highlight\","
+            "        \"id\": \"20\","
+            "        \"name\": \"How to do\""
+            "      }"
+            "    }"
+            "  ],"
+            "  \"message\": \"\","
+            "  \"message_rich\": ["
+            "    \"\","
+            "    []"
+            "  ],"
+            "  \"object_type\": \"tables_row\","
+            "  \"object_id\": 42,"
+            "  \"object_name\": \"#42\","
+            "  \"objects\": {"
+            "    \"42\": \"#42\""
+            "  },"
+            "  \"link\": \"https://nextcloud.local/apps/tables/#/table/5/row/42\","
+            "  \"icon\": \"https://nextcloud.local/apps/files/img/change.svg\","
+            "  \"datetime\": \"2026-01-30T08:47:02+00:00\","
+            "  \"previews\": []"
+            "}"_ba, &parseError);
+
+        QCOMPARE(parseError.error, QJsonParseError::NoError);
+        QVERIFY(activityJsonDocument.isObject());
+        const auto activityJsonObject = activityJsonDocument.object();
+
+        OCC::Activity activity = OCC::Activity::fromActivityJson(activityJsonObject, account);
+        // GitHub #9327: the placeholder `{col-20}` was not replaced before.
+        QCOMPARE(activity._subjectDisplay, "You have updated cell How to do on row #42 in table Welcome to Nextcloud Tables!"_L1);
+    }
 };
 
 QTEST_MAIN(TestActivityData)


### PR DESCRIPTION
Since 31.0.0 the rich parameters are subject to validation (starting with a letter; only letters, digits, dashes, underscores, and periods may follow).  Reuse the server's validation regexp for these parameters in the activity data.

Resolves #9327.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
