### PR TITLE
Bugfix/use display name for e2ee shares

### DIFF
--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -521,6 +521,7 @@ void ShareManager::createE2EeShareJob(const QString &fullRemotePath,
                                                                          UpdateE2eeFolderUsersMetadataJob::Add,
                                                                          fullRemotePath,
                                                                          sharee->shareWith(),
+                                                                         sharee->displayName(),
                                                                          QSslCertificate{},
                                                                          this);
 

--- a/src/libsync/updatee2eefolderusersmetadatajob.cpp
+++ b/src/libsync/updatee2eefolderusersmetadatajob.cpp
@@ -21,6 +21,7 @@ UpdateE2eeFolderUsersMetadataJob::UpdateE2eeFolderUsersMetadataJob(const Account
                                                                    const Operation operation,
                                                                    const QString &fullRemotePath,
                                                                    const QString &folderUserId,
+                                                                   const QString &folderUserDisplayName,
                                                                    const QSslCertificate &certificate,
                                                                    QObject *parent)
     : QObject{parent}
@@ -30,6 +31,7 @@ UpdateE2eeFolderUsersMetadataJob::UpdateE2eeFolderUsersMetadataJob(const Account
     , _operation{operation}
     , _fullRemotePath{Utility::noLeadingSlashPath(fullRemotePath)}
     , _folderUserId{folderUserId}
+    , _folderUserDisplayName{folderUserDisplayName}
     , _folderUserCertificate{certificate}
 {
     Q_ASSERT(_syncFolderRemotePath == QStringLiteral("/") || _fullRemotePath.startsWith(_syncFolderRemotePath));
@@ -78,7 +80,7 @@ void UpdateE2eeFolderUsersMetadataJob::start(const bool keepLock)
 void UpdateE2eeFolderUsersMetadataJob::slotStartE2eeMetadataJobs()
 {
     if (_operation == Operation::Add && _folderUserCertificate.isNull()) {
-        emit finished(404, tr("Could not fetch public key for user %1").arg(_folderUserId));
+        emit finished(404, tr("Could not fetch public key for user %1").arg(_folderUserDisplayName));
         return;
     }
 
@@ -106,7 +108,7 @@ void UpdateE2eeFolderUsersMetadataJob::slotFetchMetadataJobFinished(int statusCo
     }
 
     if (!_encryptedFolderMetadataHandler->folderMetadata() || !_encryptedFolderMetadataHandler->folderMetadata()->isValid()) {
-        emit finished(403, tr("Could not add or remove user %1 to access folder %2").arg(_folderUserId).arg(_fullRemotePath));
+        emit finished(403, tr("Could not add or remove user %1 to access folder %2").arg(_folderUserDisplayName).arg(_fullRemotePath));
         return;
     }
     startUpdate();

--- a/src/libsync/updatee2eefolderusersmetadatajob.h
+++ b/src/libsync/updatee2eefolderusersmetadatajob.h
@@ -33,7 +33,15 @@ public:
         QString password;
     };
     
-    explicit UpdateE2eeFolderUsersMetadataJob(const AccountPtr &account, SyncJournalDb *journalDb,const QString &syncFolderRemotePath, const Operation operation, const QString &fullRemotePath = {}, const QString &folderUserId = {}, const QSslCertificate &certificate = QSslCertificate{}, QObject *parent = nullptr);
+    explicit UpdateE2eeFolderUsersMetadataJob(const AccountPtr &account,
+                                              SyncJournalDb *journalDb,
+                                              const QString &syncFolderRemotePath,
+                                              const Operation operation,
+                                              const QString &fullRemotePath = {},
+                                              const QString &folderUserId = {},
+                                              const QString &folderUserDisplayName = {},
+                                              const QSslCertificate &certificate = QSslCertificate{},
+                                              QObject *parent = nullptr);
     ~UpdateE2eeFolderUsersMetadataJob() override = default;
 
 public:
@@ -84,6 +92,7 @@ private:
     Operation _operation = Invalid;
     QString _fullRemotePath;
     QString _folderUserId;
+    QString _folderUserDisplayName;
     QSslCertificate _folderUserCertificate;
     QByteArray _folderToken;
     // needed when re-encrypting nested folders' metadata after top-level folder's metadata has changed

--- a/src/libsync/updatemigratede2eemetadatajob.cpp
+++ b/src/libsync/updatemigratede2eemetadatajob.cpp
@@ -38,6 +38,7 @@ void UpdateMigratedE2eeMetadataJob::start()
                                                                                      UpdateE2eeFolderUsersMetadataJob::Add,
                                                                                      _fullRemotePath,
                                                                                      propagator()->account()->davUser(),
+                                                                                     propagator()->account()->displayName(),
                                                                                      propagator()->account()->e2e()->getCertificate());
     updateMedatadaAndSubfoldersJob->setParent(this);
     updateMedatadaAndSubfoldersJob->setSubJobSyncItems(_subJobItems);


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
