### PR TITLE
fix: remove unused COPY_SECUREFILEDROP_LINK socket command

### DIFF
--- a/src/gui/macOS/findersyncservice.mm
+++ b/src/gui/macOS/findersyncservice.mm
@@ -193,7 +193,6 @@ Q_LOGGING_CATEGORY(lcMacFinderSyncService, "nextcloud.gui.macfindersyncservice",
     static const QSet<QString> allowedCommands = {
         QStringLiteral("SHARE"),
         QStringLiteral("LEAVESHARE"),
-        QStringLiteral("COPY_SECUREFILEDROP_LINK"),
         QStringLiteral("COPY_PRIVATE_LINK"),
         QStringLiteral("EMAIL_PRIVATE_LINK"),
         QStringLiteral("OPEN_PRIVATE_LINK"),
@@ -448,5 +447,4 @@ QList<QMap<QString, QString>> FinderSyncService::getMenuItems(const QStringList 
 } // namespace Mac
 
 } // namespace OCC
-
 

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -906,20 +906,6 @@ public:
 
 #endif
 
-void SocketApi::command_COPY_SECUREFILEDROP_LINK(const QString &localFile, SocketListener *)
-{
-    const auto fileData = FileData::get(localFile);
-    if (!fileData.folder) {
-        return;
-    }
-
-    const auto account = fileData.folder->accountState()->account();
-    const auto getOrCreatePublicLinkShareJob = new GetOrCreatePublicLinkShare(account, fileData.serverRelativePath, true, this);
-    connect(getOrCreatePublicLinkShareJob, &GetOrCreatePublicLinkShare::done, this, [](const QString &url) { copyUrlToClipboard(url); });
-    connect(getOrCreatePublicLinkShareJob, &GetOrCreatePublicLinkShare::error, this, [=, this]() { emit shareCommandReceived(fileData.localPath); });
-    getOrCreatePublicLinkShareJob->run();
-}
-
 // Windows Shell / Explorer pinning fallbacks, see issue: https://github.com/nextcloud/desktop/issues/1599
 #ifdef Q_OS_WIN
 void SocketApi::command_COPYASPATH(const QString &localFile, SocketListener *)

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -129,7 +129,6 @@ private:
     Q_INVOKABLE void command_ENCRYPT(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_SHARE(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_LEAVESHARE(const QString &localFile, OCC::SocketListener *listener);
-    Q_INVOKABLE void command_COPY_SECUREFILEDROP_LINK(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_COPY_PRIVATE_LINK(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_EMAIL_PRIVATE_LINK(const QString &localFile, OCC::SocketListener *listener);
     Q_INVOKABLE void command_OPEN_PRIVATE_LINK(const QString &localFile, OCC::SocketListener *listener);


### PR DESCRIPTION
### Motivation
- Reduce the exposed/unnecessary socket API surface by removing an unsecured socket endpoint that had no producers or call sites in the codebase.

### Description
- Removed `COPY_SECUREFILEDROP_LINK` from the FinderSync allow-list in `src/gui/macOS/findersyncservice.mm` so the macOS extension can no longer invoke it.
- Removed the `Q_INVOKABLE` declaration for `command_COPY_SECUREFILEDROP_LINK` from `src/gui/socketapi/socketapi.h`.
- Removed the `SocketApi::command_COPY_SECUREFILEDROP_LINK` implementation from `src/gui/socketapi/socketapi.cpp`.

### Testing
- Verified there are no remaining references by searching for `COPY_SECUREFILEDROP_LINK` and `command_COPY_SECUREFILEDROP_LINK` with `rg`, which returned no hits after the change (success).
- Inspected related helpers such as `GetOrCreatePublicLinkShare` to ensure no dependent behavior was removed (manual code inspection, success).
- Attempted `xcodebuild build -target NextcloudDev` as recommended for macOS build verification but the environment lacks `xcodebuild`, so a full macOS build could not be run here (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60a3f3c9c8333be2fbfa4e95063fe)