### PR TITLE
fix(integration): only call parseEndpoints if fileId is not empty.

### DIFF
--- a/src/gui/integration/fileactionsmodel.cpp
+++ b/src/gui/integration/fileactionsmodel.cpp
@@ -88,6 +88,16 @@ void FileActionsModel::setAccountState(AccountState *accountState)
     _accountState = accountState;
     _accountUrl = _accountState->account()->url().toString();
     Q_EMIT accountStateChanged();
+
+    if (!_localPath.isEmpty()) {
+        qCDebug(lcFileActions) << "Local path is set with" << _fileId << ", calling setupFileProperties().";
+        setupFileProperties();
+    }
+
+    if (!_fileId.isEmpty() && !_localPath.isEmpty()) {
+        qCDebug(lcFileActions) << "File id is set with" << _fileId << ", calling parseEndpoints().";
+        parseEndpoints();
+    }
 }
 
 QString FileActionsModel::localPath() const


### PR DESCRIPTION
When right clicking on a file and on File actions, the users was always seeing the error "The file ID is empty for <filename>".

We can not control when QML instantiates the file id, but we can make sure the file id is not set to empty. For file provider the local path also needs to be validated.