### PR TITLE
feat: add file provider open-in-browser context action

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+CustomActions.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension+CustomActions.swift
@@ -58,6 +58,40 @@ extension FileProviderExtension: NSFileProviderCustomAction {
                 onItemsWithIdentifiers: itemIdentifiers,
                 completionHandler: completionHandler
             )
+        case "com.nextcloud.desktopclient.FileProviderExt.OpenInBrowserAction":
+            guard let itemIdentifier = itemIdentifiers.first else {
+                logger.error("Failed to get first item identifier for open in browser action.")
+                completionHandler(NSFileProviderError(.noSuchItem))
+                return Progress()
+            }
+
+            guard let dbManager else {
+                logger.error("Cannot open in browser due to database manager not being available.", [.item: itemIdentifier])
+                completionHandler(NSFileProviderError(.cannotSynchronize))
+                return Progress()
+            }
+
+            Task {
+                guard let userVisibleURL = try await manager?.getUserVisibleURL(for: itemIdentifier) else {
+                    logger.error("Failed to get user-visible URL for item.", [.item: itemIdentifier])
+                    completionHandler(NSFileProviderError(.noSuchItem))
+                    return
+                }
+
+                guard let metadata = dbManager.itemMetadata(itemIdentifier) else {
+                    logger.error("Failed to get metadata for item.", [.item: itemIdentifier])
+                    completionHandler(NSFileProviderError(.cannotSynchronize))
+                    return
+                }
+
+                let path = userVisibleURL.path
+                let domainIdentifier = domain.identifier.rawValue
+                logger.info("Telling main app to open item in browser.", [.item: path, .domain: domainIdentifier])
+                app?.openInBrowserForPath(path, remoteItemPath: metadata.path, withDomainIdentifier: domainIdentifier)
+                completionHandler(nil)
+            }
+
+            return Progress()
         default:
             logger.error("Unsupported action: \(actionIdentifier.rawValue)")
             completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
@@ -45,6 +45,14 @@
 				<key>NSExtensionFileProviderActionName</key>
 				<string>File actions</string>
 			</dict>
+			<dict>
+				<key>NSExtensionFileProviderActionActivationRule</key>
+				<string>SUBQUERY ( fileproviderItems, $fileproviderItem, !($fileproviderItem.contentType.identifier UTI-CONFORMS-TO "public.folder") ).@count &gt; 0</string>
+				<key>NSExtensionFileProviderActionIdentifier</key>
+				<string>com.nextcloud.desktopclient.FileProviderExt.OpenInBrowserAction</string>
+				<key>NSExtensionFileProviderActionName</key>
+				<string>Open in browser</string>
+			</dict>
 		</array>
 		<key>NSExtensionFileProviderDocumentGroup</key>
 		<string>$(DEVELOPMENT_TEAM).$(OC_APPLICATION_REV_DOMAIN)</string>

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/AppProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Services/AppProtocol.h
@@ -24,6 +24,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)presentFileActions:(NSString *)fileId path:(NSString *)path remoteItemPath:(NSString *)remoteItemPath withDomainIdentifier:(NSString *)domainIdentifier;
 
 /**
+ * @brief The file provider extension can request opening an item in the browser.
+ *
+ * The main app decides whether to use direct editing (`EDIT`) or private link (`OPEN_PRIVATE_LINK`)
+ * depending on the direct editor availability for the given local file.
+ *
+ * @param path The local and absolute path for the item to open.
+ * @param remoteItemPath The server-side path of the item (reserved for future fallback logic).
+ * @param domainIdentifier The file provider domain identifier for the account that manages this file.
+ */
+- (void)openInBrowserForPath:(NSString *)path remoteItemPath:(NSString *)remoteItemPath withDomainIdentifier:(NSString *)domainIdentifier;
+
+/**
  * @brief The file provider extension can report its synchronization status as a string constant value to the main app through this method.
  * @param status The synchronization status string.
  * @param domainIdentifier The file provider domain identifier for which the status is reported.
@@ -34,4 +46,3 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 #endif /* AppProtocol_h */
-

--- a/src/gui/macOS/fileproviderservice.mm
+++ b/src/gui/macOS/fileproviderservice.mm
@@ -14,6 +14,8 @@
 #include <QMetaObject>
 
 #include "accountmanager.h"
+#include "folderman.h"
+#include "socketapi/socketapi.h"
 
 namespace OCC {
 
@@ -107,6 +109,37 @@ Q_LOGGING_CATEGORY(lcMacFileProviderService, "nextcloud.gui.macfileproviderservi
                               Q_ARG(OCC::SyncResult::Status, syncState));
 }
 
+- (void)openInBrowserForPath:(NSString *)path remoteItemPath:(NSString *)remoteItemPath withDomainIdentifier:(NSString *)domainIdentifier
+{
+    Q_UNUSED(remoteItemPath)
+    Q_UNUSED(domainIdentifier)
+
+    const auto localPath = QString::fromNSString(path);
+
+    qCDebug(OCC::lcMacFileProviderService) << "Received open in browser request for path:" << localPath;
+
+    if (!_service) {
+        qCWarning(OCC::lcMacFileProviderService) << "No service available to open item in browser";
+        return;
+    }
+
+    auto *const socketApi = OCC::FolderMan::instance()->socketApi();
+    if (!socketApi) {
+        qCWarning(OCC::lcMacFileProviderService) << "SocketApi is unavailable, cannot open item in browser:" << localPath;
+        return;
+    }
+
+    // Execute on the socket API object thread.
+    QMetaObject::invokeMethod(socketApi, [socketApi, localPath]() {
+        OCC::SocketListener *nullListener = nullptr;
+        if (socketApi->getDirectEditorForLocalFile(localPath)) {
+            socketApi->command_EDIT(localPath, nullListener);
+        } else {
+            socketApi->command_OPEN_PRIVATE_LINK(localPath, nullListener);
+        }
+    }, Qt::QueuedConnection);
+}
+
 @end
 
 namespace OCC {
@@ -166,4 +199,3 @@ void FileProviderService::setLatestReceivedSyncStatus(const QString &userId, Syn
 } // namespace Mac
 
 } // namespace OCC
-


### PR DESCRIPTION
### Motivation
- Provide the same "Open in browser" behavior available for standard sync context menus to the Apple File Provider integration so users get consistent office/direct-editing experience.
- Let the File Provider extension delegate the decision between direct editing and opening a private link to the main app, reusing existing `SocketApi` logic.

### Description
- Add a new File Provider custom action `Open in browser` in `FileProviderExt/Info.plist` for non-folder items so the action appears in the File Provider actions list.
- Extend the XPC `AppProtocol` with `openInBrowserForPath:remoteItemPath:withDomainIdentifier:` so the extension can request the main app to open the item in the browser.
- Implement the extension-side handler in `FileProviderExtension+CustomActions.swift` that resolves the user-visible path and metadata and calls the new XPC method on the app delegate.
- Implement `openInBrowserForPath` in `src/gui/macOS/fileproviderservice.mm` which routes the request to `SocketApi` on its thread and executes `command_EDIT` if `getDirectEditorForLocalFile(...)` returns an editor or `command_OPEN_PRIVATE_LINK` otherwise.

### Testing
- Attempted to build with `xcodebuild build -scheme desktopclient` but the command cannot run in this environment because `xcodebuild` is not available, so an integrated build could not be verified.
- No automated unit test runs were performed; the change was committed and compiles should be validated on a macOS build machine with Xcode (run `xcodebuild` as described in project docs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce40a89da88333be75caa346b0e64c)