### PR TITLE
fix(discovery): do not sync shares with "Allow download and sync" unset

### DIFF
--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -9,6 +9,7 @@
 #include "accountfwd.h"
 #include "capabilities.h"
 #include "clientsideencryptionjobs.h"
+#include "common/remotepermissions.h"
 #include "common/utility.h"
 #include "configfile.h"
 #include "cookiejar.h"
@@ -1287,6 +1288,11 @@ void Account::listRemoteFolder(QPromise<OCC::PlaceholderCreateInfo> *promise, co
                                           newEntry);
         if (newEntry.isDirectory) {
             newEntry.size = 0;
+        }
+
+        if (!newEntry.remotePerm.isNull() && !newEntry.remotePerm.hasPermission(RemotePermissions::CanRead)) {
+            qCWarning(lcAccount()) << "skip non-readable item" << absoluteItemPathName;
+            return;
         }
 
         promise->emplaceResult(itemFileName, itemFileName.toStdWString(), absoluteItemPathName, newEntry);

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -843,7 +843,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
             item->_direction = SyncFileItem::Down;
             item->_instruction = CSYNC_INSTRUCTION_SYNC;
             item->_type = ItemTypeVirtualFileDownload;
-        } else if (serverEntry.isValid() && !serverEntry.isDirectory && !serverEntry.remotePerm.isNull() && !serverEntry.remotePerm.hasPermission(RemotePermissions::CanRead)) {
+        } else if (serverEntry.isValid() && !serverEntry.remotePerm.isNull() && !serverEntry.remotePerm.hasPermission(RemotePermissions::CanRead)) {
             item->_instruction = CSYNC_INSTRUCTION_REMOVE;
             item->_direction = SyncFileItem::Down;
         } else if (dbEntry._etag != serverEntry.etag) {
@@ -938,7 +938,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
         return;
     }
 
-    if (serverEntry.isValid() && !serverEntry.isDirectory && !serverEntry.remotePerm.isNull() && !serverEntry.remotePerm.hasPermission(RemotePermissions::CanRead)) {
+    if (serverEntry.isValid() && !serverEntry.remotePerm.isNull() && !serverEntry.remotePerm.hasPermission(RemotePermissions::CanRead)) {
         item->_instruction = CSYNC_INSTRUCTION_IGNORE;
         emit _discoveryData->itemDiscovered(item);
 

--- a/test/testaccount.cpp
+++ b/test/testaccount.cpp
@@ -18,6 +18,7 @@
 #include "syncenginetestutils.h"
 
 using namespace OCC;
+using namespace Qt::StringLiterals;
 
 class TestAccount: public QObject
 {
@@ -108,9 +109,12 @@ private slots:
         QTest::newRow("root = /; requesting A/") << "" << "A/" << QStringList{ "A/a1", "A/a2", "A/sub1" };
         QTest::newRow("root = /; requesting A/sub1/") << "" << "A/sub1/" << QStringList{ "A/sub1/sub2" };
         QTest::newRow("root = /; requesting A/sub1/sub2") << "" << "A/sub1/sub2/" << QStringList{};
+        QTest::newRow("root = /; requesting A/sub_nodownload/") << "" << "A/sub_nodownload/" << QStringList{};
         QTest::newRow("root = /A; requesting A/") << "/A" << "A/" << QStringList{ "a1", "a2", "sub1" };
         QTest::newRow("root = /A; requesting A/sub1") << "/A" << "A/sub1/" << QStringList{ "sub1/sub2" };
         QTest::newRow("root = /A; requesting A/sub1/sub2") << "/A" << "A/sub1/sub2/" << QStringList{};
+        QTest::newRow("root = /A; requesting A/sub_nodownload/") << "/A" << "A/sub_nodownload/" << QStringList{};
+        QTest::newRow("root = /shared_nodownload; requesting shared_nodownload/") << "/shared_nodownload" << "shared_nodownload/" << QStringList{};
     }
 
     void testAccount_listRemoteFolder()
@@ -122,6 +126,26 @@ private slots:
         FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
         fakeFolder.remoteModifier().mkdir("A/sub1");
         fakeFolder.remoteModifier().mkdir("A/sub1/sub2");
+        fakeFolder.remoteModifier().mkdir("A/sub1/sub2");
+
+        // prepare shares that are not allowed to be downloaded
+        std::function<void(FileInfo &)> makeSharedNoDownload;
+        makeSharedNoDownload = [&makeSharedNoDownload](FileInfo &fileInfo) -> void {
+            fileInfo.isShared = true;
+            fileInfo.downloadForbidden = true;
+            for (auto &subItem : fileInfo.children) {
+                makeSharedNoDownload(subItem);
+            }
+        };
+        FileInfo sharedNoDownload { "shared_nodownload"_L1, { { "file1"_L1, 32 }, { "file2"_L1, 32 } } };
+        FileInfo sharedNoDownloadSub { "subdir"_L1, { { "file3"_L1, 32 }, { "file4"_L1, 32 } } };
+        FileInfo aSubSharedNoDownload { "sub_nodownload"_L1, { { "file4"_L1, 32 }, { "file5"_L1, 32 } } };
+        sharedNoDownload.children.insert(sharedNoDownloadSub.name, std::move(sharedNoDownloadSub));
+        makeSharedNoDownload(sharedNoDownload);
+        makeSharedNoDownload(aSubSharedNoDownload);
+        fakeFolder.remoteModifier().children.insert(sharedNoDownload.name, std::move(sharedNoDownload));
+        fakeFolder.remoteModifier().find("A")->children.insert(aSubSharedNoDownload.name, std::move(aSubSharedNoDownload));
+
         const auto account = fakeFolder.account();
 
         QEventLoop localEventLoop;

--- a/test/testpermissions.cpp
+++ b/test/testpermissions.cpp
@@ -876,11 +876,19 @@ private slots:
         });
 
         fakeFolder.remoteModifier().insert("file");
