### PR TITLE
Push File Ignore List

### DIFF
--- a/src/gui/macOS/fileprovider_mac.mm
+++ b/src/gui/macOS/fileprovider_mac.mm
@@ -61,6 +61,12 @@ void FileProvider::configureXPC()
         qCInfo(lcMacFileProvider) << "Initialised file provider XPC.";
         _xpc->connectToFileProviderDomains();
         _xpc->authenticateFileProviderDomains();
+        // Push the ignore list immediately after authenticating — the extension
+        // treats a missing ignore list the same way it treats missing
+        // credentials (rejecting callbacks with `.notAuthenticated`) so the
+        // two must be injected together, not only when the user happens to
+        // open the ignore-list settings UI.
+        _xpc->setIgnoreList();
     } else {
         qCWarning(lcMacFileProvider) << "Could not initialise file provider XPC.";
     }

--- a/src/gui/macOS/fileproviderxpc_mac.mm
+++ b/src/gui/macOS/fileproviderxpc_mac.mm
@@ -124,6 +124,11 @@ void FileProviderXPC::slotAccountStateChanged(const AccountState::State state) c
     case AccountState::Connected:
         // Provide credentials
         authenticateFileProviderDomain(fileProviderDomainId);
+        // Push the ignore list alongside credentials — the extension rejects
+        // `modifyItem` and friends with `.notAuthenticated` as long as its
+        // `ignoredFiles` is still `nil`, so a domain that comes online after
+        // startup needs both halves of the configuration, not just the one.
+        setIgnoreList();
         break;
     }
 }


### PR DESCRIPTION
This affects `master` and targets `34.0.0` only because it fixes a regression in the recent socket replacement with XPC.

The ignore file list was not pushed on every appropriate occasion to the extension which resulted in `.notAuthenticated` errors.