### PR TITLE
chore: PPA Debian package type is a community packaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -98,11 +98,11 @@ body:
         - "Official Windows MSI"
         - "Official macOS 12+ universal pkg"
         - "Official macOS Virtual files 12+ universal pkg"
-        - "Community PPA"
-        - "Community FlatPak"
-        - "Community SNAP package"
-        - "Distro package manager"
-        - "Compiled it myself"
+        - "Community PPA (please test with the AppImage package ?)"
+        - "Community FlatPak (please test with the AppImage package ?)"
+        - "Community SNAP package (please test with the AppImage package ?)"
+        - "Distro package manager (please test with the AppImage package ?)"
+        - "Compiled it myself (please test with the AppImage package ?)"
         - "Other"
     validations:
       required: true


### PR DESCRIPTION
makes it clearer that PPA debian package type os not official but community maintained

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
