### PR TITLE
fix(settings): add missing endGroup() in Folder::removeFromSettings

### DIFF
--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -992,6 +992,7 @@ void Folder::removeFromSettings() const
     settings->endGroup();
     settings->beginGroup(QLatin1String("FoldersWithPlaceholders"));
     settings->remove(FolderMan::escapeAlias(_definition.alias));
+    settings->endGroup();
 }
 
 bool Folder::pathIsIgnored(const QString &path) const


### PR DESCRIPTION
The last beginGroup("FoldersWithPlaceholders") call was never closed with endGroup(), leaving the QSettings group stack dirty.