### PR TITLE
fix(file-provider): Working Set Change Enumeration

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -447,18 +447,50 @@ public final class FilesDatabaseManager: Sendable {
         }
     }
 
+    ///
+    /// Mark an item as deleted.
+    ///
+    /// This is a soft delete and does not actually delete data for which there is ``removeItemMetadata(ocId:)``.
+    ///
+    /// - Parameters:
+    ///     - ocId: The unique identifier of the item.
+    ///
     @discardableResult public func deleteItemMetadata(ocId: String) -> Bool {
         do {
             let results = itemMetadatas.where { $0.ocId == ocId }
             let database = ncDatabase()
+
             try database.write {
-                logger.debug("Deleting item metadata. \(ocId)")
                 results.forEach { $0.deleted = true }
+                logger.debug("Marked item as deleted.", [.item: ocId])
             }
+
             return true
         } catch {
-            logger.error("Could not delete item metadata with ocId \(ocId).", [.error: error])
+            logger.error("Could not mark item as deleted.", [.item: ocId, .error: error])
             return false
+        }
+    }
+
+    ///
+    /// Hard delete an item.
+    ///
+    /// Unlike ``deleteItemMetadata(ocId:)``, this actually deletes a data record.
+    ///
+    /// - Parameters:
+    ///     - ocId: The unique identifier of the item.
+    ///
+    public func removeItemMetadata(ocId: String) {
+        do {
+            let database = ncDatabase()
+            let results = itemMetadatas.where { $0.ocId == ocId }
+
+            try database.write {
+                database.delete(results)
+                logger.debug("Removed item metadata from database.", [.item: ocId])
+            }
+        } catch {
+            logger.error("Could not remove item metadata.", [.item: ocId, .error: error])
         }
     }
 
@@ -538,13 +570,12 @@ public final class FilesDatabaseManager: Sendable {
         return NSFileProviderItemIdentifier(parentMetadata.ocId)
     }
 
