### PR TITLE
fix: suppress duplicate "The log output cannot be saved" popups

### DIFF
--- a/src/libsync/logger.cpp
+++ b/src/libsync/logger.cpp
@@ -372,13 +372,17 @@ void Logger::setLogFileNoLock(const QString &name)
     }
 
     if (!openSucceeded) {
-        postGuiMessage(tr("Error"),
-                       QString(tr("<nobr>File \"%1\"<br/>cannot be opened for writing.<br/><br/>"
-                                  "The log output <b>cannot</b> be saved!</nobr>"))
-                           .arg(name));
+        if (!_didShowLogWriteError) {
+            _didShowLogWriteError = true;
+            postGuiMessage(tr("Error"),
+                           QString(tr("<nobr>File \"%1\"<br/>cannot be opened for writing.<br/><br/>"
+                                      "The log output <b>cannot</b> be saved!</nobr>"))
+                               .arg(name));
+        }
         return;
     }
 
+    _didShowLogWriteError = false;
     _logstream.reset(new QTextStream(&_logFile));
 }
 
@@ -402,13 +406,17 @@ void Logger::setPermanentDeleteLogFileNoLock(const QString &name)
     }
 
     if (!openSucceeded) {
-        postGuiMessage(tr("Error"),
-                       QString(tr("<nobr>File \"%1\"<br/>cannot be opened for writing.<br/><br/>"
-                                  "The log output <b>cannot</b> be saved!</nobr>"))
-                           .arg(name));
+        if (!_didShowLogWriteError) {
+            _didShowLogWriteError = true;
+            postGuiMessage(tr("Error"),
+                           QString(tr("<nobr>File \"%1\"<br/>cannot be opened for writing.<br/><br/>"
+                                      "The log output <b>cannot</b> be saved!</nobr>"))
+                               .arg(name));
+        }
         return;
     }
 
+    _didShowLogWriteError = false;
     _permanentDeleteLogStream.reset(new QTextStream(&_permanentDeleteLogFile));
 }
 

--- a/src/libsync/logger.h
+++ b/src/libsync/logger.h
@@ -114,6 +114,7 @@ private:
     int _crashLogIndex = 0;
     QFile _permanentDeleteLogFile;
     QScopedPointer<QTextStream> _permanentDeleteLogStream;
+    bool _didShowLogWriteError = false;
 };
 
 } // namespace OCC


### PR DESCRIPTION
### Motivation
- Prevent users from being flooded with repeated error dialogs when the logger cannot open or rotate log files (for example when disk is full).

### Description
- Added a private `bool _didShowLogWriteError` to `Logger` to record whether the write-failure dialog has already been shown.
- Updated `setLogFileNoLock` to show the "The log output cannot be saved" popup only once per persistent failure and reset the flag after a successful open.
- Applied the same one-time-popup behavior to `setPermanentDeleteLogFileNoLock` so both normal and permanent-delete log outputs behave consistently.