### PR TITLE
Persistent access to security scoped synchronization folders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ SPDX-FileCopyrightText: <YEAR> Nextcloud GmbH and Nextcloud contributors
 SPDX-License-Identifier: GPL-2.0-or-later
 ```
 
+Avoid creating source files that implement multiple types; instead, place each type in its own dedicated source file.
+
 ## Commit and Pull Request Guidelines
 
 - **Commits**: Follow Conventional Commits format. Use `feat: ...`, `fix: ...`, or `refactor: ...` as appropriate in the commit message prefix.

--- a/admin/osx/macosx.entitlements.cmake
+++ b/admin/osx/macosx.entitlements.cmake
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>@DEVELOPMENT_TEAM@.@APPLICATION_REV_DOMAIN@</string>

--- a/src/common/common.cmake
+++ b/src/common/common.cmake
@@ -33,6 +33,10 @@ elseif(APPLE)
         ${CMAKE_CURRENT_LIST_DIR}/utility_mac.mm
         ${CMAKE_CURRENT_LIST_DIR}/utility_mac_sandbox.h
         ${CMAKE_CURRENT_LIST_DIR}/utility_mac_sandbox.mm
+        ${CMAKE_CURRENT_LIST_DIR}/macsandboxpersistentaccess.h
+        ${CMAKE_CURRENT_LIST_DIR}/macsandboxpersistentaccess.mm
+        ${CMAKE_CURRENT_LIST_DIR}/macsandboxsecurityscopedaccess.h
+        ${CMAKE_CURRENT_LIST_DIR}/macsandboxsecurityscopedaccess.mm
     )
 elseif(UNIX AND NOT APPLE)
     list(APPEND common_SOURCES

--- a/src/common/macsandboxpersistentaccess.h
+++ b/src/common/macsandboxpersistentaccess.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <memory>
+
+namespace OCC {
+namespace Utility {
+
+/**
+ * @brief RAII wrapper for persistent security-scoped resource access
+ *
+ * Unlike MacSandboxSecurityScopedAccess which is intended for short-lived
+ * access during a single operation, this class manages long-lived access
+ * to a security-scoped URL resolved from persisted bookmark data.
+ *
+ * Designed to be stored on Folder objects for the folder's entire lifetime,
+ * ensuring the sandboxed app retains access to sync folder paths across
+ * restart boundaries.
+ *
+ * Usage:
+ * @code
+ * QByteArray bookmarkData = folderDefinition.securityScopedBookmarkData;
+ * auto access = MacSandboxPersistentAccess::createFromBookmarkData(bookmarkData);
+ * if (access && access->isValid()) {
+ *     // The local sync folder path is now accessible
+ * }
+ * @endcode
+ */
+class MacSandboxPersistentAccess
+{
+public:
+    ~MacSandboxPersistentAccess();
+
+    // Non-copyable, movable
+    MacSandboxPersistentAccess(const MacSandboxPersistentAccess &) = delete;
+    MacSandboxPersistentAccess &operator=(const MacSandboxPersistentAccess &) = delete;
+    MacSandboxPersistentAccess(MacSandboxPersistentAccess &&) noexcept;
+    MacSandboxPersistentAccess &operator=(MacSandboxPersistentAccess &&) noexcept;
+
+    /**
+     * @brief Create a persistent access wrapper by resolving bookmark data
+     * @param bookmarkData The app-scoped bookmark data previously created via createSecurityScopedBookmarkData()
+     * @return A unique pointer to the access wrapper, or nullptr if bookmarkData is empty
+     */
+    [[nodiscard]] static std::unique_ptr<MacSandboxPersistentAccess> createFromBookmarkData(const QByteArray &bookmarkData);
+
+    /**
+     * @brief Check if the security-scoped access was successfully acquired
+     * @return true if access is valid and the path can be accessed
+     */
+    [[nodiscard]] bool isValid() const;
+
+    /**
+     * @brief Check if the resolved bookmark was reported as stale by macOS
+     *
+     * A stale bookmark still works, but may stop working in the future.
+     * When stale, callers should recreate the bookmark data via
+     * createSecurityScopedBookmarkData() and persist the new data.
+     *
+     * @return true if the bookmark was stale when resolved
+     */
+    [[nodiscard]] bool isStale() const;
+
+private:
+    explicit MacSandboxPersistentAccess(const QByteArray &bookmarkData);
+
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+} // namespace Utility
+} // namespace OCC

--- a/src/common/macsandboxpersistentaccess.mm
+++ b/src/common/macsandboxpersistentaccess.mm
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "macsandboxpersistentaccess.h"
+
+#include <QLoggingCategory>
+#include <QString>
+
+#import <Foundation/Foundation.h>
+
+Q_LOGGING_CATEGORY(lcMacSandboxPersistent, "nextcloud.common.mac.sandbox.persistent", QtInfoMsg)
+
+namespace OCC {
+namespace Utility {
+
+class MacSandboxPersistentAccess::Impl
+{
+public:
+    explicit Impl(const QByteArray &bookmarkData)
+        : _nsUrl(nullptr)
+        , _hasAccess(false)
+        , _isStale(false)
+    {
+        if (bookmarkData.isEmpty()) {
+            qCWarning(lcMacSandboxPersistent) << "Empty bookmark data provided";
+            return;
+        }
+
+        @autoreleasepool {
+            NSData *nsBookmarkData = [NSData dataWithBytes:bookmarkData.constData()
+                                                    length:bookmarkData.size()];
+            if (!nsBookmarkData) {
+                qCWarning(lcMacSandboxPersistent) << "Failed to create NSData from bookmark data";
+                return;
+            }
+
+            BOOL isStale = NO;
+            NSError *error = nil;
+            _nsUrl = [[NSURL URLByResolvingBookmarkData:nsBookmarkData
+                                                options:NSURLBookmarkResolutionWithSecurityScope
+                                          relativeToURL:nil
+                                    bookmarkDataIsStale:&isStale
+                                                  error:&error] retain];
+
+            if (error) {
+                qCWarning(lcMacSandboxPersistent) << "Failed to resolve bookmark data:"
+                                        << QString::fromNSString([error localizedDescription]);
+                return;
+            }
+
+            if (!_nsUrl) {
+                qCWarning(lcMacSandboxPersistent) << "Resolved URL is nil";
+                return;
+            }
+
+            if (isStale) {
+                _isStale = true;
+                qCWarning(lcMacSandboxPersistent) << "Bookmark data is stale for path:"
+                                        << QString::fromNSString([_nsUrl path])
+                                        << "- the bookmark should be recreated";
+            }
+
+            _hasAccess = [_nsUrl startAccessingSecurityScopedResource];
+
+            if (_hasAccess) {
+                qCInfo(lcMacSandboxPersistent) << "Successfully started persistent access to security-scoped resource:"
+                                     << QString::fromNSString([_nsUrl path]);
+            } else {
+                qCWarning(lcMacSandboxPersistent) << "Failed to start persistent access to security-scoped resource:"
+                                        << QString::fromNSString([_nsUrl path]);
+            }
+        }
+    }
+
+    ~Impl()
+    {
+        @autoreleasepool {
+            if (_hasAccess && _nsUrl) {
+                [_nsUrl stopAccessingSecurityScopedResource];
+                qCDebug(lcMacSandboxPersistent) << "Stopped persistent access to security-scoped resource";
+                _hasAccess = false;
+            }
+
+            if (_nsUrl) {
+                [_nsUrl release];
+                _nsUrl = nullptr;
+            }
+        }
+    }
+
+    // Non-copyable
+    Impl(const Impl &) = delete;
+    Impl &operator=(const Impl &) = delete;
+
+    [[nodiscard]] bool hasAccess() const { return _hasAccess; }
+    [[nodiscard]] bool isStale() const { return _isStale; }
+
+private:
+    NSURL *_nsUrl;
+    bool _hasAccess;
+    bool _isStale;
+};
+
+MacSandboxPersistentAccess::MacSandboxPersistentAccess(const QByteArray &bookmarkData)
+    : _impl(std::make_unique<Impl>(bookmarkData))
+{
+}
+
+MacSandboxPersistentAccess::~MacSandboxPersistentAccess() = default;
+
+MacSandboxPersistentAccess::MacSandboxPersistentAccess(MacSandboxPersistentAccess &&) noexcept = default;
+
+MacSandboxPersistentAccess &MacSandboxPersistentAccess::operator=(MacSandboxPersistentAccess &&) noexcept = default;
+
+std::unique_ptr<MacSandboxPersistentAccess> MacSandboxPersistentAccess::createFromBookmarkData(const QByteArray &bookmarkData)
+{
+    if (bookmarkData.isEmpty()) {
+        return nullptr;
+    }
+    return std::unique_ptr<MacSandboxPersistentAccess>(new MacSandboxPersistentAccess(bookmarkData));
+}
+
+bool MacSandboxPersistentAccess::isValid() const
+{
+    return _impl && _impl->hasAccess();
+}
+
+bool MacSandboxPersistentAccess::isStale() const
+{
+    return _impl && _impl->isStale();
+}
+
+} // namespace Utility
+} // namespace OCC

--- a/src/common/macsandboxsecurityscopedaccess.h
+++ b/src/common/macsandboxsecurityscopedaccess.h
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <QUrl>
+#include <memory>
+
+namespace OCC {
+namespace Utility {
+
+/**
+ * @brief RAII wrapper for macOS security-scoped resource access
+ * 
+ * When working with files selected by the user via QFileDialog in a sandboxed
+ * macOS app, the returned URLs are security-scoped bookmarks that require
+ * explicit access management via startAccessingSecurityScopedResource() and
+ * stopAccessingSecurityScopedResource().
+ * 
+ * This class provides RAII semantics to ensure proper cleanup.
+ * 
+ * Usage:
+ * @code
+ * QUrl fileUrl = QFileDialog::getSaveFileUrl(...);
+ * if (!fileUrl.isEmpty()) {
+ *     auto scopedAccess = MacSandboxSecurityScopedAccess::create(fileUrl);
+ *     if (scopedAccess->isValid()) {
+ *         // Now you can access the file
+ *         QFile file(fileUrl.toLocalFile());
+ *         file.open(QIODevice::WriteOnly);
+ *     }
+ * }
+ * @endcode
+ */
+class MacSandboxSecurityScopedAccess
+{
+public:
+    ~MacSandboxSecurityScopedAccess();
+
+    // Non-copyable, movable
+    MacSandboxSecurityScopedAccess(const MacSandboxSecurityScopedAccess&) = delete;
+    MacSandboxSecurityScopedAccess& operator=(const MacSandboxSecurityScopedAccess&) = delete;
+    MacSandboxSecurityScopedAccess(MacSandboxSecurityScopedAccess&&) noexcept;
+    MacSandboxSecurityScopedAccess& operator=(MacSandboxSecurityScopedAccess&&) noexcept;
+
+    /**
+     * @brief Create a security-scoped access wrapper for the given URL
+     * @param url The URL to access (typically from QFileDialog)
+     * @return A unique pointer to the access wrapper
+     */
+    [[nodiscard]] static std::unique_ptr<MacSandboxSecurityScopedAccess> create(const QUrl &url);
+
+    /**
+     * @brief Check if the security-scoped access was successfully acquired
+     * @return true if access is valid and the file can be accessed
+     */
+    [[nodiscard]] bool isValid() const;
+
+private:
+    explicit MacSandboxSecurityScopedAccess(const QUrl &url);
+
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+} // namespace Utility
+} // namespace OCC

--- a/src/common/macsandboxsecurityscopedaccess.mm
+++ b/src/common/macsandboxsecurityscopedaccess.mm
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "macsandboxsecurityscopedaccess.h"
+
+#include <QLoggingCategory>
+
+#import <Foundation/Foundation.h>
+
+Q_LOGGING_CATEGORY(lcMacSandbox, "nextcloud.common.mac.sandbox", QtInfoMsg)
+
+namespace OCC {
+namespace Utility {
+
+class MacSandboxSecurityScopedAccess::Impl
+{
+public:
+    explicit Impl(const QUrl &url)
+        : _url(url)
+        , _nsUrl(nullptr)
+        , _hasAccess(false)
+    {
+        if (!url.isValid() || url.isEmpty()) {
+            qCWarning(lcMacSandbox) << "Invalid or empty URL provided";
+            return;
+        }
+
+        // Convert QUrl to NSURL
+        const QString localPath = url.toLocalFile();
+        if (localPath.isEmpty()) {
+            qCWarning(lcMacSandbox) << "URL does not represent a local file:" << url;
+            return;
+        }
+
+        @autoreleasepool {
+            _nsUrl = [[NSURL fileURLWithPath:localPath.toNSString()] retain];
+            
+            if (!_nsUrl) {
+                qCWarning(lcMacSandbox) << "Failed to create NSURL from path:" << localPath;
+                return;
+            }
+
+            // Start accessing the security-scoped resource
+            _hasAccess = [_nsUrl startAccessingSecurityScopedResource];
+            
+            if (_hasAccess) {
+                qCDebug(lcMacSandbox) << "Successfully started accessing security-scoped resource:" << localPath;
+            } else {
+                qCWarning(lcMacSandbox) << "Failed to start accessing security-scoped resource:" << localPath;
+            }
+        }
+    }
+
+    ~Impl()
+    {
+        @autoreleasepool {
+            if (_hasAccess && _nsUrl) {
+                [_nsUrl stopAccessingSecurityScopedResource];
+                qCDebug(lcMacSandbox) << "Stopped accessing security-scoped resource";
+                _hasAccess = false;
+            }
+            
+            if (_nsUrl) {
+                [_nsUrl release];
+                _nsUrl = nullptr;
+            }
+        }
+    }
+
+    // Non-copyable
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+
+    [[nodiscard]] bool hasAccess() const { return _hasAccess; }
+
+private:
+    QUrl _url;
+    NSURL *_nsUrl;
+    bool _hasAccess;
+};
+
+MacSandboxSecurityScopedAccess::MacSandboxSecurityScopedAccess(const QUrl &url)
+    : _impl(std::make_unique<Impl>(url))
+{
+}
+
+MacSandboxSecurityScopedAccess::~MacSandboxSecurityScopedAccess() = default;
+
+MacSandboxSecurityScopedAccess::MacSandboxSecurityScopedAccess(MacSandboxSecurityScopedAccess&&) noexcept = default;
+
+MacSandboxSecurityScopedAccess& MacSandboxSecurityScopedAccess::operator=(MacSandboxSecurityScopedAccess&&) noexcept = default;
+
+std::unique_ptr<MacSandboxSecurityScopedAccess> MacSandboxSecurityScopedAccess::create(const QUrl &url)
+{
+    return std::unique_ptr<MacSandboxSecurityScopedAccess>(new MacSandboxSecurityScopedAccess(url));
+}
+
+bool MacSandboxSecurityScopedAccess::isValid() const
+{
+    return _impl && _impl->hasAccess();
+}
+
+} // namespace Utility
+} // namespace OCC

--- a/src/common/utility_mac_sandbox.h
+++ b/src/common/utility_mac_sandbox.h
@@ -5,74 +5,36 @@
 
 #pragma once
 
-#include <QUrl>
+#include "macsandboxsecurityscopedaccess.h"
+#include "macsandboxpersistentaccess.h"
+
+#include <QByteArray>
 #include <QString>
-#include <memory>
 
 namespace OCC {
 namespace Utility {
 
 /**
- * @brief RAII wrapper for macOS security-scoped resource access
- * 
- * When working with files selected by the user via QFileDialog in a sandboxed
- * macOS app, the returned URLs are security-scoped bookmarks that require
- * explicit access management via startAccessingSecurityScopedResource() and
- * stopAccessingSecurityScopedResource().
- * 
- * This class provides RAII semantics to ensure proper cleanup.
- * 
- * Usage:
- * @code
- * QUrl fileUrl = QFileDialog::getSaveFileUrl(...);
- * if (!fileUrl.isEmpty()) {
- *     auto scopedAccess = MacSandboxSecurityScopedAccess::create(fileUrl);
- *     if (scopedAccess->isValid()) {
- *         // Now you can access the file
- *         QFile file(fileUrl.toLocalFile());
- *         file.open(QIODevice::WriteOnly);
- *     }
- * }
- * @endcode
+ * @brief Create app-scoped security-scoped bookmark data for a local path
+ *
+ * This should be called while the app still has access to the path (e.g. right
+ * after the user selects a folder via QFileDialog). The returned data can be
+ * persisted to settings and later resolved with
+ * MacSandboxPersistentAccess::createFromBookmarkData() to regain access
+ * after an app restart.
+ *
+ * @param localPath The local file system path to create a bookmark for
+ * @return The bookmark data as a QByteArray, or an empty QByteArray on failure
  */
-class MacSandboxSecurityScopedAccess
-{
-public:
-    ~MacSandboxSecurityScopedAccess();
-
-    // Non-copyable, movable
-    MacSandboxSecurityScopedAccess(const MacSandboxSecurityScopedAccess&) = delete;
-    MacSandboxSecurityScopedAccess& operator=(const MacSandboxSecurityScopedAccess&) = delete;
-    MacSandboxSecurityScopedAccess(MacSandboxSecurityScopedAccess&&) noexcept;
-    MacSandboxSecurityScopedAccess& operator=(MacSandboxSecurityScopedAccess&&) noexcept;
-
-    /**
-     * @brief Create a security-scoped access wrapper for the given URL
-     * @param url The URL to access (typically from QFileDialog)
-     * @return A unique pointer to the access wrapper
-     */
-    [[nodiscard]] static std::unique_ptr<MacSandboxSecurityScopedAccess> create(const QUrl &url);
-
-    /**
-     * @brief Check if the security-scoped access was successfully acquired
-     * @return true if access is valid and the file can be accessed
-     */
-    [[nodiscard]] bool isValid() const;
-
-private:
-    explicit MacSandboxSecurityScopedAccess(const QUrl &url);
-
-    class Impl;
-    std::unique_ptr<Impl> _impl;
-};
+[[nodiscard]] QByteArray createSecurityScopedBookmarkData(const QString &localPath);
 
 /**
  * @brief Get the real user home directory path
- * 
+ *
  * In sandboxed macOS apps, QStandardPaths::HomeLocation returns the sandbox
  * container directory, not the actual user home directory. This function uses
  * NSHomeDirectory() to retrieve the real home directory path.
- * 
+ *
  * @return The real user home directory path
  */
 [[nodiscard]] QString getRealHomeDirectory();


### PR DESCRIPTION
To retain access to security scoped locations on a device across sandboxed app launches, their access must be persisted using bookmarks.

## Problem

After quitting and launching the client again it no longer could access synchronization folders in the file system.

## Solution

Create bookmarks for those security scoped resources and persist them as part of the folder configuration.