### PR TITLE
fix(propagateuploadng): do not encode davUrl

### DIFF
--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -25,6 +25,8 @@
 #include <cmath>
 #include <cstring>
 
+using namespace Qt::StringLiterals;
+
 namespace OCC {
 
 constexpr auto relativeUploadsPath = "remote.php/dav/uploads/";
@@ -80,9 +82,9 @@ QUrl PropagateUploadFileNG::chunkUrl(const int chunk) const
 QByteArray PropagateUploadFileNG::destinationHeader() const
 {
     const auto davUrl = Utility::trailingSlashPath(propagator()->account()->davUrl().toString());
-    const auto remotePath = Utility::noLeadingSlashPath(propagator()->fullRemotePath(_fileToUpload._file));
+    const auto remotePath = QUrl::toPercentEncoding(Utility::noLeadingSlashPath(propagator()->fullRemotePath(_fileToUpload._file)), "/"_ba);
     const auto destination = QString(davUrl + remotePath);
-    return QUrl::toPercentEncoding(destination, "/");
+    return destination.toUtf8();
 }
 
 void PropagateUploadFileNG::doStartUpload()

--- a/test/testchunkingng.cpp
+++ b/test/testchunkingng.cpp
@@ -151,6 +151,7 @@ private slots:
         QVERIFY(destinationHeader.contains("SQ-0.5%25BF-150"));
         QVERIFY(destinationHeader.contains("/A/SQ-0.5%25BF-150/"));
         QVERIFY(!destinationHeader.contains("%2F"));
+        QVERIFY(destinationHeader.startsWith("http://"));
     }
 
     // Test resuming when there's a confusing chunk added


### PR DESCRIPTION
sabre/dav does not seem to approve of percent-encoded base URLs (e.g. `http%3A//nextcloud.local/...`), it will then consider them as absolute paths and fail.

--> adapt fix from #9334 to only encode the remote path, as sabre parses those paths just fine.

Resolves: #9582

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
