### PR TITLE
fix: normalize server apps menu icon size

### DIFF
--- a/src/gui/tray/TrayWindowHeader.qml
+++ b/src/gui/tray/TrayWindowHeader.qml
@@ -120,6 +120,8 @@ Rectangle {
                         text: "  " + model.appName
                         font.pixelSize: Style.topLinePixelSize
                         icon.source: "image://tray-image-provider/" + model.appIconUrl
+                        icon.width: Style.trayWindowMenuIconSize
+                        icon.height: Style.trayWindowMenuIconSize
                         icon.color: palette.windowText
                         onTriggered: UserAppsModel.openAppUrl(appUrl)
                         Accessible.role: Accessible.MenuItem

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -177,6 +177,7 @@ QtObject {
     readonly property int trayWindowMenuOffsetY: 2
 
     readonly property int trayWindowMenuEntriesMargin: 6
+    readonly property int trayWindowMenuIconSize: 16
 
     // animation durations
     readonly property int shortAnimationDuration: 200


### PR DESCRIPTION
### Motivation
- Server app icons in the tray "More apps" menu rendered at inconsistent sizes because some SVGs have different intrinsic viewbox/canvas sizes, making the menu look visually unbalanced.

### Description
- Introduce a new style constant `Style.trayWindowMenuIconSize` (set to `16`) and apply it to each server app `MenuItem` by setting `icon.width` and `icon.height` in `src/gui/tray/TrayWindowHeader.qml` so all menu icons render at a uniform size.

### Testing
- Ran repository checks `git diff --check` and `git status --short` which confirmed the intended changes and reported no diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d170dc9c83339ce0ad7ece10e55e)