### PR TITLE
keep sync dylib install_name as @rpath through cmake --install

### DIFF
--- a/src/csync/CMakeLists.txt
+++ b/src/csync/CMakeLists.txt
@@ -115,7 +115,17 @@ if(BUILD_OWNCLOUD_OSX_BUNDLE)
     # @loader_path/../Frameworks.  Setting BUILD_WITH_INSTALL_RPATH prevents CMake
     # from trying to adjust RPATHs at cmake --install time (which would conflict
     # with changes macdeployqt has already made).
-    set_target_properties(nextcloud_csync PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+    #
+    # INSTALL_NAME_DIR "@rpath" keeps the dylib's install_name as
+    # @rpath/libnextcloud_csync.0.dylib through cmake --install.  Without it CMake
+    # defaults to ${CMAKE_INSTALL_PREFIX}/lib/libnextcloud_csync.0.dylib and rewrites
+    # the nextcloud executable's @rpath reference to that absolute path during
+    # install -- a path nothing is ever installed to -- causing dyld to fail at
+    # launch with "Library not loaded: .../build/.../lib/libnextcloud_csync.0.dylib".
+    set_target_properties(nextcloud_csync PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_NAME_DIR "@rpath"
+    )
 endif()
 
 if(BUILD_OWNCLOUD_OSX_BUNDLE)

--- a/src/libsync/CMakeLists.txt
+++ b/src/libsync/CMakeLists.txt
@@ -284,7 +284,17 @@ if(BUILD_OWNCLOUD_OSX_BUNDLE)
     # @loader_path/../Frameworks.  Setting BUILD_WITH_INSTALL_RPATH prevents CMake
     # from trying to adjust RPATHs at cmake --install time (which would conflict
     # with changes macdeployqt has already made).
-    set_target_properties(nextcloudsync PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+    #
+    # INSTALL_NAME_DIR "@rpath" keeps the dylib's install_name as
+    # @rpath/libnextcloudsync.0.dylib through cmake --install.  Without it CMake
+    # defaults to ${CMAKE_INSTALL_PREFIX}/lib/libnextcloudsync.0.dylib and rewrites
+    # the nextcloud executable's @rpath reference to that absolute path during
+    # install -- a path nothing is ever installed to -- causing dyld to fail at
+    # launch with "Library not loaded: .../build/.../lib/libnextcloudsync.0.dylib".
+    set_target_properties(nextcloudsync PROPERTIES
+        BUILD_WITH_INSTALL_RPATH TRUE
+        INSTALL_NAME_DIR "@rpath"
+    )
 endif()
 
 if(NOT BUILD_OWNCLOUD_OSX_BUNDLE)


### PR DESCRIPTION
**This has bothered me since weeks now! I mostly needed to perform a clean build after code changes which costs too much time!** 😌

## Summary

Fixes a dyld `Library not loaded` crash on launch of the macOS build that reproduced on every rebuild. Setting `INSTALL_NAME_DIR "@rpath"` on the `nextcloudsync` and `nextcloud_csync` library targets stops `cmake --install` from rewriting `@rpath/libfoo.dylib` references into absolute build-tree paths that nothing ever installs.

## Symptom

After building with Craft (`admin/osx/mac-crafter`, which most commonly runs through the `NextcloudDev` Xcode scheme → `Craft.sh`), launching the installed app crashes immediately:

```
dyld[…]: Library not loaded:
  /Users/<user>/…/build/macos-clang-arm64/lib/libnextcloudsync.0.dylib
Referenced from: /Applications/NextcloudDev.app/Contents/MacOS/NextcloudDev
Reason: tried: '…/build/macos-clang-arm64/lib/libnextcloudsync.0.dylib'
  (no such file), …
```

`otool -L` on the installed binary confirms an absolute, build-tree-specific reference:

```
/Users/<user>/…/build/macos-clang-arm64/lib/libnextcloudsync.0.dylib
/Users/<user>/…/build/macos-clang-arm64/lib/libnextcloud_csync.0.dylib
```

That directory is never populated — the dylibs are installed to `NextcloudDev.app/Contents/MacOS/` (via `install(TARGETS)`) and `Contents/Frameworks/` (via `macdeployqt`).

## Why it happens

Each build writes the following into `work/build/src/gui/cmake_install.cmake`:

```cmake
execute_process(COMMAND install_name_tool
  -change "@rpath/libnextcloud_csync.0.dylib" "/…/lib/libnextcloud_csync.0.dylib"
  -change "@rpath/libnextcloudsync.0.dylib"   "/…/lib/libnextcloudsync.0.dylib"
  "…/NextcloudDev.app/Contents/MacOS/NextcloudDev")
```

CMake derives the replacement from each library target's install_name. With `INSTALL_NAME_DIR` unset, CMake defaults the install-time install_name to `${CMAKE_INSTALL_PREFIX}/lib/libfoo.dylib` regardless of where the `install(TARGETS)` rule actually places the file. So the executable, which links against `@rpath/libfoo.dylib` at build time, gets those references rewritten to `${CMAKE_INSTALL_PREFIX}/lib/libfoo.dylib` on install — a location nothing ever writes to.

You can verify the boundary with `otool`:

- Build-tree bundle (`work/build/bin/NextcloudDev.app/.../NextcloudDev`): `@rpath/libnextcloudsync.0.dylib` + rpath `@loader_path/../Frameworks` ✅ (macdeployqt's output)
- Image bundle (`image-Debug-master/NextcloudDev.app/.../NextcloudDev`): `/…/build/macos-clang-arm64/lib/libnextcloudsync.0.dylib` ❌ (`cmake --install` corrupted it)
- Installed app (`/Applications/NextcloudDev.app/.../NextcloudDev`): same as image, because `mac-crafter` just copies the image to the product path.

### Why clean builds seemed to work

The same broken rewrite happens on clean builds too. A clean build that "worked" was situational — a prior build leaving a stale dylib at `build/.../lib/`, a cached binary from before the regression, or the install step having aborted earlier. There is nothing self-healing here; every `cmake --install` produces the broken reference.

### Why earlier fixes aren't enough

- `d1090baca7` set `BUILD_WITH_INSTALL_RPATH TRUE` on `nextcloud` to stop CMake from trying to `-delete_rpath` a build-tree RPATH that macdeployqt had already removed. That addresses RPATH bookkeeping only.
- `314b3d1638` added `-libpath=${BIN_OUTPUT_DIRECTORY}` to macdeployqt so it could locate our dylibs, and added `BUILD_WITH_INSTALL_RPATH TRUE` to `nextcloudsync` / `nextcloud_csync`. Also RPATH-only.

Neither touched `install_name_tool -change`, which is what breaks the references.

## Fix

Set `INSTALL_NAME_DIR "@rpath"` on `nextcloudsync` and `nextcloud_csync`:

```cmake
set_target_properties(nextcloudsync PROPERTIES
    BUILD_WITH_INSTALL_RPATH TRUE
    INSTALL_NAME_DIR "@rpath"
)
```

With that:

- `cmake --install` keeps each dylib's `LC_ID_DYLIB` as `@rpath/libfoo.dylib`.
- The `-change` baked into `cmake_install.cmake` rewrites `@rpath/libfoo.dylib` → `@rpath/libfoo.dylib`, i.e. a no-op. The executable's references stay `@rpath/…`.
- The binary's `@loader_path/../Frameworks` rpath (added by macdeployqt) resolves each reference to the dylib macdeployqt already copied into `Contents/Frameworks/`.

No changes to `admin/osx/mac-crafter` or the Xcode scheme wrapper are needed; the fix is entirely in CMake.

## Test plan

- [ ] Run the `NextcloudDev` scheme in Xcode against a clean build dir (`rm -rf build`) and confirm `/Applications/NextcloudDev.app` launches.
- [ ] Touch a source file (e.g. a whitespace-only edit in `src/gui/application.cpp`), rebuild and relaunch from Xcode without a clean — previously this crashed, should now work.
- [ ] Inspect the installed binary:
  ```
  otool -L /Applications/NextcloudDev.app/Contents/MacOS/NextcloudDev | grep nextcloud
  ```
  Expected: both lines show `@rpath/libnextcloud{,_}sync.0.dylib`, not an absolute `build/…/lib/` path.
- [ ] Inspect an installed dylib:
  ```
  otool -D /Applications/NextcloudDev.app/Contents/Frameworks/libnextcloudsync.0.dylib
  ```
  Expected: `@rpath/libnextcloudsync.0.dylib`.
- [ ] Confirm the packaged/release path still works: run a full `mac-crafter` run with `--package` and verify the produced bundle launches.