### PR TITLE
feat(macOS): QtWebEngine Switch

### DIFF
--- a/admin/osx/mac-crafter/Sources/Commands/Build.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Build.swift
@@ -91,6 +91,9 @@ struct Build: AsyncParsableCommand {
     @Flag(help: "Build File Provider Module.")
     var buildFileProviderModule = false
     
+    @Flag(help: "Build without QtWebEngine.")
+    var withoutWebEngine = false
+
     @Flag(help: "Build without Sparkle auto-updater.")
     var disableAutoUpdater = false
     
@@ -202,7 +205,8 @@ struct Build: AsyncParsableCommand {
             "\(craftBlueprintName).osxArchs=\(arch)",
             "\(craftBlueprintName).buildTests=\(buildTests ? "True" : "False")",
             "\(craftBlueprintName).buildMacOSBundle=\(disableAppBundle ? "False" : "True")",
-            "\(craftBlueprintName).buildFileProviderModule=\(buildFileProviderModule ? "True" : "False")"
+            "\(craftBlueprintName).buildFileProviderModule=\(buildFileProviderModule ? "True" : "False")",
+            "\(craftBlueprintName).buildWithWebEngine=\(withoutWebEngine ? "False" : "True")"
         ]
         
         if let overrideServerUrl {

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Craft.sh
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudDev/Craft.sh
@@ -37,4 +37,5 @@ swift run mac-crafter \
     --disable-auto-updater \
     --build-file-provider-module \
     --code-sign-identity="Apple Development" \
+    --without-web-engine \
     "$DESKTOP_CLIENT_PROJECT_ROOT"


### PR DESCRIPTION
- This adds an optional flag to `mac-crafter` to disable the build and inclusion of QtWebEngine in the client which is useful specifically for developer builds in the daily workflow which does not require this overhead for the global scale sign-in.
- Closes #9448.
- Blocked by https://github.com/nextcloud/desktop-client-blueprints/pull/36