### PR TITLE
Preserve dirty user data on domain removal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,31 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 The following details are important when working on the desktop client on macOS.
 
+### Requirements
+
 - Latest stable Xcode available is required to be installed in the development environment.
+
+### Project Structure
+
 - There is a self-contained and independent build tool called mac-crafter in `./admin/osx/mac-crafter` implemented as a Swift package which builds as an executable.
 - To enable a macOS app build, the file `./shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Build.xcconfig` must be created if not existent already and it must contain the Xcode build setting `CODE_SIGN_IDENTITY=Apple Development`.
 - To verify that the project builds successfully on macOS, mac-crafter can be run in its own directory with these arguments: `swift run mac-crafter --build-path=DerivedData --product-path=/Applications --build-type=Debug --dev --disable-auto-updater --build-file-provider-module`
 - The macOS app includes a FinderSync extension.
 - The macOS app can be built to include a file provider extension and file provider UI extension.
 - The macOS extensions bundled with the main app are built in the Xcode project in `./shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj`. The build system later copies the built extension bundles into the main app bundle on its own. The Xcode project does not build the main app.
-- The main app manages file provider domains and the communication with them via XPC in source code files located in `./src/gui/macOS` and usually are written in Objective-C++ (implementation files with `.mm` extension, sometimes having a `_mac` suffix in their name while their corresponding header files do not). The PIMPL pattern is an established convention here.
+- The main app manages file provider domains and the communication with them via XPC in source code files located in `./src/gui/macOS` and usually are written in Objective-C++ (implementation files with `.mm` extension, sometimes having a `_mac` suffix in their name while their corresponding header files do not).
+
+### Code Style
+
+- The PIMPL pattern is an established convention in the Objective-C++ source code files under `src/gui/macOS`.
+- To abstract macOS and Objective-C specific APIs, prefer to use Qt and C++ types in public identifiers declared in headers. Use and prefer Objective-C or native macOS features only internally in implementations. This rule applies only to the code in `src/gui/macOS`, though.
 - When writing code in Swift, respect strict concurrency rules and Swift 6 compatibility.