-    private func managedMaterialisedItemMetadatas(account: String) -> Results<RealmItemMetadata> {
+    private func managedMaterialisedItemMetadatas() -> Results<RealmItemMetadata> {
         itemMetadatas.where { candidate in
-            let belongsToAccount = candidate.account == account
             let isVisitedDirectory = candidate.directory && candidate.visitedDirectory
             let isDownloadedFile = candidate.directory == false && candidate.downloaded
 
-            return belongsToAccount && (isVisitedDirectory || isDownloadedFile)
+            return isVisitedDirectory || isDownloadedFile
         }
     }
 
@@ -556,67 +587,97 @@ public final class FilesDatabaseManager: Sendable {
     ///
     /// - Returns: An array of sendable metadata objects.
     ///
-    public func materialisedItemMetadatas(account: String) -> [SendableItemMetadata] {
-        managedMaterialisedItemMetadatas(account: account).toUnmanagedResults()
+    public func materialisedItemMetadatas(account _: String) -> [SendableItemMetadata] {
+        managedMaterialisedItemMetadatas().toUnmanagedResults()
     }
 
-    public func pendingWorkingSetChanges(account: Account, since date: Date) -> (updated: [SendableItemMetadata], deleted: [SendableItemMetadata]) {
-        let accId = account.ncKitAccount
-        let pending = managedMaterialisedItemMetadatas(account: accId).where { $0.syncTime > date }
-        var updated = pending.where { !$0.deleted }.toUnmanagedResults()
-        var deleted = pending.where { $0.deleted }.toUnmanagedResults()
-        var handledUpdateOcIds = Set(updated.map(\.ocId))
+    ///
+    /// Look up the not yet synchronized changes and deletions in the materialized items since the last given synchronization time.
+    ///
+    /// - Parameters:
+    ///     - date: All items with a synchronization time later than this are considered.
+    ///
+    /// - Returns: Locally changed items in the working set grouped by "updated" and "deleted".
+    ///
+    public func pendingWorkingSetChanges(since date: Date) -> (updated: [SendableItemMetadata], deleted: [SendableItemMetadata]) {
+        logger.debug("Gathering pending working set changes...")
+        let pendingChanges = managedMaterialisedItemMetadatas().where { $0.syncTime > date }
+        var updatedItems = pendingChanges.where { !$0.deleted }.toUnmanagedResults()
+        var deletedItems = pendingChanges.where { $0.deleted }.toUnmanagedResults()
 
-        updated
-            .map { $0.remotePath() }
+        for item in updatedItems {
+            logger.debug("Found updated item.", [.item: item.ocId, .name: item.fileName])
+        }
+
+        for item in deletedItems {
+            logger.debug("Found deleted item.", [.item: item.ocId, .name: item.fileName])
+        }
+
+        var updatedItemIdentifiers = Set(updatedItems.map(\.ocId))
+        var deletedItemIdentifiers = Set(deletedItems.map(\.ocId))
+
+        updatedItems // Look for changed children
+            .filter {
+                $0.directory // files do not have any children to look for
+            }
+            .map {
+                $0.remotePath()
+            }
             .forEach { serverUrl in
-                logger.debug("Checking updated item...", [.url: serverUrl])
-
                 itemMetadatas
-                    .where { $0.serverUrl == serverUrl && $0.syncTime > date }
-                    .forEach { metadata in
-                        guard !handledUpdateOcIds.contains(metadata.ocId) else {
-                            return
-                        }
+                    .where {
+                        $0.serverUrl == serverUrl && $0.syncTime > date
+                    }
+                    .forEach { child in
+                        let sendableMetadata = SendableItemMetadata(value: child)
 
-                        handledUpdateOcIds.insert(metadata.ocId)
-                        let sendableMetadata = SendableItemMetadata(value: metadata)
+                        if child.deleted {
+                            guard deletedItemIdentifiers.contains(child.ocId) == false else {
+                                return
+                            }
 
-                        if metadata.deleted {
-                            deleted.append(sendableMetadata)
-                            logger.debug("Appended deleted item to working set changes.", [.item: metadata.ocId, .url: serverUrl])
+                            deletedItemIdentifiers.insert(child.ocId)
+                            deletedItems.append(sendableMetadata)
+                            logger.debug("Appended deleted item to working set changes.", [.item: child.ocId, .url: serverUrl])
                         } else {
-                            updated.append(sendableMetadata)
-                            logger.debug("Appended updated item to working set changes.", [.item: metadata.ocId, .url: serverUrl])
+                            guard updatedItemIdentifiers.contains(child.ocId) == false else {
+                                return
+                            }
+
+                            updatedItemIdentifiers.insert(child.ocId)
+                            updatedItems.append(sendableMetadata)
+                            logger.debug("Appended updated item to working set changes.", [.item: child.ocId, .url: serverUrl])
                         }
                     }
             }
 
-        let handledDeleteOcIds = Set(deleted.map(\.ocId))
-
-        deleted
-            .map { $0.remotePath() }
+        deletedItems // Look for deleted children recursively
+            .filter {
+                $0.directory // files do not have any children to look for
+            }
+            .map {
+                $0.remotePath()
+            }
             .forEach { serverUrl in
-                logger.debug("Verifying deleted item...", [.url: serverUrl])
-
                 itemMetadatas.where {
                     $0.serverUrl.starts(with: serverUrl) && $0.syncTime > date
-                }.forEach { metadata in
-                    guard metadata.isLockFileOfLocalOrigin == false else {
-                        logger.info("Excluding item from deletion because it is a lock file from local origin.", [.item: metadata.ocId])
+                }.forEach { child in
+                    guard child.isLockFileOfLocalOrigin == false else {
+                        logger.info("Excluding item from deletion because it is a lock file from local origin.", [.item: child.ocId, .name: child.fileName])
                         return
                     }
 
-                    guard !handledDeleteOcIds.contains(metadata.ocId) else {
+                    guard !deletedItemIdentifiers.contains(child.ocId) else {
                         return
                     }
 
-                    deleted.append(SendableItemMetadata(value: metadata))
-                    logger.debug("Appended deleted item to working set changes.", [.item: metadata.ocId, .url: serverUrl])
+                    deletedItemIdentifiers.insert(child.ocId)
+                    deletedItems.append(SendableItemMetadata(value: child))
+                    logger.debug("Appended deleted item to working set changes.", [.item: child.ocId, .url: serverUrl])
                 }
             }
 
-        return (updated, deleted)
+        return (updatedItems, deletedItems)
     }
 
     public func itemsMetadataByFileNameSuffix(suffix: String) -> [SendableItemMetadata] {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -37,7 +37,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         domain: NSFileProviderDomain? = nil,
         pageSize: Int = 1000,
         log: any FileProviderLogging
-    ) {
+    ) throws {
         self.enumeratedItemIdentifier = enumeratedItemIdentifier
         self.remoteInterface = remoteInterface
         self.account = account
@@ -51,17 +51,15 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             serverUrl = account.davFilesUrl
             enumeratedItemMetadata = nil
         } else {
-            logger.debug("Providing enumerator for item with identifier.", [.item: enumeratedItemIdentifier])
-            enumeratedItemMetadata = dbManager.itemMetadata(
-                enumeratedItemIdentifier
-            )
+            enumeratedItemMetadata = dbManager.itemMetadata(enumeratedItemIdentifier)
 
-            if let enumeratedItemMetadata {
-                serverUrl = enumeratedItemMetadata.serverUrl + "/" + enumeratedItemMetadata.fileName
-            } else {
-                serverUrl = ""
-                logger.error("Could not find itemMetadata for file with identifier.", [.item: enumeratedItemIdentifier])
+            guard let enumeratedItemMetadata, enumeratedItemMetadata.deleted == false else {
+                logger.error("Could not find item with identifier.", [.item: enumeratedItemIdentifier])
+                throw NSFileProviderError(.noSuchItem)
             }
+
+            logger.debug("Providing enumerator for item with identifier.", [.item: enumeratedItemIdentifier, .name: enumeratedItemMetadata.fileName])
+            serverUrl = enumeratedItemMetadata.serverUrl + "/" + enumeratedItemMetadata.fileName
         }
 
         logger.info("Set up enumerator.", [.account: self.account.ncKitAccount, .url: serverUrl])
@@ -69,7 +67,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     }
 
     public func invalidate() {
-        logger.debug("Enumerator is being invalidated.", [.item: enumeratedItemIdentifier])
+        logger.debug("Enumerator is being invalidated.", [.item: enumeratedItemIdentifier, .name: enumeratedItemMetadata?.fileName])
     }
 
     // MARK: - Protocol methods
@@ -112,6 +110,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             let ncKitAccount = account.ncKitAccount
             // Visited folders and downloaded files
             let materialisedItems = dbManager.materialisedItemMetadatas(account: ncKitAccount)
+                .filter { !$0.deleted }
             completeEnumerationObserver(observer, nextPage: nil, itemMetadatas: materialisedItems)
             return
         }
@@ -248,7 +247,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
 
             Task {
                 await checkMaterializedItemsOnServer()
-                let pendingLocalChanges = dbManager.pendingWorkingSetChanges(account: account, since: date)
+                let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
 
                 completeChangesObserver(
                     observer,
@@ -434,6 +433,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         // This way we ensure we visit parent folders before their children.
         let materializedItems = dbManager
             .materialisedItemMetadatas(account: account.ncKitAccount)
+            .filter { !$0.deleted }
             .sorted { $0.remotePath().count < $1.remotePath().count }
 
         var allNewMetadatas = [SendableItemMetadata]()
@@ -639,15 +639,15 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         }
 
         for metadata in newMetadatas {
-            logger.debug("Got added metadata.", [.item: metadata.ocId, .name: metadata.fileName])
+            logger.debug("Got added metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
         }
 
         for metadata in updatedMetadatas {
-            logger.debug("Got updated metadata.", [.item: metadata.ocId, .name: metadata.fileName])
+            logger.debug("Got updated metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
         }
 
         for metadata in deletedMetadatas {
-            logger.debug("Got deleted metadata.", [.item: metadata.ocId, .name: metadata.fileName])
+            logger.debug("Got deleted metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
         }
 
         // The file provider framework does not differentiate between newly added and updated items, hence the collections are merged.
@@ -671,6 +671,10 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
                     }
 
                     observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+
+                    for metadata in deletedMetadatas {
+                        dbManager.removeItemMetadata(ocId: metadata.ocId)
+                    }
                 }
             } catch let error as NSError { // This error can only mean a missing parent item identifier
                 guard handleInvalidParent else {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -340,13 +340,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         super.init()
     }
 
-    public static func storedItem(
-        identifier: NSFileProviderItemIdentifier,
-        account: Account,
-        remoteInterface: RemoteInterface,
-        dbManager: FilesDatabaseManager,
-        log: any FileProviderLogging
-    ) async -> Item? {
+    public static func storedItem(identifier: NSFileProviderItemIdentifier, account: Account, remoteInterface: RemoteInterface, dbManager: FilesDatabaseManager, log: any FileProviderLogging) async -> Item? {
         // resolve the given identifier to a record in the model
 
         let remoteSupportsTrash = await remoteInterface.supportsTrash(account: account)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -129,7 +129,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         debugPrint(db) // Avoid build-time warning about unused variable, ensure compiler won't free
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -209,7 +209,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         notVisitedDir.visitedDirectory = false
         Self.dbManager.addItemMetadata(notVisitedDir)
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
@@ -262,7 +262,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         notVisitedDir.visitedDirectory = false
         Self.dbManager.addItemMetadata(notVisitedDir)
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
@@ -533,7 +533,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         nonMaterialisedItem.syncTime = now
         Self.dbManager.addItemMetadata(nonMaterialisedItem)
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -618,7 +618,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(childFolderMetadata)
 
         // 2. Act: Enumerate changes for the working set
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -697,7 +697,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(folderMetadata)
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -754,7 +754,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemA.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteItemA.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -787,7 +787,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         // Check download state is not just always true
         Self.dbManager.addItemMetadata(remoteItemB.toItemMetadata(account: Self.account))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemB.identifier))
-        let enumerator2 = Enumerator(
+        let enumerator2 = try Enumerator(
             enumeratedItemIdentifier: .init(remoteItemB.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -834,7 +834,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemA.identifier))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemB.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -863,13 +863,10 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let dbItemAMetadata = try XCTUnwrap(
             Self.dbManager.itemMetadata(ocId: remoteItemA.identifier)
         )
-        let dbItemBMetadata = try XCTUnwrap(
-            Self.dbManager.itemMetadata(ocId: remoteItemB.identifier)
-        )
         let dbItemCMetadata = try XCTUnwrap(
             Self.dbManager.itemMetadata(ocId: remoteItemC.identifier)
         )
-        XCTAssertTrue(dbItemBMetadata.deleted)
+        XCTAssertNil(Self.dbManager.itemMetadata(ocId: remoteItemB.identifier))
         XCTAssertEqual(dbFolderMetadata.etag, remoteFolder.versionIdentifier)
         XCTAssertTrue(dbFolderMetadata.downloaded)
         XCTAssertEqual(dbItemAMetadata.etag, remoteItemA.versionIdentifier)
@@ -952,7 +949,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemA.identifier))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemB.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1041,7 +1038,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(folderMetadata)
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1119,7 +1116,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         remoteItemA.parent = remoteInterface.rootItem
         rootItem.children = [remoteItemA]
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1154,7 +1151,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let db = Self.dbManager.ncDatabase() // Strong ref for in memory test db
         debugPrint(db) // Avoid build-time warning about unused variable, ensure compiler won't free
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .trashContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1179,7 +1176,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         )
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteTrashItemA.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .trashContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1206,7 +1203,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(Self.dbManager.itemMetadata(ocId: remoteTrashItemA.identifier)?.deleted, true)
     }
 
-    func testTrashItemEnumerationFailWhenNoTrashInCapabilities() async {
+    func testTrashItemEnumerationFailWhenNoTrashInCapabilities() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         XCTAssert(remoteInterface.capabilities.contains(##""undelete": true,"##))
         remoteInterface.capabilities =
@@ -1214,7 +1211,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
 
         let db = Self.dbManager.ncDatabase() // Strong ref for in memory test db
         debugPrint(db) // Avoid build-time warning about unused variable, ensure compiler won't free
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .trashContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1248,7 +1245,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         remoteFolder.versionIdentifier = "NEW"
         remoteItemA.versionIdentifier = "NEW_ETAG"
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1267,7 +1264,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertTrue(updatedMetadata.downloaded, "Downloaded state should be preserved")
     }
 
-    func testTrashChangeEnumerationFailWhenNoTrashInCapabilities() async {
+    func testTrashChangeEnumerationFailWhenNoTrashInCapabilities() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         XCTAssert(remoteInterface.capabilities.contains(##""undelete": true,"##))
         remoteInterface.capabilities =
@@ -1275,7 +1272,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
 
         let db = Self.dbManager.ncDatabase() // Strong ref for in memory test db
         debugPrint(db) // Avoid build-time warning about unused variable, ensure compiler won't free
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .trashContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1311,7 +1308,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         rootItem.children.append(remoteLockFileItem)
         remoteLockFileItem.parent = rootItem
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1340,7 +1337,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItemA.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteItemA.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1410,7 +1407,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(folderMetadata)
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1449,7 +1446,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, pagination: true)
 
         // 2. Create enumerator for the empty folder with a specific pageSize.
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: NSFileProviderItemIdentifier(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1516,7 +1513,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, pagination: true)
 
         // 2. Create enumerator with pageSize > number of children.
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: NSFileProviderItemIdentifier(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1585,7 +1582,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(initialMetadata.etag, "OLD_ETAG")
 
         // 2. Act: Enumerate the folder, which will trigger an update
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1626,7 +1623,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         XCTAssertFalse(initialMetadata.visitedDirectory, "Folder should initially not be marked as visited")
 
         // 2. Act: Enumerate the folder (depth-1 read)
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1676,7 +1673,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(notVisitedFolder)
 
         // 2. Act: Enumerate working set
-        let workingSetEnumerator = Enumerator(
+        let workingSetEnumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1709,7 +1706,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         rootItem.children.append(notVisitedRemoteFolder)
         notVisitedRemoteFolder.parent = rootItem
 
-        let folderEnumerator = Enumerator(
+        let folderEnumerator = try Enumerator(
             enumeratedItemIdentifier: .init(notVisitedFolder.ocId),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1725,7 +1722,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
                       "Folder should now be marked as visited after enumeration")
 
         // 6. Act: Enumerate working set again
-        let workingSetEnumerator2 = Enumerator(
+        let workingSetEnumerator2 = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1789,7 +1786,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
 
         Self.dbManager.addItemMetadata(remoteFolder.toItemMetadata(account: Self.account))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,
@@ -1860,7 +1857,7 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
 
         Self.dbManager.addItemMetadata(remoteFolder.toItemMetadata(account: Self.account))
 
-        let enumerator = Enumerator(
+        let enumerator = try Enumerator(
             enumeratedItemIdentifier: .init(remoteFolder.identifier),
             account: Self.account,
             remoteInterface: remoteInterface,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -1127,52 +1127,37 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
     func testMaterialisedFiles() throws {
         let itemA = RealmItemMetadata()
         let itemB = RealmItemMetadata()
-        let itemC = RealmItemMetadata()
         let folderA = RealmItemMetadata()
         let folderB = RealmItemMetadata()
-        let folderC = RealmItemMetadata()
         let notFolderA = RealmItemMetadata()
-        let notFolderB = RealmItemMetadata()
 
         folderA.directory = true
         folderB.directory = true
-        folderC.directory = true
 
         itemA.ocId = "itemA"
         itemB.ocId = "itemB"
-        itemC.ocId = "itemC"
         folderA.ocId = "folderA"
         folderB.ocId = "folderB"
-        folderC.ocId = "folderC"
         notFolderA.ocId = "notFolderA"
-        notFolderB.ocId = "notFolderB"
 
         itemA.account = Self.account.ncKitAccount
         itemB.account = Self.account.ncKitAccount
-        itemC.account = "another account"
         folderA.account = Self.account.ncKitAccount
         folderB.account = Self.account.ncKitAccount
-        folderC.account = "another account"
         notFolderA.account = Self.account.ncKitAccount
-        notFolderB.account = "another account"
 
         itemA.downloaded = true
         itemB.downloaded = false
-        itemC.downloaded = true
         folderA.visitedDirectory = true
         folderB.visitedDirectory = false
-        folderC.visitedDirectory = true
         notFolderA.visitedDirectory = true
-        notFolderB.visitedDirectory = true
 
         let realm = Self.dbManager.ncDatabase()
         try realm.write {
             realm.add(itemA)
             realm.add(itemB)
-            realm.add(itemC)
             realm.add(folderA)
             realm.add(folderB)
-            realm.add(folderC)
         }
 
         // Test with addItemMetadata too
@@ -1363,9 +1348,7 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         Self.dbManager.addItemMetadata(nonMatChildRecent)
 
         // 2. Act
-        let result = Self.dbManager.pendingWorkingSetChanges(
-            account: Self.account, since: anchorDate
-        )
+        let result = Self.dbManager.pendingWorkingSetChanges(since: anchorDate)
 
         // 3. Assert - Updated items
         let updatedIds = Set(result.updated.map(\.ocId))

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -169,19 +169,11 @@ import OSLog
         let progress = Progress()
         Task {
             progress.totalUnitCount = 1
-            if let item = await Item.storedItem(
-                identifier: identifier,
-                account: ncAccount,
-                remoteInterface: ncKit,
-                dbManager: dbManager,
-                log: log
-            ) {
+            if let item = await Item.storedItem(identifier: identifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log), item.metadata.deleted == false {
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
             } else {
-                completionHandler(
-                    nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier)
-                )
+                completionHandler(nil, NSFileProviderError(.noSuchItem))
             }
         }
         return progress
@@ -483,7 +475,7 @@ import OSLog
             throw NSFileProviderError(.cannotSynchronize)
         }
 
-        return Enumerator(
+        return try Enumerator(
             enumeratedItemIdentifier: containerItemIdentifier,
             account: ncAccount,
             remoteInterface: ncKit,


### PR DESCRIPTION
Fixes #9602

- Removed obsolete account argument from FilesDatabaseManager.pendingWorkingSetChanges()
- Removed obsolete account argument from FilesDatabaseManager.managedMaterialisedItemMetadatas()
- Introduced hard delete for items reported as deleted
- Refactored FilesDatabaseManager.pendingWorkingSetChanges() for clarity
- Initializer of Enumerator now throws .noSuchItem if it is initialized for a non-system container and inexistent identifier
- Excluding softly deleted items from materialized item enumeration
- Improved code formatting