### PR TITLE
fix(macOS): macOS 13 Ventura Compatibility

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -291,6 +291,7 @@ endif()
 IF( APPLE )
     list(APPEND client_SRCS cocoainitializer_mac.mm)
     list(APPEND client_SRCS systray_mac_common.mm)
+    list(APPEND client_SRCS macOS/singleinstancemanager_mac.mm)
 
     list(APPEND client_SRCS systray_mac_usernotifications.mm)
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -395,7 +395,11 @@ Application::Application(int &argc, char **argv)
     _shellExtensionsServer.reset(new ShellExtensionsServer);
 #endif
 
+#ifdef Q_OS_MACOS
+    connect(&_singleApp, &OCC::SingleInstanceManager::messageReceived, this, &Application::slotParseMessage);
+#else
     connect(&_singleApp, &KDSingleApplication::messageReceived, this, &Application::slotParseMessage);
+#endif
 
     // create accounts and folders from a legacy desktop client or from the current config file
     setupAccountsAndFolders();

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -12,7 +12,11 @@
 #include "clientproxy.h"
 #include "folderman.h"
 
+#ifdef Q_OS_MACOS
+#include "macOS/singleinstancemanager_mac.h"
+#else
 #include <KDSingleApplication>
+#endif
 
 #include <QApplication>
 #include <QPointer>
@@ -125,7 +129,11 @@ private:
 
     QPointer<ownCloudGui> _gui;
 
+#ifdef Q_OS_MACOS
+    OCC::SingleInstanceManager _singleApp;
+#else
     KDSingleApplication _singleApp;
+#endif
 
     Theme *_theme;
 

--- a/src/gui/macOS/singleinstancemanager_mac.h
+++ b/src/gui/macOS/singleinstancemanager_mac.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <QObject>
+
+class QLocalServer;
+
+namespace OCC {
+
+/**
+ * @brief macOS single-instance guard using a UNIX socket in the app's
+ *        sandboxed home directory.
+ *
+ * This replaces KDSingleApplication on macOS because KDSingleApplication's
+ * default socket path ($TMPDIR/kdsingleapp-<uid>-<appname>) has two fatal
+ * problems on macOS 13 Ventura:
+ *
+ *  1. Path too long: on macOS 13, $TMPDIR uses the /private/var/... canonical
+ *     form, making the full socket path 110 bytes — 7 bytes over the 103-char
+ *     limit imposed by struct sockaddr_un.sun_path[104].  On macOS 14+ the
+ *     /private prefix is absent so the same path is only 102 bytes and just
+ *     fits.
+ *
+ *  2. Sandbox denial: the macOS 13 App Sandbox does not grant network-bind for
+ *     UNIX sockets placed in $TMPDIR, even when the com.apple.security.network
+ *     .server entitlement is present.  That entitlement only covers TCP/UDP
+ *     binding; coverage for UNIX sockets in $TMPDIR was added in macOS 14.
+ *
+ * The fix is to place the socket in the app's sandboxed home directory
+ * (~/Library/Containers/com.nextcloud.desktopclient/Data), which the sandbox
+ * has always allowed for both file I/O and UNIX socket binding.  A two-
+ * character filename ("si") keeps the total path well within the 103-char
+ * limit for any macOS username (max 31 chars → 96-char path total).
+ *
+ * The public interface is intentionally identical to the KDSingleApplication
+ * methods and signals used by Application, so Application needs no logic
+ * changes — only a conditional type selection in its header.
+ *
+ * This can be removed as soon as macOS 13 Ventura no longer is supported.
+ */
+class SingleInstanceManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SingleInstanceManager(QObject *parent = nullptr);
+    ~SingleInstanceManager() override;
+
+    [[nodiscard]] bool isPrimaryInstance() const;
+    bool sendMessage(const QByteArray &data, int timeout = 1000);
+
+signals:
+    void messageReceived(const QByteArray &message);
+
+private:
+    [[nodiscard]] static QString socketPath();
+    void onNewConnection();
+
+    bool _isPrimary = false;
+    QLocalServer *_server = nullptr;
+};
+
+} // namespace OCC