+        fakeFolder.remoteModifier().mkdir("folder");
+        fakeFolder.remoteModifier().insert("folder/file");
 
-        auto fileItem = fakeFolder.remoteModifier().find("file");
-        Q_ASSERT(fileItem);
-        fileItem->isShared = true;
-        fileItem->downloadForbidden = true;
+        const auto setDownloadForbiddenShare = [&fakeFolder](const QString &relativePath) -> void {
+            auto fileInfo = fakeFolder.remoteModifier().find(relativePath);
+            Q_ASSERT(fileInfo);
+            fileInfo->isShared = true;
+            fileInfo->downloadForbidden = true;
+        };
+
+        setDownloadForbiddenShare("file");
+        setDownloadForbiddenShare("folder");
+        setDownloadForbiddenShare("folder/file");
 
         // also hook into discovery!!
         SyncFileItemVector discovery;
@@ -890,6 +898,8 @@ private slots:
 
         QVERIFY(itemInstruction(completeSpy, "file", CSYNC_INSTRUCTION_IGNORE));
         QVERIFY(discoveryInstruction(discovery, "file", CSYNC_INSTRUCTION_IGNORE));
+        QVERIFY(itemInstruction(completeSpy, "folder", CSYNC_INSTRUCTION_IGNORE));
+        QVERIFY(discoveryInstruction(discovery, "folder", CSYNC_INSTRUCTION_IGNORE));
     }
 
     void testExistingFileBecomeForbiddenDownload()
@@ -898,9 +908,18 @@ private slots:
         QObject parent;
 
         fakeFolder.remoteModifier().insert("file");
-        auto fileInfo = fakeFolder.remoteModifier().find("file");
-        Q_ASSERT(fileInfo);
-        fileInfo->isShared = true;
+        fakeFolder.remoteModifier().mkdir("folder");
+        fakeFolder.remoteModifier().insert("folder/file");
+
+        const auto setShared = [&fakeFolder](const QString &relativePath) -> void {
+            auto fileInfo = fakeFolder.remoteModifier().find(relativePath);
+            Q_ASSERT(fileInfo);
+            fileInfo->isShared = true;
+        };
+
+        setShared("file");
+        setShared("folder");
+        setShared("folder/file");
 
         QVERIFY(fakeFolder.syncOnce());
 
@@ -914,10 +933,16 @@ private slots:
             return nullptr;
         });
 
-        auto fileItem = fakeFolder.remoteModifier().find("file", FileInfo::Invalidate);
-        Q_ASSERT(fileItem);
-        fileItem->isShared = true;
-        fileItem->downloadForbidden = true;
+        const auto setDownloadForbidden = [&fakeFolder](const QString &relativePath) -> void {
+            auto fileInfo = fakeFolder.remoteModifier().find(relativePath, FileInfo::Invalidate);
+            Q_ASSERT(fileInfo);
+            fileInfo->isShared = true;
+            fileInfo->downloadForbidden = true;
+        };
+
+        setDownloadForbidden("file");
+        setDownloadForbidden("folder");
+        setDownloadForbidden("folder/file");
 
         // also hook into discovery!!
         SyncFileItemVector discovery;
@@ -927,6 +952,10 @@ private slots:
 
         QVERIFY(itemInstruction(completeSpy, "file", CSYNC_INSTRUCTION_REMOVE));
         QVERIFY(discoveryInstruction(discovery, "file", CSYNC_INSTRUCTION_REMOVE));
+        QVERIFY(itemInstruction(completeSpy, "folder", CSYNC_INSTRUCTION_REMOVE));
+        QVERIFY(discoveryInstruction(discovery, "folder", CSYNC_INSTRUCTION_REMOVE));
+        QVERIFY(itemInstruction(completeSpy, "folder/file", CSYNC_INSTRUCTION_NONE));
+        QVERIFY(discoveryInstruction(discovery, "folder/file", CSYNC_INSTRUCTION_REMOVE));
     }
 
     void testChangingPermissionsWithoutEtagChange()


### PR DESCRIPTION
The option does not only apply to files, but also to folders.

Also: do not display shared items without that option in Windows on-demand folders

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
