### PR TITLE
feat(e2ee): add basic support for e2ee metadata format 2.1

### DIFF
--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -410,6 +410,8 @@ void FolderMetadata::setupVersionFromExistingMetadata(const QByteArray &metadata
         _existingMetadataVersion = MetadataVersion::Version1_2;
     } else if (versionStringFromMetadata == QStringLiteral("2.0") || versionStringFromMetadata == QStringLiteral("2")) {
         _existingMetadataVersion = MetadataVersion::Version2_0;
+    } else if (versionStringFromMetadata == QStringLiteral("2.1")) {
+        _existingMetadataVersion = MetadataVersion::Version2_1;
     } else if (versionStringFromMetadata == QStringLiteral("1.0")
         || versionStringFromMetadata == QStringLiteral("1.1")) {
         // We used to have an intermediate 1.1 after applying a security-vulnerability fix for metadata keys.
@@ -845,6 +847,7 @@ quint64 FolderMetadata::newCounter() const
 EncryptionStatusEnums::ItemEncryptionStatus FolderMetadata::fromMedataVersionToItemEncryptionStatus(const MetadataVersion metadataVersion)
 {
     switch (metadataVersion) {
+    case FolderMetadata::MetadataVersion::Version2_1:
     case FolderMetadata::MetadataVersion::Version2_0:
         return SyncFileItem::EncryptionStatus::EncryptedMigratedV2_0;
     case FolderMetadata::MetadataVersion::Version1_2:

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -36,14 +36,6 @@ class OWNCLOUDSYNC_EXPORT FolderMetadata : public QObject
         QByteArray encryptedMetadataKey;
     };
 
-    // based on api-version and "version" key in metadata JSON
-    enum MetadataVersion {
-        VersionUndefined = -1,
-        Version1,
-        Version1_2,
-        Version2_0,
-    };
-
     struct UserWithFileDropEntryAccess {
         QString userId;
         QByteArray decryptedFiledropKey;
@@ -89,6 +81,16 @@ public:
         HardwareCertificate,
     };
     Q_ENUM(CertificateType)
+
+    // based on api-version and "version" key in metadata JSON
+    enum class MetadataVersion {
+        VersionUndefined = -1,
+        Version1,
+        Version1_2,
+        Version2_0,
+        Version2_1,
+    };
+    Q_ENUM(MetadataVersion)
 
     FolderMetadata(AccountPtr account, const QString &remoteFolderRoot, FolderType folderType = FolderType::Nested);
     /*


### PR DESCRIPTION
add ability to use encrypted root folder with 2.1 metadata format

this is lacking ability to create public encrypted share link

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
