### PR TITLE
Drop macOS 12 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_policy(SET CMP0071 NEW) # Enable use of QtQuick compiler/generated code
 project(client)
 
 if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum OSX deployment version")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum OSX deployment version")
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/admin/osx/mac-crafter/Package.swift
+++ b/admin/osx/mac-crafter/Package.swift
@@ -11,7 +11,7 @@ import PackageDescription
 let package = Package(
     name: "mac-crafter",
     platforms: [
-        .macOS(.v12),
+        .macOS(.v13),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.4.0")

--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -5,7 +5,7 @@
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>LSMinimumSystemVersion</key>
-    <string>12.0</string>
+    <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>CFBundleDevelopmentRegion</key>

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -18,7 +18,7 @@ CreateCache = False
 # Category is case sensitive
 [GeneralSettings]
 
-General/MacDeploymentTarget = 12.0
+General/MacDeploymentTarget = 13.0
 
 Compile/BuildType = RelWithDebInfo
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "NextcloudFileProviderKit",
     platforms: [
         .iOS(.v16),
-        .macOS(.v12),
+        .macOS(.v13),
         .visionOS(.v1)
     ],
     products: [

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+KeepDownloaded.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+KeepDownloaded.swift
@@ -6,17 +6,6 @@ import RealmSwift
 
 public extension FilesDatabaseManager {
     func set(keepDownloaded: Bool, for metadata: SendableItemMetadata) throws -> SendableItemMetadata? {
-        guard #available(macOS 13.0, iOS 16.0, visionOS 1.0, *) else {
-            let error = "Could not update keepDownloaded status for item because the system does not support this state."
-            logger.error(error, [.item: metadata.ocId, .name: metadata.fileName])
-
-            throw NSError(
-                domain: Self.errorDomain,
-                code: NSFeatureUnsupportedError,
-                userInfo: [NSLocalizedDescriptionKey: error]
-            )
-        }
-
         guard let result = itemMetadatas.where({ $0.ocId == metadata.ocId }).first else {
             let error = "Did not update keepDownloaded for item metadata as it was not found."
             logger.error(error, [.item: metadata.ocId, .name: metadata.fileName])

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -117,12 +117,9 @@ public extension Item {
 
             if let domain, let localUrl = await localUrlForContents(domain: domain) {
                 return (localUrl, self, nil)
-            } else if #available(macOS 13.0, *) {
-                logger.error("Could not get local contents URL for lock file, erroring.")
-                return (nil, self, NSFileProviderError(.excludedFromSync))
             } else {
-                logger.error("Could not get local contents URL for lock file, nilling.")
-                return (nil, self, nil)
+                logger.error("Could not get local content URL for lock file.")
+                return (nil, self, NSFileProviderError(.excludedFromSync))
             }
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Ignored.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Ignored.swift
@@ -67,10 +67,6 @@ extension Item {
             log: log
         )
 
-        if #available(macOS 13.0, *) {
-            return (item, NSFileProviderError(.excludedFromSync))
-        } else {
-            return (item, nil)
-        }
+        return (item, NSFileProviderError(.excludedFromSync))
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
@@ -24,16 +24,10 @@ public extension Item {
             }
         }
 
-        if #available(macOS 13.0, iOS 16.0, visionOS 1.0, *) {
-            if keepDownloaded, !isDownloaded {
-                try await manager.requestDownloadForItem(withIdentifier: itemIdentifier)
-            } else {
-                try await manager.requestModification(
-                    of: [.lastUsedDate], forItemWithIdentifier: itemIdentifier
-                )
-            }
+        if keepDownloaded, !isDownloaded {
+            try await manager.requestDownloadForItem(withIdentifier: itemIdentifier)
         } else {
-            try await manager.signalEnumerator(for: .workingSet)
+            try await manager.requestModification(of: [.lastUsedDate], forItemWithIdentifier: itemIdentifier)
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
@@ -74,26 +74,14 @@ extension Item {
 
         guard await assertRequiredCapabilities(domain: domain, itemIdentifier: itemTemplate.itemIdentifier, account: account, remoteInterface: remoteInterface, logger: logger) else {
             logger.debug("Excluding lock file from synchronizing due to lack of server-side locking capability.", [.item: itemTemplate.itemIdentifier, .name: itemTemplate.filename])
-
-            let error = if #available(macOS 13.0, *) {
-                NSFileProviderError(.excludedFromSync)
-            } else {
-                NSFileProviderError(.cannotSynchronize)
-            }
-
-            return (nil, error)
+            return (nil, NSFileProviderError(.excludedFromSync))
         }
 
         logger.info("Item to create is a lock file. Will attempt to lock the associated file on the server.", [.name: itemTemplate.filename])
 
         guard let targetFileName = originalFileName(fromLockFileName: itemTemplate.filename, dbManager: dbManager) else {
             logger.error("Will not lock the target file because it could not be determined based on the lock file name.", [.name: itemTemplate.filename])
-
-            if #available(macOS 13.0, *) {
-                return (nil, NSFileProviderError(.excludedFromSync))
-            } else {
-                return (nil, NSFileProviderError(.cannotSynchronize))
-            }
+            return (nil, NSFileProviderError(.excludedFromSync))
         }
 
         logger.debug("Derived target file name for lock file.", [.name: targetFileName])

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -578,12 +578,7 @@ public extension Item {
             }
 
             modifiedItem = modifiedIgnored
-
-            if #available(macOS 13.0, *) {
-                return (modifiedItem, NSFileProviderError(.excludedFromSync))
-            } else {
-                return (modifiedItem, nil)
-            }
+            return (modifiedItem, NSFileProviderError(.excludedFromSync))
         }
 
         // We are handling an item that is available locally but not on the server -- so create it

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Trash.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Trash.swift
@@ -73,12 +73,7 @@ extension Item {
         )
         else {
             logger.error("Did not find trashed item in trash, asking for a rescan.", [.item: modifiedItem])
-
-            if #available(macOS 11.3, *) {
-                return (dirtyItem, NSFileProviderError(.unsyncedEdits))
-            } else {
-                return (dirtyItem, NSFileProviderError(.syncAnchorExpired))
-            }
+            return (dirtyItem, NSFileProviderError(.unsyncedEdits))
         }
 
         var postDeleteMetadata = targetItemNKTrash.toItemMetadata(account: account)
