### PR TITLE
fix(file-provider): Fetch share options by user ID not user name (#9074)

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Sharing/ShareTableViewDataSource.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderUIExt/Sharing/ShareTableViewDataSource.swift
@@ -59,7 +59,7 @@ class ShareTableViewDataSource: NSObject, NSTableViewDataSource, NSTableViewDele
                 account: account.ncKitAccount,
                 urlBase: account.serverUrl,
                 user: account.username,
-                userId: account.username,
+                userId: account.id,
                 password: account.password,
                 userAgent: userAgent,
                 groupIdentifier: ""


### PR DESCRIPTION
Closes #9074

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
