### PR TITLE
Add support for nc://addAccount URI to launch account setup flow

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -64,6 +64,8 @@ set(client_SRCS
     accountsetupfromcommandlinejob.cpp
     accountsetupcommandlinemanager.h
     accountsetupcommandlinemanager.cpp
+    addaccounturlhandler.h
+    addaccounturlhandler.cpp
     application.h
     application.cpp
     invalidfilenamedialog.h

--- a/src/gui/addaccounturlhandler.cpp
+++ b/src/gui/addaccounturlhandler.cpp
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "addaccounturlhandler.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QUrlQuery>
+
+#include "config.h"
+#include "editlocallymanager.h"
+#include "owncloudsetupwizard.h"
+
+namespace OCC::AddAccountUrlHandler {
+
+bool isAddAccountActionUrl(const QUrl &url)
+{
+    if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
+        return false;
+    }
+
+    const auto pathParts = url.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
+    const auto hasAddAccountHost = url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
+    const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
+    return hasAddAccountHost || hasAddAccountPath;
+}
+
+QUrl parseAddAccountServerUrl(const QUrl &url)
+{
+    if (!isAddAccountActionUrl(url)) {
+        return {};
+    }
+
+    const auto query = QUrlQuery(url);
+    const auto serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
+    if (serverUrlRaw.isEmpty()) {
+        return {};
+    }
+
+    const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
+    if (!serverUrl.isValid() || serverUrl.host().isEmpty()) {
+        return {};
+    }
+    if (serverUrl.scheme() != QLatin1String("https") && serverUrl.scheme() != QLatin1String("http")) {
+        return {};
+    }
+
+    return serverUrl;
+}
+
+bool handleAddAccountUrl(const QUrl &url)
+{
+    if (!isAddAccountActionUrl(url)) {
+        return false;
+    }
+
+    const auto serverUrl = parseAddAccountServerUrl(url);
+    if (serverUrl.isValid()) {
+        OwncloudSetupWizard::runWizardForLoginFlow(serverUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+    } else {
+        EditLocallyManager::showError(QCoreApplication::translate("Application", "Invalid account setup URL"),
+                                      QCoreApplication::translate("Application", "The provided addAccount URL could not be parsed."));
+    }
+
+    return true;
+}
+
+}

--- a/src/gui/addaccounturlhandler.h
+++ b/src/gui/addaccounturlhandler.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <QUrl>
+
+namespace OCC::AddAccountUrlHandler {
+
+[[nodiscard]] bool isAddAccountActionUrl(const QUrl &url);
+[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url);
+
+/**
+ * @brief Handle addAccount URL if applicable.
+ * @return true if URL was recognized as addAccount and handled (success or validation error), false otherwise.
+ */
+[[nodiscard]] bool handleAddAccountUrl(const QUrl &url);
+
+}
+

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -7,6 +7,7 @@
 #include "application.h"
 
 #include "account.h"
+#include "addaccounturlhandler.h"
 #include "accountmanager.h"
 #include "accountsetupcommandlinemanager.h"
 #include "accountstate.h"
@@ -49,7 +50,6 @@
 #include <QMessageBox>
 #include <QDesktopServices>
 #include <QGuiApplication>
-#include <QUrlQuery>
 #include <QVersionNumber>
 #include <QRandomGenerator>
 #include <QHttp2Configuration>
@@ -66,42 +66,6 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcApplication, "nextcloud.gui.application", QtInfoMsg)
 
 namespace {
-
-[[nodiscard]] bool isAddAccountActionUrl(const QUrl &url)
-{
-    if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
-        return false;
-    }
-    const auto pathParts = url.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
-    const auto hasAddAccountHost = url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
-    const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
-    return hasAddAccountHost || hasAddAccountPath;
-}
-
-[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
-{
-    // Supported format:
-    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
-    if (!isAddAccountActionUrl(url)) {
-        return {};
-    }
-
-    const auto query = QUrlQuery(url);
-    const auto serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
-    if (serverUrlRaw.isEmpty()) {
-        return {};
-    }
-
-    const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
-    if (!serverUrl.isValid() || serverUrl.host().isEmpty()) {
-        return {};
-    }
-    if (serverUrl.scheme() != QLatin1String("https") && serverUrl.scheme() != QLatin1String("http")) {
-        return {};
-    }
-
-    return serverUrl;
-}
 
 static const char optionsC[] =
         "Options:\n"
@@ -979,7 +943,7 @@ void Application::parseOptions(const QStringList &options)
                 showHint(errorParsingLocalFileEditingUrl.toStdString());
             }
         } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))) {
-            _addAccountServerUrl = parseAddAccountServerUrl(QUrl::fromUserInput(option));
+            _addAccountServerUrl = AddAccountUrlHandler::parseAddAccountServerUrl(QUrl::fromUserInput(option));
             if (!_addAccountServerUrl.isValid()) {
                 const auto errorParsingAddAccountUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
                 qCInfo(lcApplication) << errorParsingAddAccountUrl;
@@ -1294,15 +1258,8 @@ bool Application::event(QEvent *event)
         } else if (!openEvent->url().isEmpty() && openEvent->url().isValid()) {
             // On macOS, Qt does not handle receiving a custom URI as it does on other systems (as an application argument).
             // Instead, it sends out a QFileOpenEvent. We therefore need custom handling for our URI handling on macOS.
-            if (isAddAccountActionUrl(openEvent->url())) {
-                const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url());
-                if (addAccountServerUrl.isValid()) {
-                    qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
-                    OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
-                } else {
-                    EditLocallyManager::showError(tr("Invalid account setup URL"),
-                                                  tr("The provided addAccount URL could not be parsed."));
-                }
+            if (AddAccountUrlHandler::handleAddAccountUrl(openEvent->url())) {
+                // URL was an addAccount action (valid or invalid) and was handled.
             } else {
                 qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
                 EditLocallyManager::instance()->handleRequest(openEvent->url());

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -67,7 +67,32 @@ Q_LOGGING_CATEGORY(lcApplication, "nextcloud.gui.application", QtInfoMsg)
 
 namespace {
 
-    static const char optionsC[] =
+[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
+{
+    // Supported format:
+    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
+    if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
+        return {};
+    }
+    if (url.host() != QLatin1String("addAccount")) {
+        return {};
+    }
+
+    const auto query = QUrlQuery(url);
+    const auto serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
+    if (serverUrlRaw.isEmpty()) {
+        return {};
+    }
+
+    const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
+    if (!serverUrl.isValid() || serverUrl.host().isEmpty()
+        || (serverUrl.scheme() != QLatin1String("https") && serverUrl.scheme() != QLatin1String("http"))) {
+        return {};
+    }
+    return serverUrl;
+}
+
+static const char optionsC[] =
         "Options:\n"
         "  --help, -h                 : show this help screen.\n"
         "  --version, -v              : show version information.\n"
@@ -477,6 +502,7 @@ Application::Application(int &argc, char **argv)
     _gui->createTray();
 
     handleEditLocallyFromOptions();
+    handleAddAccountFromOptions();
 
 #ifdef Q_OS_MACOS
     // If any sync folder needs sandbox reapproval after upgrading to v33+,
@@ -845,6 +871,7 @@ void Application::slotParseMessage(const QByteArray &message)
         }
 
         handleEditLocallyFromOptions();
+        handleAddAccountFromOptions();
 
         if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine();
@@ -939,6 +966,13 @@ void Application::parseOptions(const QStringList &options)
                 const auto errorParsingLocalFileEditingUrl = QStringLiteral("The supplied url for local file editing '%1' is invalid!").arg(option);
                 qCInfo(lcApplication) << errorParsingLocalFileEditingUrl;
                 showHint(errorParsingLocalFileEditingUrl.toStdString());
+            }
+        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))) {
+            _addAccountServerUrl = parseAddAccountServerUrl(QUrl::fromUserInput(option));
+            if (!_addAccountServerUrl.isValid()) {
+                const auto errorParsingAddAccountUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
+                qCInfo(lcApplication) << errorParsingAddAccountUrl;
+                showHint(errorParsingAddAccountUrl.toStdString());
             }
         } else if (option == QStringLiteral("--overrideserverurl")) {
             if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
@@ -1079,6 +1113,16 @@ void Application::handleEditLocallyFromOptions()
 
     EditLocallyManager::instance()->handleRequest(_editFileLocallyUrl);
     _editFileLocallyUrl.clear();
+}
+
+void Application::handleAddAccountFromOptions()
+{
+    if (!_addAccountServerUrl.isValid()) {
+        return;
+    }
+
+    OwncloudSetupWizard::runWizardForLoginFlow(_addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+    _addAccountServerUrl.clear();
 }
 
 QString enforcedLanguage()
@@ -1239,8 +1283,13 @@ bool Application::event(QEvent *event)
         } else if (!openEvent->url().isEmpty() && openEvent->url().isValid()) {
             // On macOS, Qt does not handle receiving a custom URI as it does on other systems (as an application argument).
             // Instead, it sends out a QFileOpenEvent. We therefore need custom handling for our URI handling on macOS.
-            qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
-            EditLocallyManager::instance()->handleRequest(openEvent->url());
+            if (const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url()); addAccountServerUrl.isValid()) {
+                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
+                OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+            } else {
+                qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
+                EditLocallyManager::instance()->handleRequest(openEvent->url());
+            }
         } else {
             const auto errorParsingLocalFileEditingUrl = QStringLiteral("The supplied url for local file editing '%1' is invalid!").arg(openEvent->url().toString());
             qCInfo(lcApplication) << errorParsingLocalFileEditingUrl;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -67,17 +67,22 @@ Q_LOGGING_CATEGORY(lcApplication, "nextcloud.gui.application", QtInfoMsg)
 
 namespace {
 
-[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
+[[nodiscard]] bool isAddAccountActionUrl(const QUrl &url)
 {
-    // Supported format:
-    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
-        return {};
+        return false;
     }
     const auto pathParts = url.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
     const auto hasAddAccountHost = url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
     const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
-    if (!hasAddAccountHost && !hasAddAccountPath) {
+    return hasAddAccountHost || hasAddAccountPath;
+}
+
+[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
+{
+    // Supported format:
+    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
+    if (!isAddAccountActionUrl(url)) {
         return {};
     }
 
@@ -1289,9 +1294,15 @@ bool Application::event(QEvent *event)
         } else if (!openEvent->url().isEmpty() && openEvent->url().isValid()) {
             // On macOS, Qt does not handle receiving a custom URI as it does on other systems (as an application argument).
             // Instead, it sends out a QFileOpenEvent. We therefore need custom handling for our URI handling on macOS.
-            if (const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url()); addAccountServerUrl.isValid()) {
-                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
-                OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+            if (isAddAccountActionUrl(openEvent->url())) {
+                const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url());
+                if (addAccountServerUrl.isValid()) {
+                    qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
+                    OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+                } else {
+                    EditLocallyManager::showError(tr("Invalid account setup URL"),
+                                                  tr("The provided addAccount URL could not be parsed."));
+                }
             } else {
                 qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
                 EditLocallyManager::instance()->handleRequest(openEvent->url());

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -74,7 +74,10 @@ namespace {
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
         return {};
     }
-    if (url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) != 0) {
+    const auto pathParts = url.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
+    const auto hasAddAccountHost = url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
+    const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) == 0;
+    if (!hasAddAccountHost && !hasAddAccountPath) {
         return {};
     }
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -67,29 +67,24 @@ Q_LOGGING_CATEGORY(lcApplication, "nextcloud.gui.application", QtInfoMsg)
 
 namespace {
 
-[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
+[[nodiscard]] QUrl parseLoginFlowServerUrl(const QUrl &url)
 {
-    // Supported formats:
-    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
+    // Supported format:
     // - nc://login/user:&password:&server:http://localhost:8033
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
         return {};
     }
-    auto serverUrlRaw = QString{};
-
-    if (url.host() == QLatin1String("addAccount")) {
-        const auto query = QUrlQuery(url);
-        serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
-    } else if (url.host() == QLatin1String("login")) {
-        const auto urlPath = url.path().mid(1);
-        for (const auto &part : urlPath.split(QLatin1Char('&'), Qt::SkipEmptyParts)) {
-            if (part.startsWith(QLatin1String("server:"))) {
-                serverUrlRaw = part.mid(7);
-                break;
-            }
-        }
-    } else {
+    if (url.host() != QLatin1String("login")) {
         return {};
+    }
+
+    auto serverUrlRaw = QString{};
+    const auto urlPath = url.path().mid(1);
+    for (const auto &part : urlPath.split(QLatin1Char('&'), Qt::SkipEmptyParts)) {
+        if (part.startsWith(QLatin1String("server:"))) {
+            serverUrlRaw = part.mid(7);
+            break;
+        }
     }
 
     const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
@@ -513,7 +508,7 @@ Application::Application(int &argc, char **argv)
     _gui->createTray();
 
     handleEditLocallyFromOptions();
-    handleAddAccountFromOptions();
+    handleLoginFromOptions();
 
 #ifdef Q_OS_MACOS
     // If any sync folder needs sandbox reapproval after upgrading to v33+,
@@ -882,7 +877,7 @@ void Application::slotParseMessage(const QByteArray &message)
         }
 
         handleEditLocallyFromOptions();
-        handleAddAccountFromOptions();
+        handleLoginFromOptions();
 
         if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine();
@@ -978,13 +973,12 @@ void Application::parseOptions(const QStringList &options)
                 qCInfo(lcApplication) << errorParsingLocalFileEditingUrl;
                 showHint(errorParsingLocalFileEditingUrl.toStdString());
             }
-        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))
-                   || option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://login"))) {
-            _addAccountServerUrl = parseAddAccountServerUrl(QUrl::fromUserInput(option));
-            if (!_addAccountServerUrl.isValid()) {
-                const auto errorParsingAddAccountUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
-                qCInfo(lcApplication) << errorParsingAddAccountUrl;
-                showHint(errorParsingAddAccountUrl.toStdString());
+        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://login"))) {
+            _loginFlowServerUrl = parseLoginFlowServerUrl(QUrl::fromUserInput(option));
+            if (!_loginFlowServerUrl.isValid()) {
+                const auto errorParsingLoginUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
+                qCInfo(lcApplication) << errorParsingLoginUrl;
+                showHint(errorParsingLoginUrl.toStdString());
             }
         } else if (option == QStringLiteral("--overrideserverurl")) {
             if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
@@ -1127,14 +1121,14 @@ void Application::handleEditLocallyFromOptions()
     _editFileLocallyUrl.clear();
 }
 
-void Application::handleAddAccountFromOptions()
+void Application::handleLoginFromOptions()
 {
-    if (!_addAccountServerUrl.isValid()) {
+    if (!_loginFlowServerUrl.isValid()) {
         return;
     }
 
-    OwncloudSetupWizard::runWizardForLoginFlow(_addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
-    _addAccountServerUrl.clear();
+    OwncloudSetupWizard::runWizardForLoginFlow(_loginFlowServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+    _loginFlowServerUrl.clear();
 }
 
 QString enforcedLanguage()
@@ -1295,9 +1289,9 @@ bool Application::event(QEvent *event)
         } else if (!openEvent->url().isEmpty() && openEvent->url().isValid()) {
             // On macOS, Qt does not handle receiving a custom URI as it does on other systems (as an application argument).
             // Instead, it sends out a QFileOpenEvent. We therefore need custom handling for our URI handling on macOS.
-            if (const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url()); addAccountServerUrl.isValid()) {
-                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
-                OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+            if (const auto loginFlowServerUrl = parseLoginFlowServerUrl(openEvent->url()); loginFlowServerUrl.isValid()) {
+                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << loginFlowServerUrl;
+                OwncloudSetupWizard::runWizardForLoginFlow(loginFlowServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
             } else {
                 qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
                 EditLocallyManager::instance()->handleRequest(openEvent->url());

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -67,24 +67,21 @@ Q_LOGGING_CATEGORY(lcApplication, "nextcloud.gui.application", QtInfoMsg)
 
 namespace {
 
-[[nodiscard]] QUrl parseLoginFlowServerUrl(const QUrl &url)
+[[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
 {
     // Supported format:
-    // - nc://login/user:&password:&server:http://localhost:8033
+    // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
         return {};
     }
-    if (url.host() != QLatin1String("login")) {
+    if (url.host() != QLatin1String("addAccount")) {
         return {};
     }
 
-    auto serverUrlRaw = QString{};
-    const auto urlPath = url.path().mid(1);
-    for (const auto &part : urlPath.split(QLatin1Char('&'), Qt::SkipEmptyParts)) {
-        if (part.startsWith(QLatin1String("server:"))) {
-            serverUrlRaw = part.mid(7);
-            break;
-        }
+    const auto query = QUrlQuery(url);
+    const auto serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
+    if (serverUrlRaw.isEmpty()) {
+        return {};
     }
 
     const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
@@ -508,7 +505,7 @@ Application::Application(int &argc, char **argv)
     _gui->createTray();
 
     handleEditLocallyFromOptions();
-    handleLoginFromOptions();
+    handleAddAccountFromOptions();
 
 #ifdef Q_OS_MACOS
     // If any sync folder needs sandbox reapproval after upgrading to v33+,
@@ -877,7 +874,7 @@ void Application::slotParseMessage(const QByteArray &message)
         }
 
         handleEditLocallyFromOptions();
-        handleLoginFromOptions();
+        handleAddAccountFromOptions();
 
         if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine();
@@ -973,12 +970,12 @@ void Application::parseOptions(const QStringList &options)
                 qCInfo(lcApplication) << errorParsingLocalFileEditingUrl;
                 showHint(errorParsingLocalFileEditingUrl.toStdString());
             }
-        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://login"))) {
-            _loginFlowServerUrl = parseLoginFlowServerUrl(QUrl::fromUserInput(option));
-            if (!_loginFlowServerUrl.isValid()) {
-                const auto errorParsingLoginUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
-                qCInfo(lcApplication) << errorParsingLoginUrl;
-                showHint(errorParsingLoginUrl.toStdString());
+        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))) {
+            _addAccountServerUrl = parseAddAccountServerUrl(QUrl::fromUserInput(option));
+            if (!_addAccountServerUrl.isValid()) {
+                const auto errorParsingAddAccountUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);
+                qCInfo(lcApplication) << errorParsingAddAccountUrl;
+                showHint(errorParsingAddAccountUrl.toStdString());
             }
         } else if (option == QStringLiteral("--overrideserverurl")) {
             if (it.hasNext() && !it.peekNext().startsWith(QLatin1String("--"))) {
@@ -1121,14 +1118,14 @@ void Application::handleEditLocallyFromOptions()
     _editFileLocallyUrl.clear();
 }
 
-void Application::handleLoginFromOptions()
+void Application::handleAddAccountFromOptions()
 {
-    if (!_loginFlowServerUrl.isValid()) {
+    if (!_addAccountServerUrl.isValid()) {
         return;
     }
 
-    OwncloudSetupWizard::runWizardForLoginFlow(_loginFlowServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
-    _loginFlowServerUrl.clear();
+    OwncloudSetupWizard::runWizardForLoginFlow(_addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+    _addAccountServerUrl.clear();
 }
 
 QString enforcedLanguage()
@@ -1289,9 +1286,9 @@ bool Application::event(QEvent *event)
         } else if (!openEvent->url().isEmpty() && openEvent->url().isValid()) {
             // On macOS, Qt does not handle receiving a custom URI as it does on other systems (as an application argument).
             // Instead, it sends out a QFileOpenEvent. We therefore need custom handling for our URI handling on macOS.
-            if (const auto loginFlowServerUrl = parseLoginFlowServerUrl(openEvent->url()); loginFlowServerUrl.isValid()) {
-                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << loginFlowServerUrl;
-                OwncloudSetupWizard::runWizardForLoginFlow(loginFlowServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+            if (const auto addAccountServerUrl = parseAddAccountServerUrl(openEvent->url()); addAccountServerUrl.isValid()) {
+                qCInfo(lcApplication) << "macOS: Opening account setup flow from custom URL for server:" << addAccountServerUrl;
+                OwncloudSetupWizard::runWizardForLoginFlow(addAccountServerUrl, qApp, SLOT(slotownCloudWizardDone(int)));
             } else {
                 qCInfo(lcApplication) << "macOS: Opening local file for editing: " << openEvent->url();
                 EditLocallyManager::instance()->handleRequest(openEvent->url());

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -476,8 +476,10 @@ Application::Application(int &argc, char **argv)
 
     _gui->createTray();
 
-    handleEditLocallyFromOptions();
+    // Handle addAccount first to avoid accidentally running edit-locally
+    // handling when both URL types are present.
     handleAddAccountFromOptions();
+    handleEditLocallyFromOptions();
 
 #ifdef Q_OS_MACOS
     // If any sync folder needs sandbox reapproval after upgrading to v33+,
@@ -845,8 +847,9 @@ void Application::slotParseMessage(const QByteArray &message)
             qApp->quit();
         }
 
-        handleEditLocallyFromOptions();
+        // Keep same priority order as startup handling.
         handleAddAccountFromOptions();
+        handleEditLocallyFromOptions();
 
         if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine();

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -74,7 +74,7 @@ namespace {
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
         return {};
     }
-    if (url.host() != QLatin1String("addAccount")) {
+    if (url.host().compare(QLatin1String("addaccount"), Qt::CaseInsensitive) != 0) {
         return {};
     }
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -69,26 +69,37 @@ namespace {
 
 [[nodiscard]] QUrl parseAddAccountServerUrl(const QUrl &url)
 {
-    // Supported format:
+    // Supported formats:
     // - nc://addAccount?server_url=https%3A%2F%2Fcloud.example.com
+    // - nc://login/user:&password:&server:http://localhost:8033
     if (url.scheme() != QLatin1String(APPLICATION_URI_HANDLER_SCHEME)) {
         return {};
     }
-    if (url.host() != QLatin1String("addAccount")) {
-        return {};
-    }
+    auto serverUrlRaw = QString{};
 
-    const auto query = QUrlQuery(url);
-    const auto serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
-    if (serverUrlRaw.isEmpty()) {
+    if (url.host() == QLatin1String("addAccount")) {
+        const auto query = QUrlQuery(url);
+        serverUrlRaw = query.queryItemValue(QStringLiteral("server_url"));
+    } else if (url.host() == QLatin1String("login")) {
+        const auto urlPath = url.path().mid(1);
+        for (const auto &part : urlPath.split(QLatin1Char('&'), Qt::SkipEmptyParts)) {
+            if (part.startsWith(QLatin1String("server:"))) {
+                serverUrlRaw = part.mid(7);
+                break;
+            }
+        }
+    } else {
         return {};
     }
 
     const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
-    if (!serverUrl.isValid() || serverUrl.host().isEmpty()
-        || (serverUrl.scheme() != QLatin1String("https") && serverUrl.scheme() != QLatin1String("http"))) {
+    if (!serverUrl.isValid() || serverUrl.host().isEmpty()) {
         return {};
     }
+    if (serverUrl.scheme() != QLatin1String("https") && serverUrl.scheme() != QLatin1String("http")) {
+        return {};
+    }
+
     return serverUrl;
 }
 
@@ -967,7 +978,8 @@ void Application::parseOptions(const QStringList &options)
                 qCInfo(lcApplication) << errorParsingLocalFileEditingUrl;
                 showHint(errorParsingLocalFileEditingUrl.toStdString());
             }
-        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))) {
+        } else if (option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://addAccount"))
+                   || option.startsWith(QStringLiteral(APPLICATION_URI_HANDLER_SCHEME "://login"))) {
             _addAccountServerUrl = parseAddAccountServerUrl(QUrl::fromUserInput(option));
             if (!_addAccountServerUrl.isValid()) {
                 const auto errorParsingAddAccountUrl = QStringLiteral("The supplied url for account setup '%1' is invalid!").arg(option);

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -116,7 +116,7 @@ private:
     void setHelp();
 
     void handleEditLocallyFromOptions();
-    void handleAddAccountFromOptions();
+    void handleLoginFromOptions();
 
     AccountManager::AccountsRestoreResult restoreLegacyAccount();
     void setupConfigFile();
@@ -155,7 +155,7 @@ private:
     bool _debugMode = false;
     bool _backgroundMode = false;
     QUrl _editFileLocallyUrl;
-    QUrl _addAccountServerUrl;
+    QUrl _loginFlowServerUrl;
 
     ClientProxy _proxy;
 

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -116,7 +116,7 @@ private:
     void setHelp();
 
     void handleEditLocallyFromOptions();
-    void handleLoginFromOptions();
+    void handleAddAccountFromOptions();
 
     AccountManager::AccountsRestoreResult restoreLegacyAccount();
     void setupConfigFile();
@@ -155,7 +155,7 @@ private:
     bool _debugMode = false;
     bool _backgroundMode = false;
     QUrl _editFileLocallyUrl;
-    QUrl _loginFlowServerUrl;
+    QUrl _addAccountServerUrl;
 
     ClientProxy _proxy;
 

--- a/src/gui/application.h
+++ b/src/gui/application.h
@@ -116,6 +116,7 @@ private:
     void setHelp();
 
     void handleEditLocallyFromOptions();
+    void handleAddAccountFromOptions();
 
     AccountManager::AccountsRestoreResult restoreLegacyAccount();
     void setupConfigFile();
@@ -154,6 +155,7 @@ private:
     bool _debugMode = false;
     bool _backgroundMode = false;
     QUrl _editFileLocallyUrl;
+    QUrl _addAccountServerUrl;
 
     ClientProxy _proxy;
 

--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -11,6 +11,9 @@
 
 #include "application.h"
 #include "editlocallymanager.h"
+#include "owncloudsetupwizard.h"
+
+#include <QUrlQuery>
 
 /* In theory, we should be able to just capture QFileOpenEvents
  * when we open our custom URLs in our Application class and be
@@ -51,6 +54,16 @@
 {
     NSURL* url = [NSURL URLWithString:[[event paramDescriptorForKeyword:keyDirectObject] stringValue]];
     const auto qtUrl = QUrl::fromNSURL(url);
+    if (qtUrl.host() == QStringLiteral("addAccount")) {
+        const auto urlQuery = QUrlQuery{qtUrl};
+        const auto serverUrlRaw = urlQuery.queryItemValue(QStringLiteral("server_url"));
+        const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
+        if (serverUrl.isValid() && !serverUrl.host().isEmpty()) {
+            OCC::OwncloudSetupWizard::runWizardForLoginFlow(serverUrl, qApp, SLOT(slotownCloudWizardDone(int)));
+            return;
+        }
+    }
+
     OCC::EditLocallyManager::instance()->handleRequest(qtUrl);
 }
 

--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -13,6 +13,7 @@
 #include "editlocallymanager.h"
 #include "owncloudsetupwizard.h"
 
+#include <QCoreApplication>
 #include <QUrlQuery>
 
 /* In theory, we should be able to just capture QFileOpenEvents
@@ -63,8 +64,11 @@
         const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
         if (serverUrl.isValid() && !serverUrl.host().isEmpty()) {
             OCC::OwncloudSetupWizard::runWizardForLoginFlow(serverUrl, qApp, SLOT(slotownCloudWizardDone(int)));
-            return;
+        } else {
+            OCC::EditLocallyManager::showError(QCoreApplication::translate("Application", "Invalid account setup URL"),
+                                               QCoreApplication::translate("Application", "The provided addAccount URL could not be parsed."));
         }
+        return;
     }
 
     OCC::EditLocallyManager::instance()->handleRequest(qtUrl);

--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -54,7 +54,10 @@
 {
     NSURL* url = [NSURL URLWithString:[[event paramDescriptorForKeyword:keyDirectObject] stringValue]];
     const auto qtUrl = QUrl::fromNSURL(url);
-    if (qtUrl.host().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0) {
+    const auto pathParts = qtUrl.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
+    const auto hasAddAccountHost = qtUrl.host().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0;
+    const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0;
+    if (hasAddAccountHost || hasAddAccountPath) {
         const auto urlQuery = QUrlQuery{qtUrl};
         const auto serverUrlRaw = urlQuery.queryItemValue(QStringLiteral("server_url"));
         const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);

--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -54,7 +54,7 @@
 {
     NSURL* url = [NSURL URLWithString:[[event paramDescriptorForKeyword:keyDirectObject] stringValue]];
     const auto qtUrl = QUrl::fromNSURL(url);
-    if (qtUrl.host() == QStringLiteral("addAccount")) {
+    if (qtUrl.host().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0) {
         const auto urlQuery = QUrlQuery{qtUrl};
         const auto serverUrlRaw = urlQuery.queryItemValue(QStringLiteral("server_url"));
         const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);

--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -10,11 +10,8 @@
 #import <AppKit/NSApplication.h>
 
 #include "application.h"
+#include "addaccounturlhandler.h"
 #include "editlocallymanager.h"
-#include "owncloudsetupwizard.h"
-
-#include <QCoreApplication>
-#include <QUrlQuery>
 
 /* In theory, we should be able to just capture QFileOpenEvents
  * when we open our custom URLs in our Application class and be
@@ -55,19 +52,7 @@
 {
     NSURL* url = [NSURL URLWithString:[[event paramDescriptorForKeyword:keyDirectObject] stringValue]];
     const auto qtUrl = QUrl::fromNSURL(url);
-    const auto pathParts = qtUrl.path().split(QLatin1Char('/'), Qt::SkipEmptyParts);
-    const auto hasAddAccountHost = qtUrl.host().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0;
-    const auto hasAddAccountPath = !pathParts.isEmpty() && pathParts.constFirst().compare(QStringLiteral("addaccount"), Qt::CaseInsensitive) == 0;
-    if (hasAddAccountHost || hasAddAccountPath) {
-        const auto urlQuery = QUrlQuery{qtUrl};
-        const auto serverUrlRaw = urlQuery.queryItemValue(QStringLiteral("server_url"));
-        const auto serverUrl = QUrl::fromUserInput(serverUrlRaw);
-        if (serverUrl.isValid() && !serverUrl.host().isEmpty()) {
-            OCC::OwncloudSetupWizard::runWizardForLoginFlow(serverUrl, qApp, SLOT(slotownCloudWizardDone(int)));
-        } else {
-            OCC::EditLocallyManager::showError(QCoreApplication::translate("Application", "Invalid account setup URL"),
-                                               QCoreApplication::translate("Application", "The provided addAccount URL could not be parsed."));
-        }
+    if (OCC::AddAccountUrlHandler::handleAddAccountUrl(qtUrl)) {
         return;
     }
 

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -88,7 +88,7 @@ void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *
     owncloudSetupWizard = new OwncloudSetupWizard(parent);
     if (pendingLoginFlowServerUrl.isValid()) {
         owncloudSetupWizard->setupTemporaryLoginFlowFromUrl(pendingLoginFlowServerUrl);
-        pendingLoginFlowServerUrl = {};
+        pendingLoginFlowServerUrl = QUrl{};
     }
     connect(owncloudSetupWizard, SIGNAL(ownCloudWizardDone(int)), obj, amember);
     connect(owncloudSetupWizard->_ocWizard, &OwncloudWizard::wizardClosed, obj, [] { owncloudSetupWizard.clear(); });

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -63,10 +63,12 @@ OwncloudSetupWizard::OwncloudSetupWizard(QObject *parent)
 
 OwncloudSetupWizard::~OwncloudSetupWizard()
 {
+    clearTemporaryThemeOverride();
     _ocWizard->deleteLater();
 }
 
 static QPointer<OwncloudSetupWizard> owncloudSetupWizard = nullptr;
+static QUrl pendingLoginFlowServerUrl = {};
 
 void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *parent)
 {
@@ -84,11 +86,21 @@ void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *
     }
 
     owncloudSetupWizard = new OwncloudSetupWizard(parent);
+    if (pendingLoginFlowServerUrl.isValid()) {
+        owncloudSetupWizard->setupTemporaryLoginFlowFromUrl(pendingLoginFlowServerUrl);
+        pendingLoginFlowServerUrl = {};
+    }
     connect(owncloudSetupWizard, SIGNAL(ownCloudWizardDone(int)), obj, amember);
     connect(owncloudSetupWizard->_ocWizard, &OwncloudWizard::wizardClosed, obj, [] { owncloudSetupWizard.clear(); });
 
     FolderMan::instance()->setSyncEnabled(false);
     owncloudSetupWizard->startWizard();
+}
+
+void OwncloudSetupWizard::runWizardForLoginFlow(const QUrl &serverUrl, QObject *obj, const char *amember, QWidget *parent)
+{
+    pendingLoginFlowServerUrl = serverUrl;
+    runWizard(obj, amember, parent);
 }
 
 bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
@@ -146,6 +158,36 @@ void OwncloudSetupWizard::startWizard()
     _ocWizard->adjustWizardSize();
     _ocWizard->open();
     _ocWizard->raise();
+}
+
+void OwncloudSetupWizard::setupTemporaryLoginFlowFromUrl(const QUrl &serverUrl)
+{
+    if (!serverUrl.isValid()) {
+        return;
+    }
+
+    auto *theme = Theme::instance();
+    _previousOverrideServerUrl = theme->overrideServerUrl();
+    _previousForceOverrideServerUrl = theme->forceOverrideServerUrl();
+    _previousStartLoginFlowAutomatically = theme->startLoginFlowAutomatically();
+    _hasTemporaryThemeOverride = true;
+
+    theme->setOverrideServerUrl(serverUrl.toString());
+    theme->setForceOverrideServerUrl(true);
+    theme->setStartLoginFlowAutomatically(true);
+}
+
+void OwncloudSetupWizard::clearTemporaryThemeOverride()
+{
+    if (!_hasTemporaryThemeOverride) {
+        return;
+    }
+
+    auto *theme = Theme::instance();
+    theme->setOverrideServerUrl(_previousOverrideServerUrl);
+    theme->setForceOverrideServerUrl(_previousForceOverrideServerUrl);
+    theme->setStartLoginFlowAutomatically(_previousStartLoginFlowAutomatically);
+    _hasTemporaryThemeOverride = false;
 }
 
 // also checks if an installation is valid and determines auth type in a second step
@@ -711,6 +753,7 @@ bool OwncloudSetupWizard::ensureStartFromScratch(const QString &localFolder)
 // Method executed when the user end has finished the basic setup.
 void OwncloudSetupWizard::slotAssistantFinished(int result)
 {
+    clearTemporaryThemeOverride();
     FolderMan *folderMan = FolderMan::instance();
 
     if (result == QDialog::Rejected) {
@@ -779,6 +822,7 @@ void OwncloudSetupWizard::slotAssistantFinished(int result)
 
 void OwncloudSetupWizard::slotSkipFolderConfiguration()
 {
+    clearTemporaryThemeOverride();
     applyAccountChanges();
 
     disconnect(_ocWizard, &OwncloudWizard::basicSetupFinished,

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -36,6 +36,7 @@ class OwncloudSetupWizard : public QObject
 public:
     /** Run the wizard */
     static void runWizard(QObject *obj, const char *amember, QWidget *parent = nullptr);
+    static void runWizardForLoginFlow(const QUrl &serverUrl, QObject *obj, const char *amember, QWidget *parent = nullptr);
     static bool bringWizardToFrontIfVisible();
 
 signals:
@@ -66,6 +67,8 @@ private slots:
 private:
     explicit OwncloudSetupWizard(QObject *parent = nullptr);
     ~OwncloudSetupWizard() override;
+    void setupTemporaryLoginFlowFromUrl(const QUrl &serverUrl);
+    void clearTemporaryThemeOverride();
     void startWizard();
     void testOwnCloudConnect();
     void createRemoteFolder();
@@ -77,6 +80,10 @@ private:
     OwncloudWizard *_ocWizard = nullptr;
     QString _initLocalFolder;
     QString _remoteFolder;
+    bool _hasTemporaryThemeOverride = false;
+    QString _previousOverrideServerUrl;
+    bool _previousForceOverrideServerUrl = false;
+    bool _previousStartLoginFlowAutomatically = false;
 };
 }
 


### PR DESCRIPTION
### Motivation
- Provide a way to trigger the account setup/login flow from a custom URI (`nc://addAccount`) and from macOS `QFileOpenEvent` URI delivery.
- Allow passing a server URL in the URI so the setup wizard starts pre-filled and enforces that server for the login flow.
- Temporarily override theme settings to enforce the supplied server URL for the duration of the wizard, then restore previous values.

### Description
- Add `parseAddAccountServerUrl` helper to validate and extract `server_url` from `nc://addAccount?server_url=...` URIs.
- Wire parsing into command-line/IPC path by adding `_addAccountServerUrl`, `handleAddAccountFromOptions`, and handling `APPLICATION_URI_HANDLER_SCHEME://addAccount` in `Application::parseOptions` and `Application::slotParseMessage`.
- Handle macOS `QFileOpenEvent` URIs to launch the account setup flow when an `addAccount` URI is received; otherwise preserve existing local-file-edit handling.
- Add `OwncloudSetupWizard::runWizardForLoginFlow` to queue a login flow URL via a `pendingLoginFlowServerUrl` static and reuse existing `runWizard` path.
- Implement temporary theme override methods `setupTemporaryLoginFlowFromUrl` and `clearTemporaryThemeOverride` in `OwncloudSetupWizard` to set `overrideServerUrl`, `forceOverrideServerUrl`, and `startLoginFlowAutomatically` during the wizard and to restore previous theme state on completion, rejection, or destruction.
- Ensure the temporary override is cleared in the wizard destructor, in `slotAssistantFinished`, and in `slotSkipFolderConfiguration`.

### Testing
- No new automated tests were added for this change.
- Manual/local build and smoke testing verified that `nc://addAccount` URIs start the setup wizard and that theme override is restored after the wizard completes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87e3f73088333a6c28bab7667ade4)