### PR TITLE
feat(craft): update craft commit to get newer openssl releases

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Linux Appimage Package
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.1-1
+    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.2-2
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/macos-craft-ci.yml
+++ b/.github/workflows/macos-craft-ci.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Add required blueprint repositories
         if: steps.cache-craft-restore.outputs.cache-hit != 'true'
         run: |
-          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|master|"
-          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|master|"
+          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|stable-33.0|"
+          python "${{ env.CRAFT_MASTER_LOCATION }}/CraftMaster.py" --config "${{ env.CRAFT_MASTER_CONFIG }}" --target ${{ env.CRAFT_TARGET }} -c --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|stable-33.0|"
 
       - name: Setup Craft
         if: steps.cache-craft-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -31,8 +31,8 @@ jobs:
               if($LASTEXITCODE -ne 0) {exit $LASTEXITCODE}
           }
           
-          craft --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|master|"
-          craft --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|master|"
+          craft --add-blueprint-repository "https://github.com/nextcloud/craft-blueprints-kde.git|stable-33.0|"
+          craft --add-blueprint-repository "https://github.com/nextcloud/desktop-client-blueprints.git|stable-33.0|"
           craft craft
           craft --install-deps nextcloud-client
           

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -66,4 +66,4 @@ SIGN_PACKAGE = False
 
 [Custom_Variables_for_Brander]
 qtPath = /root/linux-gcc-x86_64
-dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.2-1
+dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.2-2

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -28,7 +28,7 @@ ShortPath/Enabled = False
 ShortPath/EnableJunctions = False
 
 Packager/RepositoryUrl = https://download.nextcloud.com/desktop/development/craftCache/
-Packager/CacheVersion = master-qt-6.10.2
+Packager/CacheVersion = stable-33.0-qt-6.10.2
 ContinuousIntegration/Enabled = True
 
 Packager/UseCache = ${Variables:UseCache}

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: GPL-2.0-or-later
 [General]
-Branch = master
-# CraftUrl = https://github.com/allexzander/craft.git
-CraftRevision = d9d06ff743183104bc50698e376807976fa0e460
+Branch = stable-33.0-qt-6.10.2
+CraftUrl = https://github.com/nextcloud/craft.git
+CraftRevision = 6c7312ae194caf13e4c45b6241a22f1bbf2df5c2
 ShallowClone = False
 
 # Variables defined here override the default value


### PR DESCRIPTION
switch to our craft clone
switch to stable-33.0-qt-6.10.2 stable branch
use the commit with newer openssl releases

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
