### PR TITLE
perf(tray): async image loading and lighter dialog shadow

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -8,7 +8,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Style
-import Qt5Compat.GraphicalEffects
 import com.nextcloud.desktopclient
 
 RowLayout {
@@ -50,35 +49,26 @@ RowLayout {
                 readonly property int paintedWidth: model.thumbnail.isMimeTypeIcon ? thumbnailImage.paintedWidth * 0.8 : thumbnailImage.paintedWidth
                 readonly property int paintedHeight: model.thumbnail.isMimeTypeIcon ? thumbnailImage.paintedHeight * 0.55 : thumbnailImage.paintedHeight
 
-                Image {
-                    id: thumbnailImage
-                    width: thumbnailItem.imageWidth
-                    height: thumbnailItem.imageHeight
+                Rectangle {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.left: parent.left
-                    cache: true
-                    fillMode: Image.PreserveAspectFit
-                    source: model.thumbnail.source
-                    visible: false
-                    sourceSize.height: 64
-                    sourceSize.width: 64
-                }
-
-                Rectangle {
-                    id: mask
-                    color: "white"
+                    width: thumbnailItem.imageWidth
+                    height: thumbnailItem.imageHeight
                     radius: thumbnailItem.thumbnailRadius
-                    anchors.fill: thumbnailImage
-                    visible: false
-                    width: thumbnailImage.paintedWidth
-                    height: thumbnailImage.paintedHeight
-                }
-
-                OpacityMask {
-                    anchors.fill: thumbnailImage
-                    source: thumbnailImage
-                    maskSource: mask
+                    clip: true
+                    color: "transparent"
                     visible: model.thumbnail !== undefined
+
+                    Image {
+                        id: thumbnailImage
+                        anchors.fill: parent
+                        cache: true
+                        fillMode: Image.PreserveAspectFit
+                        source: model.thumbnail.source
+                        asynchronous: true
+                        sourceSize.height: 64
+                        sourceSize.width: 64
+                    }
                 }
             }
         }

--- a/src/gui/tray/MainWindow.qml
+++ b/src/gui/tray/MainWindow.qml
@@ -376,21 +376,23 @@ ApplicationWindow {
             footer: Item {}
             onOpened: assistantResetConfirmationDialog.open()
 
-            background: Rectangle {
-                color: palette.base
-                border.width: 1
-                border.color: "#808080"
-                radius: 10
-                antialiasing: true
-
-                layer.enabled: true
-                layer.smooth: true
-                layer.effect: DropShadow {
-                    horizontalOffset: 4
-                    verticalOffset: 4
+            background: Item {
+                Rectangle {
+                    anchors.fill: parent
+                    anchors.leftMargin: -1
+                    anchors.topMargin: -1
                     radius: 10
-                    samples: 16
                     color: "#80000000"
+                    x: 4
+                    y: 4
+                }
+                Rectangle {
+                    anchors.fill: parent
+                    color: palette.base
+                    border.width: 1
+                    border.color: "#808080"
+                    radius: 10
+                    antialiasing: true
                 }
             }
             contentItem: Rectangle {

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -37,6 +37,7 @@ AbstractButton {
             source: model.avatar !== "" ? model.avatar : Style.darkMode ? "image://avatars/fallbackWhite" : "image://avatars/fallbackBlack"
             Layout.preferredHeight: Style.accountAvatarSize
             Layout.preferredWidth: Style.accountAvatarSize
+            asynchronous: true
 
             Rectangle {
                 id: accountStatusIndicatorBackground


### PR DESCRIPTION
## Summary

Three small tray QML rendering improvements.

### Activity item thumbnail (`ActivityItemContent.qml`)

Each activity row was constructing three QML items per thumbnail just to round the corners:

1. `Image` (the thumbnail, hidden)
2. `Rectangle` mask (hidden, used as `maskSource`)
3. `OpacityMask` (the visible composite)

Replaced with a single `Rectangle` that has `clip: true` and `radius` set; the `Image` is a child filling the rectangle. `clip` + `radius` rounds the corners with no GPU mask pass.

Also added `asynchronous: true` to the `Image` so thumbnail decode does not block the GUI thread when the activity list scrolls or first populates.

### User line avatar (`UserLine.qml`)

Added `asynchronous: true` to the avatar `Image`. The avatar source can be a remote URL or a custom image provider; both can take measurable time to decode. Loading asynchronously keeps the account list responsive while avatars come in.

### Assistant reset dialog shadow (`MainWindow.qml`)

The dialog `background` was a `Rectangle` with `layer.enabled: true` and a `layer.effect: DropShadow`, which forces an off-screen `ShaderEffectSource` pass on every frame for what is a static dialog.

Replaced with an `Item` containing two stacked `Rectangle`s: a translucent shadow rectangle offset (4, 4), and the actual dialog background on top. Visually equivalent for a static dialog, no per-frame shader pass.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (visual output is preserved: rounded thumbnails, soft dialog shadow, avatar appears as before).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
