### PR TITLE
fix(read-only): make the parent folder writable before deleting a file

### DIFF
--- a/src/gui/conflictsolver.cpp
+++ b/src/gui/conflictsolver.cpp
@@ -109,6 +109,10 @@ bool ConflictSolver::deleteLocalVersion()
         return false;
     }
 
+    const auto fileInfo = QFileInfo{_localVersionFilename};
+    const auto parentFolderPath = fileInfo.dir().absolutePath();
+    const auto parentPermissionsHandler = FileSystem::FilePermissionsRestore{parentFolderPath, FileSystem::FolderPermissions::ReadWrite};
+
     if (FileSystem::isDir(_localVersionFilename)) {
         return FileSystem::removeRecursively(_localVersionFilename);
     } else {


### PR DESCRIPTION
to solve a conflict, we may need to delete a file inside a read-only folder

we need to ensure that temporary the parent folder can be modified

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
