### PR TITLE
fix(macOS): Open app settings on necessity of sandbox folder migration

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -478,6 +478,18 @@ Application::Application(int &argc, char **argv)
 
     handleEditLocallyFromOptions();
 
+#ifdef Q_OS_MACOS
+    // If any sync folder needs sandbox reapproval after upgrading to v33+,
+    // automatically open the settings dialog on the first affected account
+    // so the user is guided to grant access as quickly as possible.
+    for (const auto &folder : FolderMan::instance()->map()) {
+        if (folder->needsSandboxBookmark()) {
+            QTimer::singleShot(0, _gui.data(), &ownCloudGui::slotShowSettingsForSandboxReapproval);
+            break;
+        }
+    }
+#endif
+
     if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
         AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine();
     }

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -252,7 +252,7 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
         }
 #ifdef Q_OS_MACOS
         if (folder->needsSandboxBookmark()) {
-            errors.prepend(tr("Select the synchronization folder to restore access."));
+            errors.prepend(tr("Due to recent security improvements, the client no longer has access to the folder. Your approval is required one time to restore access. Please select the synchronization folder root."));
         }
 #endif
         return errors;


### PR DESCRIPTION
Verification pending.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