@@ -200,12 +195,7 @@ extension Item {
 
         guard modifiedItem.metadata.trashbinOriginalLocation != "" else {
             logger.error("Could not scan restored item. The trashed file's original location is invalid.", [.name: modifiedItem.filename])
-
-            if #available(macOS 11.3, *) {
-                return (modifiedItem, NSFileProviderError(.unsyncedEdits))
-            }
-
-            return (modifiedItem, NSFileProviderError(.cannotSynchronize))
+            return (modifiedItem, NSFileProviderError(.unsyncedEdits))
         }
 
         let originalLocation = account.davFilesUrl + "/" + modifiedItem.metadata.trashbinOriginalLocation
@@ -230,11 +220,7 @@ extension Item {
                 """
             )
 
-            if #available(macOS 11.3, *) {
-                return (modifiedItem, NSFileProviderError(.unsyncedEdits))
-            }
-
-            return (modifiedItem, enumerateError.fileProviderError)
+            return (modifiedItem, NSFileProviderError(.unsyncedEdits))
         }
 
         guard target.ocId == modifiedItem.itemIdentifier.rawValue else {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -58,15 +58,8 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             }
         }
 
-        // .allowsEvicting deprecated on macOS 13.0+, use contentPolicy instead
-        if #unavailable(macOS 13.0), !metadata.keepDownloaded {
-            capabilities.insert(.allowsEvicting)
-        }
-        #if os(macOS)
-            if #available(macOS 11.3, *) {
-                capabilities.insert(.allowsExcludingFromSync)
-            }
-        #endif
+        capabilities.insert(.allowsExcludingFromSync)
+
         return capabilities
     }
 
@@ -200,13 +193,11 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             // Note that only files, not folders, should be lockable/unlockable
             userInfoDict["locked"] = metadata.lock
         }
-        if #available(macOS 13.0, iOS 16.0, visionOS 1.0, *) {
-            userInfoDict["displayKeepDownloaded"] = !metadata.keepDownloaded
-            userInfoDict["displayAllowAutoEvicting"] = metadata.keepDownloaded
-            userInfoDict["displayEvict"] = metadata.downloaded && !metadata.keepDownloaded
-        } else {
-            userInfoDict["displayEvict"] = metadata.downloaded
-        }
+
+        userInfoDict["displayKeepDownloaded"] = !metadata.keepDownloaded
+        userInfoDict["displayAllowAutoEvicting"] = metadata.keepDownloaded
+        userInfoDict["displayEvict"] = metadata.downloaded && !metadata.keepDownloaded
+
         // https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html
         if metadata.permissions.uppercased().contains("R"), // Shareable
            ![.rootContainer, .trashContainer].contains(itemIdentifier)
@@ -228,8 +219,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
     }
 
     public var keepDownloaded: Bool {
-        guard #available(macOS 13.0, iOS 16.0, visionOS 1.0, *) else { return false }
-        return metadata.keepDownloaded
+        metadata.keepDownloaded
     }
 
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
@@ -157,11 +157,7 @@ public extension ItemMetadata {
         guard hasPreview else {
             return nil
         }
-        guard #available(macOS 13.0, iOS 16.0, visionOS 1.0, *) else {
-            return URL(
-                string: "\(urlBase.urlEncoded ?? "")/index.php/core/preview?fileId=\(fileId)&x=\(size.width)&y=\(size.height)&a=true"
-            )
-        }
+
         return URL(string: urlBase.urlEncoded ?? "")?
             .appending(components: "index.php", "core", "preview")
             .appending(queryItems: [

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -718,12 +718,7 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
 
         XCTAssertNil(createdItem)
         let unwrappedError = try XCTUnwrap(error) as? NSFileProviderError
-        let expectedError = if #available(macOS 13.0, *) {
-            NSFileProviderError(.excludedFromSync)
-        } else {
-            NSFileProviderError(.cannotSynchronize)
-        }
-        XCTAssertEqual(unwrappedError, expectedError)
+        XCTAssertEqual(unwrappedError, NSFileProviderError(.excludedFromSync))
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: lockFileMetadata.ocId))
         XCTAssertFalse(targetRemote.locked)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -1346,11 +1346,7 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
             ignoredFiles: ignoredMatcher,
             dbManager: Self.dbManager
         )
-        if #available(macOS 13.0, *) {
-            XCTAssertEqual(error as? NSFileProviderError, NSFileProviderError(.excludedFromSync))
-        } else {
-            XCTAssertNil(error)
-        }
+        XCTAssertEqual(error as? NSFileProviderError, NSFileProviderError(.excludedFromSync))
         XCTAssertNotNil(resultItem)
         XCTAssertEqual(resultItem?.metadata.fileName, "error.bak")
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -776,11 +776,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
 
         // Excluding from sync is macOS-specific and always added if available
         var platformExpected = expected
-        #if os(macOS)
-            if #available(macOS 11.3, *) {
-                platformExpected.insert(.allowsExcludingFromSync)
-            }
-        #endif
+        platformExpected.insert(.allowsExcludingFromSync)
 
         XCTAssertEqual(item.capabilities, platformExpected)
     }
@@ -811,11 +807,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         ]
 
         var platformExpected = expected
-        #if os(macOS)
-            if #available(macOS 11.3, *) {
-                platformExpected.insert(.allowsExcludingFromSync)
-            }
-        #endif
+        platformExpected.insert(.allowsExcludingFromSync)
 
         XCTAssertEqual(item.capabilities, platformExpected)
     }
@@ -837,38 +829,31 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         // Trashing and Excluding from Sync might still be allowed as they don't depend on the
         // permission string
         var expected: NSFileProviderItemCapabilities = [.allowsTrashing]
-
-        #if os(macOS)
-            if #available(macOS 11.3, *) {
-                expected.insert(.allowsExcludingFromSync)
-            }
-        #endif
+        expected.insert(.allowsExcludingFromSync)
 
         XCTAssertEqual(item.capabilities, expected)
     }
 
     #if os(macOS)
         func testCapabilitiesMacOSExclusion() {
-            if #available(macOS 11.3, *) {
-                var metadata = SendableItemMetadata(
-                    ocId: "macos-exclusion", fileName: "file.txt", account: Self.account
-                )
-                metadata.permissions = ""
-                let item = Item(
-                    metadata: metadata,
-                    parentItemIdentifier: .rootContainer,
-                    account: Self.account,
-                    remoteInterface: MockRemoteInterface(account: Self.account),
-                    dbManager: Self.dbManager,
-                    remoteSupportsTrash: true,
-                    log: FileProviderLogMock()
-                )
+            var metadata = SendableItemMetadata(
+                ocId: "macos-exclusion", fileName: "file.txt", account: Self.account
+            )
+            metadata.permissions = ""
+            let item = Item(
+                metadata: metadata,
+                parentItemIdentifier: .rootContainer,
+                account: Self.account,
+                remoteInterface: MockRemoteInterface(account: Self.account),
+                dbManager: Self.dbManager,
+                remoteSupportsTrash: true,
+                log: FileProviderLogMock()
+            )
 
-                XCTAssertTrue(
-                    item.capabilities.contains(.allowsExcludingFromSync),
-                    "Should allow excluding from sync on supported macOS versions."
-                )
-            }
+            XCTAssertTrue(
+                item.capabilities.contains(.allowsExcludingFromSync),
+                "Should allow excluding from sync on supported macOS versions."
+            )
         }
     #endif
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -302,16 +302,8 @@ import OSLog
             if error == nil {
                 removeSyncAction(actionId)
             } else {
-                // Do not consider the exclusion of a file a synchronization error resulting in a misleading status report because exclusion is expected.
-                // Though, the exclusion error code is only available starting with macOS 13, hence this logic reads a bit more cumbersome.
-
-                if #available(macOS 13.0, *) {
-                    if let fileProviderError = error as? NSFileProviderError, fileProviderError.code == .excludedFromSync {
-                        removeSyncAction(actionId)
-                    } else {
-                        insertErrorAction(actionId)
-                        signalEnumerator(completionHandler: { _ in })
-                    }
+                if let fileProviderError = error as? NSFileProviderError, fileProviderError.code == .excludedFromSync {
+                    removeSyncAction(actionId)
                 } else {
                     insertErrorAction(actionId)
                     signalEnumerator(completionHandler: { _ in })

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Extensions/NKShare+Extensions.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Extensions/NKShare+Extensions.swift
@@ -58,11 +58,8 @@ extension NKShare {
         }
 
         var config = NSImage.SymbolConfiguration(textStyle: .body, scale: .large)
-        if #available(macOS 12.0, *) {
-            config = config.applying(
-                .init(paletteColors: [.controlBackgroundColor, .controlAccentColor])
-            )
-        }
+        config = config.applying(.init(paletteColors: [.controlBackgroundColor, .controlAccentColor]))
+
         return image?.withSymbolConfiguration(config)
     }
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Sharing/ShareTableItemView.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Sharing/ShareTableItemView.swift
@@ -52,9 +52,7 @@ class ShareTableItemView: NSTableCellView {
             accessibilityDescription: String(localized: "Public link has been copied icon")
         )
         var config = NSImage.SymbolConfiguration(scale: .medium)
-        if #available(macOS 12.0, *) {
-            config = config.applying(.init(hierarchicalColor: .systemGreen))
-        }
+        config = config.applying(.init(hierarchicalColor: .systemGreen))
         copiedButtonImage = copiedButtonImage?.withSymbolConfiguration(config)
         copyLinkButton.image = copiedButtonImage
         tempButtonTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { timer in

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Build.xcconfig
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Build.xcconfig
@@ -27,3 +27,8 @@ OC_APPLICATION_REV_DOMAIN=$(OC_APPLICATION_REV_DOMAIN:default=com.nextcloud.desk
 // Hardened runtime as required for notarization.
 //
 ENABLE_HARDENED_RUNTIME=YES
+
+//
+// The required macOS version for all targets of the project.
+//
+MACOSX_DEPLOYMENT_TARGET=13.0

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.pbxproj
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.pbxproj
@@ -999,7 +999,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1044,7 +1043,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(OC_APPLICATION_REV_DOMAIN).$(PRODUCT_NAME)";
@@ -1104,7 +1102,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1165,7 +1162,6 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1226,7 +1222,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -1283,7 +1278,6 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -1491,7 +1485,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1539,7 +1532,6 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1590,7 +1582,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OC_OEM_SHARE_ICNS = "";
 				ONLY_ACTIVE_ARCH = YES;
@@ -1636,7 +1627,6 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OC_OEM_SHARE_ICNS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/src/gui/macOS/fileproviderdomainmanager.mm
+++ b/src/gui/macOS/fileproviderdomainmanager.mm
@@ -354,14 +354,7 @@ public:
         auto domainDisplayName = account->displayName();
         domainDisplayName.replace('.', QChar(0x2024));
         NSFileProviderDomain * const domain = [[NSFileProviderDomain alloc] initWithIdentifier:domainId.toNSString() displayName:domainDisplayName.toNSString()];
-
-        if (@available(macOS 13.0, *)) {
-            // supportsSyncingTrash is only available on macOS 13 and later.
-            // The trash is a server feature of which the availability can change any time.
-            // Its availability is checked on demand by the file provider extension itself.
-            domain.supportsSyncingTrash = YES;
-        }
-
+        domain.supportsSyncingTrash = YES;
         addDomain(domain);
         AccountManager::instance()->setFileProviderDomainIdentifier(accountId, domainId);
 

--- a/src/gui/macOS/fileprovideritemmetadata_mac.mm
+++ b/src/gui/macOS/fileprovideritemmetadata_mac.mm
@@ -72,10 +72,8 @@ FileProviderItemMetadata FileProviderItemMetadata::fromNSFileProviderItem(const 
     metadata._capabilities = bridgedNsFileProviderItem.capabilities;
     metadata._fileSystemFlags = bridgedNsFileProviderItem.fileSystemFlags;
     metadata._childItemCount = bridgedNsFileProviderItem.childItemCount.unsignedIntegerValue;
-    if (@available(macOS 12.0, *)) {
-        metadata._typeOsCode = bridgedNsFileProviderItem.typeAndCreator.type;
-        metadata._creatorOsCode = bridgedNsFileProviderItem.typeAndCreator.creator;
-    }
+    metadata._typeOsCode = bridgedNsFileProviderItem.typeAndCreator.type;
+    metadata._creatorOsCode = bridgedNsFileProviderItem.typeAndCreator.creator;
     metadata._documentSize = bridgedNsFileProviderItem.documentSize.unsignedLongLongValue;
     metadata._mostRecentVersionDownloaded = bridgedNsFileProviderItem.mostRecentVersionDownloaded;
     metadata._uploading = bridgedNsFileProviderItem.uploading;


### PR DESCRIPTION
- Raised required macOS version to 13 for Swift packages.
- Removed fallback code switches for macOS and file provider framework releases before macOS 13.
- Consolidated Xcode project build settings into single declaration in build settings file.