### PR TITLE
fix: scroll folder list to matched item on type-to-select

### DIFF
--- a/src/gui/folderstatusview.cpp
+++ b/src/gui/folderstatusview.cpp
@@ -33,4 +33,14 @@ QRect FolderStatusView::visualRect(const QModelIndex &index) const
     return rect;
 }
 
+void FolderStatusView::keyboardSearch(const QString &search)
+{
+    QTreeView::keyboardSearch(search);
+
+    const auto index = currentIndex();
+    if (index.isValid()) {
+        scrollTo(index, QAbstractItemView::EnsureVisible);
+    }
+}
+
 } // namespace OCC

--- a/src/gui/folderstatusview.h
+++ b/src/gui/folderstatusview.h
@@ -23,6 +23,7 @@ public:
 
     [[nodiscard]] QModelIndex indexAt(const QPoint &point) const override;
     [[nodiscard]] QRect visualRect(const QModelIndex &index) const override;
+    void keyboardSearch(const QString &search) override;
 };
 
 } // namespace OCC


### PR DESCRIPTION
### Motivation
- Restore expected type-to-select behavior in account settings so pressing a letter not only updates the selection indicator but also brings the matched row into the visible viewport.

### Description
- Added an override for `FolderStatusView::keyboardSearch` and implemented it to call `QTreeView::keyboardSearch(search)` and then `scrollTo(currentIndex(), QAbstractItemView::EnsureVisible)` so the matched item is scrolled into view.

### Testing
- Ran `git diff --check` which succeeded. 
- Attempted `xcodebuild build -target NextcloudDev` in the macOS integration directory but the `xcodebuild` tool is not available in this environment, so build verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d1e7c5fc8333ae15dfc294d63db8)