### PR TITLE
fix(e2ee): ensure PIN input dialog is top most window

### DIFF
--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -1193,7 +1193,8 @@ void ClientSideEncryption::initializeHardwareTokenEncryption(QWidget *settingsDi
                                                tr("Enter Certificate USB Token PIN:"),
                                                QLineEdit::Password,
                                                {},
-                                               &ok);
+                                               &ok,
+                                               Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
                 if (!ok || newPin.isEmpty()) {
                     qCWarning(lcCse()) << "an USER pin is required";
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
