### PR TITLE
fix(macOS): hide dock icon when closing settings with ⌘+W

### DIFF
--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -153,7 +153,7 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     // People perceive this as a Window, so also make Ctrl+W work
     auto *closeWindowAction = new QAction(this);
     closeWindowAction->setShortcut(QKeySequence("Ctrl+W"));
-    connect(closeWindowAction, &QAction::triggered, this, &SettingsDialog::accept);
+    connect(closeWindowAction, &QAction::triggered, this, &SettingsDialog::close);
     addAction(closeWindowAction);
 
     setObjectName("Settings"); // required as group for saveGeometry call


### PR DESCRIPTION
## Summary

Fixes #9328

When the settings window is closed by clicking the window's close button, the macOS dock icon
disappears as expected. However, closing the window with ⌘+W left the dock icon visible.

## Root cause

The `ForegroundBackground` event filter (`foregroundbackground_mac.mm`) listens for `QEvent::Close`
to call `ToBackground()`, which hides the dock icon.

- **Close button**: Qt sends `QEvent::Close` → event filter fires → dock icon hides.
- **⌘+W shortcut**: Was connected to `SettingsDialog::accept()`, which calls `QDialog::done()` →
  `hide()` → emits `QEvent::Hide`, **not** `QEvent::Close`. The event filter never fires.

## Fix

Connect the ⌘+W shortcut to `close()` instead of `accept()`. `QWidget::close()` sends a
`QEvent::Close`, which:

1. Triggers the `ForegroundBackground` event filter → hides the dock icon
2. Invokes `SettingsDialog::reject()` (QDialog's default close behavior) → saves window geometry
3. Deletes the dialog via `WA_DeleteOnClose`

This matches the close button's behavior exactly.