### PR TITLE
perf(logging): reduce logging overhead in hot paths

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1823,7 +1823,7 @@ void User::slotQuotaChanged(const int64_t &usedBytes, const int64_t &availableBy
 
     const auto percent = (double)usedBytes / (double)total * 100.0;
     const auto percentInt = qMin(qRound(percent), 100);
-    qCDebug(lcActivity) << tr("Quota is updated; %1 percent of the total space is used.").arg(QString::number(percentInt));
+    qCDebug(lcActivity) << "Quota updated:" << percentInt << "% used";
 
     int thresholdPassed = 0;
     if (_lastQuotaPercent < 80 && percentInt >= 80) {

--- a/src/libsync/basepropagateremotedeleteencrypted.cpp
+++ b/src/libsync/basepropagateremotedeleteencrypted.cpp
@@ -12,7 +12,7 @@
 #include "deletejob.h"
 #include "owncloudpropagator.h"
 
-Q_LOGGING_CATEGORY(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED, "nextcloud.sync.propagator.remove.encrypted")
+Q_LOGGING_CATEGORY(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED, "nextcloud.sync.propagator.remove.encrypted", QtInfoMsg)
 
 namespace OCC {
 

--- a/src/libsync/propagateremotedeleteencrypted.cpp
+++ b/src/libsync/propagateremotedeleteencrypted.cpp
@@ -13,7 +13,7 @@
 
 using namespace OCC;
 
-Q_LOGGING_CATEGORY(PROPAGATE_REMOVE_ENCRYPTED, "nextcloud.sync.propagator.remove.encrypted")
+Q_LOGGING_CATEGORY(PROPAGATE_REMOVE_ENCRYPTED, "nextcloud.sync.propagator.remove.encrypted", QtInfoMsg)
 
 PropagateRemoteDeleteEncrypted::PropagateRemoteDeleteEncrypted(OwncloudPropagator *propagator, SyncFileItemPtr item, QObject *parent)
     : BasePropagateRemoteDeleteEncrypted(propagator, item, parent)

--- a/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
+++ b/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
@@ -31,7 +31,7 @@ namespace {
 
 using namespace OCC;
 
-Q_LOGGING_CATEGORY(PROPAGATE_REMOVE_ENCRYPTED_ROOTFOLDER, "nextcloud.sync.propagator.remove.encrypted.rootfolder")
+Q_LOGGING_CATEGORY(PROPAGATE_REMOVE_ENCRYPTED_ROOTFOLDER, "nextcloud.sync.propagator.remove.encrypted.rootfolder", QtInfoMsg)
 
 PropagateRemoteDeleteEncryptedRootFolder::PropagateRemoteDeleteEncryptedRootFolder(OwncloudPropagator *propagator, SyncFileItemPtr item, QObject *parent)
     : BasePropagateRemoteDeleteEncrypted(propagator, item, parent)


### PR DESCRIPTION
## Summary

Reduces logging overhead in several frequently-hit code paths:

- **`PUTFileJob::start()`**: removes a dead debug lambda that constructed a temporary `QLoggingCategory` on every upload progress tick. The progress signal is already connected to the proper handler on the next line, so the lambda was a no-op that ran on every chunk.
- **`SyncJournalDb::setFileRecord`**: downgrades the 28-field log line from `qCInfo` to `qCDebug` so it no longer fires in production on every file record update. With large syncs this generates a substantial amount of log spam at info level.
- **`Q_LOGGING_CATEGORY` defaults**: adds `QtInfoMsg` default to three category declarations that were missing it, preventing debug-level output from being active by default in those modules.
- **`usermodel.cpp` quota update**: removes `tr()` and `QString::number()` allocations from a `qCDebug` call that runs on every quota refresh, even when debug logging is not enabled.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
