### PR TITLE
fix: respect auto update check on macOS

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -65,7 +65,8 @@ private:
 
 - (BOOL)backgroundUpdateChecksAllowed
 {
-    const BOOL allowUpdateCheck = OCC::ConfigFile().skipUpdateCheck() ? NO : YES;
+    const auto config = OCC::ConfigFile();
+    const BOOL allowUpdateCheck = config.skipUpdateCheck() ? NO : config.autoUpdateCheck() ? YES : NO;
     qCInfo(OCC::lcUpdater) << "Updater may check for updates:" << (allowUpdateCheck ? "YES" : "NO");
     return allowUpdateCheck;
 }
@@ -74,6 +75,10 @@ private:
 {
     Q_UNUSED(updater)
     Q_UNUSED(updateCheck)
+    if (updateCheck == SPUUpdateCheckUserInitiated) {
+        return OCC::ConfigFile().skipUpdateCheck() ? NO : YES;
+    }
+
     return [self backgroundUpdateChecksAllowed];
 }
 
@@ -288,11 +293,12 @@ void SparkleUpdater::checkForUpdate()
 
 void SparkleUpdater::backgroundCheckForUpdate()
 {
-    if (autoUpdaterAllowed() && !ConfigFile().skipUpdateCheck()) {
+    const auto config = ConfigFile();
+    if (autoUpdaterAllowed() && !config.skipUpdateCheck() && config.autoUpdateCheck()) {
         qCInfo(OCC::lcUpdater) << "launching background check";
         [_interface->updaterController.updater checkForUpdatesInBackground];
     } else {
-        qCInfo(OCC::lcUpdater) << "not launching background check, auto updater not allowed or update check skipped in config";
+        qCInfo(OCC::lcUpdater) << "not launching background check, auto updater not allowed or update check disabled in config";
     }
 }
 


### PR DESCRIPTION
### Motivation
- The Sparkle-based macOS updater ignored the "Automatically check for updates" UI setting which caused background checks and daily notifications even when users disabled automatic updates.

### Description
- In `src/gui/updater/sparkleupdater_mac.mm` the delegate now consults `ConfigFile::autoUpdateCheck()` as well as `skipUpdateCheck()`, `updater:mayPerformUpdateCheck:` allows `SPUUpdateCheckUserInitiated` checks even when automatic checks are disabled, and `SparkleUpdater::backgroundCheckForUpdate()` was updated to avoid launching background checks when `autoUpdateCheck` is false and to improve the log message.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1374f92c8333afced6b686d154e1)