### PR TITLE
perf(discovery): reduce per-file allocations in discovery phase

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -303,9 +303,10 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const Entries &ent
     }
 
     const auto &localName = entries.localEntry.name;
-    const auto splitName = localName.split('.');
-    const auto &baseName = splitName.first();
-    const auto extension = splitName.size() > 1 ? splitName.last() : QString();
+    const auto firstDotIndex = localName.indexOf(QLatin1Char('.'));
+    const auto lastDotIndex = localName.lastIndexOf(QLatin1Char('.'));
+    const auto baseName = firstDotIndex >= 0 ? QStringView(localName).left(firstDotIndex) : QStringView(localName);
+    const auto extension = lastDotIndex >= 0 ? QStringView(localName).mid(lastDotIndex + 1) : QStringView();
     const auto accountCaps = _discoveryData->_account->capabilities();
     const auto forbiddenFilenames = accountCaps.forbiddenFilenames();
     const auto forbiddenBasenames = accountCaps.forbiddenFilenameBasenames();


### PR DESCRIPTION
## Summary

Two micro-optimizations to the discovery hot path that fire once per file/directory in a sync. With large folder trees these allocations add up to noticeable GC and heap churn.

### Changes

- **Filename parsing**: `QString::split('.')` allocates a `QList<QString>` plus copies for each segment, just to recover the basename and extension. Replaced with `indexOf` / `lastIndexOf` to find the cut points directly.
- **Zero-copy slices**: the basename and extension are then taken as `QStringView` slices into the original `QString` rather than allocating new owned `QString` copies. The downstream forbidden-filename / forbidden-basename / forbidden-extension comparisons all compare against `QStringView`-compatible data, so no copies are needed.

Behavior is unchanged — same parsing results.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
