### PR TITLE
perf(gui): remove full-window OpacityMask compositing from tray

### DIFF
--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -108,20 +108,6 @@ ApplicationWindow {
         }
     }
 
-    OpacityMask {
-        anchors.fill: parent
-        anchors.margins: Style.trayWindowBorderWidth
-        source: ShaderEffectSource {
-            sourceItem: trayWindowMainItem
-            hideSource: true
-        }
-        maskSource: Rectangle {
-            width: trayWindow.width
-            height: trayWindow.height
-            radius: Systray.useNormalWindow ? 0.0 : Style.trayWindowRadius
-        }
-    }
-
     Drawer {
         id: userStatusDrawer
         width: parent.width


### PR DESCRIPTION
## Summary

The tray window was being rendered to an off-screen texture and composited through a `Qt5Compat.GraphicalEffects.OpacityMask` on every frame just to achieve rounded corners.

This is unnecessary because `trayWindowMainItem` already has `clip: true` and `radius` set, which handles corner rounding directly without the GPU overhead of a full `ShaderEffectSource` pass.

Removing the OpacityMask layer eliminates a per-frame full-window texture pass, which is particularly beneficial on integrated GPUs and when the tray is animating.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (visual output is unchanged — corners still rounded by clip + radius).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