+
+### Tests
+
+- When implementing new test suites, prefer Swift Testing over XCTest for implementation.
+- When implementing test cases using Swift Testing, do not prefix test method names with "test".
+- Take the mock implementations in the `NextcloudFileProviderKitMocks` module of the `NextcloudFileProviderKit` package into consideration to avoid generating your own mocks when an already existing and matching mock can be found there.
+- If there the implementation of mock types is inevitable, implement them in dedicated source code files and in a generic way, so they can be reused across all tests in a test target.
+- If the implementation of an existing mock type does not fulfill the requirements introduced by new tests, prefer updating the existing type before implementing a mostly redundant alternative type.
+- Do not test for logging by subjects under test.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/DirtyUserDataObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/DirtyUserDataObserver.swift
@@ -1,0 +1,58 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import FileProvider
+
+///
+/// An enumeration observer for materialized items which reports the existence of dirty user data to the completion handler.
+///
+public final class DirtyUserDataObserver: NSObject, NSFileProviderEnumerationObserver {
+    private let completionHandler: (Bool) -> Void
+    private var hasDirtyUserData = false
+    private var logger: FileProviderLogger
+
+    ///
+    /// - Parameters:
+    ///     - completionHandler: The handler to call for on completion of the enumeration. The provided boolean indicates whether dirty user data exists or not.
+    ///
+    public init(log: any FileProviderLogging, completionHandler: @escaping (Bool) -> Void) {
+        self.completionHandler = completionHandler
+        logger = FileProviderLogger(category: "DirtyUserDataObserver", log: log)
+        super.init()
+        logger.debug("Initialized.")
+    }
+
+    public func didEnumerate(_ updatedItems: [any NSFileProviderItemProtocol]) {
+        logger.debug("Did enumerate \(updatedItems.count) items.")
+
+        for item in updatedItems {
+            guard item.itemIdentifier != .rootContainer else {
+                continue
+            }
+
+            guard item.itemIdentifier != .trashContainer else {
+                continue
+            }
+
+            guard item.itemIdentifier != .workingSet else {
+                continue
+            }
+
+            if item.isUploaded == false {
+                logger.info("Found item which is not uploaded yet!", [.item: item.itemIdentifier, .name: item.filename])
+                hasDirtyUserData = true
+                return
+            }
+        }
+    }
+
+    public func finishEnumerating(upTo _: NSFileProviderPage?) {
+        logger.info("Finished enumerating. \(hasDirtyUserData ? "Dirty user data found." : "No dirty user data found.")")
+        completionHandler(hasDirtyUserData)
+    }
+
+    public func finishEnumeratingWithError(_ error: any Error) {
+        logger.error("Finished enumerating with error. \(hasDirtyUserData ? "Dirty user data found." : "No dirty user data found.")", [.error: error])
+        completionHandler(hasDirtyUserData)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Enumeration/DirtyUserDataObserverTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Enumeration/DirtyUserDataObserverTests.swift
@@ -1,0 +1,264 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import Testing
+
+@Suite("DirtyUserDataObserver Tests")
+struct DirtyUserDataObserverTests {
+    let mockLog: FileProviderLogMock
+
+    init() {
+        mockLog = FileProviderLogMock()
+    }
+
+    @Test("Observer initialization")
+    func initialization() {
+        var completionCalled = false
+
+        _ = DirtyUserDataObserver(log: mockLog) { _ in
+            completionCalled = true
+        }
+
+        #expect(!completionCalled, "Completion should not be called on initialization")
+    }
+
+    @Test("Finish enumerating with no items should report no dirty data")
+    func finishEnumeratingWithNoItems() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == false, "Should report no dirty data when no items enumerated")
+    }
+
+    @Test("Enumerate only uploaded items should report no dirty data")
+    func enumerateOnlyUploadedItems() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let uploadedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("3"), filename: "file3.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(uploadedItems)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == false, "Should report no dirty data when all items are uploaded")
+    }
+
+    @Test("Enumerate with one non-uploaded item should report dirty data")
+    func enumerateWithNonUploadedItem() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let mixedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: false),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("3"), filename: "file3.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(mixedItems)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == true, "Should report dirty data when at least one item is not uploaded")
+    }
+
+    @Test("Enumerate with all non-uploaded items should report dirty data")
+    func enumerateWithAllNonUploadedItems() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let nonUploadedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: false),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: false)
+        ]
+
+        observer.didEnumerate(nonUploadedItems)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == true, "Should report dirty data when all items are not uploaded")
+    }
+
+    @Test("Multiple enumeration batches with uploaded items should report no dirty data")
+    func multipleEnumerationBatchesWithUploadedItems() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let batch1 = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: true)
+        ]
+
+        let batch2 = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("3"), filename: "file3.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("4"), filename: "file4.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(batch1)
+        observer.didEnumerate(batch2)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == false, "Should report no dirty data when all batches contain only uploaded items")
+    }
+
+    @Test("Multiple enumeration batches with dirty data in second batch")
+    func multipleEnumerationBatchesWithDirtyDataInSecondBatch() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let batch1 = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: true)
+        ]
+
+        let batch2 = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("3"), filename: "file3.txt", isUploaded: false),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("4"), filename: "file4.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(batch1)
+        observer.didEnumerate(batch2)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == true, "Should report dirty data when any batch contains non-uploaded items")
+    }
+
+    @Test("Finish enumerating with error should call completion handler")
+    func finishEnumeratingWithError() {
+        var hasDirtyData: Bool?
+        var completionCallCount = 0
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+            completionCallCount += 1
+        }
+
+        let uploadedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(uploadedItems)
+
+        let testError = NSError(domain: "TestError", code: 1, userInfo: nil)
+        observer.finishEnumeratingWithError(testError)
+
+        #expect(hasDirtyData == false, "Should report no dirty data even with error when all items are uploaded")
+        #expect(completionCallCount == 1, "Completion handler should be called exactly once")
+    }
+
+    @Test("Finish enumerating with error and dirty data should report dirty data")
+    func finishEnumeratingWithErrorAndDirtyData() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let nonUploadedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: false)
+        ]
+
+        observer.didEnumerate(nonUploadedItems)
+
+        let testError = NSError(domain: "TestError", code: 1, userInfo: nil)
+        observer.finishEnumeratingWithError(testError)
+
+        #expect(hasDirtyData == true, "Should report dirty data even with error when non-uploaded items exist")
+    }
+
+    @Test("Empty enumeration batch should not affect result")
+    func emptyEnumerationBatch() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        observer.didEnumerate([])
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == false, "Should report no dirty data when only empty batches are enumerated")
+    }
+
+    @Test("Finish enumerating with next page should still complete")
+    func finishEnumeratingWithNextPage() throws {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        let uploadedItems = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(uploadedItems)
+
+        let nextPage = try NSFileProviderPage(#require("nextPageToken".data(using: .utf8)))
+        observer.finishEnumerating(upTo: nextPage)
+
+        #expect(hasDirtyData == false, "Should complete with no dirty data when next page exists but all items are uploaded")
+    }
+
+    @Test("Early return optimization when dirty data found")
+    func earlyReturnOptimization() {
+        var hasDirtyData: Bool?
+
+        let observer = DirtyUserDataObserver(log: mockLog) { result in
+            hasDirtyData = result
+        }
+
+        // First item is not uploaded, should trigger early return
+        let items = [
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: false),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("2"), filename: "file2.txt", isUploaded: true),
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("3"), filename: "file3.txt", isUploaded: true)
+        ]
+
+        observer.didEnumerate(items)
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(hasDirtyData == true, "Should report dirty data when first item is not uploaded")
+    }
+
+    @Test("Completion handler is called only once")
+    func completionHandlerCalledOnce() {
+        var completionCallCount = 0
+
+        let observer = DirtyUserDataObserver(log: mockLog) { _ in
+            completionCallCount += 1
+        }
+
+        observer.didEnumerate([
+            MockFileProviderItem(identifier: NSFileProviderItemIdentifier("1"), filename: "file1.txt", isUploaded: true)
+        ])
+
+        observer.finishEnumerating(upTo: nil)
+
+        #expect(completionCallCount == 1, "Completion handler should be called exactly once")
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Mocks/FileProviderItemMock.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Mocks/FileProviderItemMock.swift
@@ -1,0 +1,24 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import FileProvider
+
+final class MockFileProviderItem: NSObject, NSFileProviderItemProtocol {
+    var itemIdentifier: NSFileProviderItemIdentifier
+    var filename: String
+    var isUploaded: Bool
+
+    init(identifier: NSFileProviderItemIdentifier, filename: String, isUploaded: Bool) {
+        itemIdentifier = identifier
+        self.filename = filename
+        self.isUploaded = isUploaded
+    }
+
+    var parentItemIdentifier: NSFileProviderItemIdentifier {
+        .rootContainer
+    }
+
+    var capabilities: NSFileProviderItemCapabilities {
+        []
+    }
+}

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientCommunicationProtocol.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+ClientCommunicationProtocol.swift
@@ -1,9 +1,30 @@
 //  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
 //  SPDX-License-Identifier: GPL-2.0-or-later
 
+import FileProvider
 import NextcloudFileProviderKit
 
 extension FileProviderExtension: ClientCommunicationProtocol {
+    func hasDirtyUserData(completionHandler: ((Bool) -> Void)?) {
+        logger.debug("Dirty user data check is requested.")
+
+        guard let completionHandler else {
+            logger.error("Cannot check for dirty user data, completion handler is nil.")
+            return
+        }
+
+        guard let manager = NSFileProviderManager(for: domain) else {
+            logger.error("Cannot check for dirty user data, file provider manager unavailable.")
+            completionHandler(false)
+            return
+        }
+
+        let observer = DirtyUserDataObserver(log: log, completionHandler: completionHandler)
+        let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+        let enumerator = manager.enumeratorForMaterializedItems()
+        enumerator.enumerateItems(for: observer, startingAt: page)
+    }
+
     func getFileProviderDomainIdentifier(completionHandler: @escaping (String?, Error?) -> Void) {
         logger.debug("Returning file provider domain identifier.", [.domain: domain.identifier.rawValue])
         completionHandler(domain.identifier.rawValue, nil)

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/ClientCommunicationProtocol.h
@@ -15,6 +15,11 @@
  */
 - (void)getFileProviderDomainIdentifierWithCompletionHandler:(void(^)(NSString *extensionAccountId, NSError *error))completionHandler;
 
+/**
+ * @brief Ask the file provider extension whether it has dirty user data.
+ */
+- (void)hasDirtyUserDataWithCompletionHandler:(void(^)(BOOL hasDirtyUserData))completionHandler;
+
 - (void)configureAccountWithUser:(NSString *)user
                           userId:(NSString *)userId
                        serverUrl:(NSString *)serverUrl

--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -48,13 +48,15 @@ public:
 
     /**
      * @brief Remove a file provider domain independent from an account.
+     * @return The path to the location where preserved dirty user data is stored, or an empty QString if none.
      */
-    void removeDomain(NSFileProviderDomain *domain);
+    QString removeDomain(NSFileProviderDomain *domain);
 
     /**
      * @brief Remove the file provider domain for the given account.
+     * @return The path to the location where preserved dirty user data is stored, or an empty QString if none.
      */
-    void removeDomainByAccount(const OCC::AccountState * const accountState);
+    QString removeDomainByAccount(const OCC::AccountState * const accountState);
 
     void start();
 
@@ -63,6 +65,13 @@ public:
     NSFileProviderDomain *domainForAccount(const OCC::Account *account) const;
 
     void signalEnumeratorChanged(const OCC::Account * const account);
+
+    /**
+     * @brief Get the user-visible URL for a file provider domain's root container.
+     * @param domainIdentifier The identifier of the file provider domain.
+     * @return The user-visible URL of the domain's root container, or an empty QString if not found.
+     */
+    [[nodiscard]] QString userVisibleUrlForDomainIdentifier(const QString &domainIdentifier) const;
 
 public slots:
     /**

--- a/src/gui/macOS/fileproviderdomainmanager.mm
+++ b/src/gui/macOS/fileproviderdomainmanager.mm
@@ -174,24 +174,33 @@ public:
      * @brief Synchronous and logging wrapper for `[NSFileProviderManager removeDomain:]`.
      *
      * Implicitly calls `removeFileProviderDomainData`, too.
+     * 
+     * @return The path to the location where preserved dirty user data is stored, or an empty QString if none.
      */
-    void removeDomain(NSFileProviderDomain *domain)
+    QString removeDomain(NSFileProviderDomain *domain)
     {
         qCInfo(lcMacFileProviderDomainManager) << "Removing domain"
                                                << domain.identifier;
 
         dispatch_group_t dispatchGroup = dispatch_group_create();
         dispatch_group_enter(dispatchGroup);
+        
+        __block NSURL *preservedDataURL = nil;
 
-        [NSFileProviderManager removeDomain:domain mode:NSFileProviderDomainRemovalModeRemoveAll completionHandler:^(NSURL * const dataURL, NSError * const error) {
-            (void)dataURL; // dataURL is currently unused
-
+        [NSFileProviderManager removeDomain:domain mode:NSFileProviderDomainRemovalModePreserveDirtyUserData completionHandler:^(NSURL * const dataURL, NSError * const error) {
             if (error) {
                 qCWarning(lcMacFileProviderDomainManager) << "Error removing domain"
                                                           << error.code
                                                           << error.localizedDescription;
                 dispatch_group_leave(dispatchGroup);
                 return;
+            }
+
+            if (dataURL) {
+                preservedDataURL = [dataURL copy];
+                qCInfo(lcMacFileProviderDomainManager) << "Domain removed with preserved data at:" << dataURL.path;
+            } else {
+                qCInfo(lcMacFileProviderDomainManager) << "Domain removed with no preserved data";
             }
 
             removeFileProviderDomainData(domain.identifier);
@@ -201,6 +210,12 @@ public:
         }];
 
         dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
+        
+        if (preservedDataURL) {
+            return QString::fromNSString(preservedDataURL.path);
+        }
+        
+        return {};
     }
 
     void signalEnumerator(NSFileProviderDomain *domain)
@@ -222,6 +237,57 @@ public:
         }];
 
         dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
+    }
+
+    /**
+     * @brief Synchronous wrapper to get the user-visible URL for a domain's root container.
+     */
+    QString getUserVisibleUrlForDomain(NSFileProviderDomain *domain)
+    {
+        if (!domain) {
+            qCWarning(lcMacFileProviderDomainManager) << "Cannot get user-visible URL for nil domain";
+            return {};
+        }
+
+        qCInfo(lcMacFileProviderDomainManager) << "Getting user-visible URL for domain" << domain.identifier;
+        
+        NSFileProviderManager * const manager = [NSFileProviderManager managerForDomain:domain];
+        dispatch_group_t dispatchGroup = dispatch_group_create();
+        dispatch_group_enter(dispatchGroup);
+
+        __block NSURL *resultURL = nil;
+
+        [manager getUserVisibleURLForItemIdentifier:NSFileProviderRootContainerItemIdentifier completionHandler:^(NSURL * const url, NSError * const error) {
+            if (error) {
+                qCWarning(lcMacFileProviderDomainManager) << "Error getting user-visible URL for domain"
+                                                          << domain.identifier
+                                                          << ":"
+                                                          << error.code
+                                                          << error.localizedDescription;
+                dispatch_group_leave(dispatchGroup);
+                return;
+            }
+
+            if (url) {
+                resultURL = [url copy];
+                qCInfo(lcMacFileProviderDomainManager) << "Got user-visible URL for domain"
+                                                       << domain.identifier
+                                                       << ":"
+                                                       << url.path;
+            } else {
+                qCWarning(lcMacFileProviderDomainManager) << "No user-visible URL returned for domain" << domain.identifier;
+            }
+
+            dispatch_group_leave(dispatchGroup);
+        }];
+
+        dispatch_group_wait(dispatchGroup, DISPATCH_TIME_FOREVER);
+
+        if (resultURL) {
+            return QString::fromNSString(resultURL.path);
+        }
+
+        return {};
     }
 
     // MARK: - Higher Level Domain Management
@@ -417,13 +483,13 @@ void FileProviderDomainManager::reconnectAll()
     d->reconnectAll();
 }
 
-void FileProviderDomainManager::removeDomain(NSFileProviderDomain *domain)
+QString FileProviderDomainManager::removeDomain(NSFileProviderDomain *domain)
 {
     if (!d || !domain) {
-        return;
+        return {};
     }
 
-    d->removeDomain(domain);
+    return d->removeDomain(domain);
 }
 
 QString FileProviderDomainManager::addDomainForAccount(const AccountState * const accountState)
@@ -462,6 +528,25 @@ void FileProviderDomainManager::signalEnumeratorChanged(const Account * const ac
     d->signalEnumerator(domain);
 }
 
+QString FileProviderDomainManager::userVisibleUrlForDomainIdentifier(const QString &domainIdentifier) const
+{
+    if (!d || domainIdentifier.isEmpty()) {
+        return {};
+    }
+
+    const auto domains = d->getDomains();
+
+    for (NSFileProviderDomain * const domain : domains) {
+        if (domainIdentifier == QString::fromNSString(domain.identifier)) {
+            return d->getUserVisibleUrlForDomain(domain);
+        }
+    }
+
+    qCWarning(lcMacFileProviderDomainManager) << "No file provider domain found with identifier"
+                                              << domainIdentifier;
+    return {};
+}
+
 void FileProviderDomainManager::slotHandleFileIdsChanged(const OCC::Account * const account, const QList<qint64> &fileIds)
 {
     // NOTE: The fileIds argument is ignored for now but retained in the signature for future use.
@@ -487,26 +572,26 @@ void FileProviderDomainManager::slotHandleFileIdsChanged(const OCC::Account * co
     d->signalEnumerator(domain);
 }
 
-void FileProviderDomainManager::removeDomainByAccount(const AccountState * const accountState)
+QString FileProviderDomainManager::removeDomainByAccount(const AccountState * const accountState)
 {
     if (!d) {
-        return;
+        return {};
     }
 
     Q_ASSERT(accountState);
     const auto account = accountState->account();
 
     if (!account) {
-        return;
+        return {};
     }
 
     NSFileProviderDomain * const domain = domainForAccount(account.data());
 
     if (!domain) {
-        return;
+        return {};
     }
 
-    d->removeDomain(domain);
+    return d->removeDomain(domain);
 }
 
 void FileProviderDomainManager::disconnectFileProviderDomainForAccount(const AccountState * const accountState, const QString &reason)

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -22,6 +22,8 @@ namespace Mac {
 class FileProviderSettingsController : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool isOperationInProgress READ isOperationInProgress NOTIFY operationInProgressChanged)
+    Q_PROPERTY(QString operationMessage READ operationMessage NOTIFY operationMessageChanged)
 
 public:
     static FileProviderSettingsController *instance();
@@ -38,6 +40,13 @@ public:
     void migrateToAppSandbox();
 
     [[nodiscard]] Q_INVOKABLE bool vfsEnabledForAccount(const QString &userIdAtHost) const;
+    [[nodiscard]] bool isOperationInProgress() const;
+    [[nodiscard]] QString operationMessage() const;
+
+signals:
+    void operationInProgressChanged();
+    void operationMessageChanged();
+    void vfsEnabledForAccountChanged(const QString &userIdAtHost);
 
 public slots:
     void setVfsEnabledForAccount(const QString &userIdAtHost, const bool setEnabled, const bool showInformationDialog = true);
@@ -46,12 +55,15 @@ private:
     explicit FileProviderSettingsController(QObject *parent = nullptr);
 
     [[nodiscard]] QString fileProviderDomainIdentifierForAccount(const QString &userIdAtHost) const;
+    void setOperationInProgress(bool inProgress, const QString &message = QString());
 
     class MacImplementation;
     friend class MacImplementation;
     MacImplementation *d;
 
     QHash<QString, UserInfo*> _userInfos;
+    bool _isOperationInProgress = false;
+    QString _operationMessage;
 };
 
 } // Mac

