### PR TITLE
fix(windows/vfs): do not create DB record for invalid virtual items

### DIFF
--- a/src/common/vfs.h
+++ b/src/common/vfs.h
@@ -32,11 +32,18 @@ class VfsPrivate;
 class SyncFileItem;
 using SyncFileItemPtr = QSharedPointer<SyncFileItem>;
 
+enum class VirtualItemCreationStatus {
+    Unknown,
+    Success,
+    Error,
+};
+
 struct OCSYNC_EXPORT PlaceholderCreateInfo {
     QString name;
     std::wstring stdWStringName;
     QString fullPath;
     RemoteInfo parsedProperties;
+    VirtualItemCreationStatus creationStatus = VirtualItemCreationStatus::Unknown;
 };
 
 /** Collection of parameters for initializing a Vfs instance. */

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -134,7 +134,7 @@ void cfApiSendTransferInfo(const CF_CONNECTION_KEY &connectionKey, const CF_TRAN
 void cfApiSendPlaceholdersTransferInfo(const CF_CONNECTION_KEY &connectionKey,
                                        const CF_TRANSFER_KEY &transferKey,
                                        NTSTATUS status,
-                                       const QList<OCC::PlaceholderCreateInfo> &newEntries,
+                                       QList<OCC::PlaceholderCreateInfo> &newEntries,
                                        qint64 currentPlaceholdersCount,
                                        qint64 totalPlaceholdersCount,
                                        const QString &serverPath)
@@ -198,6 +198,15 @@ void cfApiSendPlaceholdersTransferInfo(const CF_CONNECTION_KEY &connectionKey,
     const qint64 cfExecuteresult = CfExecute(&opInfo, &opParams);
     if (cfExecuteresult != S_OK) {
         qCCritical(lcCfApiWrapper) << "Couldn't send transfer info" << QString::number(transferKey.QuadPart, 16) << ":" << cfExecuteresult << QString::fromWCharArray(_com_error(cfExecuteresult).ErrorMessage());
+    }
+
+    for (auto virtualItemIndex = 0; virtualItemIndex < newEntries.size(); ++virtualItemIndex) {
+        auto oneItem = opParams.TransferPlaceholders.PlaceholderArray[virtualItemIndex];
+        if (oneItem.Result == S_OK) {
+            newEntries[virtualItemIndex].creationStatus = OCC::VirtualItemCreationStatus::Success;
+        } else {
+            newEntries[virtualItemIndex].creationStatus = OCC::VirtualItemCreationStatus::Error;
+        }
     }
 
     qCInfo(lcCfApiWrapper()) << "number of processes entries:" << opParams.TransferPlaceholders.EntriesProcessed;
@@ -516,16 +525,17 @@ void CALLBACK cfApiFetchPlaceHolders(const CF_CALLBACK_INFO *callbackInfo, const
     }
 
     const auto sendTransferError = [=] {
+        auto emptyList = QList<OCC::PlaceholderCreateInfo>{};
         cfApiSendPlaceholdersTransferInfo(callbackInfo->ConnectionKey,
                                           callbackInfo->TransferKey,
                                           STATUS_UNSUCCESSFUL,
-                                          {},
+                                          emptyList,
                                           0,
                                           0,
                                           {});
     };
 
-    const auto sendTransferInfo = [=](const QList<OCC::PlaceholderCreateInfo> &newEntries, const QString &serverPath) {
+    const auto sendTransferInfo = [=](QList<OCC::PlaceholderCreateInfo> &newEntries, const QString &serverPath) {
         cfApiSendPlaceholdersTransferInfo(callbackInfo->ConnectionKey,
                                           callbackInfo->TransferKey,
                                           STATUS_SUCCESS,

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -536,6 +536,12 @@ int VfsCfApi::finalizeNewPlaceholders(const QList<PlaceholderCreateInfo> &newEnt
     const auto &journal = params().journal;
 
     for (const auto &entryInfo : newEntries) {
+        if (entryInfo.creationStatus == VirtualItemCreationStatus::Error ||
+            entryInfo.creationStatus == VirtualItemCreationStatus::Unknown) {
+            qCWarning(lcCfApi()) << "do not create DB record for virtual item not created" << entryInfo.fullPath;
+            continue;
+        }
+
         auto folderRecord = SyncJournalFileRecord{};
 
         folderRecord._checksumHeader = entryInfo.parsedProperties.checksumHeader;


### PR DESCRIPTION
when populating a folders on-demand, only create DB record for items having been successfully created by the Windows VFS API

Close #9736

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
