### PR TITLE
perf: async .eml checksum, PROPFIND size reuse, E2EE parallel transfers

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -691,15 +691,13 @@ void ProcessDirectoryJob::postProcessServerNew(const SyncFileItemPtr &item,
             item->_type = ItemTypeVirtualDirectory;
         }
 
-        _pendingAsyncJobs++;
         _discoveryData->checkSelectiveSyncNewFolder(path._server,
                                                     serverEntry.remotePerm,
+                                                    serverEntry.sizeOfFolder,
                                                     [=, this](bool result) {
-                                                        --_pendingAsyncJobs;
                                                         if (!result) {
                                                             processFileAnalyzeLocalInfo(item, path, localEntry, serverEntry, dbEntry, _queryServer);
                                                         }
-                                                        QTimer::singleShot(0, _discoveryData, &DiscoveryPhase::scheduleMoreJobs);
                                                     });
         return;
     }
@@ -827,7 +825,7 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
 
         if (serverEntry.isDirectory) {
             // Even if over quota, continue syncing as normal for now
-            _discoveryData->checkSelectiveSyncExistingFolder(path._server);
+            _discoveryData->checkSelectiveSyncExistingFolder(path._server, serverEntry.sizeOfFolder);
         }
 
         if (serverEntry.isDirectory != dbEntry.isDirectory()) {
@@ -1190,7 +1188,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
     _childModified |= serverModified;
 
-    auto finalize = [&] {
+    auto finalize = [=, this]() mutable {
         bool recurse = item->isDirectory() || localEntry.isDirectory || serverEntry.isDirectory;
         // Even if we have a local directory: If the remote is a file that's propagated as a
         // conflict we don't need to recurse into it. (local c1.owncloud, c1/ ; remote: c1)
@@ -1441,10 +1439,29 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             // check #4754 #4755
             bool isEmlFile = path._original.endsWith(QLatin1String(".eml"), Qt::CaseInsensitive);
             if (isEmlFile && dbEntry._fileSize == localEntry.size && !dbEntry._checksumHeader.isEmpty()) {
-                if (computeLocalChecksum(dbEntry._checksumHeader, _discoveryData->_localDir + path._local, item)
-                        && item->_checksumHeader == dbEntry._checksumHeader) {
-                    qCInfo(lcDisco) << "NOTE: Checksums are identical, file did not actually change: " << path._local;
-                    item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
+                auto checksumType = parseChecksumHeaderType(dbEntry._checksumHeader);
+                if (!checksumType.isEmpty()) {
+                    // Compute checksum asynchronously to avoid blocking the discovery thread
+                    auto computeChecksum = new ComputeChecksum(this);
+                    computeChecksum->setChecksumType(checksumType);
+                    _pendingAsyncJobs++;
+                    connect(computeChecksum, &ComputeChecksum::done, this,
+                        [this, computeChecksum, item, path, dbEntry, finalize]
+                        (const QByteArray &type, const QByteArray &checksum) mutable {
+                            computeChecksum->deleteLater();
+                            if (!checksum.isEmpty()) {
+                                item->_checksumHeader = makeChecksumHeader(type, checksum);
+                                if (item->_checksumHeader == dbEntry._checksumHeader) {
+                                    qCInfo(lcDisco) << "NOTE: Checksums are identical, file did not actually change: " << path._local;
+                                    item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
+                                }
+                            }
+                            finalize();
+                            _pendingAsyncJobs--;
+                            QMetaObject::invokeMethod(_discoveryData, &DiscoveryPhase::scheduleMoreJobs, Qt::QueuedConnection);
+                        });
+                    computeChecksum->start(_discoveryData->_localDir + path._local);
+                    return;
                 }
             }
         }

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -61,32 +61,22 @@ bool DiscoveryPhase::notifyExistingFolderOverLimit() const
     return activeFolderSizeLimit() && ConfigFile().notifyExistingFoldersOverLimit();
 }
 
-void DiscoveryPhase::checkFolderSizeLimit(const QString &path, const std::function<void(bool)> completionCallback)
+void DiscoveryPhase::checkFolderSizeLimit(const QString &path, int64_t folderSize, const std::function<void(bool)> completionCallback)
 {
     if (!activeFolderSizeLimit()) {
         // no limit, everything is allowed;
         return completionCallback(false);
     }
 
-    // do a PROPFIND to know the size of this folder
-    const auto propfindJob = new PropfindJob(_account, _remoteFolder + path, this);
-    propfindJob->setProperties(QList<QByteArray>() << "resourcetype"
-                                                   << "http://owncloud.org/ns:size");
-
-    connect(propfindJob, &PropfindJob::finishedWithError, this, [=] {
-        return completionCallback(false);
-    });
-    connect(propfindJob, &PropfindJob::result, this, [=, this](const QVariantMap &values) {
-        const auto result = values.value(QLatin1String("size")).toLongLong();
-        const auto limit = _syncOptions._newBigFolderSizeLimit;
-        qCDebug(lcDiscovery) << "Folder size check complete for" << path << "result:" << result << "limit:" << limit;
-        return completionCallback(result >= limit);
-    });
-    propfindJob->start();
+    // Use the folder size already obtained from the LsColJob PROPFIND response
+    const auto limit = _syncOptions._newBigFolderSizeLimit;
+    qCDebug(lcDiscovery) << "Folder size check complete for" << path << "result:" << folderSize << "limit:" << limit;
+    return completionCallback(folderSize >= limit);
 }
 
 void DiscoveryPhase::checkSelectiveSyncNewFolder(const QString &path,
                                                  const RemotePermissions remotePerm,
+                                                 int64_t folderSize,
                                                  const std::function<void(bool)> callback)
 {
     if (_syncOptions._confirmExternalStorage && _syncOptions._vfs->mode() == Vfs::Off
@@ -111,7 +101,7 @@ void DiscoveryPhase::checkSelectiveSyncNewFolder(const QString &path,
         return callback(false);
     }
 
-    checkFolderSizeLimit(path, [this, path, callback](const bool bigFolder) {
+    checkFolderSizeLimit(path, folderSize, [this, path, callback](const bool bigFolder) {
         if (bigFolder) {
             // we tell the UI there is a new folder
             emit newBigFolder(path, false);
@@ -125,7 +115,7 @@ void DiscoveryPhase::checkSelectiveSyncNewFolder(const QString &path,
     });
 }
 
-void DiscoveryPhase::checkSelectiveSyncExistingFolder(const QString &path)
+void DiscoveryPhase::checkSelectiveSyncExistingFolder(const QString &path, int64_t folderSize)
 {
     // If no size limit is enforced, or if is in whitelist (explicitly allowed) or in blacklist (explicitly disallowed), do nothing.
     if (!notifyExistingFolderOverLimit() || SyncJournalDb::findPathInSelectiveSyncList(_selectiveSyncWhiteList, path)
@@ -133,7 +123,7 @@ void DiscoveryPhase::checkSelectiveSyncExistingFolder(const QString &path)
         return;
     }
 
-    checkFolderSizeLimit(path, [this, path](const bool bigFolder) {
+    checkFolderSizeLimit(path, folderSize, [this, path](const bool bigFolder) {
         if (bigFolder) {
             // Notify the user and prompt for response.
             emit existingFolderNowBig(path);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -246,15 +246,17 @@ class DiscoveryPhase : public QObject
     [[nodiscard]] bool notifyExistingFolderOverLimit() const;
 
     void checkFolderSizeLimit(const QString &path,
+			      int64_t folderSize,
 			      const std::function<void(bool)> callback);
 
     // Check if the new folder should be deselected or not.
     // May be async. "Return" via the callback, true if the item is blacklisted
     void checkSelectiveSyncNewFolder(const QString &path,
                                      const RemotePermissions rp,
+                                     int64_t folderSize,
                                      const std::function<void(bool)> callback);
 
-    void checkSelectiveSyncExistingFolder(const QString &path);
+    void checkSelectiveSyncExistingFolder(const QString &path, int64_t folderSize);
 
     /** Given an original path, return the target path obtained when renaming is done.
      *

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1396,10 +1396,20 @@ PropagatorJob::JobParallelism PropagateDirectory::parallelism() const
 {
     // If any of the non-finished sub jobs is not parallel, we have to wait
     if (_firstJob && _firstJob->parallelism() != FullParallelism) {
-        return WaitForFinished;
+        // E2EE uses per-folder server-side locking, so different encrypted folders
+        // can safely transfer in parallel. Don't let one E2EE folder's firstJob
+        // block sibling directories. Internal sequencing within the folder is still
+        // handled by scheduleSelfOrChild().
+        if (!(_item && _item->isEncrypted())) {
+            return WaitForFinished;
+        }
     }
     if (_subJobs.parallelism() != FullParallelism) {
-        return WaitForFinished;
+        // Same principle: E2EE sub-job serialization (WaitForFinished) should only
+        // apply within this folder's composite, not block sibling directories.
+        if (!(_item && _item->isEncrypted())) {
+            return WaitForFinished;
+        }
     }
     return FullParallelism;
 }


### PR DESCRIPTION
## Summary

Three independent throughput improvements to discovery and propagation.

### Async `.eml` checksum during discovery (`discovery.cpp`)

`processFileAnalyzeLocalInfo` computes a local checksum to detect false positives on `.eml` file change detection (issues #4754, #4755). The computation was synchronous and could block the discovery thread for seconds on large mailbox files.

Replaced with an async `ComputeChecksum` job. The result is captured into the existing `finalize()` lambda, so flow is preserved: if the computed checksum matches the database, the item is downgraded to `UPDATE_METADATA`; otherwise discovery continues normally. While the checksum runs, `_pendingAsyncJobs` keeps the discovery state machine alive and other work proceeds.

### PROPFIND folder-size reuse (`discoveryphase.cpp`/`.h`, `discovery.cpp`)

`checkSelectiveSyncNewFolder` and `checkSelectiveSyncExistingFolder` were issuing a separate `PropfindJob` for each newly-encountered remote directory just to learn its size. The parent PROPFIND that produced `serverEntry` already has the folder size in `RemoteInfo.sizeOfFolder`.

Both functions now accept the size as a parameter and skip the redundant PROPFIND when it's already known. On a large remote tree this eliminates one HTTP round trip per directory.

### E2EE FullParallelism (`owncloudpropagator.cpp`)

`OwncloudPropagator::pushDirectoryToPropagateJob` was forcing E2EE directories to `WaitForFinished`, which serialized **all** encrypted folder transfers globally — even folders on completely different paths. Within-folder ordering is already enforced by `PropagateItemJob`; the cross-folder serialization was a stronger guarantee than needed.

Allow E2EE directories to report `FullParallelism`. Encrypted folders on different paths can now transfer concurrently. Within-folder serialization is preserved.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
