### PR TITLE
chore(ci): update images

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-1
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/linux-clang-compile-tests.yml
+++ b/.github/workflows/linux-clang-compile-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Linux Clang compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-1
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/linux-gcc-compile-tests.yml
+++ b/.github/workflows/linux-gcc-compile-tests.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Linux GCC compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-1
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: SonarCloud analysis
     runs-on: [ubuntu-latest, self-hosted]
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-1
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
     env:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed


### PR DESCRIPTION
should allow running sonar-scanner again (nextcloud/docker-ci#910)

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
