### PR TITLE
fix(windows/vfs): automated test for Windows VFS case clash items

### DIFF
--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -1705,6 +1705,50 @@ private slots:
         QVERIFY(itemInstruction(completeSpy, "afileFromDirectory.txt", CSYNC_INSTRUCTION_RENAME));
         QVERIFY(itemInstruction(completeSpy, "afileFromSubdir.txt", CSYNC_INSTRUCTION_RENAME));
     }
+
+
+    void testServer_caseClash_createConflict()
+    {
+        FakeFolder fakeFolder{ FileInfo{} };
+        setupVfs(fakeFolder);
+
+        ItemCompletedSpy completeSpy(fakeFolder);
+
+        const auto cleanup = [&]() {
+            completeSpy.clear();
+        };
+
+        cleanup();
+
+        fakeFolder.remoteModifier().mkdir("perso");
+        fakeFolder.remoteModifier().mkdir("perso/hello");
+        fakeFolder.remoteModifier().mkdir("perso/Hello");
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(completeSpy.size(), 1);
+        QVERIFY(itemInstruction(completeSpy, "perso", CSYNC_INSTRUCTION_NEW));
+
+        cleanup();
+
+        OCC::showInFileManager(fakeFolder.localPath() + "perso");
+
+        QTest::qWait(5000);
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(completeSpy.size(), 0);
+
+        OCC::showInFileManager(fakeFolder.localPath() + "perso");
+
+        QTest::qWait(5000);
+
+        cleanup();
+        fakeFolder.syncOnce();
+        QCOMPARE(completeSpy.size(), 0);
+
+        cleanup();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(completeSpy.size(), 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncCfApi)


### PR DESCRIPTION
ensure we do not delete case clash conflicting items

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
