### PR TITLE
fix(i18n): let Qt handle plural forms

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -413,9 +413,7 @@ void FolderMan::setupFoldersHelper(QSettings &settings, AccountStatePtr account,
         }
     }
     if (sandboxFolderCount > 0) {
-        const auto message = sandboxFolderCount == 1
-            ? tr("A sync folder requires access re-approval after the app update. Please open settings to grant access.")
-            : tr("%n sync folders require access re-approval after the app update. Please open settings to grant access.", "", sandboxFolderCount);
+        const auto message = tr("%n sync folders require access re-approval after the app update. Please open settings to grant access.", "", sandboxFolderCount);
         // Defer to ensure the tray/systray is initialized before posting
         QTimer::singleShot(0, this, [message]() {
             Logger::instance()->postGuiLog(Theme::instance()->appNameGUI(), message);


### PR DESCRIPTION
Resolves #9620

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
