### PR TITLE
fix(networksettings): get rid of uic warning

### DIFF
--- a/src/gui/networksettings.ui
+++ b/src/gui/networksettings.ui
@@ -488,10 +488,6 @@
          </spacer>
         </item>
        </layout>
-       <zorder>autoUploadLimitRadioButton</zorder>
-       <zorder>uploadLimitRadioButton</zorder>
-       <zorder>noUploadLimitRadioButton</zorder>
-       <zorder>verticalSpacer_3</zorder>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Saw this in the build logs:

```
AutoUic: src/gui/networksettings.ui: Warning: Z-order assignment: 'verticalSpacer_3' is not a valid widget.
```

The other group box does not have any zorder set either -- so let's just remove that section.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
