### PR TITLE
Run time switch for debug logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,19 @@ The following details are important and only relevant when working on the deskto
 - When writing code in Swift, respect strict concurrency rules and Swift 6 compatibility.
 - Manage memory explicitly and manually when writing or updating code located under `./src`. For example, do not use features like `__weak` from automatic reference counting in Objective-C because ARC is not used in this project.
 
+#### Logging
+
+These instructions are restricted to `./shell_integration/MacOSX/NextcloudIntegration/FileProviderExt` and `./shell_integration/MacOSX/NextcloudFileProviderKit`:
+
+- Use the `FileProviderLog` and `FileProviderLogger` types for logging.
+- One `FileProviderLog` is set up by a `FileProviderExtension` instance. That needs to be reused and passed down every call stack.
+- Every initialized object in the call stack must set up its own `FileProviderLogger` with the `category` argument being a string literal equal to the name of the type initializing it.
+- Log messages should be a single line string.
+- Log messages must not contain line breaks.
+- Log messages must not contain interpolations.
+- Log messages must end with a full stop.
+- Relevant run time values to log must be provided through the `arguments` argument.
+
 ### Tests
 
 - When implementing new test suites, prefer Swift Testing over XCTest for implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ These instructions are restricted to `./shell_integration/MacOSX/NextcloudIntegr
 - Log messages must not contain interpolations.
 - Log messages must end with a full stop.
 - Relevant run time values to log must be provided through the `arguments` argument.
+- Inclusion of `.debug`-level messages is controlled at runtime by the `debugLoggingEnabled` boolean key under the `com.nextcloud.desktopclient.FileProviderExt` domain in `UserDefaults.standard`. When unset, DEBUG builds include debug messages and release builds do not. Administrators can flip the value with `defaults write` for troubleshooting; changes propagate live via KVO. The gate applies to both Apple unified logging and the JSONL file output. See `Logging.md`.
 
 ### Tests
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
@@ -3,13 +3,12 @@
 
 import FileProvider
 import Foundation
-import NextcloudFileProviderKit
 import os
 
 ///
 /// Abstraction for the user defaults specific to file provider domains.
 ///
-struct FileProviderDomainDefaults {
+public struct FileProviderDomainDefaults {
     ///
     /// > Warning: Do not change the raw values of these keys, as they are used in UserDefaults. Any change would make the already stored value inaccessible and be like a reset.
     ///
@@ -30,7 +29,7 @@ struct FileProviderDomainDefaults {
 
     let logger: FileProviderLogger
 
-    init(identifier: NSFileProviderDomainIdentifier, log: any FileProviderLogging) {
+    public init(identifier: NSFileProviderDomainIdentifier, log: any FileProviderLogging) {
         self.identifier = identifier
         self.logger = FileProviderLogger(category: "FileProviderDomainDefaults", log: log)
     }
@@ -60,7 +59,7 @@ struct FileProviderDomainDefaults {
     ///
     /// The address of the server to connect to.
     ///
-    var serverUrl: String? {
+    public var serverUrl: String? {
         get {
             let identifier = self.identifier.rawValue
 
@@ -90,7 +89,7 @@ struct FileProviderDomainDefaults {
     ///
     /// The user name associated with the domain.
     ///
-    var user: String? {
+    public var user: String? {
         get {
             let identifier = self.identifier.rawValue
 
@@ -120,7 +119,7 @@ struct FileProviderDomainDefaults {
     ///
     /// The full user identifier associated with the domain.
     ///
-    var userId: String? {
+    public var userId: String? {
         get {
             let identifier = self.identifier.rawValue
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
@@ -20,6 +20,7 @@ public struct FileProviderDomainDefaults {
         case user
         case userId
         case serverUrl
+        case debugLoggingEnabled
     }
 
     ///
@@ -142,6 +143,40 @@ public struct FileProviderDomainDefaults {
                 logger.error("Ignoring new value for \"userId\" because it is an empty string for file provider domain \"\(identifier)\"!")
             } else {
                 internalConfig[ConfigKey.userId.rawValue] = newValue
+            }
+        }
+    }
+
+    ///
+    /// Controls whether `.debug`-level messages are included in logging output.
+    ///
+    /// Unlike the other properties on this type, this value is **process-global and shared across all file provider domains**.
+    /// It is stored at the top level of `UserDefaults.standard`, bypassing the per-domain `internalConfig` dictionary, because `FileProviderLog` is instantiated once per process and administrators configure it with a single `defaults write` command per extension bundle.
+    ///
+    /// When unset, debug logging is enabled in DEBUG builds and disabled in release builds, matching the previous compile-time behavior.
+    /// Administrators can override at runtime for troubleshooting.
+    ///
+    public var debugLoggingEnabled: Bool? {
+        get {
+            let key = ConfigKey.debugLoggingEnabled.rawValue
+
+            if let value = UserDefaults.standard.object(forKey: key) as? Bool {
+                logger.debug("Returning existing value \"\(value)\" for \"debugLoggingEnabled\" (process-global).")
+                return value
+            } else {
+                logger.debug("No existing value for \"debugLoggingEnabled\" (process-global) found.")
+                return nil
+            }
+        }
+
+        set {
+            let key = ConfigKey.debugLoggingEnabled.rawValue
+
+            if let newValue {
+                UserDefaults.standard.set(newValue, forKey: key)
+            } else {
+                logger.debug("Removing key \"debugLoggingEnabled\" (process-global) because the new value is nil.")
+                UserDefaults.standard.removeObject(forKey: key)
             }
         }
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
@@ -32,7 +32,7 @@ public struct FileProviderDomainDefaults {
 
     public init(identifier: NSFileProviderDomainIdentifier, log: any FileProviderLogging) {
         self.identifier = identifier
-        self.logger = FileProviderLogger(category: "FileProviderDomainDefaults", log: log)
+        logger = FileProviderLogger(category: "FileProviderDomainDefaults", log: log)
     }
 
     ///
@@ -62,7 +62,7 @@ public struct FileProviderDomainDefaults {
     ///
     public var serverUrl: String? {
         get {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if let value = internalConfig[ConfigKey.serverUrl.rawValue] as? String {
                 logger.debug("Returning existing value \"\(value)\" for \"serverUrl\" for file provider domain \"\(identifier)\".")
@@ -74,7 +74,7 @@ public struct FileProviderDomainDefaults {
         }
 
         set {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if newValue == nil {
                 logger.debug("Removing key \"serverUrl\" for file provider domain \"\(identifier)\" because the new value is nil.")
@@ -92,7 +92,7 @@ public struct FileProviderDomainDefaults {
     ///
     public var user: String? {
         get {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if let value = internalConfig[ConfigKey.user.rawValue] as? String {
                 logger.debug("Returning existing value \"\(value)\" for \"user\" for file provider domain \"\(identifier)\".")
@@ -104,7 +104,7 @@ public struct FileProviderDomainDefaults {
         }
 
         set {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if newValue == nil {
                 logger.debug("Removing key \"user\" for file provider domain \"\(identifier)\" because the new value is nil.")
@@ -122,7 +122,7 @@ public struct FileProviderDomainDefaults {
     ///
     public var userId: String? {
         get {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if let value = internalConfig[ConfigKey.userId.rawValue] as? String {
                 logger.debug("Returning existing value \"\(value)\" for \"userId\" for file provider domain \"\(identifier)\".")
@@ -134,7 +134,7 @@ public struct FileProviderDomainDefaults {
         }
 
         set {
-            let identifier = self.identifier.rawValue
+            let identifier = identifier.rawValue
 
             if newValue == nil {
                 logger.debug("Removing key \"userId\" for file provider domain \"\(identifier)\" because the new value is nil.")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -3,7 +3,6 @@
 
 @preconcurrency import FileProvider
 import Foundation
-import NextcloudKit
 import os
 
 ///
@@ -16,11 +15,12 @@ import os
 ///
 /// In general, there should be only one instance for every process.
 ///
-/// Messages are forwarded to Apple's unified logging system in addition to being written to the JSONL log file, in both debug and release builds.
+/// This actor owns the JSON Lines log file. Forwarding to Apple's unified logging system is handled by ``FileProviderLogger``, which tags each message with the calling type's category.
 ///
 /// Whether `.debug`-level messages are included is controlled at runtime by the `debugLoggingEnabled` boolean key under the file provider extension's domain in `UserDefaults.standard`.
 /// When the key is unset, debug logging is enabled in DEBUG builds and disabled in release builds, matching the previous compile-time behavior.
 /// The value is observed via KVO, so changes made with `defaults write` take effect without restarting the extension.
+/// The gate applies to both the JSONL output here and the unified logging forwarding done by ``FileProviderLogger``.
 /// See `Logging.md` for administrator instructions.
 ///
 /// > To Do: Consider using macros for the calls so the calling functions and files can be recorded, too!
@@ -62,9 +62,10 @@ public actor FileProviderLog: FileProviderLogging {
     var handle: FileHandle?
 
     ///
-    /// The fallback logger.
+    /// Unified logger used for self-diagnostics of this actor, tagged with the category `"FileProviderLog"`.
     ///
-    /// This is important in case the actual log file could be created or written to.
+    /// Used for messages about this actor's own concerns — log file rotation, startup and KVO transitions of the debug-logging gate, and errors that prevent writing to the JSONL file.
+    /// Messages emitted by callers are forwarded to Apple's unified logging system by ``FileProviderLogger`` under the respective calling type's category instead.
     ///
     let logger: Logger
 
@@ -89,7 +90,7 @@ public actor FileProviderLog: FileProviderLogging {
     /// Initialized from `UserDefaults.standard` (key `"debugLoggingEnabled"`) at startup and kept in sync via KVO so changes propagate live.
     /// When the key is unset, falls back to the build-configuration default: enabled in DEBUG builds, disabled otherwise.
     ///
-    var debugLoggingEnabled: Bool
+    public var debugLoggingEnabled: Bool
 
     ///
     /// Retains the KVO token that reacts to changes of the `debugLoggingEnabled` user default.
@@ -301,52 +302,10 @@ public actor FileProviderLog: FileProviderLogging {
         }
     }
 
-    private func writeToUnifiedLoggingSystem(level: OSLogType, message: String, details: [FileProviderLogDetailKey: (any Sendable)?], file: StaticString, function: StaticString, line: UInt) {
-        if details.isEmpty {
-            logger.log(level: level, "\(message, privacy: .public)\n\n\(file, privacy: .public):\(line, privacy: .public) \(function, privacy: .public)")
-            return
-        }
-
-        let sortedKeys = details.keys.sorted()
-
-        let detailDescriptions: [String] = sortedKeys.compactMap { key in
-            let valueDescription: String = switch details[key] {
-                case let account as Account:
-                    account.ncKitAccount
-                case let date as Date:
-                    messageDateFormatter.string(from: date)
-                case let error as NSError:
-                    error.debugDescription
-                case let lock as NKLock:
-                    lock.token ?? "nil"
-                case let item as NSFileProviderItem:
-                    item.itemIdentifier.rawValue
-                case let identifier as NSFileProviderItemIdentifier:
-                    identifier.rawValue
-                case let url as URL:
-                    url.absoluteString
-                case let text as String:
-                    text
-                case let request as NSFileProviderRequest:
-                    "requestingExecutable: \(request.requestingExecutable?.path ?? "nil"), isFileViewerRequest: \(request.isFileViewerRequest), isSystemRequest: \(request.isSystemRequest)"
-                case nil:
-                    "nil"
-                default:
-                    "<unsupported log detail value type>"
-            }
-
-            return "- \(key.rawValue): \(valueDescription)"
-        }
-
-        logger.log(level: level, "\(message, privacy: .public)\n\n\(detailDescriptions.joined(separator: "\n"), privacy: .public)\n\n\(file, privacy: .public):\(line, privacy: .public) \(function, privacy: .public)")
-    }
-
     public func write(category: String, level: OSLogType, message: String, details: [FileProviderLogDetailKey: (any Sendable)?], file: StaticString, function: StaticString, line: UInt) {
         if level == .debug && !debugLoggingEnabled {
             return
         }
-
-        writeToUnifiedLoggingSystem(level: level, message: message, details: details, file: file, function: function, line: line)
 
         rotateLogFileIfNeeded() // Check if log file needs rotation before writing anything.
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -16,9 +16,12 @@ import os
 ///
 /// In general, there should be only one instance for every process.
 ///
-/// Messages with debug level are written only for debug configuration builds.
+/// Messages are forwarded to Apple's unified logging system in addition to being written to the JSONL log file, in both debug and release builds.
 ///
-/// Debug configuration builds also write to the unified logging system as an alternative to view logged messages.
+/// Whether `.debug`-level messages are included is controlled at runtime by the `debugLoggingEnabled` boolean key under the file provider extension's domain in `UserDefaults.standard`.
+/// When the key is unset, debug logging is enabled in DEBUG builds and disabled in release builds, matching the previous compile-time behavior.
+/// The value is observed via KVO, so changes made with `defaults write` take effect without restarting the extension.
+/// See `Logging.md` for administrator instructions.
 ///
 /// > To Do: Consider using macros for the calls so the calling functions and files can be recorded, too!
 ///
@@ -81,6 +84,22 @@ public actor FileProviderLog: FileProviderLogging {
     let subsystem: String
 
     ///
+    /// Whether `.debug`-level messages are included in both the JSONL file output and Apple unified logging.
+    ///
+    /// Initialized from `UserDefaults.standard` (key `"debugLoggingEnabled"`) at startup and kept in sync via KVO so changes propagate live.
+    /// When the key is unset, falls back to the build-configuration default: enabled in DEBUG builds, disabled otherwise.
+    ///
+    var debugLoggingEnabled: Bool
+
+    ///
+    /// Retains the KVO token that reacts to changes of the `debugLoggingEnabled` user default.
+    ///
+    /// Marked `nonisolated(unsafe)` so it can be assigned during `init` (after `self` escapes via the observer closure) and read from the non-isolated `deinit`.
+    /// Safe in practice because it is written exactly once in `init` before the instance is visible to any other thread and read only in `deinit` after all other references have been dropped.
+    ///
+    nonisolated(unsafe) var debugLoggingObservation: NSKeyValueObservation?
+
+    ///
     /// Initialize a new log file abstraction.
     ///
     /// - Parameters:
@@ -103,15 +122,85 @@ public actor FileProviderLog: FileProviderLogging {
         subsystem = Bundle.main.bundleIdentifier ?? ""
         logger = Logger(subsystem: subsystem, category: "FileProviderLog")
 
+        let defaultFallback = Self.buildConfigurationDefaultDebugLoggingEnabled
+        let raw = UserDefaults.standard.object(forKey: "debugLoggingEnabled")
+
+        if raw == nil {
+            debugLoggingEnabled = defaultFallback
+            logger.log(level: .default, "Debug logging \(defaultFallback ? "enabled" : "disabled", privacy: .public) (build fallback; `debugLoggingEnabled` default is unset).")
+        } else if let number = raw as? NSNumber {
+            debugLoggingEnabled = number.boolValue
+            logger.log(level: .default, "Debug logging \(number.boolValue ? "enabled" : "disabled", privacy: .public) (from `debugLoggingEnabled` user default).")
+        } else {
+            debugLoggingEnabled = defaultFallback
+            logger.error("Ignoring non-boolean value for `debugLoggingEnabled` user default. Falling back to build default (\(defaultFallback ? "enabled" : "disabled", privacy: .public)).")
+        }
+
         guard let logsDirectory = fileManager.fileProviderDomainLogDirectory(for: identifier) else {
             logger.error("Failed to get URL for file provider domain logs!")
             file = nil
             handle = nil
             logsDirectory = nil
+            debugLoggingObservation = UserDefaults.standard.observe(\.debugLoggingEnabled, options: [.new]) { [weak self] _, _ in
+                Task { [weak self] in
+                    await self?.reloadDebugLoggingEnabled()
+                }
+            }
             return
         }
 
         self.logsDirectory = logsDirectory
+        debugLoggingObservation = UserDefaults.standard.observe(\.debugLoggingEnabled, options: [.new]) { [weak self] _, _ in
+            Task { [weak self] in
+                await self?.reloadDebugLoggingEnabled()
+            }
+        }
+    }
+
+    deinit {
+        debugLoggingObservation?.invalidate()
+    }
+
+    ///
+    /// Build-configuration default for ``debugLoggingEnabled``, used when the user default is unset.
+    ///
+    private static var buildConfigurationDefaultDebugLoggingEnabled: Bool {
+        #if DEBUG
+            return true
+        #else
+            return false
+        #endif
+    }
+
+    ///
+    /// Re-reads the `debugLoggingEnabled` user default and updates ``debugLoggingEnabled`` accordingly.
+    ///
+    /// Called from the KVO observer when `defaults write` (or `defaults delete`) changes the value in another process.
+    ///
+    func reloadDebugLoggingEnabled() {
+        let defaultFallback = Self.buildConfigurationDefaultDebugLoggingEnabled
+        let raw = UserDefaults.standard.object(forKey: "debugLoggingEnabled")
+        let newValue: Bool
+        let source: String
+
+        if raw == nil {
+            newValue = defaultFallback
+            source = "build fallback; `debugLoggingEnabled` default is unset"
+        } else if let number = raw as? NSNumber {
+            newValue = number.boolValue
+            source = "from `debugLoggingEnabled` user default"
+        } else {
+            newValue = defaultFallback
+            logger.error("Ignoring non-boolean value for `debugLoggingEnabled` user default. Falling back to build default.")
+            source = "build fallback; `debugLoggingEnabled` default is of an unsupported type"
+        }
+
+        if newValue == debugLoggingEnabled {
+            return
+        }
+
+        debugLoggingEnabled = newValue
+        logger.log(level: .default, "Debug logging \(newValue ? "enabled" : "disabled", privacy: .public) (\(source, privacy: .public)).")
     }
 
     ///
@@ -253,17 +342,11 @@ public actor FileProviderLog: FileProviderLogging {
     }
 
     public func write(category: String, level: OSLogType, message: String, details: [FileProviderLogDetailKey: (any Sendable)?], file: StaticString, function: StaticString, line: UInt) {
-        #if DEBUG
+        if level == .debug && !debugLoggingEnabled {
+            return
+        }
 
-            writeToUnifiedLoggingSystem(level: level, message: message, details: details, file: file, function: function, line: line)
-
-        #else
-
-            if level == .debug {
-                return // We want debug messages only in debug builds.
-            }
-
-        #endif
+        writeToUnifiedLoggingSystem(level: level, message: message, details: details, file: file, function: function, line: line)
 
         rotateLogFileIfNeeded() // Check if log file needs rotation before writing anything.
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -303,7 +303,7 @@ public actor FileProviderLog: FileProviderLogging {
     }
 
     public func write(category: String, level: OSLogType, message: String, details: [FileProviderLogDetailKey: (any Sendable)?], file: StaticString, function: StaticString, line: UInt) {
-        if level == .debug && !debugLoggingEnabled {
+        if level == .debug, !debugLoggingEnabled {
             return
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
@@ -1,6 +1,9 @@
 //  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 //  SPDX-License-Identifier: LGPL-3.0-or-later
 
+@preconcurrency import FileProvider
+import Foundation
+import NextcloudKit
 import os
 
 ///
@@ -9,6 +12,9 @@ import os
 /// - Automatically augments messages with the once configured category.
 /// - Translates the designated methods to the log level argument.
 /// - Provides synchronous methods to dispatch log messages to the underlying actor.
+///
+/// Each instance holds its own `Logger` for forwarding to Apple's unified logging system, tagged with the configured ``category`` so messages are searchable per calling type.
+/// The JSON Lines log file is written through the shared ``FileProviderLogging`` actor.
 ///
 /// This must be instantiated per instance of calling types.
 /// Statically or lazily defining a single instance of this for all instances of a calling type is not possible due to the dependency on ``FileProviderLog``.
@@ -26,15 +32,23 @@ public struct FileProviderLogger: Sendable {
     let log: any FileProviderLogging
 
     ///
+    /// The underlying unified logger tagged with ``category``.
+    ///
+    let logger: Logger
+
+    ///
     /// Create a new logger which is supposed to be used by individual types and their instances.
     ///
     public init(category: String, log: any FileProviderLogging) {
         self.category = category
         self.log = log
+        self.logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: category)
     }
 
     ///
     /// Dispatch a task to write a message with the level `OSLogType.debug`.
+    ///
+    /// Inclusion of debug messages is gated by the shared ``FileProviderLogging/debugLoggingEnabled`` flag; both unified logging and the JSONL file output are skipped when the flag is off.
     ///
     /// - Parameters:
     ///     - message: A human-readable message, preferably generic and without interpolations. The `details` argument is for arguments.
@@ -45,6 +59,11 @@ public struct FileProviderLogger: Sendable {
     ///
     public func debug(_ message: String, _ details: [FileProviderLogDetailKey: (any Sendable)?] = [:], file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line) {
         Task {
+            guard await log.debugLoggingEnabled else {
+                return
+            }
+
+            writeToUnifiedLoggingSystem(level: .debug, message: message, details: details, file: file, function: function, line: line)
             await log.write(category: category, level: .debug, message: message, details: details, file: file, function: function, line: line)
         }
     }
@@ -61,6 +80,7 @@ public struct FileProviderLogger: Sendable {
     ///
     public func info(_ message: String, _ details: [FileProviderLogDetailKey: (any Sendable)?] = [:], file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line) {
         Task {
+            writeToUnifiedLoggingSystem(level: .info, message: message, details: details, file: file, function: function, line: line)
             await log.write(category: category, level: .info, message: message, details: details, file: file, function: function, line: line)
         }
     }
@@ -77,6 +97,7 @@ public struct FileProviderLogger: Sendable {
     ///
     public func error(_ message: String, _ details: [FileProviderLogDetailKey: (any Sendable)?] = [:], file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line) {
         Task {
+            writeToUnifiedLoggingSystem(level: .error, message: message, details: details, file: file, function: function, line: line)
             await log.write(category: category, level: .error, message: message, details: details, file: file, function: function, line: line)
         }
     }
@@ -93,7 +114,48 @@ public struct FileProviderLogger: Sendable {
     ///
     public func fault(_ message: String, _ details: [FileProviderLogDetailKey: (any Sendable)?] = [:], file: StaticString = #filePath, function: StaticString = #function, line: UInt = #line) {
         Task {
+            writeToUnifiedLoggingSystem(level: .fault, message: message, details: details, file: file, function: function, line: line)
             await log.write(category: category, level: .fault, message: message, details: details, file: file, function: function, line: line)
         }
+    }
+
+    private func writeToUnifiedLoggingSystem(level: OSLogType, message: String, details: [FileProviderLogDetailKey: (any Sendable)?], file: StaticString, function: StaticString, line: UInt) {
+        if details.isEmpty {
+            logger.log(level: level, "\(message, privacy: .public)\n\n\(file, privacy: .public):\(line, privacy: .public) \(function, privacy: .public)")
+            return
+        }
+
+        let sortedKeys = details.keys.sorted()
+
+        let detailDescriptions: [String] = sortedKeys.compactMap { key in
+            let valueDescription: String = switch details[key] {
+                case let account as Account:
+                    account.ncKitAccount
+                case let date as Date:
+                    date.ISO8601Format()
+                case let error as NSError:
+                    error.debugDescription
+                case let lock as NKLock:
+                    lock.token ?? "nil"
+                case let item as NSFileProviderItem:
+                    item.itemIdentifier.rawValue
+                case let identifier as NSFileProviderItemIdentifier:
+                    identifier.rawValue
+                case let url as URL:
+                    url.absoluteString
+                case let text as String:
+                    text
+                case let request as NSFileProviderRequest:
+                    "requestingExecutable: \(request.requestingExecutable?.path ?? "nil"), isFileViewerRequest: \(request.isFileViewerRequest), isSystemRequest: \(request.isSystemRequest)"
+                case nil:
+                    "nil"
+                default:
+                    "<unsupported log detail value type>"
+            }
+
+            return "- \(key.rawValue): \(valueDescription)"
+        }
+
+        logger.log(level: level, "\(message, privacy: .public)\n\n\(detailDescriptions.joined(separator: "\n"), privacy: .public)\n\n\(file, privacy: .public):\(line, privacy: .public) \(function, privacy: .public)")
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
@@ -42,7 +42,7 @@ public struct FileProviderLogger: Sendable {
     public init(category: String, log: any FileProviderLogging) {
         self.category = category
         self.log = log
-        self.logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: category)
+        logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: category)
     }
 
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogging.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogging.swift
@@ -8,12 +8,21 @@ import os
 ///
 public protocol FileProviderLogging: Actor {
     ///
-    /// Write a message to the unified logging system and current log file.
+    /// Whether `.debug`-level messages are currently included in the logging output.
+    ///
+    /// ``FileProviderLogger`` reads this before forwarding debug messages to Apple's unified logging system so the gate applies to both destinations.
+    /// The value is controlled at runtime via the `debugLoggingEnabled` user default; see `Logging.md`.
+    ///
+    var debugLoggingEnabled: Bool { get }
+
+    ///
+    /// Write a message to the current JSON Lines log file.
     ///
     /// Usually, you do not need or want to use this but the methods provided by ``FileProviderLogger`` instead.
+    /// Forwarding to Apple's unified logging system is handled by ``FileProviderLogger`` so that each message is tagged with the calling type's category.
     ///
     /// - Parameters:
-    ///     - category: The unified logging category to use. Usually, this is the logging type.
+    ///     - category: The logging category to use. Usually, this is the logging type.
     ///     - level: The severity of the message.
     ///     - message: A human-readable message, preferably generic and without interpolations. The `details` argument is for arguments.
     ///     - details: Structured and contextual details about a message.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/UserDefaults+DebugLoggingEnabled.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/UserDefaults+DebugLoggingEnabled.swift
@@ -1,0 +1,16 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+extension UserDefaults {
+    ///
+    /// KVO-observable accessor for the process-global `debugLoggingEnabled` user default.
+    ///
+    /// The `@objc dynamic` attribute is required so `FileProviderLog` can observe the key via `\.debugLoggingEnabled` and react to changes made by `defaults write` without restarting the extension.
+    /// `NSNumber?` is used instead of `Bool` so observers can distinguish a reset (key absent) from an explicit `false`.
+    ///
+    @objc dynamic var debugLoggingEnabled: NSNumber? {
+        object(forKey: "debugLoggingEnabled") as? NSNumber
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
@@ -6,6 +6,8 @@ import NextcloudFileProviderKit
 import os
 
 public actor FileProviderLogMock: FileProviderLogging {
+    public let debugLoggingEnabled: Bool = true
+
     let logger: Logger
 
     public init() {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/FileProviderExtension.swift
@@ -86,7 +86,7 @@ import OSLog
         // Set up logging.
         self.log = FileProviderLog(fileProviderDomainIdentifier: domain.identifier)
         self.logger = FileProviderLogger(category: "FileProviderExtension", log: log)
-        logger.debug("Initializing with domain identifier: \(domain.identifier.rawValue)")
+        logger.debug("Initializing with domain identifier.", [.domain: domain.identifier.rawValue])
 
         // Set up NextcloudKit.
         self.ncKit = NextcloudKit.shared
@@ -97,10 +97,8 @@ import OSLog
         NKLogFileManager.configure(logLevel: .normal)
         #endif
 
-        logger.info("Current NextcloudKit log file URL: \(NKLogFileManager.shared.currentLogFileURL().absoluteString)")
-
+        logger.info("NextcloudKit logging configured.", [.url: NKLogFileManager.shared.currentLogFileURL()])
         self.keychain = Keychain(log: log)
-
         super.init()
     }
 
@@ -146,13 +144,13 @@ import OSLog
         logger.debug("Received request for item.", [.item: identifier, .request: request])
 
         guard let ncAccount else {
-            logger.error("Not fetching item because account not set up yet.", [.item: identifier])
+            logger.debug("Not fetching item because account not set up yet.", [.item: identifier])
             completionHandler(nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
         
         guard let dbManager else {
-            logger.error("Not fetching item because database is unavailable.", [.item: identifier])
+            logger.debug("Not fetching item because database is unavailable.", [.item: identifier])
             completionHandler(nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
@@ -188,14 +186,14 @@ import OSLog
         }
 
         guard let ncAccount else {
-            logger.error("Not fetching contents for item because account not set up yet.", [.item: itemIdentifier])
+            logger.debug("Not fetching contents for item because account not set up yet.", [.item: itemIdentifier])
             insertErrorAction(actionId)
             completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let dbManager else {
-            logger.error("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
+            logger.debug("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
             completionHandler(nil, nil, NSFileProviderError(.cannotSynchronize))
             return Progress()
         }
@@ -233,26 +231,21 @@ import OSLog
         logger.debug("Received request to create item.", [.item: itemTemplate, .name: itemTemplate.filename, .request: request])
 
         guard let ncAccount else {
-            logger.error(
-                """
-                Not creating item: \(itemTemplate.itemIdentifier.rawValue)
-                as account not set up yet
-                """
-            )
+            logger.debug("Not creating item because account is not set up yet.", [.item: itemTemplate.itemIdentifier])
             insertErrorAction(actionId)
             completionHandler(itemTemplate, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let ignoredFiles else {
-            logger.error("Not creating item for identifier: \(itemTemplate.itemIdentifier.rawValue) as ignore list not set up yet.")
+            logger.debug("Not creating item because ignore list not set up yet.", [.item: itemTemplate.itemIdentifier])
             insertErrorAction(actionId)
             completionHandler(itemTemplate, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let dbManager else {
-            logger.error("Not creating item because database is unavailable.", [.item: itemTemplate.itemIdentifier])
+            logger.debug("Not creating item because database is unavailable.", [.item: itemTemplate.itemIdentifier])
             insertErrorAction(actionId)
             completionHandler(itemTemplate, [], false, NSFileProviderError(.cannotSynchronize))
             return Progress()
@@ -317,14 +310,14 @@ import OSLog
         logger.debug("Received request to modify item.", [.item: item, .request: request])
 
         guard let ncAccount else {
-            logger.error("Not modifying item because account not set up yet.", [.item: identifier])
+            logger.debug("Not modifying item because account not set up yet.", [.item: identifier])
             insertErrorAction(actionId)
             completionHandler(item, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let ignoredFiles else {
-            logger.error("Not modifying item because ignore list not set up yet.", [.item: identifier])
+            logger.debug("Not modifying item because ignore list not set up yet.", [.item: identifier])
             insertErrorAction(actionId)
             completionHandler(item, [], false, NSFileProviderError(.notAuthenticated))
             return Progress()
@@ -332,7 +325,7 @@ import OSLog
 
 
         guard let dbManager else {
-            logger.error("Not modifying item because the database is unavailable.")
+            logger.debug("Not modifying item because the database is unavailable.")
             insertErrorAction(actionId)
             completionHandler(item, [], false, NSFileProviderError(.cannotSynchronize))
             return Progress()
@@ -401,21 +394,21 @@ import OSLog
         logger.debug("Received request to delete item.", [.item: identifier, .request: request])
 
         guard let ncAccount else {
-            logger.error("Not deleting item \(identifier.rawValue), account not set up yet")
+            logger.debug("Not deleting item because account is not set up yet.", [.item: identifier])
             insertErrorAction(actionId)
             completionHandler(NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let ignoredFiles else {
-            logger.error("Not deleting \(identifier.rawValue), ignore list not received")
+            logger.debug("Not deleting item because ignore list not received.", [.item: identifier])
             insertErrorAction(actionId)
             completionHandler(NSFileProviderError(.notAuthenticated))
             return Progress()
         }
 
         guard let dbManager else {
-            logger.error("Not deleting item \(identifier.rawValue), db manager unavailable")
+            logger.debug("Not deleting item because database unavailable.", [.item: identifier])
             insertErrorAction(actionId)
             completionHandler(NSFileProviderError(.cannotSynchronize))
             return Progress()
@@ -457,12 +450,12 @@ import OSLog
         logger.debug("System requested enumerator.", [.item: containerItemIdentifier])
 
         guard let ncAccount else {
-            logger.error("Not providing enumerator for container with identifier \(containerItemIdentifier.rawValue) yet as account not set up")
+            logger.debug("Not providing enumerator for item because account is not set up yet.", [.item: containerItemIdentifier])
             throw NSFileProviderError(.notAuthenticated)
         }
 
         guard let dbManager else {
-            logger.error("Not providing enumerator for container with identifier \(containerItemIdentifier.rawValue) yet as db manager is unavailable")
+            logger.debug("Not providing enumerator for item because database is unavailable.", [.item: containerItemIdentifier])
             throw NSFileProviderError(.cannotSynchronize)
         }
 
@@ -478,19 +471,19 @@ import OSLog
 
     func materializedItemsDidChange(completionHandler: @escaping () -> Void) {
         guard let ncAccount else {
-            logger.error("Not purging stale local file metadatas, account not set up")
+            logger.debug("Not purging stale local file metadatas because account not set up.")
             completionHandler()
             return
         }
 
         guard let dbManager else {
-            logger.error("Not purging stale local file metadatas. db manager unabilable for domain: \(self.domain.displayName)")
+            logger.debug("Not purging stale local file metadatas because database is not available.")
             completionHandler()
             return
         }
 
         guard let manager = manager else {
-            logger.error("Could not get file provider manager for domain: \(self.domain.displayName)")
+            logger.debug("Could not get file provider manager.")
             completionHandler()
             return
         }
@@ -508,7 +501,7 @@ import OSLog
 
     func signalEnumerator(completionHandler: @escaping (_ error: Error?) -> Void) {
         guard let manager = manager else {
-            logger.error("Could not get file provider manager for domain, could not signal enumerator. This might lead to future conflicts.")
+            logger.error("Cannot get file provider manager for domain. Cannot signal enumerator.")
             return
         }
 
@@ -517,7 +510,7 @@ import OSLog
 
     private func signalEnumeratorAfterAccountSetup() {
         guard let manager = manager else {
-            logger.error("Could not get file provider manager for domain \(self.domain.displayName), cannot notify after account setup")
+            logger.error("Could not get manager for domain. Cannot signal enumerator after account setup.")
             return
         }
 
@@ -525,12 +518,11 @@ import OSLog
 
         manager.signalErrorResolved(NSFileProviderError(.notAuthenticated)) { error in
             if error != nil {
-                self.logger.error("Error resolving not authenticated, received error: \(error!.localizedDescription)")
+                self.logger.error("Cannot resolve .notAuthenticated error.", [.error: error?.localizedDescription])
             }
         }
 
-        logger.debug("Signalling enumerators for user \(self.ncAccount!.username) at server \(self.ncAccount!.serverUrl)")
-
+        logger.debug("Signalling enumerators.")
         notifyChange()
     }
 
@@ -558,25 +550,25 @@ import OSLog
         logger.info("Setting up domain account for user: \(user), userId: \(userId), serverUrl: \(serverUrl), password: \(password.isEmpty ? "<empty>" : "<not-empty>"), ncKitAccount: \(account.ncKitAccount)")
 
         guard password.isEmpty == false else {
-            logger.info("Cancelling domain account setup because \"password\" is an empty string!")
+            logger.info("Cancelling domain account setup because \"password\" is an empty string.")
             completionHandler?(NSError(.missingAccountInformation))
             return
         }
 
         guard serverUrl.isEmpty == false else {
-            logger.info("Cancelling domain account setup because \"serverUrl\" is an empty string!")
+            logger.info("Cancelling domain account setup because \"serverUrl\" is an empty string.")
             completionHandler?(NSError(.missingAccountInformation))
             return
         }
 
         guard user.isEmpty == false else {
-            logger.info("Cancelling domain account setup because \"user\" is an empty string!")
+            logger.info("Cancelling domain account setup because \"user\" is an empty string.")
             completionHandler?(NSError(.missingAccountInformation))
             return
         }
 
         guard userId.isEmpty == false else {
-            logger.info("Cancelling domain account setup because \"userId\" is an empty string!")
+            logger.info("Cancelling domain account setup because \"userId\" is an empty string.")
             completionHandler?(NSError(.missingAccountInformation))
             return
         }
@@ -585,7 +577,7 @@ import OSLog
 
         if account == ncAccount || account == pendingAccount {
             setupLock.unlock()
-            logger.info("Cancelling domain account setup because of receiving the same account information repeatedly!")
+            logger.info("Cancelling domain account setup because of receiving the same account information repeatedly.")
             completionHandler?(nil)
             return
         }
@@ -665,23 +657,23 @@ import OSLog
                 break
             }
 
-            logger.info("\(account.username) authentication try timed out. Trying again soon.")
+            logger.info("Authentication try timed out. Trying again soon.")
             try? await Task.sleep(nanoseconds: authTimeout)
         }
 
         switch (authAttemptState) {
             case .authenticationError:
-                logger.error("Authentication of \"\(account.username)\" failed due to bad credentials, cancelling domain account setup!")
+                logger.error("Authentication failed due to bad credentials.")
                 completionHandler?(NSError(.invalidCredentials))
                 return
             case .connectionError:
                 // Despite multiple connection attempts we are still getting connection issues.
                 // Connection error should be provided
-                logger.error("Authentication of \"\(account.username)\" try failed, no connection.")
+                logger.error("Authentication failed due to a connection error.")
                 completionHandler?(NSError(.connection))
                 return
             case .success:
-                logger.info("Successfully authenticated! Nextcloud account set up in file provider extension. User: \(account.username) at server: \(account.serverUrl)")
+                logger.info("Successfully authenticated.")
         }
 
         await MainActor.run {
@@ -715,7 +707,7 @@ import OSLog
         actionsLock.unlock()
 
         guard let argument else {
-            logger.error("State argument is nil!")
+            logger.error("State argument is nil.")
             return
         }
 

--- a/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.pbxproj
+++ b/shell_integration/MacOSX/NextcloudIntegration/NextcloudIntegration.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		538E396D27F4765000FA63D5 /* FileProviderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538E396C27F4765000FA63D5 /* FileProviderExtension.swift */; };
 		538E397627F4765000FA63D5 /* FileProviderExt.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 538E396727F4765000FA63D5 /* FileProviderExt.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		53B979812B84C81F002DA742 /* DocumentActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B979802B84C81F002DA742 /* DocumentActionViewController.swift */; };
-		53D666612B70C9A70042C03D /* FileProviderDomainDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53D666602B70C9A70042C03D /* FileProviderDomainDefaults.swift */; };
 		53ED473029C9CE0B00795DB1 /* FileProviderExtension+NSFileProviderServicing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53ED472F29C9CE0B00795DB1 /* FileProviderExtension+NSFileProviderServicing.swift */; };
 		53FE14502B8E0658006C4193 /* ShareTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FE144F2B8E0658006C4193 /* ShareTableViewDataSource.swift */; };
 		53FE14592B8E3F6C006C4193 /* ShareTableItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FE14582B8E3F6C006C4193 /* ShareTableItemView.swift */; };
@@ -122,7 +121,6 @@
 		53B9797E2B84C81F002DA742 /* FileProviderUIExt.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FileProviderUIExt.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		53B979802B84C81F002DA742 /* DocumentActionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentActionViewController.swift; sourceTree = "<group>"; };
 		53B979852B84C81F002DA742 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		53D666602B70C9A70042C03D /* FileProviderDomainDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderDomainDefaults.swift; sourceTree = "<group>"; };
 		53ED472F29C9CE0B00795DB1 /* FileProviderExtension+NSFileProviderServicing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProviderExtension+NSFileProviderServicing.swift"; sourceTree = "<group>"; };
 		53FE144F2B8E0658006C4193 /* ShareTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTableViewDataSource.swift; sourceTree = "<group>"; };
 		53FE14582B8E3F6C006C4193 /* ShareTableItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTableItemView.swift; sourceTree = "<group>"; };
@@ -267,7 +265,6 @@
 			children = (
 				5352E85929B7BFB4002CE85C /* Extensions */,
 				5350E4C72B0C368B00F276CB /* Services */,
-				53D666602B70C9A70042C03D /* FileProviderDomainDefaults.swift */,
 				538E396C27F4765000FA63D5 /* FileProviderExtension.swift */,
 				AAA6F17C2F1E647800FFB2BA /* FileProviderExtension+NSFileProviderServiceSource.swift */,
 				AAA6F1802F1E652E00FFB2BA /* FileProviderExtension+ClientCommunicationProtocol.swift */,
@@ -737,7 +734,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA9987862E72B6EF00B2C428 /* NextcloudKit+clearAccountErrorState.swift in Sources */,
-				53D666612B70C9A70042C03D /* FileProviderDomainDefaults.swift in Sources */,
 				AAA6F17D2F1E647D00FFB2BA /* FileProviderExtension+NSFileProviderServiceSource.swift in Sources */,
 				53ED473029C9CE0B00795DB1 /* FileProviderExtension+NSFileProviderServicing.swift in Sources */,
 				AAA6F1792F1E608000FFB2BA /* FileProviderExtension+ChangeNotificationInterface.swift in Sources */,


### PR DESCRIPTION
The Nextcloud file provider extension on macOS writes a per-domain JSON Lines (`*.jsonl`) log file and simultaneously forwards messages to Apple's unified logging system. By default, `.debug`-level messages are omitted from release builds to keep log volume and disk usage reasonable. For tough support cases — where a customer needs to gather as much information as possible from a production install — the debug level can be turned on at runtime without reinstalling a different build.

## Enabling debug logging

```
defaults write com.nextcloud.desktopclient.FileProviderExt debugLoggingEnabled -bool YES
```

The change takes effect within a couple of seconds; no restart of the extension or the Mac is required.

## Disabling or resetting

To explicitly turn debug logging off:

```
defaults write com.nextcloud.desktopclient.FileProviderExt debugLoggingEnabled -bool NO
```

To reset to the build default (recommended after information gathering):

```
defaults delete com.nextcloud.desktopclient.FileProviderExt debugLoggingEnabled
```

## Defaults when unset

When the `debugLoggingEnabled` key is absent from `UserDefaults.standard` for the extension:

- **DEBUG builds**: debug logging is on (matches development expectations).
- **Release builds**: debug logging is off.

## Troubleshooting

The extension emits a line to Apple unified logging on startup and on every runtime change, stating the current effective state and whether it came from `UserDefaults` or the build fallback. If a `defaults write` command doesn't seem to take effect, check `log stream` for that line.

Non-boolean values at the `debugLoggingEnabled` key are ignored. The extension logs an error and falls back to the build default. Always use `-bool YES` / `-bool NO` with `defaults write`.