### PR TITLE
Exclude node_modules from sync

### DIFF
--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -51,3 +51,6 @@ My Saved Places.
 
 
 *.sb-*
+
+# exclude nodejs installed package folder
+node_modules


### PR DESCRIPTION
Add exclusion for node_modules directory

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->

Signed-off-by: theking2 <theking2@king.ma>