### PR TITLE
Remove Windows Shell/Explorer pinning fallback commands from SocketApi

### DIFF
--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -910,24 +910,6 @@ public:
 
 #endif
 
-// Windows Shell / Explorer pinning fallbacks, see issue: https://github.com/nextcloud/desktop/issues/1599
-#ifdef Q_OS_WIN
-void SocketApi::command_COPYASPATH(const QString &localFile, SocketListener *)
-{
-    setClipboardText(localFile);
-}
-
-void SocketApi::command_OPENNEWWINDOW(const QString &localFile, SocketListener *)
-{
-    QDesktopServices::openUrl(QUrl::fromLocalFile(localFile));
-}
-
-void SocketApi::command_OPEN(const QString &localFile, SocketListener *socketListener)
-{
-    command_OPENNEWWINDOW(localFile, socketListener);
-}
-#endif
-
 // Fetches the private link url asynchronously and then calls the target slot
 void SocketApi::fetchPrivateLinkUrlHelper(const QString &localFile, const std::function<void(const QString &url)> &targetFun)
 {

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -143,13 +143,6 @@ private:
 
     void setFileLock(const QString &localFile, const SyncFileItem::LockStatus lockState) const;
 
-    // Windows Shell / Explorer pinning fallbacks, see issue: https://github.com/nextcloud/desktop/issues/1599
-#ifdef Q_OS_WIN
-    Q_INVOKABLE void command_COPYASPATH(const QString &localFile, OCC::SocketListener *listener);
-    Q_INVOKABLE void command_OPENNEWWINDOW(const QString &localFile, OCC::SocketListener *listener);
-    Q_INVOKABLE void command_OPEN(const QString &localFile, OCC::SocketListener *listener);
-#endif
-
     // Fetch the private link and call targetFun
     void fetchPrivateLinkUrlHelper(const QString &localFile, const std::function<void(const QString &url)> &targetFun);
 


### PR DESCRIPTION
### Motivation

- Remove legacy Windows-specific fallback handlers for shell/explorer pinning that were guarded by `#ifdef Q_OS_WIN` and referenced in issue trackers.

### Description

- Deleted the Windows-only implementations of `command_COPYASPATH`, `command_OPENNEWWINDOW`, and `command_OPEN` from `src/gui/socketapi/socketapi.cpp`.
- Removed the corresponding `Q_INVOKABLE` declarations for `command_COPYASPATH`, `command_OPENNEWWINDOW`, and `command_OPEN` from `src/gui/socketapi/socketapi.h`.
- Eliminated the `#ifdef Q_OS_WIN`/`#endif` wrapper and related fallback logic to simplify platform-specific handling in `SocketApi`.

### Testing

- Built the project after the change to ensure there are no missing references, and the build completed successfully.
- Ran the existing automated unit test suite, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6563f5e888333b67a5a69e5762e6c)