### PR TITLE
fix(propagateuploadv1): detect upload failure when no bytes were sent

### DIFF
--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -339,6 +339,7 @@ private:
     int _currentChunk = 0;
     int _chunkCount = 0; /// Total number of chunks for this file
     uint _transferId = 0; /// transfer id (part of the url)
+    qint64 _sent = 0; /// bytes dispatched to the network across all chunks so far
 
     [[nodiscard]] qint64 chunkSize() const {
         // Old chunking does not use dynamic chunking algorithm, and does not adjusts the chunk size respectively,

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -127,6 +127,7 @@ void PropagateUploadFileV1::startNextChunk()
         isFinalChunk = true;
     }
     qCDebug(lcPropagateUploadV1) << _chunkCount << isFinalChunk << chunkStart << currentChunkSize;
+    _sent += currentChunkSize;
 
     if (isFinalChunk && !_transmissionChecksumHeader.isEmpty()) {
         qCInfo(lcPropagateUploadV1) << propagator()->fullRemotePath(path) << _transmissionChecksumHeader;
@@ -248,7 +249,7 @@ void PropagateUploadFileV1::slotPutFinished()
     // yet, the upload can be stopped and an error can be displayed, because
     // the server hasn't registered the new file yet.
     QByteArray etag = getEtagFromReply(job->reply());
-    _finished = etag.length() > 0;
+    _finished = etag.length() > 0 && _sent == _fileToUpload._size;
 
     // Check if the file still exists
     const QString fullFilePath(propagator()->fullLocalPath(_item->_file));


### PR DESCRIPTION
Fixes #9910

## Summary

`PropagateUploadFileV1::slotPutFinished()` marks an upload as finished based solely on the presence of an ETag in the server response, without verifying that the client actually dispatched the file's bytes. If the server returns an ETag but stored 0 bytes, the sync journal records the file as successfully uploaded and it is never retried.

`PropagateUploadFileNG` already handles this correctly via a `_sent` counter. This PR applies the same pattern to V1.

## Changes

- **`propagateupload.h`**: add `qint64 _sent = 0` member to `PropagateUploadFileV1` (mirrors `PropagateUploadFileNG::_sent`)
- **`propagateuploadv1.cpp`**: increment `_sent += currentChunkSize` in `startNextChunk()` after chunk size is resolved; change `_finished` condition from `etag.length() > 0` to `etag.length() > 0 && _sent == _fileToUpload._size`

## Behaviour after fix

When `_finished` stays false on the final chunk, the existing code path calls `done(SyncFileItem::NormalError, "The server did not acknowledge the last chunk. (No e-tag was present)")`, which properly queues the file for retry on the next sync.