### PR TITLE
fix(updater): backport #9406 — respect autoUpdateCheck in Sparkle background checks

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -65,7 +65,8 @@ private:
 
 - (BOOL)backgroundUpdateChecksAllowed
 {
-    const BOOL allowUpdateCheck = OCC::ConfigFile().skipUpdateCheck() ? NO : YES;
+    const OCC::ConfigFile config;
+    const BOOL allowUpdateCheck = (!config.skipUpdateCheck() && config.autoUpdateCheck()) ? YES : NO;
     qCInfo(OCC::lcUpdater) << "Updater may check for updates:" << (allowUpdateCheck ? "YES" : "NO");
     return allowUpdateCheck;
 }
@@ -289,7 +290,8 @@ void SparkleUpdater::checkForUpdate()
 
 void SparkleUpdater::backgroundCheckForUpdate()
 {
-    if (autoUpdaterAllowed() && !ConfigFile().skipUpdateCheck()) {
+    const ConfigFile config;
+    if (autoUpdaterAllowed() && config.autoUpdateCheck()) {
         qCInfo(OCC::lcUpdater) << "launching background check";
         [_interface->updaterController.updater checkForUpdatesInBackground];
     } else {


### PR DESCRIPTION
## Summary

Backport of #9406 to `stable-4.0`.

- `backgroundUpdateChecksAllowed` now checks both `!config.skipUpdateCheck()` **and** `config.autoUpdateCheck()` before allowing Sparkle background update checks
- `backgroundCheckForUpdate()` now uses `config.autoUpdateCheck()` instead of `!ConfigFile().skipUpdateCheck()`

Without this fix, the Sparkle update dialog reappears daily on macOS even after the user clicks "Install Update", because the delegate creates an inconsistency in Sparkle 2's state management by not properly consulting the auto-update configuration.

Fixes #9704

## Test plan

- [ ] Verify that disabling "Automatically check for updates" stops the Sparkle background update dialog
- [ ] Verify that with auto-update enabled, the update flow works correctly
- [ ] Verify that `skipUpdateCheck` in `nextcloud.cfg` still prevents all update checks