### PR TITLE
fix(asyncimageresponse): enhance check for received SVG response 

### DIFF
--- a/src/gui/tray/asyncimageresponse.cpp
+++ b/src/gui/tray/asyncimageresponse.cpp
@@ -6,6 +6,7 @@
 #include "asyncimageresponse.h"
 
 #include <QIcon>
+#include <QMimeDatabase>
 #include <QPainter>
 #include <QSvgRenderer>
 
@@ -116,11 +117,10 @@ void AsyncImageResponse::processNetworkReply(QNetworkReply *reply)
         return;
     }
 
-    // check whether the reply might be an SVG by looking at the content type and the first 512 bytes of the response for `<svg`.
     // Some graphics programs export SVGs that begin with `<?xml version="1.0" [...]` and/or include some comments after that (e.g.
     // `<!-- Generator: ...`), so we can't rely on just the response to start with `<svg`.
-    if (const auto contentTypeHeader = reply->header(QNetworkRequest::ContentTypeHeader);
-        !(contentTypeHeader.toString().startsWith("image/svg"_ba) || imageData.first(qMin(imageData.size(), 512)).contains("<svg"_ba))) {
+    if (const auto mimetype = QMimeDatabase().mimeTypeForData(imageData);
+        !(mimetype.isValid() && mimetype.inherits("image/svg+xml"_L1))) {
         // Not an SVG: let's let QImage deal with the response.
         setImageAndEmitFinished(QImage::fromData(imageData).scaled(_requestedImageSize));
         return;


### PR DESCRIPTION
Some app icon SVGs do not start with `<svg` but with e.g. `<?xml` and could include some additional metadata (e.g. a generator comment or licence header ...) before the expected `<svg` tag ... therefore let's check whether the reply is an SVG by peeking at the *content-type* header and the first 512 bytes of the response if the header was not enough.

Resolves #9685, resolves #9689, resolves #9681.

fix confirmed on Windows 11 and on Linux (with `QT_QPA_PLATFORMTHEME=gtk3` as the KDE Plasma one did not run into that)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
