### PR TITLE
fix(macOS): Launch on Login

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/EnumeratorPageResponse.swift
@@ -4,7 +4,7 @@
 import Alamofire
 import Foundation
 
-struct EnumeratorPageResponse: Sendable, Codable {
+struct EnumeratorPageResponse: Codable {
     let token: String? // Required by server to serve the next page of items
     let index: Int // Needed to calculate the offset for the next paginated request
     var total: Int? // Total item count, provided in the first non-offset paginated response

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -107,7 +107,7 @@ public actor FileProviderLog: FileProviderLogging {
             logger.error("Failed to get URL for file provider domain logs!")
             file = nil
             handle = nil
-            self.logsDirectory = nil
+            logsDirectory = nil
             return
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Enumeration/DirtyUserDataObserverTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/Enumeration/DirtyUserDataObserverTests.swift
@@ -6,7 +6,6 @@ import FileProvider
 import NextcloudFileProviderKitMocks
 import Testing
 
-@Suite("DirtyUserDataObserver Tests")
 struct DirtyUserDataObserverTests {
     let mockLog: FileProviderLogMock
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorPageResponseTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorPageResponseTests.swift
@@ -7,7 +7,7 @@ import Foundation
 import NextcloudFileProviderKitMocks
 import Testing
 
-@Suite struct EnumeratorPageResponseTests {
+struct EnumeratorPageResponseTests {
     private func createMockAFDataResponse(
         headers: [String: String]?,
         statusCode: Int = 200,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteInterfaceTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteInterfaceTests.swift
@@ -10,7 +10,7 @@ import NextcloudKit
 import Testing
 @testable import TestInterface
 
-@Suite("RemoteInterface Extension Tests", .serialized)
+@Suite(.serialized)
 struct RemoteInterfaceExtensionTests {
     let testAccount = Account(user: "a1", id: "1", serverUrl: "example.com", password: "pass")
     let otherAccount = Account(user: "a2", id: "2", serverUrl: "example.com", password: "word")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RetrievedCapabilitiesActorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RetrievedCapabilitiesActorTests.swift
@@ -8,7 +8,6 @@ import Testing
 @testable import TestInterface
 import XCTest
 
-@Suite("RetrievedCapabilitiesActor tests")
 struct RetrievedCapabilitiesActorTests {
     let account1 = "acc1"
     let account2 = "acc2"

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -150,6 +150,9 @@ namespace Utility {
     OCSYNC_EXPORT bool hasSystemLaunchOnStartup(const QString &appName);
     OCSYNC_EXPORT bool hasLaunchOnStartup(const QString &appName);
     OCSYNC_EXPORT void setLaunchOnStartup(const QString &appName, const QString &guiName, const bool launch);
+    /** On macOS, returns true when the login item is registered but awaiting user approval
+     *  in System Settings → General → Login Items. Always returns false on other platforms. */
+    OCSYNC_EXPORT bool launchOnStartupRequiresApproval();
     OCSYNC_EXPORT uint convertSizeToUint(size_t &convertVar);
     OCSYNC_EXPORT int convertSizeToInt(size_t &convertVar);
 

--- a/src/common/utility_mac.mm
+++ b/src/common/utility_mac.mm
@@ -4,17 +4,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-#include "result.h"
 #include "utility.h"
 
-#include <QCoreApplication>
-#include <QDir>
 #include <QLoggingCategory>
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreServices/CoreServices.h>
-#import <Foundation/NSFileManager.h>
 #import <Foundation/NSUserDefaults.h>
+#import <ServiceManagement/SMAppService.h>
 
 namespace OCC {
 
@@ -74,115 +71,25 @@ QString Utility::syncFolderDisplayName(const QString &folder, const QString &dis
     return {};
 }
 
-static Result<void, QString> writePlistToFile(NSString *plistFile, NSDictionary *plist)
-{
-    NSError *error = nil;
-
-    // Check if the directory exists. On a fresh installation for example, the directory does not
-    // exist, so writing the plist file below will fail.
-    const auto plistDir = QFileInfo(QString::fromNSString(plistFile)).dir();
-    if (!plistDir.exists()) {
-        if (!QDir().mkpath(plistDir.path())) {
-            return QString(QStringLiteral("Failed to create directory '%1'")).arg(plistDir.path());
-        }
-
-        // Permissions always seem to be 0700, so set that.
-        // Note: the Permission enum documentation states that on unix the owner permissions are
-        // returned, but: "This behavior might change in a future Qt version." So we play it safe,
-        // and set both the user and the owner permissions to rwx.
-        if (!QFile(plistDir.path()).setPermissions(QFileDevice::ReadOwner | QFileDevice::ReadUser | QFileDevice::WriteOwner | QFileDevice::WriteUser | QFileDevice::ExeOwner | QFileDevice::ExeUser)) {
-            qCInfo(lcUtility()) << "Failed to set directory permmissions for" << plistDir.path();
-        }
-    }
-
-    // Now write the file.
-    qCInfo(lcUtility()) << "Writing plist file" << QString::fromNSString(plistFile); // Especially for branded clients: log the file name, so it can be found when debugging.
-    if (![plist writeToURL:[NSURL fileURLWithPath:plistFile isDirectory:NO] error:&error]) {
-        return QString::fromNSString(error.localizedDescription);
-    }
-
-    return {};
-}
-
-static Result<NSDictionary *, QString> readPlistFromFile(NSString *plistFile)
-{
-    NSError *error = nil;
-    if (NSDictionary *plist = [NSDictionary dictionaryWithContentsOfURL:[NSURL fileURLWithPath:plistFile isDirectory:NO] error:&error]) {
-        return plist;
-    } else {
-        return QString::fromNSString(error.localizedDescription);
-    }
-}
-
 bool Utility::hasLaunchOnStartup(const QString &appName)
 {
     Q_UNUSED(appName)
 
     @autoreleasepool {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *appIdentifier = QCoreApplication::organizationDomain().toNSString();
-        NSString *plistFile = [NSHomeDirectory() stringByAppendingFormat:@"/Library/LaunchAgents/%@.plist", appIdentifier];
-
-        if ([fileManager fileExistsAtPath:plistFile]) {
-            auto maybePlist = readPlistFromFile(plistFile);
-            if (!maybePlist) {
-                qCInfo(lcUtility()).nospace() << "Cannot read '" << QString::fromNSString(plistFile)
-                                              << "', probably not a valid plist file";
-                return false;
-            }
-
-            if (NSDictionary *plist = *maybePlist) {
-                // yes, there is a valid plist file...
-                if (id label = plist[@"Label"]) {
-                    // ... with a label...
-                    if ([appIdentifier isEqualToString:label]) {
-                        // ... and yes, it's the correct app-id...
-                        if (id program = plist[@"Program"]) {
-                            // .. and there is a program mentioned ...
-                            // (Note: case insensitive compare, because most fs setups on mac are case insensitive)
-                            if ([QCoreApplication::applicationFilePath().toNSString() compare:program options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-                                // ... and it's our executable ..
-                                if (NSNumber *value = plist[@"RunAtLoad"]) {
-                                    // yes, there is even a RunAtLoad key, so use it!
-                                    return [value boolValue];
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        const auto status = [SMAppService mainAppService].status;
+        qCDebug(lcUtility) << "Login item status:" << static_cast<NSInteger>(status);
+        // Treat RequiresApproval as registered: the user's intent is set and the item
+        // is pending approval in System Settings → General → Login Items.
+        return status == SMAppServiceStatusEnabled
+            || status == SMAppServiceStatusRequiresApproval;
     }
-
-    return false;
 }
 
-static Result<void, QString> writeNewPlistFile(NSString *plistFile, NSString *fullPath, bool enable)
+bool Utility::launchOnStartupRequiresApproval()
 {
-    NSDictionary *plistTemplate = @{
-        @"Label" : QCoreApplication::organizationDomain().toNSString(),
-        @"KeepAlive" : @NO,
-        @"Program" : fullPath,
-        @"RunAtLoad" : enable ? @YES : @NO
-    };
-
-    return writePlistToFile(plistFile, plistTemplate);
-}
-
-static Result<void, QString> modifyPlist(NSString *plistFile, NSDictionary *plist, bool enable)
-{
-    if (NSNumber *value = plist[@"RunAtLoad"]) {
-        // ok, there is a key
-        if ([value boolValue] == enable) {
-            // nothing to do
-            return {};
-        }
+    @autoreleasepool {
+        return [SMAppService mainAppService].status == SMAppServiceStatusRequiresApproval;
     }
-
-    // now either the key was missing, or it had the wrong value, so set the key and write the plist back
-    NSMutableDictionary *newPlist = [plist mutableCopy];
-    newPlist[@"RunAtLoad"] = enable ? @YES : @NO;
-    return writePlistToFile(plistFile, newPlist);
 }
 
 void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName, bool enable)
@@ -191,62 +98,32 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName,
     Q_UNUSED(guiName)
 
     @autoreleasepool {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *fullPath = QCoreApplication::applicationFilePath().toNSString();
-        NSString *appIdentifier = QCoreApplication::organizationDomain().toNSString();
-        NSString *plistFile = [NSHomeDirectory() stringByAppendingFormat:@"/Library/LaunchAgents/%@.plist", appIdentifier];
+        SMAppService *service = [SMAppService mainAppService];
+        NSError *error = nil;
 
-        // An error might occur in the code below, but we cannot report anything, so we just ignore them.
-
-        if ([fileManager fileExistsAtPath:plistFile]) {
-            auto maybePlist = readPlistFromFile(plistFile);
-            if (!maybePlist) {
-                // broken plist, overwrite it
-                auto result = writeNewPlistFile(plistFile, fullPath, enable);
-                if (!result) {
-                    qCWarning(lcUtility) << Q_FUNC_INFO << result.error();
-                }
+        if (enable) {
+            if (![service registerAndReturnError:&error]) {
+                qCWarning(lcUtility) << "Failed to register login item:"
+                                     << QString::fromNSString(error.localizedDescription);
                 return;
             }
-            NSDictionary *plist = *maybePlist;
-
-            id programValue = plist[@"Program"];
-            if (programValue == nil) {
-                // broken plist, overwrite it
-                auto result = writeNewPlistFile(plistFile, fullPath, enable);
-                if (!result) {
-                    qCWarning(lcUtility) << result.error();
-                }
-            } else if (![fileManager fileExistsAtPath:programValue]) {
-                // Ok, a plist from some removed program, overwrite it
-                auto result = writeNewPlistFile(plistFile, fullPath, enable);
-                if (!result) {
-                    qCWarning(lcUtility) << result.error();
-                }
-            } else if ([fullPath compare:programValue options:NSCaseInsensitiveSearch] == NSOrderedSame) { // (Note: case insensitive compare, because most fs setups on mac are lse if (![fileManager fileExistscase insensitive)
-                // Wohoo, it's ours! Now carefully change only the RunAtLoad entry. If any value for
-                // e.g. KeepAlive was changed, we leave it as-is.
-                auto result = modifyPlist(plistFile, plist, enable);
-                if (!result) {
-                    qCWarning(lcUtility) << result.error();
-                }
-            } else if ([fullPath hasPrefix:@"/Applications/"]) {
-                // ok, we seem to be an officially installed application, overwrite the file
-                auto result = writeNewPlistFile(plistFile, fullPath, enable);
-                if (!result) {
-                    qCWarning(lcUtility) << result.error();
-                }
-            } else {
-                qCInfo(lcUtility) << "We're not an installed application, there is anoter executable "
-                                     "mentioned in the plist file, and that executable seems to exist, "
-                                     "so let's not touch the file.";
-            }
+            qCInfo(lcUtility) << "Successfully registered login item";
         } else {
-            // plist doens't exist, write a new one.
-            auto result = writeNewPlistFile(plistFile, fullPath, enable);
-            if (!result) {
-                qCWarning(lcUtility) << result.error();
+            if (![service unregisterAndReturnError:&error]) {
+                qCWarning(lcUtility) << "Failed to unregister login item:"
+                                     << QString::fromNSString(error.localizedDescription);
+                return;
             }
+            qCInfo(lcUtility) << "Successfully unregistered login item";
+        }
+
+        const auto resultStatus = service.status;
+        const auto effectivelyEnabled = resultStatus == SMAppServiceStatusEnabled
+            || resultStatus == SMAppServiceStatusRequiresApproval;
+        if ((enable && !effectivelyEnabled) || (!enable && effectivelyEnabled)) {
+            qCWarning(lcUtility) << "Login item status after update does not match intent."
+                                 << "Expected enabled:" << enable
+                                 << "Actual status:" << static_cast<NSInteger>(resultStatus);
         }
     }
 }

--- a/src/common/utility_unix.cpp
+++ b/src/common/utility_unix.cpp
@@ -133,6 +133,11 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName,
     }
 }
 
+bool Utility::launchOnStartupRequiresApproval()
+{
+    return false;
+}
+
 bool Utility::hasDarkSystray()
 {
     return true;

--- a/src/common/utility_win.cpp
+++ b/src/common/utility_win.cpp
@@ -283,6 +283,11 @@ void Utility::setLaunchOnStartup(const QString &appName, const QString &guiName,
     }
 }
 
+bool Utility::launchOnStartupRequiresApproval()
+{
+    return false;
+}
+
 bool Utility::hasDarkSystray()
 {
     if(Utility::registryGetKeyValue(    HKEY_CURRENT_USER,

--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -88,7 +88,9 @@ target_link_libraries(nextcloud_csync PRIVATE SQLite::SQLite3)
 if (APPLE)
     find_library(FOUNDATION_LIBRARY NAMES Foundation)
     find_library(CORESERVICES_LIBRARY NAMES CoreServices)
+    find_library(SERVICEMANAGEMENT_LIBRARY NAMES ServiceManagement)
     target_link_libraries(nextcloud_csync PUBLIC ${FOUNDATION_LIBRARY} ${CORESERVICES_LIBRARY})
+    target_link_libraries(nextcloud_csync PRIVATE ${SERVICEMANAGEMENT_LIBRARY})
 endif()
 
 set_target_properties(

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -274,7 +274,7 @@ GeneralSettings::GeneralSettings(QWidget *parent)
         _ui->autostartCheckBox->setToolTip(tr("You cannot disable autostart because system-wide autostart is enabled."));
     } else {
         connect(_ui->autostartCheckBox, &QAbstractButton::toggled, this, &GeneralSettings::slotToggleLaunchOnStartup);
-        _ui->autostartCheckBox->setChecked(ConfigFile().launchOnSystemStartup());
+        _ui->autostartCheckBox->setChecked(Utility::hasLaunchOnStartup(Theme::instance()->appName()));
     }
 
     // setup about section
@@ -655,9 +655,27 @@ void GeneralSettings::slotToggleLaunchOnStartup(bool enable)
         return;
     }
 
-    ConfigFile configFile;
-    configFile.setLaunchOnSystemStartup(enable);
     Utility::setLaunchOnStartup(theme->appName(), theme->appNameGUI(), enable);
+
+    const auto actualState = Utility::hasLaunchOnStartup(theme->appName());
+    ConfigFile configFile;
+    configFile.setLaunchOnSystemStartup(actualState);
+
+    if (actualState != enable) {
+        const QSignalBlocker blocker(_ui->autostartCheckBox);
+        _ui->autostartCheckBox->setChecked(actualState);
+    }
+
+#ifdef Q_OS_MACOS
+    if (enable && Utility::launchOnStartupRequiresApproval()) {
+        QMessageBox::information(
+            this,
+            tr("Login Item Requires Approval"),
+            tr("The login item has been registered but needs your approval to become active. "
+               "Please open System Settings → General → Login Items and enable %1 there.")
+                .arg(theme->appNameGUI()));
+    }
+#endif
 }
 
 void GeneralSettings::slotToggleOptionalServerNotifications(bool enable)

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -70,6 +70,12 @@ private slots:
 
     void testLaunchOnStartup()
     {
+#ifdef Q_OS_MACOS
+        // The macOS implementation uses SMAppService, which operates on the running app's
+        // system-level login item registration and requires a properly signed app bundle.
+        // Neither condition holds in a unit test runner, so this test is not applicable on macOS.
+        QSKIP("SMAppService-based launch-on-startup cannot be unit-tested outside a signed app bundle.");
+#endif
         QString postfix = QString::number(OCC::Utility::rand());
 
         const QString appName = QString::fromLatin1("testLaunchOnStartup.%1").arg(postfix);


### PR DESCRIPTION
Fixes #9761 by updating the code to use the [Service Management](https://developer.apple.com/documentation/servicemanagement) framework which became available with macOS 13 which also is our minimum deployment target. This is an API compatible with sandboxed apps which no longer uses deprecated APIs to meddle in system files outside the app sandbox.

On macOS, users can manage login items in the central system settings. Switches in the user interface of third-party apps are only a redundant convenience alternative.

## Screenshots

<img width="893" height="284" alt="Bildschirmfoto 2026-04-02 um 11 01 47" src="https://github.com/user-attachments/assets/c00bb22c-6364-4cf0-bf74-c1c9e7946b1d" />
<img width="573" height="225" alt="Bildschirmfoto 2026-04-02 um 11 02 08" src="https://github.com/user-attachments/assets/7e63fcb4-9428-415c-b493-227b2fa0c3b9" />
