### PR TITLE
fix: respect auto update toggle on macOS

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -65,7 +65,8 @@ private:
 
 - (BOOL)backgroundUpdateChecksAllowed
 {
-    const BOOL allowUpdateCheck = OCC::ConfigFile().skipUpdateCheck() ? NO : YES;
+    const OCC::ConfigFile config;
+    const BOOL allowUpdateCheck = (!config.skipUpdateCheck() && config.autoUpdateCheck()) ? YES : NO;
     qCInfo(OCC::lcUpdater) << "Updater may check for updates:" << (allowUpdateCheck ? "YES" : "NO");
     return allowUpdateCheck;
 }
@@ -288,7 +289,8 @@ void SparkleUpdater::checkForUpdate()
 
 void SparkleUpdater::backgroundCheckForUpdate()
 {
-    if (autoUpdaterAllowed() && !ConfigFile().skipUpdateCheck()) {
+    const ConfigFile config;
+    if (autoUpdaterAllowed() && config.autoUpdateCheck()) {
         qCInfo(OCC::lcUpdater) << "launching background check";
         [_interface->updaterController.updater checkForUpdatesInBackground];
     } else {


### PR DESCRIPTION
### Motivation
- macOS users reported that disabling “Automatically check for updates” did not stop Sparkle background checks and daily notifications. 
- The code previously only consulted `skipUpdateCheck()` and ignored the `autoUpdateCheck()` preference, causing unexpected background update activity.

### Description
- Updated `src/gui/updater/sparkleupdater_mac.mm` to consult the `ConfigFile` instance when deciding whether background checks are allowed. 
- `NCSparkleUpdaterDelegate::backgroundUpdateChecksAllowed` now returns `YES` only if both `!config.skipUpdateCheck()` and `config.autoUpdateCheck()` are true. 
- `SparkleUpdater::backgroundCheckForUpdate` now checks `config.autoUpdateCheck()` (in addition to `autoUpdaterAllowed()`) before launching a background check.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e50813b488333ac290c95df9b3ae4)