### PR TITLE
fix(macOS): Sparkle Sandboxing

### DIFF
--- a/admin/osx/macosx.entitlements.cmake
+++ b/admin/osx/macosx.entitlements.cmake
@@ -18,6 +18,11 @@
 	<array>
 		<string>@APPLICATION_REV_DOMAIN@.FinderSyncService</string>
 	</array>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>@APPLICATION_REV_DOMAIN@-spks</string>
+		<string>@APPLICATION_REV_DOMAIN@-spki</string>
+	</array>
 @DEBUG_ENTITLEMENTS@
 </dict>
 </plist>

--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -46,6 +46,8 @@
     <string>dsa_pub.pem</string>
     <key>SUPublicEDKey</key>
     <string>c3RcfDWDayvsYSZW8FhZN1UOJhvPVN30zleb4zOqbtU=</string>
+    <key>SUEnableInstallerLauncherService</key>
+    <true/>
     <key>UTExportedTypeDeclarations</key>
     <array>
         <dict>


### PR DESCRIPTION
Configured Sparkle to be sandboxed according to [its documentation](https://sparkle-project.org/documentation/sandboxing/).