### PR TITLE
fix: use text emoji replacements to avoid creating duplicate labels

### DIFF
--- a/.github/workflows/bug-report-labeler.yml
+++ b/.github/workflows/bug-report-labeler.yml
@@ -22,11 +22,11 @@ jobs:
             let label = '';
             
             if (/### Operating system\s*\n+macOS\b/.test(normalizedBody)) {
-              label = 'os: 🍎 macOS';
+              label = 'os: :apple: macOS';
             } else if (/### Operating system\s*\n+Windows\b/.test(normalizedBody)) {
-              label = 'os: 🚪 Windows';
+              label = 'os: :door: Windows';
             } else if (/### Operating system\s*\n+Linux\b/.test(normalizedBody)) {
-              label = 'os: 🐧 Linux';
+              label = 'os: :penguin: Linux';
             }
             
             if (label) {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
