### PR TITLE
Remove obsolete launch agent after installation

### DIFF
--- a/admin/osx/post_install.sh.cmake
+++ b/admin/osx/post_install.sh.cmake
@@ -14,4 +14,13 @@ if [ -x "$(command -v pluginkit)" ]; then
     pluginkit -e use -i @APPLICATION_REV_DOMAIN@.FinderSyncExt
 fi
 
+# Remove legacy LaunchAgent plist from all users if present, became obsolete with version 33.0.0
+dscl . -list /Users NFSHomeDirectory 2>/dev/null | awk '{print $2}' | while read -r USER_HOME; do
+    LAUNCH_AGENT_PLIST="$USER_HOME/Library/LaunchAgents/@APPLICATION_REV_DOMAIN@.plist"
+
+    if [ -f "$LAUNCH_AGENT_PLIST" ]; then
+        rm "$LAUNCH_AGENT_PLIST"
+    fi
+done
+
 exit 0


### PR DESCRIPTION
Affects #9929: Add post installation script step to delete the obsolete launch agent file to avoid multiple client instances.

I would like to verify this only afterwards with a daily build before closing #9929.