### PR TITLE
fix: prevent E2EE metadata rollback

### DIFF
--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -66,6 +66,7 @@ public:
 
     void keyValueStoreSet(const QString &key, QVariant value);
     [[nodiscard]] qint64 keyValueStoreGetInt(const QString &key, qint64 defaultValue);
+    [[nodiscard]] QString keyValueStoreGetString(const QString &key, const QString &defaultValue = {});
     void keyValueStoreDelete(const QString &key);
 
     [[nodiscard]] bool deleteFileRecord(const QString &filename, bool recursively = false);

--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -77,6 +77,7 @@ FolderMetadata::FolderMetadata(AccountPtr account,
     , _metadataKeyForEncryption(rootEncryptedFolderInfo.keyForEncryption)
     , _metadataKeyForDecryption(rootEncryptedFolderInfo.keyForDecryption)
     , _keyChecksums(rootEncryptedFolderInfo.keyChecksums)
+    , _counter(rootEncryptedFolderInfo.counter)
     , _initialSignature(signature)
 {
     Q_ASSERT(!_remoteFolderRoot.isEmpty());
@@ -213,17 +214,32 @@ void FolderMetadata::setupExistingMetadata(const QByteArray &metadata)
 
     const auto cipherTextDocument = QJsonDocument::fromJson(cipherTextDecrypted);
 
+    const auto previousKeyChecksums = _keyChecksums;
     const auto keyCheckSums = cipherTextDocument[keyChecksumsKey].toArray();
-    if (!keyCheckSums.isEmpty()) {
-        _keyChecksums.clear();
-    }
-    for (auto it = keyCheckSums.constBegin(); it != keyCheckSums.constEnd(); ++it) {
-        const auto keyChecksum = it->toVariant().toString().toUtf8();
-        if (!keyChecksum.isEmpty()) {
-            //TODO: check that no hash has been removed from the keyChecksums
-            // How do we check that?
-            _keyChecksums.insert(keyChecksum);
+    if (keyCheckSums.isEmpty()) {
+        if (_isRootEncryptedFolder && !previousKeyChecksums.isEmpty()) {
+            qCWarning(lcCseMetadata()) << "Missing keyChecksums in metadata.";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return;
         }
+    } else {
+        QSet<QByteArray> parsedKeyChecksums;
+        for (auto it = keyCheckSums.constBegin(); it != keyCheckSums.constEnd(); ++it) {
+            const auto keyChecksum = it->toVariant().toString().toUtf8();
+            if (!keyChecksum.isEmpty()) {
+                parsedKeyChecksums.insert(keyChecksum);
+            }
+        }
+        if (_isRootEncryptedFolder && !previousKeyChecksums.isEmpty()) {
+            for (auto it = previousKeyChecksums.constBegin(); it != previousKeyChecksums.constEnd(); ++it) {
+                if (!parsedKeyChecksums.contains(*it)) {
+                    qCWarning(lcCseMetadata()) << "Detected removal of metadata key checksums.";
+                    _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+                    return;
+                }
+            }
+        }
+        _keyChecksums = parsedKeyChecksums;
     }
 
     if (!verifyMetadataKey(metadataKeyForDecryption())) {
@@ -238,10 +254,13 @@ void FolderMetadata::setupExistingMetadata(const QByteArray &metadata)
 
     const auto counterVariantFromJson = cipherTextObj.value(counterKey).toVariant();
     if (counterVariantFromJson.isValid() && counterVariantFromJson.canConvert<quint64>()) {
-        // TODO: We need to check counter: new counter must be greater than locally stored counter
-        // What does that mean? We store the counter in metadata, should we now store it in local database as we do for all file records in SyncJournal?
-        // What if metadata was not updated for a while? The counter will then not be greater than locally stored (in SyncJournal DB?)
-        _counter = counterVariantFromJson.value<quint64>();
+        const auto counterFromJson = counterVariantFromJson.value<quint64>();
+        if (_counter > 0 && counterFromJson < _counter) {
+            qCWarning(lcCseMetadata()) << "Detected metadata counter rollback.";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return;
+        }
+        _counter = counterFromJson;
     }
 
     for (auto it = files.constBegin(), end = files.constEnd(); it != end; ++it) {
@@ -833,6 +852,11 @@ QByteArray FolderMetadata::initialMetadata() const
 quint64 FolderMetadata::newCounter() const
 {
     return _counter + 1;
+}
+
+quint64 FolderMetadata::counter() const
+{
+    return _counter;
 }
 
 EncryptionStatusEnums::ItemEncryptionStatus FolderMetadata::fromMedataVersionToItemEncryptionStatus(const MetadataVersion metadataVersion)

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -132,6 +132,7 @@ public:
     [[nodiscard]] bool isVersion2AndUp() const;
 
     [[nodiscard]] quint64 newCounter() const;
+    [[nodiscard]] quint64 counter() const;
 
     [[nodiscard]] QByteArray metadataSignature() const;
 


### PR DESCRIPTION
Summary: Validate E2EE metadata counter and keyChecksums; persist values in journal; add regression tests.
Tests: Not run (requires KF6Archive + Qt 6.8+).