### PR TITLE
fix(e2ee/vfs): disable on-demand population of encrypted folders

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -675,7 +675,8 @@ void ProcessDirectoryJob::postProcessServerNew(const SyncFileItemPtr &item,
         if (!localEntry.isValid() &&
             opts._vfs->mode() == Vfs::WindowsCfApi &&
             _pinState != PinState::AlwaysLocal &&
-            !FileSystem::isExcludeFile(item->_file)) {
+            !FileSystem::isExcludeFile(item->_file) &&
+            !item->isEncrypted()) {
             item->_type = ItemTypeVirtualDirectory;
         }
 

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -418,7 +418,7 @@ OCC::Result<OCC::Vfs::ConvertToPlaceholderResult, QString> updatePlaceholderStat
     OCC::Utility::UnixTimeToLargeIntegerFiletime(modtime, &metadata.BasicInfo.ChangeTime);
 
     qCInfo(lcCfApiWrapper) << "updatePlaceholderState" << path << modtime;
-    const auto updateFlags = item.isDirectory() ? CF_UPDATE_FLAG_MARK_IN_SYNC | CF_UPDATE_FLAG_ENABLE_ON_DEMAND_POPULATION : CF_UPDATE_FLAG_MARK_IN_SYNC;
+    const auto updateFlags = item.isDirectory() && !item.isEncrypted() ? CF_UPDATE_FLAG_MARK_IN_SYNC | CF_UPDATE_FLAG_ENABLE_ON_DEMAND_POPULATION : CF_UPDATE_FLAG_MARK_IN_SYNC;
 
     const auto result = CfUpdatePlaceholder(OCC::CfApiWrapper::handleForPath(path).get(), updateType == CfApiUpdateMetadataType::AllMetadata ? &metadata : nullptr,
                                               fileId.data(), static_cast<DWORD>(fileId.size()),


### PR DESCRIPTION
on Windows VFS, disable on-demand population of encrypted folders

short term fix to prevent issues with the commbination of both features

long term, the proper fix is to make it possible to use on-demand folders VFS with encrypted folders

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
