### PR TITLE
fix(macOS): Fix background update check incorrectly calling Sparkle when `automaticallyChecksForUpdates` is `NO`

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -266,6 +266,7 @@ bool SparkleUpdater::autoUpdaterAllowed()
     // See https://github.com/owncloud/client/issues/2931
     NSString *bundlePath = [[NSBundle mainBundle] bundlePath];
     NSString *expectedPath = [NSString stringWithFormat:@"/Applications/%@", [bundlePath lastPathComponent]];
+
     if (![expectedPath isEqualTo:bundlePath]) {
         qCWarning(lcUpdater) << "We are not in /Applications, won't check for update!";
         return false;
@@ -289,13 +290,25 @@ void SparkleUpdater::checkForUpdate()
 
 void SparkleUpdater::backgroundCheckForUpdate()
 {
-    const ConfigFile config;
-    if (autoUpdaterAllowed() && config.autoUpdateCheck()) {
-        qCInfo(OCC::lcUpdater) << "launching background check";
-        [_interface->updaterController.updater checkForUpdatesInBackground];
-    } else {
-        qCInfo(OCC::lcUpdater) << "not launching background check, auto updater not allowed or update check skipped in config";
+    if (!autoUpdaterAllowed()) {
+        qCInfo(OCC::lcUpdater) << "not launching background check, auto updater not allowed";
+        return;
     }
+
+    const ConfigFile config;
+
+    if (!config.autoUpdateCheck()) {
+        qCInfo(OCC::lcUpdater) << "not launching background check, update check skipped in config";
+        return;
+    }
+
+    if (!_interface->updaterController.updater.automaticallyChecksForUpdates) {
+        qCInfo(OCC::lcUpdater) << "not launching background check, automaticallyChecksForUpdates is disabled";
+        return;
+    }
+
+    qCInfo(OCC::lcUpdater) << "launching background check";
+    [_interface->updaterController.updater checkForUpdatesInBackground];
 }
 
 QString SparkleUpdater::statusString() const


### PR DESCRIPTION
Fixes #9662

### Problem

On macOS, Sparkle would log the following warning at startup:

> "Calling -[SPUUpdater checkForUpdatesInBackground] for your own bundle when Sparkle is set to ask the user permission to check for updates in the background automatically and when automaticallyChecksForUpdates is NO leads to incorrect behavior."

This happened because `backgroundCheckForUpdate()` called `checkForUpdatesInBackground` relying solely on Nextcloud's own config (`autoUpdateCheck`) — without consulting Sparkle's own `automaticallyChecksForUpdates` property. The two settings have independent sources of truth: `config.autoUpdateCheck()` reads from Nextcloud's `QSettings`-backed config file, while `automaticallyChecksForUpdates` is managed by Sparkle in `NSUserDefaults` and reflects whether Sparkle has been initialised and granted permission by the user. They can diverge, for example on a fresh install before Sparkle has shown its first-run permission prompt.

### Fix

- Added `automaticallyChecksForUpdates` as a third guard in `backgroundCheckForUpdate()`, preventing the call to `checkForUpdatesInBackground` when Sparkle is not in a state to handle it.
- Refactored the single compound `if/else` into individual early-return guard blocks (each with its own log message) so that logs precisely identify which condition prevented the background check from running.