### PR TITLE
chore: update Craft and craft cache

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -3,7 +3,7 @@
 [General]
 Branch = master
 # CraftUrl = https://github.com/allexzander/craft.git
-CraftRevision = 7b73acd32984b67d7e1054c9a02e3d86eca9a030
+CraftRevision = d9d06ff743183104bc50698e376807976fa0e460
 ShallowClone = False
 
 # Variables defined here override the default value
@@ -28,7 +28,7 @@ ShortPath/Enabled = False
 ShortPath/EnableJunctions = False
 
 Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
-Packager/CacheVersion = master-qt-6.10.1
+Packager/CacheVersion = master-qt-6.10.2
 ContinuousIntegration/Enabled = True
 
 Packager/UseCache = ${Variables:UseCache}
@@ -38,7 +38,7 @@ Packager/CacheDir = ${Variables:Root}\cache
 [BlueprintSettings]
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
-libs/qt6.version = 6.10.1
+libs/qt6.version = 6.10.2
 craft/craft-blueprints-kde.revision = master
 
 [windows-msvc2022_64-cl]
@@ -58,7 +58,7 @@ Paths/Python = /Users/runner/hostedtoolcache/Python/3.12.3/arm64
 General/ABI = linux-gcc-x86_64
 Paths/Python = /usr/bin/python3
 Packager/RepositoryUrl = https://files.kde.org/craft/Qt6/
-Packager/CacheVersion = 25.12
+Packager/CacheVersion = 26.02
 
 [Env]
 CRAFT_CODESIGN_CERTIFICATE =
@@ -66,4 +66,4 @@ SIGN_PACKAGE = False
 
 [Custom_Variables_for_Brander]
 qtPath = /root/linux-gcc-x86_64
-dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.1-1
+dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.2-1


### PR DESCRIPTION
Qt 6.10.2 includes a fix for a crash for QtWebEngine ...

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
