### PR TITLE
Prevent unnecessary logging about an inexistent trash container item in database

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
@@ -61,11 +61,18 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
             } else {
                 stillMaterializedItems.insert(enumeratedIdentifier)
 
-                guard var metadata = if enumeratedIdentifier == .rootContainer {
-                    dbManager.rootItemMetadata(account: account)
-                } else {
-                    dbManager.itemMetadata(enumeratedIdentifier)
-                } else {
+                var metadata: SendableItemMetadata?
+
+                switch enumeratedIdentifier {
+                    case .rootContainer:
+                        metadata = dbManager.rootItemMetadata(account: account)
+                    case .trashContainer:
+                        continue // there is no placeholder item for the trash container in the database
+                    default:
+                        metadata = dbManager.itemMetadata(enumeratedIdentifier)
+                }
+
+                guard var metadata else {
                     logger.error("No metadata for enumerated item found.", [.item: enumeratedIdentifier])
                     continue
                 }


### PR DESCRIPTION
The logs are always spammed with messages like this:

```json
{
    "category": "MaterializedEnumerationObserver",
    "date": "2026.04.20 11:29:01.776",
    "details": {
        "item": "NSFileProviderTrashContainerItemIdentifier"
    },
    "level": "error",
    "message": "No metadata for enumerated item found."
}
```

These are pointless and that is expected because we do not have a placeholder item in the database for the trash container.