### PR TITLE
fix: make tray account menu scrollable

### DIFF
--- a/src/gui/tray/CurrentAccountHeaderButton.qml
+++ b/src/gui/tray/CurrentAccountHeaderButton.qml
@@ -60,6 +60,18 @@ Button {
         height: Math.min(implicitHeight, maxMenuHeight)
         closePolicy: Menu.CloseOnPressOutsideParent | Menu.CloseOnEscape
 
+        contentItem: ListView {
+            clip: true
+            implicitHeight: contentHeight
+            model: accountMenu.contentModel
+            currentIndex: accountMenu.currentIndex
+            boundsBehavior: Flickable.StopAtBounds
+
+            ScrollBar.vertical: ScrollBar {
+                policy: ScrollBar.AsNeeded
+            }
+        }
+
         onClosed: {
             // HACK: reload account Instantiator immediately by resetting it - could be done better I guess
             // see also onVisibleChanged above


### PR DESCRIPTION
### Motivation
- The account dropdown menu in the tray could exceed the tray window height when many accounts exist, preventing access to other tray content and requiring the menu to become scrollable.

### Description
- Added a `contentItem` ListView to the account `Menu` in `src/gui/tray/CurrentAccountHeaderButton.qml` that uses `accountMenu.contentModel`, clips content, uses `Flickable.StopAtBounds`, and provides a vertical `ScrollBar` with `policy: ScrollBar.AsNeeded` so the menu stays within the tray height.

### Testing
- No automated tests were run for this UI-only change (manual UI validation expected during integration testing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e14744c0083339e0a71a79a0a70ab)