### PR TITLE
Fix login flow by avoiding manual redirect policy on macOS client

### DIFF
--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -86,7 +86,7 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         // We handle redirects ourselves in AbstractNetworkJob::slotFinished
         // Qt's automatic handling of redirects will transmit all set headers from the original
         // request again, including e.g. `Authorization`.
-        newRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
+        newRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     }
 
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);

--- a/src/libsync/accessmanager.cpp
+++ b/src/libsync/accessmanager.cpp
@@ -112,7 +112,7 @@ QNetworkReply *AccessManager::createRequest(QNetworkAccessManager::Operation op,
         // We handle redirects ourselves in AbstractNetworkJob::slotFinished
         // Qt's automatic handling of redirects will transmit all set headers from the original
         // request again, including e.g. `Authorization`.
-        newRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::ManualRedirectPolicy);
+        newRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     }
 
     const auto reply = QNetworkAccessManager::createRequest(op, newRequest, outgoingData);


### PR DESCRIPTION
## Summary

Fix login flow by changing redirect handling from `ManualRedirectPolicy` to `NoLessSafeRedirectPolicy` in `src/libsync/accessmanager.cpp`.

## Problem

The current desktop client fails during account setup/login with a redirect-related error, while:

- server endpoints respond correctly
- curl tests succeed
- Nextcloud Desktop 4.0.2 works
- current versions fail

## Fix

Replace:
QNetworkRequest::ManualRedirectPolicy

with:
QNetworkRequest::NoLessSafeRedirectPolicy

## Result

With this change:

- Login Flow v2 completes successfully
- app password is returned
- DAV access works
- account setup succeeds

## Additional context

This appears to be a regression compared to 4.0.2.

## Related issue

Fixes https://github.com/nextcloud/desktop/issues/9794