### PR TITLE
fix(cmd): don't open the database twice with --unsyncedfolders

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -277,11 +277,6 @@ void parseOptions(const QStringList &app_args, CmdOptions *options)
  */
 void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
 {
-    SqlDatabase db;
-    if (!db.openOrCreateReadWrite(journal->databaseFilePath())) {
-        return;
-    }
-
     bool ok = false;
 
     const auto selectiveSyncList = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);


### PR DESCRIPTION
The openOrCreateReadWrite function is called in checkConnect already, resulting in the database being opened twice in exclusive mode, causing SQLite to complain the database is locked.

Closes #3422

This bit of code was added in 2015, which was probably working fine before the DB was moved to exclusive mode in 2019. The above issue was created 2 years later. That being said, not being familiar with the code, I am not certain that what I removed is not used for other purposes. So I invite you to take this into consideration while reviewing.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
