### PR TITLE
chore: switch craft to proper branch and commit for updated openssl

### DIFF
--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -3,7 +3,7 @@
 [General]
 Branch = stable-4.0-qt-6.9.3
 CraftUrl = https://github.com/nextcloud/craft.git
-CraftRevision = 40a91d38c431d0f496d7eb77b8300599c7242214
+CraftRevision = 7a6af6465396c2271d3f4b49d5a4c13c052a3aeb
 ShallowClone = False
 
 # Variables defined here override the default value

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: GPL-2.0-or-later
 [General]
-Branch = master
+Branch = stable-4.0-qt-6.9.3
 CraftUrl = https://github.com/nextcloud/craft.git
-CraftRevision = 80c10e7702096a912aa32be2d6e8b32f30a351fe
+CraftRevision = 40a91d38c431d0f496d7eb77b8300599c7242214
 ShallowClone = False
 
 # Variables defined here override the default value


### PR DESCRIPTION
switch to stable-4.0-qt-6.9.3 stable branch
use the commit with newer openssl releases

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
