### PR TITLE
perf(sync): remove 3ms scheduling delay between propagation jobs

### DIFF
--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -892,7 +892,7 @@ void OwncloudPropagator::scheduleNextJob()
 {
     if (_jobScheduled) return; // don't schedule more than 1
     _jobScheduled = true;
-    QTimer::singleShot(3, this, &OwncloudPropagator::scheduleNextJobImpl);
+    QMetaObject::invokeMethod(this, &OwncloudPropagator::scheduleNextJobImpl, Qt::QueuedConnection);
 }
 
 void OwncloudPropagator::scheduleNextJobImpl()


### PR DESCRIPTION
## Summary

### `scheduleNextJob` 3ms timer

`OwncloudPropagator::scheduleNextJob` schedules the next call via `QTimer::singleShot(3, ...)`. The 3ms delay was originally there to debounce re-entry, but the `_jobScheduled` flag at the top of the function already prevents that — once set, repeat calls return immediately.

Replaced with `QMetaObject::invokeMethod(Qt::QueuedConnection)` which posts to the event loop with no artificial delay.

With 10,000 small files this delay accumulates to roughly 30 seconds of scheduling latency that is pure idle time on the event loop. On a sync of many tiny files this is the dominant cost of the propagator.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
