### PR TITLE
fix(win32): avoid removing db record if rename source/dest is equal

### DIFF
--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -74,8 +74,9 @@ void PropagateRemoteMove::start()
 
     QString origin = propagator()->adjustRenamedPath(_item->_file);
     qCInfo(lcPropagateRemoteMove) << origin << _item->_renameTarget;
+    _originIsSameAsTarget = origin == _item->_renameTarget;
 
-    if (origin == _item->_renameTarget) {
+    if (_originIsSameAsTarget) {
         // The parent has been renamed already so there is nothing more to do.
 
         if (!_item->_encryptedFileName.isEmpty()) {
@@ -260,7 +261,7 @@ void PropagateRemoteMove::finalize()
 
     const auto targetFile = propagator()->fullLocalPath(_item->_renameTarget);
 
-    if (FileSystem::fileExists(targetFile)) {
+    if (!_originIsSameAsTarget && FileSystem::fileExists(targetFile)) {
         // Delete old db data.
         if (!propagator()->_journal->deleteFileRecord(_item->_originalFile)) {
             qCWarning(lcPropagateRemoteMove) << "could not delete file from local DB" << _item->_originalFile;

--- a/src/libsync/propagateremotemove.h
+++ b/src/libsync/propagateremotemove.h
@@ -59,5 +59,8 @@ public:
 private slots:
     void slotMoveJobFinished();
     void finalize();
+
+private:
+    bool _originIsSameAsTarget = false;
 };
 }


### PR DESCRIPTION
If the rename target is the same as the source, the metadata record was removed.  This is somewhat fine for classic sync, but with VFS enabled the next sync run would end up removing the moved placeholder files or folders from the file system and eventually to the server.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