--- a/src/gui/macOS/fileproviderxpc.h
+++ b/src/gui/macOS/fileproviderxpc.h
@@ -27,6 +27,7 @@ public:
     explicit FileProviderXPC(QObject *parent = nullptr);
 
     [[nodiscard]] bool fileProviderDomainReachable(const QString &fileProviderDomainIdentifier, bool retry = true, bool reconfigureOnFail = true);
+    [[nodiscard]] bool fileProviderDomainHasDirtyUserData(const QString &fileProviderDomainIdentifier) const;
 
 public slots:
     void connectToFileProviderDomains();

--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -39,11 +39,36 @@ Page {
             right: parent.right
         }
 
+        spacing: Style.standardSpacing
+
         CheckBox {
             id: vfsEnabledCheckBox
             text: qsTr("Enable virtual files")
             checked: root.controller.vfsEnabledForAccount(root.accountUserIdAtHost)
+            enabled: !root.controller.isOperationInProgress
             onClicked: root.controller.setVfsEnabledForAccount(root.accountUserIdAtHost, checked)
+        }
+
+        RowLayout {
+            spacing: Style.standardSpacing
+            visible: root.controller.isOperationInProgress
+
+            Item {
+                Layout.preferredWidth: Style.standardSpacing
+                Layout.preferredHeight: 1
+            }
+
+            NCBusyIndicator {
+                id: operationIndicator
+                running: root.controller.isOperationInProgress
+                Layout.preferredWidth: Style.trayListItemIconSize * 0.6
+                Layout.preferredHeight: Style.trayListItemIconSize * 0.6
+            }
+
+            EnforcedPlainTextLabel {
+                text: root.controller.operationMessage
+                Layout.leftMargin: Style.standardSpacing / 2
+            }
         }
     }
 }


### PR DESCRIPTION
**Summary**: Closes #9417 because client-side data loss of unsynchronized items on file provider domain removal is prevented.

This also matches the behavior of iCloud Drive when it is disabled on a Mac.

In case of "dirty user data" a timestamped folder in `~/Library/CloudStorage` will be created _by macOS_ which contains all unsynchronized items. This avoids data loss on the client side when removing the file provider domain for a Nextcloud client account and does not conflict when the account possibly is set up anew.

The client reveals that folder on removal.

Also, this pull request disables the checkbox for the duration of setup or cleanup of a file provider domain, so race conditions and so on can be avoided by waiting for the transactions to complete.