### PR TITLE
fix(sharing): parse received timestamp from expiration date

### DIFF
--- a/src/gui/sharemanager.cpp
+++ b/src/gui/sharemanager.cpp
@@ -303,7 +303,7 @@ void LinkShare::slotExpireDateSet(const QJsonDocument &reply, const QVariant &va
      * they use this date.
      */
     if (data.value("expiration"_L1).isString()) {
-        _expireDate = QDate::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd 00:00:00");
+        _expireDate = QDateTime::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd hh:mm:ss").date();
     } else {
         _expireDate = value.toDate();
     }
@@ -400,7 +400,7 @@ void UserGroupShare::slotExpireDateSet(const QJsonDocument &reply, const QVarian
      * they use this date.
      */
     if (data.value("expiration"_L1).isString()) {
-        _expireDate = QDate::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd 00:00:00");
+        _expireDate = QDateTime::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd hh:mm:ss").date();
     } else {
         _expireDate = value.toDate();
     }
@@ -608,7 +608,7 @@ QSharedPointer<UserGroupShare> ShareManager::parseUserGroupShare(const QJsonObje
 
     QDate expireDate;
     if (data.value("expiration"_L1).isString()) {
-        expireDate = QDate::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd 00:00:00");
+        expireDate = QDateTime::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd hh:mm:ss").date();
     }
 
     QString note;
@@ -649,7 +649,7 @@ QSharedPointer<LinkShare> ShareManager::parseLinkShare(const QJsonObject &data) 
 
     QDate expireDate;
     if (data.value("expiration"_L1).isString()) {
-        expireDate = QDate::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd 00:00:00");
+        expireDate = QDateTime::fromString(data.value("expiration"_L1).toString(), "yyyy-MM-dd hh:mm:ss").date();
     }
     
     QString note;

--- a/test/sharetestutils.cpp
+++ b/test/sharetestutils.cpp
@@ -340,10 +340,10 @@ QNetworkReply *ShareTestHelper::handleSharePutOperation(const QNetworkAccessMana
                 auto requestKey = requestSplit.first();
                 auto requestValue = requestSplit.last();
 
-                     // We send expireDate without time but the server returns with time at 00:00:00
+                     // We send expireDate without time but the server returns with time at 23:59:59
                 if (requestKey == "expireDate") {
                     requestKey = "expiration";
-                    requestValue.append(" 00:00:00");
+                    requestValue.append(" 23:59:59");
                 }
 
                 shareObject.insert(QString(requestKey), QString(requestValue));

--- a/test/sharetestutils.h
+++ b/test/sharetestutils.h
@@ -92,7 +92,7 @@ public:
 
     static constexpr auto testFileName = "file.md";
     static constexpr auto searchResultsReplyDelay = 100;
-    static constexpr auto expectedDtFormat = "yyyy-MM-dd 00:00:00";
+    static constexpr auto expectedDtFormat = "yyyy-MM-dd 23:59:59";
 
     const QByteArray createNewShare(const Share::ShareType shareType, const QString &shareWith, const QString &password);
     [[nodiscard]] int shareCount() const;


### PR DESCRIPTION
Server version >= 33.0.1 changed the behaviour of the expiration date: instead of expiring shares at the beginning of the day, they now expire at the end of the day.

The client previously relied on the expiry time being defined as `00:00:00`, this leads to the date unable to be parsed with the expiry time set to `23:59:59`.  
Solution: just™ parse the entire time returned from the server as well! The client sets the expiration date only as `YYYY-MM-DD` anyway, so it does not need to care about the time suggested by the server at all ...

Resolves #9859

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
