### PR TITLE
fix(cfapi): avoid creation of db records if CfExecute failed 

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -1279,10 +1279,15 @@ void Account::listRemoteFolder(QPromise<OCC::PlaceholderCreateInfo> *promise, co
         }
 
         auto newEntry = RemoteInfo{};
+        newEntry.name = itemFileName;
+        newEntry.size = -1;
 
         LsColJob::propertyMapToRemoteInfo(properties,
                                           serverHasMountRootProperty() ? RemotePermissions::MountedPermissionAlgorithm::UseMountRootProperty : RemotePermissions::MountedPermissionAlgorithm::WildGuessMountedSubProperty,
                                           newEntry);
+        if (newEntry.isDirectory) {
+            newEntry.size = 0;
+        }
 
         promise->emplaceResult(itemFileName, itemFileName.toStdWString(), absoluteItemPathName, newEntry);
     });

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -550,8 +550,9 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(const QString &fi
         LsColJob::propertyMapToRemoteInfo(map,
                                           _account->serverHasMountRootProperty() ? RemotePermissions::MountedPermissionAlgorithm::UseMountRootProperty : RemotePermissions::MountedPermissionAlgorithm::WildGuessMountedSubProperty,
                                           result);
-        if (result.isDirectory)
+        if (result.isDirectory) {
             result.size = 0;
+        }
 
         _results.push_back(std::move(result));
     }

--- a/src/libsync/vfs/cfapi/cfapiwrapper.cpp
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.cpp
@@ -197,7 +197,15 @@ void cfApiSendPlaceholdersTransferInfo(const CF_CONNECTION_KEY &connectionKey,
 
     const qint64 cfExecuteresult = CfExecute(&opInfo, &opParams);
     if (cfExecuteresult != S_OK) {
-        qCCritical(lcCfApiWrapper) << "Couldn't send transfer info" << QString::number(transferKey.QuadPart, 16) << ":" << cfExecuteresult << QString::fromWCharArray(_com_error(cfExecuteresult).ErrorMessage());
+        qCCritical(lcCfApiWrapper).nospace() << "Couldn't send transfer info, consider placeholders to be invalid"
+            << " transferKey=" << QString::number(transferKey.QuadPart, 16)
+            << " cfExecuteresult=" << cfExecuteresult
+            << " errorMessage="<< QString::fromWCharArray(_com_error(cfExecuteresult).ErrorMessage());
+
+        for (auto &newEntry : newEntries) {
+            newEntry.creationStatus = OCC::VirtualItemCreationStatus::Error;
+        }
+        return;
     }
 
     for (auto virtualItemIndex = 0; virtualItemIndex < newEntries.size(); ++virtualItemIndex) {


### PR DESCRIPTION
when the call to CfExecute fails (e.g. due to "The cloud operation was canceled by user.") consider all new placeholders as invalid.
VfsCfApi::finalizeNewPlaceholders won't create a new metadata record for new, errored items which would cause random deletions in a future sync due to the combination of {db: exists, local: absent, remote: exists} => (placeholder) item was apparently removed locally; even though only the creation of the item failed ...

should help with #8983, #9858