--- a/src/gui/macOS/singleinstancemanager_mac.mm
+++ b/src/gui/macOS/singleinstancemanager_mac.mm
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "singleinstancemanager_mac.h"
+
+#include <QDir>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QLoggingCategory>
+
+namespace {
+Q_LOGGING_CATEGORY(lcSingleInstance, "nextcloud.gui.singleinstance", QtInfoMsg)
+}
+
+namespace OCC {
+
+SingleInstanceManager::SingleInstanceManager(QObject *parent)
+    : QObject(parent)
+{
+    const QString path = socketPath();
+
+    // Try to reach a running primary instance.
+    QLocalSocket probe;
+    probe.connectToServer(path, QLocalSocket::ReadWrite);
+    if (probe.waitForConnected(500)) {
+        // A live server answered — we are a secondary instance.
+        probe.disconnectFromServer();
+        _isPrimary = false;
+        qCInfo(lcSingleInstance) << "Found running instance at" << path;
+        return;
+    }
+
+    // No live instance found.  Remove any stale socket file that a previous
+    // crash may have left behind, then start listening as the primary.
+    QLocalServer::removeServer(path);
+
+    _server = new QLocalServer(this);
+    _server->setSocketOptions(QLocalServer::UserAccessOption);
+
+    if (_server->listen(path)) {
+        qCInfo(lcSingleInstance) << "Primary instance listening on" << path;
+        connect(_server, &QLocalServer::newConnection,
+                this, &SingleInstanceManager::onNewConnection);
+    } else {
+        // listen() failed for an unexpected reason.  Log it but still declare
+        // ourselves the primary — it is safer to let the app start than to
+        // block it with a spurious "already running" error.
+        qCWarning(lcSingleInstance)
+            << "Could not listen on" << path << ":" << _server->errorString()
+            << "– assuming primary instance";
+    }
+
+    _isPrimary = true;
+}
+
+SingleInstanceManager::~SingleInstanceManager()
+{
+    if (_server) {
+        QLocalServer::removeServer(socketPath());
+    }
+}
+
+// static
+QString SingleInstanceManager::socketPath()
+{
+    // In a sandboxed macOS app QDir::homePath() resolves to
+    //   ~/Library/Containers/com.nextcloud.desktopclient/Data
+    // The App Sandbox grants both file-write and network-bind access to this
+    // directory on all macOS versions, without any extra entitlements.
+    //
+    // Path budget check (worst case: macOS-maximum 31-char username):
+    //   /Users/<31 chars>/Library/Containers/com.nextcloud.desktopclient/Data/si
+    //   = 7 + 31 + 20 + 27 + 5 + 3 = 93 bytes  (limit: 103)
+    return QDir::homePath() + QStringLiteral("/si");
+}
+
+bool SingleInstanceManager::isPrimaryInstance() const
+{
+    return _isPrimary;
+}
+
+bool SingleInstanceManager::sendMessage(const QByteArray &data, int timeout)
+{
+    Q_ASSERT(!_isPrimary); // callers should only send when secondary
+
+    QLocalSocket socket;
+    socket.connectToServer(socketPath(), QLocalSocket::ReadWrite);
+    if (!socket.waitForConnected(timeout)) {
+        qCWarning(lcSingleInstance) << "sendMessage: could not connect to primary instance";
+        return false;
+    }
+    socket.write(data);
+    const bool ok = socket.waitForBytesWritten(timeout);
+    socket.disconnectFromServer();
+    return ok;
+}
+
+void SingleInstanceManager::onNewConnection()
+{
+    while (_server->hasPendingConnections()) {
+        QLocalSocket *const conn = _server->nextPendingConnection();
+        auto *const buffer = new QByteArray;
+
+        // Accumulate incoming bytes; emit when the sender closes the connection.
+        connect(conn, &QLocalSocket::readyRead, this, [conn, buffer] {
+            buffer->append(conn->readAll());
+        });
+        connect(conn, &QLocalSocket::disconnected, this, [this, conn, buffer] {
+            if (!buffer->isEmpty()) {
+                Q_EMIT messageReceived(*buffer);
+            }
+            delete buffer;
+            conn->deleteLater();
+        });
+    }
+}
+
+} // namespace OCC


### PR DESCRIPTION
Fixes #9694 - KDSingleApplication creates a UNIX socket in a temporary directory to communicate between process instances. On macOS 13 Ventura, for sandboxed apps, the paths exceeds the technical limit of allowed 103 characters. This results in failure of the socket creation, interpreted as another app instance already running.

I opened an issue about the root cause as KDAB/KDSingleApplication#115

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
