### PR TITLE
Fix File Provider Item Eviction

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
@@ -6,9 +6,7 @@ import PackageDescription
 let package = Package(
     name: "NextcloudFileProviderKit",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
-        .visionOS(.v1)
+        .macOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -21,6 +21,19 @@ public extension FilesDatabaseManager {
             .toUnmanagedResults()
     }
 
+    ///
+    /// Immediate children of a directory — i.e. items whose parent ``serverUrl``
+    /// equals the directory's full path. Unlike ``childItems(directoryMetadata:)``
+    /// this does not recurse into descendants.
+    ///
+    func immediateChildItems(directoryMetadata: SendableItemMetadata) -> [SendableItemMetadata] {
+        let directoryServerUrl = fullServerPathUrl(for: directoryMetadata)
+
+        return itemMetadatas
+            .where { $0.serverUrl == directoryServerUrl }
+            .toUnmanagedResults()
+    }
+
     func childItemCount(directoryMetadata: SendableItemMetadata) -> Int {
         let directoryServerUrl = fullServerPathUrl(for: directoryMetadata)
         return itemMetadatas

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+CustomActions.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+CustomActions.swift
@@ -46,17 +46,11 @@ extension FileProviderExtension: NSFileProviderCustomAction {
 
                 return Progress()
             case "com.nextcloud.desktopclient.FileProviderExt.KeepDownloadedAction":
-                return performKeepDownloadedAction(
-                    keepDownloaded: true,
-                    onItemsWithIdentifiers: itemIdentifiers,
-                    completionHandler: completionHandler
-                )
+                return performKeepDownloadedAction(keepDownloaded: true, onItemsWithIdentifiers: itemIdentifiers, completionHandler: completionHandler)
             case "com.nextcloud.desktopclient.FileProviderExt.AutoEvictAction":
-                return performKeepDownloadedAction(
-                    keepDownloaded: false,
-                    onItemsWithIdentifiers: itemIdentifiers,
-                    completionHandler: completionHandler
-                )
+                return performKeepDownloadedAction(keepDownloaded: false, onItemsWithIdentifiers: itemIdentifiers, completionHandler: completionHandler)
+            case "com.nextcloud.desktopclient.FileProviderExt.EvictAction":
+                return performEvictAction(onItemsWithIdentifiers: itemIdentifiers, completionHandler: completionHandler)
             default:
                 logger.error("Unsupported action: \(actionIdentifier.rawValue)")
                 completionHandler(NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
@@ -127,6 +121,79 @@ extension FileProviderExtension: NSFileProviderCustomAction {
                 completionHandler(error)
             }
         }
+        return progress
+    }
+
+    ///
+    /// Force the materialized payload of an item to be removed (made dataless), even when the item is pinned via "Always keep downloaded" (#9891).
+    ///
+    /// macOS refuses `evictItem` on items whose `contentPolicy` is`.downloadEagerlyAndKeepDownloaded`.
+    /// To honour the user's explicit "Remove download" gesture, we first clear the keep-downloaded flag — which flips `contentPolicy` back to `.inherited` and signals the framework — and then evict.
+    /// The unpin is propagated to descendants by `Item.set(keepDownloaded:domain:)` (matches `AutoEvictAction` semantics), so directories behave consistently with the pin counterpart.
+    ///
+    private func performEvictAction(onItemsWithIdentifiers itemIdentifiers: [NSFileProviderItemIdentifier], completionHandler: @Sendable @escaping ((any Error)?) -> Void) -> Progress {
+        guard let ncAccount else {
+            logger.error("Not removing downloads because account is not set up yet.")
+            completionHandler(NSFileProviderError(.notAuthenticated))
+            return Progress()
+        }
+
+        guard let dbManager else {
+            logger.error("Not removing downloads because database is unreachable.")
+            completionHandler(NSFileProviderError(.cannotSynchronize))
+            return Progress()
+        }
+
+        guard let manager else {
+            logger.error("Not removing downloads because file provider manager is not available.")
+            completionHandler(NSFileProviderError(.providerNotFound))
+            return Progress()
+        }
+
+        let progress = Progress()
+
+        if itemIdentifiers.isEmpty {
+            logger.info("No items to process for remove download action.")
+            completionHandler(nil)
+            return progress
+        }
+
+        progress.totalUnitCount = Int64(itemIdentifiers.count)
+
+        Task {
+            let localNcKit = self.ncKit
+            let localDomain = self.domain
+
+            do {
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    for identifier in itemIdentifiers {
+                        group.addTask {
+                            guard let item = await Item.storedItem(identifier: identifier, account: ncAccount, remoteInterface: localNcKit, dbManager: dbManager, log: self.log) else {
+                                throw NSError.fileProviderErrorForNonExistentItem(withIdentifier: identifier)
+                            }
+
+                            // Clear keep-downloaded so that contentPolicy changes from `.downloadEagerlyAndKeepDownloaded` back to `.inherited`. `set(keepDownloaded:)` awaits the framework's acknowledgement of the modification, so by the time it returns the policy refresh has propagated.
+                            if item.keepDownloaded {
+                                try await item.set(keepDownloaded: false, domain: localDomain)
+                            }
+
+                            try await manager.evictItem(identifier: identifier)
+                        }
+                    }
+
+                    for try await _ in group {
+                        progress.completedUnitCount += 1
+                    }
+                }
+
+                logger.info("All items successfully processed by evict action.")
+                completionHandler(nil)
+            } catch {
+                logger.error("Error during eviction: \(error.localizedDescription)")
+                completionHandler(error)
+            }
+        }
+
         return progress
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
@@ -28,15 +28,11 @@ public extension Item {
         _ = try dbManager.set(keepDownloaded: keepDownloaded, for: metadata)
 
         guard let manager = NSFileProviderManager(for: domain) else {
-            if #available(iOS 17.1, macOS 14.1, *) {
+            if #available(macOS 14.1, *) {
                 throw NSFileProviderError(.providerDomainNotFound)
             } else {
                 let providerDomainNotFoundErrorCode = -2013
-                throw NSError(
-                    domain: NSFileProviderErrorDomain,
-                    code: providerDomainNotFoundErrorCode,
-                    userInfo: [NSLocalizedDescriptionKey: "Failed to get manager for domain."]
-                )
+                throw NSError(domain: NSFileProviderErrorDomain, code: providerDomainNotFoundErrorCode, userInfo: [NSLocalizedDescriptionKey: "Failed to get manager for domain."])
             }
         }
 
@@ -53,13 +49,17 @@ public extension Item {
             try await enumerateSubtreeBreadthFirst(domain: domain)
         }
 
-        try await signalKeepDownloaded(
-            keepDownloaded: keepDownloaded,
-            identifier: itemIdentifier,
-            isDirectory: metadata.directory,
-            isDownloaded: isDownloaded,
-            manager: manager
-        )
+        try await signalKeepDownloaded(keepDownloaded: keepDownloaded, identifier: itemIdentifier, isDirectory: metadata.directory, isDownloaded: isDownloaded, manager: manager)
+
+        // When disabling, fragment the chain of pinned ancestors above this
+        // item so the unpin actually takes effect against
+        // `.downloadEagerlyAndKeepDownloaded` inheritance (#9891). Siblings at
+        // every level retain their pin via the flag already set on them by
+        // the original recursive enable; we only need to flip the path
+        // ancestors themselves to `.inherited`.
+        if !keepDownloaded {
+            try await fragmentPathToRoot(manager: manager)
+        }
 
         guard metadata.directory else { return }
 
@@ -103,20 +103,132 @@ public extension Item {
     /// already-downloaded files, and the disable path — just bump
     /// `lastUsedDate` so the framework re-evaluates eviction/pin state.
     ///
-    private func signalKeepDownloaded(
-        keepDownloaded: Bool,
-        identifier: NSFileProviderItemIdentifier,
-        isDirectory: Bool,
-        isDownloaded: Bool,
-        manager: NSFileProviderManager
-    ) async throws {
+    private func signalKeepDownloaded(keepDownloaded: Bool, identifier: NSFileProviderItemIdentifier, isDirectory: Bool, isDownloaded: Bool, manager: NSFileProviderManager) async throws {
         if keepDownloaded, !isDirectory, !isDownloaded {
             try await manager.requestDownloadForItem(withIdentifier: identifier)
         } else {
-            try await manager.requestModification(
-                of: [.lastUsedDate], forItemWithIdentifier: identifier
-            )
+            try await manager.requestModification(of: [.lastUsedDate], forItemWithIdentifier: identifier)
         }
+    }
+
+    ///
+    /// Walk the parent chain of this item, flipping every pinned ancestor's
+    /// keep-downloaded flag to `false` so its `contentPolicy` reverts from
+    /// `.downloadEagerlyAndKeepDownloaded` to `.inherited`.
+    ///
+    /// Why: the framework refuses `evictItem` on items whose effective
+    /// content policy is `.downloadEagerlyAndKeepDownloaded`, and that policy
+    /// inherits down the tree. Recursive "Always keep downloaded" sets the
+    /// strict policy on every ancestor; unpinning a deep descendant
+    /// in isolation leaves the descendant's `keepDownloaded == false` but its
+    /// effective policy unchanged because some ancestor still resolves to the
+    /// strict value. To actually free the descendant we have to cut the
+    /// ancestors out of the strict-pin chain. Siblings at each level retain
+    /// their pin via the flag already set on them by the original recursive
+    /// enable, so no sibling write is needed (#9891).
+    ///
+    /// The walk stops at the first ancestor that is not pinned; if no pinned
+    /// ancestor exists, this is a no-op (the unpin gesture targets the pin
+    /// root itself or there was no pin tree).
+    ///
+    private func fragmentPathToRoot(manager: NSFileProviderManager) async throws {
+        let outcome = fragmentPathToRootInDatabase()
+
+        // Cousins newly transitioned from `.inherited` (under a strict-pinned
+        // ancestor) to an explicit pin must be told to the framework so it
+        // refreshes their `contentPolicy` to `.downloadEagerlyAndKeepDownloaded`
+        // — otherwise the unpin of the path ancestors would silently take
+        // them down with the path.
+        for cousin in outcome.newlyPinnedCousins {
+            do {
+                try await signalKeepDownloaded(keepDownloaded: true, identifier: NSFileProviderItemIdentifier(cousin.ocId), isDirectory: cousin.directory, isDownloaded: cousin.downloaded, manager: manager)
+            } catch {
+                logger.error("Could not signal newly-pinned cousin during unpin-path fragmentation.", [.item: cousin.ocId, .name: cousin.fileName, .error: error])
+            }
+        }
+
+        // Apply ancestor flips top-down (pin root first). Order does not affect
+        // correctness — each ancestor is independent — but matches the
+        // conceptual order of "cut from the top of the strict-pin chain
+        // downward".
+        for ancestor in outcome.unpinnedAncestors.reversed() {
+            do {
+                try await signalKeepDownloaded(keepDownloaded: false, identifier: NSFileProviderItemIdentifier(ancestor.ocId), isDirectory: ancestor.directory, isDownloaded: ancestor.downloaded, manager: manager)
+            } catch {
+                logger.error("Could not signal fragmented ancestor unpin to framework.", [.item: ancestor.ocId, .name: ancestor.fileName, .error: error])
+            }
+        }
+    }
+
+    ///
+    /// Outcome of a database-only fragmentation walk.
+    ///
+    /// `unpinnedAncestors` are listed bottom-up (immediate parent first, pin
+    /// root last) — the order in which the walk discovered them. Callers that
+    /// signal the framework should emit the unpin events top-down to mirror
+    /// the conceptual "cut from the top of the strict-pin chain downward".
+    ///
+    internal struct FragmentationOutcome {
+        let unpinnedAncestors: [SendableItemMetadata]
+        let newlyPinnedCousins: [SendableItemMetadata]
+    }
+
+    ///
+    /// Database-only counterpart to ``fragmentPathToRoot(manager:)``.
+    /// Walks parents, pins every off-path immediate child ("cousin") that
+    /// isn't already pinned, then flips every pinned ancestor's flag to
+    /// `false`. The framework-side signaling is the caller's job.
+    ///
+    /// Why pin cousins explicitly instead of trusting the original recursive
+    /// enable: the recursive enable runs once at pin time and only sees
+    /// items the database knew about then. Items discovered later — e.g. a
+    /// new server-side sibling surfaced by enumeration — enter with
+    /// `keepDownloaded == false`. Without this explicit re-pin those cousins
+    /// would silently lose their pin when the path ancestors flip to
+    /// `.inherited` (#9891).
+    ///
+    /// Exposed at module scope so tests can verify the flag mutations
+    /// without needing a registered file provider domain.
+    ///
+    internal func fragmentPathToRootInDatabase() -> FragmentationOutcome {
+        // (ancestor, ocId of the child along the path) bottom-up.
+        var pinnedAncestorsAndPathChildren: [(ancestor: SendableItemMetadata, pathChildOcId: String)] = []
+        var cursor = metadata
+
+        while let parent = dbManager.parentDirectoryMetadataForItem(cursor) {
+            guard parent.keepDownloaded else {
+                break
+            }
+
+            pinnedAncestorsAndPathChildren.append((ancestor: parent, pathChildOcId: cursor.ocId))
+            cursor = parent
+        }
+
+        var newlyPinnedCousins: [SendableItemMetadata] = []
+
+        for (ancestor, pathChildOcId) in pinnedAncestorsAndPathChildren {
+            // Pin every immediate child of this ancestor except the one along
+            // the path. Cousins already flagged are skipped to avoid noisy
+            // DB writes (and noisy framework signals downstream).
+            for cousin in dbManager.immediateChildItems(directoryMetadata: ancestor) where cousin.ocId != pathChildOcId && !cousin.keepDownloaded {
+                do {
+                    _ = try dbManager.set(keepDownloaded: true, for: cousin)
+                    newlyPinnedCousins.append(cousin)
+                } catch {
+                    logger.error("Could not pin off-path sibling while fragmenting unpin path.", [.item: cousin.ocId, .name: cousin.fileName, .error: error])
+                }
+            }
+
+            // Then flip the ancestor itself.
+            do {
+                _ = try dbManager.set(keepDownloaded: false, for: ancestor)
+            } catch {
+                logger.error("Could not clear keep-downloaded on ancestor while fragmenting unpin path.", [.item: ancestor.ocId, .name: ancestor.fileName, .error: error])
+                continue
+            }
+        }
+
+        return FragmentationOutcome(unpinnedAncestors: pinnedAncestorsAndPathChildren.map(\.ancestor), newlyPinnedCousins: newlyPinnedCousins)
     }
 
     ///
@@ -153,20 +265,12 @@ public extension Item {
 
             if let readError, readError != .success {
                 if isTopLevel {
-                    logger.error(
-                        "Could not enumerate directory for keep-downloaded.",
-                        [.name: metadata.fileName, .url: remoteDirectoryPath, .error: readError]
-                    )
-                    throw readError.fileProviderError(
-                        handlingNoSuchItemErrorUsingItemIdentifier: itemIdentifier
-                    ) ?? NSFileProviderError(.cannotSynchronize)
+                    logger.error("Could not enumerate directory for keep-downloaded.", [.name: metadata.fileName, .url: remoteDirectoryPath, .error: readError])
+                    throw readError.fileProviderError(handlingNoSuchItemErrorUsingItemIdentifier: itemIdentifier) ?? NSFileProviderError(.cannotSynchronize)
                 } else {
                     // A single failing descendant must not abort the whole
                     // subtree — log and skip the rest of this branch.
-                    logger.error(
-                        "Could not enumerate descendant directory for keep-downloaded; skipping branch.",
-                        [.url: remoteDirectoryPath, .error: readError]
-                    )
+                    logger.error("Could not enumerate descendant directory for keep-downloaded; skipping branch.", [.url: remoteDirectoryPath, .error: readError])
                     isTopLevel = false
                     continue
                 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -41,12 +41,15 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             if permissions.contains("D") { // Deletable
                 capabilities.insert(.allowsDeleting)
             }
+
             if remoteSupportsTrash, !isLockFileName(filename) {
                 capabilities.insert(.allowsTrashing)
             }
+
             if permissions.contains("W"), !metadata.directory { // Updateable (file)
                 capabilities.insert(.allowsWriting)
             }
+
             if permissions.contains("NV") { // Updateable, renameable, moveable
                 capabilities.formUnion([.allowsRenaming, .allowsReparenting])
 
@@ -54,6 +57,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
                     capabilities.insert(.allowsAddingSubItems)
                 }
             }
+
             if permissions.contains("CK"), metadata.directory { // Folder not changeable but adding sub-files & -folders
                 capabilities.insert(.allowsWriting)
             }
@@ -199,6 +203,12 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
 
         userInfoDict["displayKeepDownloaded"] = !metadata.keepDownloaded
         userInfoDict["displayAllowAutoEvicting"] = metadata.keepDownloaded
+        // Restricted to non-pinned items so the action only appears once the
+        // framework has refreshed `contentPolicy` to `.inherited`. Both fields
+        // are read from the same `Item` returned by `item(for:)`, so they
+        // always agree — preventing the -2008 NonEvictable race that would
+        // otherwise occur if we tried to evict while `requestModification`'s
+        // unpin signal was still queued (#9891).
         userInfoDict["displayEvict"] = metadata.downloaded && !metadata.keepDownloaded
 
         // https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html
@@ -209,13 +219,10 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         return userInfoDict
     }
 
-    @available(macOS 13.0, iOS 16.0, visionOS 1.0, *)
     public var contentPolicy: NSFileProviderContentPolicy {
-        #if os(macOS)
-            if metadata.keepDownloaded {
-                return .downloadEagerlyAndKeepDownloaded // Unavailable in iOS.
-            }
-        #endif
+        if metadata.keepDownloaded {
+            return .downloadEagerlyAndKeepDownloaded
+        }
 
         return .inherited
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -952,4 +952,58 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         )
         XCTAssertEqual(itemB.contentPolicy, .inherited)
     }
+
+    ///
+    /// Verifies the per-item evictability signal that drives Finder's "Remove
+    /// Download" entry visibility (#9891).
+    ///
+    /// `.allowsEvicting` should appear only for items that are downloaded **and**
+    /// not pinned via "keep downloaded". Pinned items use the
+    /// `.downloadEagerlyAndKeepDownloaded` content policy, which the framework
+    /// refuses to evict — surfacing the capability would expose a Finder action
+    /// that always errors. Undownloaded items have nothing to evict.
+    ///
+    func testCapabilityAllowsEvictingMatchesDownloadAndPinState() {
+        // Undownloaded, unpinned: not evictable (no content to evict).
+        var undownloadedMetadata =
+            SendableItemMetadata(ocId: "u", fileName: "u.txt", account: Self.account)
+        undownloadedMetadata.permissions = "G"
+        let undownloadedItem = Item(
+            metadata: undownloadedMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        XCTAssertFalse(undownloadedItem.capabilities.contains(.allowsEvicting))
+
+        // Downloaded, unpinned: evictable.
+        var downloadedMetadata =
+            SendableItemMetadata(ocId: "d", fileName: "d.txt", account: Self.account)
+        downloadedMetadata.permissions = "G"
+        downloadedMetadata.downloaded = true
+        let downloadedItem = Item(
+            metadata: downloadedMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        XCTAssertTrue(downloadedItem.capabilities.contains(.allowsEvicting))
+
+        // Downloaded, pinned: not evictable (content policy refuses eviction).
+        var pinnedMetadata =
+            SendableItemMetadata(ocId: "p", fileName: "p.txt", account: Self.account)
+        pinnedMetadata.permissions = "G"
+        pinnedMetadata.downloaded = true
+        pinnedMetadata.keepDownloaded = true
+        let pinnedItem = Item(
+            metadata: pinnedMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        XCTAssertFalse(pinnedItem.capabilities.contains(.allowsEvicting))
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -217,6 +217,13 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         )
         XCTAssertTrue(canEvictPredicate.evaluate(with: fileproviderItems))
 
+        // Pinned items must NOT advertise the evict action. The framework
+        // would still report `contentPolicy == .downloadEagerlyAndKeepDownloaded`
+        // until its own refresh of the item lands, so a tight unpin-then-evict
+        // path races with -2008 NonEvictable. Gating on `!keepDownloaded`
+        // forces the user to clear the pin first; once the framework has
+        // re-fetched the item, both `displayEvict` and `contentPolicy` flip
+        // together (#9891).
         metadata.keepDownloaded = true
         let keepDownloadedItem = Item(
             metadata: metadata,
@@ -228,10 +235,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(keepDownloadedItem.userInfo?["displayEvict"])
 
         let fileproviderKeepDownloadedItems = ["fileproviderItems": [keepDownloadedItem]]
-        let cannotEvictPredicate = NSPredicate(
-            format: "SUBQUERY ( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo.displayEvict == true ).@count > 0"
-        )
-        XCTAssertFalse(cannotEvictPredicate.evaluate(with: fileproviderKeepDownloadedItems))
+        XCTAssertFalse(canEvictPredicate.evaluate(with: fileproviderKeepDownloadedItems))
     }
 
     func testItemUserInfoNoDisplayEvictState() {
@@ -299,6 +303,9 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         )
         XCTAssertEqual(itemC.userInfo?["displayKeepDownloaded"] as? Bool, false)
         XCTAssertEqual(itemC.userInfo?["displayAllowAutoEvicting"] as? Bool, true)
+        // Pinned + downloaded: NOT offered for "Remove download". The user must
+        // unpin first via "Allow automatic freeing up space"; once the
+        // framework refreshes the item, the evict entry appears (#9891).
         XCTAssertEqual(itemC.userInfo?["displayEvict"] as? Bool, false)
 
         var metadataD =
@@ -855,29 +862,27 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(item.capabilities, expected)
     }
 
-    #if os(macOS)
-        func testCapabilitiesMacOSExclusion() {
-            var metadata = SendableItemMetadata(
-                ocId: "macos-exclusion", fileName: "file.txt", account: Self.account
-            )
-            metadata.permissions = ""
-            let item = Item(
-                metadata: metadata,
-                parentItemIdentifier: .rootContainer,
-                account: Self.account,
-                remoteInterface: MockRemoteInterface(account: Self.account),
-                dbManager: Self.dbManager,
-                displayFileActions: false,
-                remoteSupportsTrash: true,
-                log: FileProviderLogMock()
-            )
+    func testCapabilitiesMacOSExclusion() {
+        var metadata = SendableItemMetadata(
+            ocId: "macos-exclusion", fileName: "file.txt", account: Self.account
+        )
+        metadata.permissions = ""
+        let item = Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager,
+            displayFileActions: false,
+            remoteSupportsTrash: true,
+            log: FileProviderLogMock()
+        )
 
-            XCTAssertTrue(
-                item.capabilities.contains(.allowsExcludingFromSync),
-                "Should allow excluding from sync on supported macOS versions."
-            )
-        }
-    #endif
+        XCTAssertTrue(
+            item.capabilities.contains(.allowsExcludingFromSync),
+            "Should allow excluding from sync on supported macOS versions."
+        )
+    }
 
     func testItemShared() {
         var sharedMetadata =
@@ -954,56 +959,79 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
     }
 
     ///
-    /// Verifies the per-item evictability signal that drives Finder's "Remove
-    /// Download" entry visibility (#9891).
+    /// Regression coverage for #9891: the "Remove download" custom action must
+    /// only be offered for items that are downloaded **and** not pinned via
+    /// "Always keep downloaded".
     ///
-    /// `.allowsEvicting` should appear only for items that are downloaded **and**
-    /// not pinned via "keep downloaded". Pinned items use the
-    /// `.downloadEagerlyAndKeepDownloaded` content policy, which the framework
-    /// refuses to evict — surfacing the capability would expose a Finder action
-    /// that always errors. Undownloaded items have nothing to evict.
+    /// Pinning is enforced by `contentPolicy == .downloadEagerlyAndKeepDownloaded`,
+    /// which the framework refuses to evict (-2008 `NonEvictable`).
+    /// `requestModification` cannot signal a `contentPolicy` field change
+    /// (`NSFileProviderItemFields` has no such case) and is queued
+    /// asynchronously — there is no synchronous way to invalidate the
+    /// framework's cached policy, so a tight unpin-then-evict path races. The
+    /// fix is to keep the entry hidden until the framework has refreshed the
+    /// item: both `displayEvict` and `contentPolicy` are read off the same
+    /// `Item` returned by `item(for:)` and therefore flip together. The user
+    /// flow is two-step: "Allow automatic freeing up space" → "Remove download".
     ///
-    func testCapabilityAllowsEvictingMatchesDownloadAndPinState() {
-        // Undownloaded, unpinned: not evictable (no content to evict).
-        var undownloadedMetadata =
-            SendableItemMetadata(ocId: "u", fileName: "u.txt", account: Self.account)
-        undownloadedMetadata.permissions = "G"
-        let undownloadedItem = Item(
-            metadata: undownloadedMetadata,
+    /// The action's activation rule in the file provider extension's
+    /// `Info.plist` is a `SUBQUERY` over `userInfo.displayEvict`, so this
+    /// asserts directly against the predicate Finder evaluates.
+    ///
+    func testItemUserInfoDisplayEvictGatedOnUnpinned() {
+        var pinnedDownloadedMetadata =
+            SendableItemMetadata(ocId: "pd", fileName: "pd.txt", account: Self.account)
+        pinnedDownloadedMetadata.downloaded = true
+        pinnedDownloadedMetadata.keepDownloaded = true
+        let pinnedDownloadedItem = Item(
+            metadata: pinnedDownloadedMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
             dbManager: Self.dbManager
         )
-        XCTAssertFalse(undownloadedItem.capabilities.contains(.allowsEvicting))
 
-        // Downloaded, unpinned: evictable.
-        var downloadedMetadata =
-            SendableItemMetadata(ocId: "d", fileName: "d.txt", account: Self.account)
-        downloadedMetadata.permissions = "G"
-        downloadedMetadata.downloaded = true
-        let downloadedItem = Item(
-            metadata: downloadedMetadata,
+        var unpinnedDownloadedMetadata =
+            SendableItemMetadata(ocId: "ud", fileName: "ud.txt", account: Self.account)
+        unpinnedDownloadedMetadata.downloaded = true
+        let unpinnedDownloadedItem = Item(
+            metadata: unpinnedDownloadedMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
             dbManager: Self.dbManager
         )
-        XCTAssertTrue(downloadedItem.capabilities.contains(.allowsEvicting))
 
-        // Downloaded, pinned: not evictable (content policy refuses eviction).
-        var pinnedMetadata =
-            SendableItemMetadata(ocId: "p", fileName: "p.txt", account: Self.account)
-        pinnedMetadata.permissions = "G"
-        pinnedMetadata.downloaded = true
-        pinnedMetadata.keepDownloaded = true
-        let pinnedItem = Item(
-            metadata: pinnedMetadata,
+        let onlyUnpinnedQualifiesPredicate = NSPredicate(
+            format: "SUBQUERY ( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo.displayEvict == true ).@count == 1"
+        )
+        XCTAssertTrue(
+            onlyUnpinnedQualifiesPredicate.evaluate(
+                with: ["fileproviderItems": [pinnedDownloadedItem, unpinnedDownloadedItem]]
+            ),
+            "Of pinned+downloaded and unpinned+downloaded, only the unpinned item must qualify for the evict action."
+        )
+
+        // Sanity: pinned but undownloaded — nothing to evict — also excluded.
+        var pinnedUndownloadedMetadata =
+            SendableItemMetadata(ocId: "pu", fileName: "pu.txt", account: Self.account)
+        pinnedUndownloadedMetadata.keepDownloaded = true
+        let pinnedUndownloadedItem = Item(
+            metadata: pinnedUndownloadedMetadata,
             parentItemIdentifier: .rootContainer,
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
             dbManager: Self.dbManager
         )
-        XCTAssertFalse(pinnedItem.capabilities.contains(.allowsEvicting))
+
+        let noEvictPredicate = NSPredicate(
+            format: "SUBQUERY ( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo.displayEvict == true ).@count == 0"
+        )
+        XCTAssertTrue(
+            noEvictPredicate.evaluate(
+                with: ["fileproviderItems": [pinnedUndownloadedItem]]
+            ),
+            "Pinned but undownloaded items have nothing to evict and must not qualify."
+        )
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/KeepDownloadedRecursiveTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/KeepDownloadedRecursiveTests.swift
@@ -193,6 +193,241 @@ final class KeepDownloadedRecursiveTests: NextcloudFileProviderKitTestCase {
         XCTAssertNil(unpinnedItem.decorations, "Unpinned items must not declare any badge, so Finder shows no overlay.")
     }
 
+    ///
+    /// Seed `seedTree`'s structure plus an additional sibling at each level
+    /// along the path to the deep file. After recursive pin and a fragmenting
+    /// unpin of the deep file, the path ancestors must lose `keepDownloaded`
+    /// and every off-path sibling must keep it (#9891).
+    ///
+    /// Tree shape:
+    ///     documents/                      (path ancestor — pin root)
+    ///       report.pdf                    (off-path sibling at level 0)
+    ///       nested/                       (path ancestor)
+    ///         note.txt                    (deep file — the unpin target)
+    ///         level-1-sibling.txt         (off-path sibling at level 1)
+    ///       documents-archive.zip         lives outside `documents/`; only
+    ///                                     here as a control to ensure the walk
+    ///                                     stops at the first non-pinned ancestor
+    ///                                     even when names share a prefix.
+    ///
+    func testFragmentDeepUnpinUnderRecursivePin() throws {
+        _ = try seedTree()
+
+        let levelOneSibling = RealmItemMetadata()
+        levelOneSibling.ocId = "level-1-sibling"
+        levelOneSibling.account = "TestAccount"
+        levelOneSibling.serverUrl = "https://cloud.example.com/files/documents/nested"
+        levelOneSibling.fileName = "level-1-sibling.txt"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write { realm.add(levelOneSibling) }
+
+        // Seed: pin the whole subtree (mirrors the recursive enable path).
+        let folderMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        _ = try Self.dbManager.set(keepDownloaded: true, for: folderMetadata)
+        for child in Self.dbManager.childItems(directoryMetadata: folderMetadata) {
+            _ = try Self.dbManager.set(keepDownloaded: true, for: child)
+        }
+
+        // Act: fragment the path from deep file up to the pin root.
+        let deepFileMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "deep-file"))
+        let deepFileItem = Item(
+            metadata: deepFileMetadata,
+            parentItemIdentifier: NSFileProviderItemIdentifier("subfolder-1"),
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        let outcome = deepFileItem.fragmentPathToRootInDatabase()
+
+        // The walk must touch both intermediate dir and root, immediate parent first.
+        XCTAssertEqual(outcome.unpinnedAncestors.map(\.ocId), ["subfolder-1", "folder-1"])
+        // Every cousin was already pinned by the recursive enable, so nothing
+        // newly transitioned from `.inherited` to strict.
+        XCTAssertTrue(outcome.newlyPinnedCousins.isEmpty)
+
+        // Path ancestors flipped to false.
+        for ocId in ["folder-1", "subfolder-1"] {
+            let stored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: ocId))
+            XCTAssertFalse(
+                stored.keepDownloaded,
+                "Path ancestor \(ocId) must be unpinned after fragmentation."
+            )
+        }
+
+        // Off-path siblings retain their pin (the recursive enable already set them).
+        for ocId in ["direct-child-file", "level-1-sibling"] {
+            let stored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: ocId))
+            XCTAssertTrue(
+                stored.keepDownloaded,
+                "Off-path sibling \(ocId) must remain pinned after fragmentation."
+            )
+        }
+
+        // The deep file itself was not touched by fragmentation (the caller —
+        // `Item.set(keepDownloaded:domain:)` — flips it before invoking the
+        // fragmentation walk). At this point it is still flagged as pinned in
+        // the DB, which we assert to pin down the contract: fragmentation
+        // operates only on ancestors.
+        let deepStored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "deep-file"))
+        XCTAssertTrue(
+            deepStored.keepDownloaded,
+            "fragmentPathToRootInDatabase must not touch the target item."
+        )
+    }
+
+    ///
+    /// Cousins enumerated *after* the original recursive enable arrive in the
+    /// database with `keepDownloaded == false` — the recursive walk has long
+    /// since finished and there is nobody to back-fill the flag for new
+    /// siblings. Without explicit cousin pinning, fragmenting an unpin path
+    /// would silently drop them out of the strict-pin chain when the path
+    /// ancestors flip to `.inherited` (#9891).
+    ///
+    /// The fragmentation walk must therefore set the flag on every off-path
+    /// immediate child it finds without it, signal those cousins back via
+    /// `newlyPinnedCousins`, and only then flip the path ancestor.
+    ///
+    func testFragmentPinsCousinsThatLackKeepDownloadedFlag() throws {
+        _ = try seedTree()
+
+        // An off-path sibling at the deepest level that was added to the DB
+        // *after* the original recursive pin and so missed it.
+        let lateCousin = RealmItemMetadata()
+        lateCousin.ocId = "late-cousin"
+        lateCousin.account = "TestAccount"
+        lateCousin.serverUrl = "https://cloud.example.com/files/documents/nested"
+        lateCousin.fileName = "late-cousin.txt"
+        // No keepDownloaded set — defaults to false.
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write { realm.add(lateCousin) }
+
+        // Original recursive enable: every then-known descendant gets flagged.
+        let folderMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        _ = try Self.dbManager.set(keepDownloaded: true, for: folderMetadata)
+        for child in Self.dbManager.childItems(directoryMetadata: folderMetadata) where child.ocId != "late-cousin" {
+            _ = try Self.dbManager.set(keepDownloaded: true, for: child)
+        }
+        // Sanity: the late cousin still has no flag.
+        XCTAssertFalse(try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "late-cousin")).keepDownloaded)
+
+        // Act: fragment from the deep file.
+        let deepFileMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "deep-file"))
+        let deepFileItem = Item(
+            metadata: deepFileMetadata,
+            parentItemIdentifier: NSFileProviderItemIdentifier("subfolder-1"),
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        let outcome = deepFileItem.fragmentPathToRootInDatabase()
+
+        // The late cousin must be reported as newly pinned and persisted with
+        // the flag set, so once the path ancestors flip to `.inherited` the
+        // OS still sees an explicit `.downloadEagerlyAndKeepDownloaded` here.
+        XCTAssertEqual(outcome.newlyPinnedCousins.map(\.ocId), ["late-cousin"])
+        XCTAssertTrue(try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "late-cousin")).keepDownloaded)
+
+        // The off-path sibling that was already pinned must not be re-reported.
+        XCTAssertFalse(
+            outcome.newlyPinnedCousins.map(\.ocId).contains("direct-child-file"),
+            "Cousins already flagged at fragmentation time must not be reported as newly pinned."
+        )
+        XCTAssertTrue(try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "direct-child-file")).keepDownloaded)
+    }
+
+    ///
+    /// Re-pinning the original pin root after fragmentation must collapse the
+    /// hole. The recursive enable in `Item.set(keepDownloaded:domain:)` does
+    /// this naturally — every descendant flag is overwritten to `true`.
+    ///
+    func testRePinAfterFragmentationCollapses() throws {
+        _ = try seedTree()
+
+        let folderMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        _ = try Self.dbManager.set(keepDownloaded: true, for: folderMetadata)
+        for child in Self.dbManager.childItems(directoryMetadata: folderMetadata) {
+            _ = try Self.dbManager.set(keepDownloaded: true, for: child)
+        }
+
+        // Fragment from the deep file.
+        let deepFileMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "deep-file"))
+        let deepFileItem = Item(
+            metadata: deepFileMetadata,
+            parentItemIdentifier: NSFileProviderItemIdentifier("subfolder-1"),
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        _ = deepFileItem.fragmentPathToRootInDatabase()
+        // Plus the deep file itself, as Item.set(keepDownloaded:domain:) would.
+        _ = try Self.dbManager.set(keepDownloaded: false, for: deepFileMetadata)
+
+        // Sanity: pin root and intermediate dir are now unpinned.
+        XCTAssertFalse(try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1")).keepDownloaded)
+        XCTAssertFalse(try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "subfolder-1")).keepDownloaded)
+
+        // Re-pin the root using the same pattern Item.set follows.
+        let refreshedFolder = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        _ = try Self.dbManager.set(keepDownloaded: true, for: refreshedFolder)
+        for child in Self.dbManager.childItems(directoryMetadata: refreshedFolder) {
+            _ = try Self.dbManager.set(keepDownloaded: true, for: child)
+        }
+
+        for ocId in ["folder-1", "direct-child-file", "subfolder-1", "deep-file"] {
+            let stored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: ocId))
+            XCTAssertTrue(
+                stored.keepDownloaded,
+                "\(ocId) must be pinned again after re-pinning the root."
+            )
+        }
+    }
+
+    ///
+    /// Unpinning the pin root directly must not produce any fragmentation —
+    /// there is no strict ancestor above it to cut. The walk returns an empty
+    /// list and no DB writes happen on parents.
+    ///
+    func testShallowUnpinIsNoFragmentation() throws {
+        _ = try seedTree()
+
+        let folderMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        _ = try Self.dbManager.set(keepDownloaded: true, for: folderMetadata)
+        for child in Self.dbManager.childItems(directoryMetadata: folderMetadata) {
+            _ = try Self.dbManager.set(keepDownloaded: true, for: child)
+        }
+
+        // Act: fragment from the pin root itself.
+        let pinnedFolder = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "folder-1"))
+        let folderItem = Item(
+            metadata: pinnedFolder,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager
+        )
+        let outcome = folderItem.fragmentPathToRootInDatabase()
+
+        XCTAssertTrue(
+            outcome.unpinnedAncestors.isEmpty,
+            "Fragmenting from the pin root must touch no ancestors — there is no strict ancestor."
+        )
+        XCTAssertTrue(
+            outcome.newlyPinnedCousins.isEmpty,
+            "Fragmenting from the pin root must not touch any cousins."
+        )
+
+        // Sanity: the root and every descendant are still pinned. The fragmentation
+        // walk does not touch the target item, and the recursive disable that
+        // `Item.set(keepDownloaded:domain:)` performs after fragmentation is what
+        // would clear them — and we have not invoked it here.
+        for ocId in ["folder-1", "direct-child-file", "subfolder-1", "deep-file"] {
+            let stored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: ocId))
+            XCTAssertTrue(stored.keepDownloaded)
+        }
+    }
+
     func testRecursivePropagationDoesNotLeakToSiblingsWithSimilarNames() throws {
         let folderMetadata = try seedTree()
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
@@ -55,6 +55,14 @@
 			</dict>
 			<dict>
 				<key>NSExtensionFileProviderActionActivationRule</key>
+				<string>SUBQUERY ( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo.displayEvict == true ).@count &gt; 0</string>
+				<key>NSExtensionFileProviderActionIdentifier</key>
+				<string>com.nextcloud.desktopclient.FileProviderExt.EvictAction</string>
+				<key>NSExtensionFileProviderActionName</key>
+				<string>Remove download</string>
+			</dict>
+			<dict>
+				<key>NSExtensionFileProviderActionActivationRule</key>
 				<string>SUBQUERY ( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo.displayFileActions == true ).@count &gt; 0</string>
 				<key>NSExtensionFileProviderActionIdentifier</key>
 				<string>com.nextcloud.desktopclient.FileProviderExt.FileActionsAction</string>

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
@@ -62,6 +62,10 @@
 				<string>File actions</string>
 			</dict>
 		</array>
+		<key>NSExtensionFileProviderAllowsContextualMenuDownloadEntry</key>
+		<false/>
+		<key>NSExtensionFileProviderAllowsUserControlledEviction</key>
+		<false/>
 		<key>NSExtensionFileProviderDocumentGroup</key>
 		<string>$(DEVELOPMENT_TEAM).$(OC_APPLICATION_REV_DOMAIN)</string>
 		<key>NSExtensionFileProviderSupportsEnumeration</key>


### PR DESCRIPTION
**Fixes #9891 and #9757.**

- Suppress Finder's own context menu item to evict file provider items because it collides with the item's content policy of being kept available offline, causing the file provider framework-level bug described in #9891.
- Added custom action to evict materialized items.
- Restrict custom evict action to items not marked to be kept offline because otherwise it will result in the same problem described in #9891. macOS needs to learn about the updated content policy first. That happens asynchronously and poses a race condition. Hence this two step process ensures the Finder bug is avoided.
- Reporting the default content policy of `.inherit` instead of `. downloadEagerlyAndKeepDownloaded ` would sabotage the reliable retention of materialized items. Hence that must be preserved.