### PR TITLE
fix: keep remote if folder was not seen by user

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -45,7 +45,8 @@ Q_LOGGING_CATEGORY(lcDb, "nextcloud.sync.database", QtInfoMsg)
         "SELECT path, inode, modtime, type, md5, fileid, remotePerm, filesize," \
         "  ignoredChildrenRemote, contentchecksumtype.name || ':' || contentChecksum, e2eMangledName, isE2eEncrypted, e2eCertificateFingerprint, " \
         "  lock, lockOwnerDisplayName, lockOwnerId, lockType, lockOwnerEditor, lockTime, lockTimeout, lockToken, isShared, lastShareStateFetchedTimestmap, " \
-        "  sharedByMe, isLivePhoto, livePhotoFile, quotaBytesUsed, quotaBytesAvailable" \
+        "  sharedByMe, isLivePhoto, livePhotoFile, quotaBytesUsed, quotaBytesAvailable," \
+        " EXISTS (SELECT * from selectivesync where selectivesync.path LIKE metadata.path || \"/%\") AS hasDescendantInSelectiveSync " \
         " FROM metadata" \
         "  LEFT JOIN checksumtype as contentchecksumtype ON metadata.contentChecksumTypeId == contentchecksumtype.id"
 
@@ -78,6 +79,7 @@ static void fillFileRecordFromGetQuery(SyncJournalFileRecord &rec, SqlQuery &que
     rec._livePhotoFile = query.stringValue(25);
     rec._folderQuota.bytesUsed = query.int64Value(26);
     rec._folderQuota.bytesAvailable = query.int64Value(27);
+    rec._hasDescendantInSelectiveSync = query.int64Value(28);
 }
 
 static QByteArray defaultJournalMode(const QString &dbPath)

--- a/src/common/syncjournalfilerecord.h
+++ b/src/common/syncjournalfilerecord.h
@@ -69,6 +69,7 @@ public:
     qint64 _fileSize = 0;
     RemotePermissions _remotePerm;
     bool _serverHasIgnoredFiles = false;
+    bool _hasDescendantInSelectiveSync;
     QByteArray _checksumHeader;
     QByteArray _e2eMangledName;
     EncryptionStatus _e2eEncryptionStatus = EncryptionStatus::NotEncrypted;

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -105,6 +105,43 @@ PropagateItemJob::~PropagateItemJob()
     }
 }
 
+bool PropagateItemJob::addPathToSelectiveSync(SyncJournalDb *journal, const QString &folder_)
+{
+    bool ok = false;
+    QStringList list = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
+    if (!ok)
+        return false;
+
+    ASSERT(!folder_.endsWith(QLatin1String("/")));
+    QString folder = folder_ + QLatin1String("/");
+
+    list.append(folder);
+
+    journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, list);
+    return true;
+}
+
+bool PropagateItemJob::removePathFromSelectiveSync(SyncJournalDb *journal, const QString &folder_)
+{
+    bool ok = false;
+    QStringList list = journal->getSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, &ok);
+    if (!ok)
+        return false;
+
+    ASSERT(!folder_.endsWith(QLatin1String("/")));
+    QString folder = folder_ + QLatin1String("/");
+
+    for (auto &s : list) {
+        if (s.startsWith(folder)) {
+            const int item = list.indexOf(s);
+            list.removeAt(item);
+        }
+    }
+
+    journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, list);
+    return true;
+}
+
 static qint64 getMinBlacklistTime()
 {
     return qMax(qEnvironmentVariableIntValue("OWNCLOUD_BLACKLIST_TIME_MIN"),

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -205,6 +205,9 @@ public:
     }
     ~PropagateItemJob() override;
 
+    static bool removePathFromSelectiveSync(SyncJournalDb *journal, const QString &folder);
+    static bool addPathToSelectiveSync(SyncJournalDb *journal, const QString &folder);
+
     bool scheduleSelfOrChild() override
     {
         if (_state != NotYetStarted) {

--- a/src/libsync/syncfileitem.cpp
+++ b/src/libsync/syncfileitem.cpp
@@ -150,6 +150,7 @@ SyncFileItemPtr SyncFileItem::fromSyncJournalFileRecord(const SyncJournalFileRec
     item->_size = rec._fileSize;
     item->_remotePerm = rec._remotePerm;
     item->_serverHasIgnoredFiles = rec._serverHasIgnoredFiles;
+    item->_hasDescendantInSelectiveSync = rec._hasDescendantInSelectiveSync;
     item->_checksumHeader = rec._checksumHeader;
     item->_encryptedFileName = rec.e2eMangledName();
     item->_e2eEncryptionStatus = EncryptionStatusEnums::fromDbEncryptionStatus(rec._e2eEncryptionStatus);

--- a/src/libsync/syncfileitem.h
+++ b/src/libsync/syncfileitem.h
@@ -272,6 +272,7 @@ public:
     Status _status BITFIELD(4);
     bool _isRestoration BITFIELD(1); // The original operation was forbidden, and this is a restoration
     bool _isSelectiveSync BITFIELD(1); // The file is removed or ignored because it is in the selective sync list
+    bool _hasDescendantInSelectiveSync; // True if the object contains a folder that is deselected for sync.
     EncryptionStatus _e2eEncryptionStatus = EncryptionStatus::NotEncrypted; // The file is E2EE or the content of the directory should be E2EE
     EncryptionStatus _e2eEncryptionServerCapability = EncryptionStatus::NotEncrypted;
     EncryptionStatus _e2eEncryptionStatusRemote = EncryptionStatus::NotEncrypted;


### PR DESCRIPTION
# Summary
If a user deletes a folder, one would expect to delete only data that the user could've seen.
In case the deleted folder contains data, that was deselected for sync - thus user didnt see that - the desktop client would also delete that unseen data on the server.

I already had some discussion about a while ago in: https://github.com/nextcloud/desktop/issues/6948 and https://help.nextcloud.com/t/desktop-client-triggered-deletions-are-deleting-not-synced-data/199356

##  Comparison to competitors
Also compared this behavior to OneDrive and Dropbox. Both keep data on the server, because they assume the has not seen it, thus does not want to delete that portion.

# Changes I did:
- extend the GET_FILE_RECORD_QUERY to query for configured selectiveSyncs of descendants
- added SyncFileItem flag indicating their descendants sync status: item->_hasDescendantInSelectiveSync

- branch the ProcessDirectoryJob::processFileAnalyzeLocalInfo procedure to distinguish between:
fully synced data (_hasDescendantInSelectiveSync==false)
and
partial synced data (_hasDescendantInSelectiveSync==true) and add some special care for this corner case

## Handling partial synced data:
- remove the deleted parent folder from the metadata table. required since I set item->_instruction to CSYNC_INSTRUCTION_NONE -> this avoids the remote delete on the server
- remove the unsynced descendant from the selectivesync table
- and add the parent folder to the selectivesync table


