### PR TITLE
fix(macOS): skip build-tree RPATH to prevent install_name_tool conflict

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -703,6 +703,12 @@ endif()
 #
 # OSX: Run macdeployqt for src/gui and for src/cmd using the -executable option
 if(BUILD_OWNCLOUD_OSX_BUNDLE AND NOT BUILD_LIBRARIES_ONLY)
+    # macdeployqt (POST_BUILD) replaces the build-tree RPATH with @loader_path/../Frameworks.
+    # Setting BUILD_WITH_INSTALL_RPATH prevents CMake from separately tracking the build-tree
+    # RPATH and then trying to delete it at cmake --install time (which would fail because
+    # macdeployqt has already removed it).
+    set_target_properties(nextcloud PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+
     get_target_property (QT_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
     get_filename_component(QT_BIN_DIR "${QT_QMAKE_EXECUTABLE}" DIRECTORY)
     find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${QT_BIN_DIR}")

--- a/src/libsync/vfs/suffix/CMakeLists.txt
+++ b/src/libsync/vfs/suffix/CMakeLists.txt
@@ -31,6 +31,11 @@ if(APPLE)
         PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
         RUNTIME_OUTPUT_DIRECTORY ${vfs_buildoutputdir}
+        # macdeployqt (POST_BUILD) removes the build-tree RPATH (work/build/bin) that CMake
+        # adds because this target depends on nextcloudsync. Without this flag CMake then tries
+        # to delete that RPATH at cmake --install time via install_name_tool and fails because
+        # macdeployqt has already eliminated it.
+        BUILD_WITH_INSTALL_RPATH TRUE
     )
     # For being loadable when client run from install dir (after make macdeployqt)
     set(vfs_installdir "${LIB_INSTALL_DIR}/../PlugIns")


### PR DESCRIPTION
CMake automatically adds the binary's RUNTIME_OUTPUT_DIRECTORY (work/build/bin) to the nextcloud executable's RPATH at build time. macdeployqt runs as a POST_BUILD step and replaces that path with @loader_path/../Frameworks (the self-contained bundle convention). When cmake --install then runs, it tries to remove the original build-tree RPATH via install_name_tool -delete_rpath, but macdeployqt has already eliminated it, causing:

  install_name_tool: no LC_RPATH load command with path:
  .../work/build/bin found in: .../NextcloudDev

Set BUILD_WITH_INSTALL_RPATH TRUE on the nextcloud target inside the BUILD_OWNCLOUD_OSX_BUNDLE block. This tells CMake to use the install RPATH (empty for a macOS bundle) during build rather than a separate build-tree RPATH, so no install_name_tool fixup is generated at cmake --install time.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
