### PR TITLE
fix(libsync): folder move or rename data loss.

### DIFF
--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -302,30 +302,31 @@ void PropagateRemoteMove::finalize()
     }
 
     if (_item->isDirectory()) {
+        QVector<SyncJournalFileRecord> childRecords;
         const auto dbQueryResult = propagator()->_journal->getFilesBelowPath(
-            _item->_originalFile.toUtf8(), [this](const SyncJournalFileRecord &record) {
-                const auto oldPath = QString::fromUtf8(record._path);
-                auto newPath = oldPath;
-                newPath.replace(0, _item->_originalFile.length(), _item->_renameTarget);
-
-                if (oldPath == newPath) {
-                    return;
-                }
-
-                if (!propagator()->_journal->deleteFileRecord(oldPath)) {
-                    qCWarning(lcPropagateRemoteMove) << "could not delete child record" << oldPath;
-                    return;
-                }
-
-                const auto newItem = SyncFileItem::fromSyncJournalFileRecord(record);
-                newItem->_file = newPath;
-                newItem->_lockToken.clear();
-                newItem->_locked = SyncFileItem::LockStatus::UnlockedItem;
-                propagator()->updateMetadata(*newItem);
+            _item->_originalFile.toUtf8(), [&childRecords](const SyncJournalFileRecord &record) {
+                childRecords.append(record);
             });
         if (!dbQueryResult) {
             done(SyncFileItem::FatalError, tr("Failed to propagate directory rename in hierarchy"), ErrorCategory::GenericError);
             return;
+        }
+        for (const auto &record : std::as_const(childRecords)) {
+            const auto oldPath = QString::fromUtf8(record._path);
+            auto newPath = oldPath;
+            newPath.replace(0, _item->_originalFile.length(), _item->_renameTarget);
+            if (oldPath == newPath) {
+                continue;
+            }
+            if (!propagator()->_journal->deleteFileRecord(oldPath)) {
+                qCWarning(lcPropagateRemoteMove) << "could not delete child record" << oldPath;
+                continue;
+            }
+            const auto childItem = SyncFileItem::fromSyncJournalFileRecord(record);
+            childItem->_file = newPath;
+            childItem->_lockToken.clear();
+            childItem->_locked = SyncFileItem::LockStatus::UnlockedItem;
+            propagator()->updateMetadata(*childItem);
         }
         propagator()->_renamedDirectories.insert(_item->_file, _item->_renameTarget);
         if (!adjustSelectiveSync(propagator()->_journal, _item->_file, _item->_renameTarget)) {

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -274,6 +274,8 @@ void PropagateRemoteMove::finalize()
 
     SyncFileItem newItem(*_item);
     newItem._type = _item->_type;
+    newItem._lockToken.clear();
+    newItem._locked = SyncFileItem::LockStatus::UnlockedItem;
     if (oldRecord.isValid()) {
         newItem._checksumHeader = oldRecord._checksumHeader;
         if (newItem._size != oldRecord._fileSize) {

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -302,6 +302,31 @@ void PropagateRemoteMove::finalize()
     }
 
     if (_item->isDirectory()) {
+        const auto dbQueryResult = propagator()->_journal->getFilesBelowPath(
+            _item->_originalFile.toUtf8(), [this](const SyncJournalFileRecord &record) {
+                const auto oldPath = QString::fromUtf8(record._path);
+                auto newPath = oldPath;
+                newPath.replace(0, _item->_originalFile.length(), _item->_renameTarget);
+
+                if (oldPath == newPath) {
+                    return;
+                }
+
+                if (!propagator()->_journal->deleteFileRecord(oldPath)) {
+                    qCWarning(lcPropagateRemoteMove) << "could not delete child record" << oldPath;
+                    return;
+                }
+
+                const auto newItem = SyncFileItem::fromSyncJournalFileRecord(record);
+                newItem->_file = newPath;
+                newItem->_lockToken.clear();
+                newItem->_locked = SyncFileItem::LockStatus::UnlockedItem;
+                propagator()->updateMetadata(*newItem);
+            });
+        if (!dbQueryResult) {
+            done(SyncFileItem::FatalError, tr("Failed to propagate directory rename in hierarchy"), ErrorCategory::GenericError);
+            return;
+        }
         propagator()->_renamedDirectories.insert(_item->_file, _item->_renameTarget);
         if (!adjustSelectiveSync(propagator()->_journal, _item->_file, _item->_renameTarget)) {
             done(SyncFileItem::FatalError, tr("Error writing metadata to the database"), ErrorCategory::GenericError);

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -302,32 +302,6 @@ void PropagateRemoteMove::finalize()
     }
 
     if (_item->isDirectory()) {
-        QVector<SyncJournalFileRecord> childRecords;
-        const auto dbQueryResult = propagator()->_journal->getFilesBelowPath(
-            _item->_originalFile.toUtf8(), [&childRecords](const SyncJournalFileRecord &record) {
-                childRecords.append(record);
-            });
-        if (!dbQueryResult) {
-            done(SyncFileItem::FatalError, tr("Failed to propagate directory rename in hierarchy"), ErrorCategory::GenericError);
-            return;
-        }
-        for (const auto &record : std::as_const(childRecords)) {
-            const auto oldPath = QString::fromUtf8(record._path);
-            auto newPath = oldPath;
-            newPath.replace(0, _item->_originalFile.length(), _item->_renameTarget);
-            if (oldPath == newPath) {
-                continue;
-            }
-            if (!propagator()->_journal->deleteFileRecord(oldPath)) {
-                qCWarning(lcPropagateRemoteMove) << "could not delete child record" << oldPath;
-                continue;
-            }
-            const auto childItem = SyncFileItem::fromSyncJournalFileRecord(record);
-            childItem->_file = newPath;
-            childItem->_lockToken.clear();
-            childItem->_locked = SyncFileItem::LockStatus::UnlockedItem;
-            propagator()->updateMetadata(*childItem);
-        }
         propagator()->_renamedDirectories.insert(_item->_file, _item->_renameTarget);
         if (!adjustSelectiveSync(propagator()->_journal, _item->_file, _item->_renameTarget)) {
             done(SyncFileItem::FatalError, tr("Error writing metadata to the database"), ErrorCategory::GenericError);

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -692,18 +692,20 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
 
     if (_item->_httpErrorCode == LockFileJob::PRECONDITION_FAILED_ERROR_CODE
         || _item->_httpErrorCode == LockFileJob::LOCKED_HTTP_ERROR_CODE) {
-        if (!_item->_lockToken.isEmpty()) {
-            SyncJournalFileRecord record;
-            if (propagator()->_journal->getFileRecord(_item->_file, &record) && record.isValid()) {
-                record._lockstate._lockToken.clear();
-                record._lockstate._locked = false;
-                if (const auto result = propagator()->_journal->setFileRecord(record); !result) {
-                    qCWarning(lcPropagateUpload) << "Failed to clear stale lock token for" << _item->_file << result.error();
-                }
+        // Clear any stale lock token from the journal. The token may be absent from
+        // _item when the file was discovered via local (not remote) discovery, so
+        // check the DB record directly rather than guarding on _item->_lockToken.
+        SyncJournalFileRecord record;
+        if (propagator()->_journal->getFileRecord(_item->_file, &record) && record.isValid()
+            && !record._lockstate._lockToken.isEmpty()) {
+            record._lockstate._lockToken.clear();
+            record._lockstate._locked = false;
+            if (const auto result = propagator()->_journal->setFileRecord(record); !result) {
+                qCWarning(lcPropagateUpload) << "Failed to clear stale lock token for" << _item->_file << result.error();
             }
-            _item->_lockToken.clear();
-            _item->_locked = SyncFileItem::LockStatus::UnlockedItem;
         }
+        _item->_lockToken.clear();
+        _item->_locked = SyncFileItem::LockStatus::UnlockedItem;
         propagator()->_anotherSyncNeeded = true;
         if (_item->_httpErrorCode == LockFileJob::PRECONDITION_FAILED_ERROR_CODE) {
             propagator()->_journal->schedulePathForRemoteDiscovery(_item->_file);

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -15,6 +15,7 @@
 #include "common/utility.h"
 #include "filesystem.h"
 #include "propagatorjobs.h"
+#include "lockfilejobs.h"
 #include "common/checksums.h"
 #include "syncengine.h"
 #include "deletejob.h"
@@ -689,13 +690,24 @@ void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
     QString errorString = job->errorStringParsingBody(&replyContent);
     qCWarning(lcPropagateUpload) << replyContent; // display the XML error in the debug
 
-    if (_item->_httpErrorCode == 412) {
-        // Precondition Failed: Either an etag or a checksum mismatch.
-
-        // Maybe the bad etag is in the database, we need to clear the
-        // parent folder etag so we won't read from DB next sync.
-        propagator()->_journal->schedulePathForRemoteDiscovery(_item->_file);
+    if (_item->_httpErrorCode == LockFileJob::PRECONDITION_FAILED_ERROR_CODE
+        || _item->_httpErrorCode == LockFileJob::LOCKED_HTTP_ERROR_CODE) {
+        if (!_item->_lockToken.isEmpty()) {
+            SyncJournalFileRecord record;
+            if (propagator()->_journal->getFileRecord(_item->_file, &record) && record.isValid()) {
+                record._lockstate._lockToken.clear();
+                record._lockstate._locked = false;
+                if (const auto result = propagator()->_journal->setFileRecord(record); !result) {
+                    qCWarning(lcPropagateUpload) << "Failed to clear stale lock token for" << _item->_file << result.error();
+                }
+            }
+            _item->_lockToken.clear();
+            _item->_locked = SyncFileItem::LockStatus::UnlockedItem;
+        }
         propagator()->_anotherSyncNeeded = true;
+        if (_item->_httpErrorCode == LockFileJob::PRECONDITION_FAILED_ERROR_CODE) {
+            propagator()->_journal->schedulePathForRemoteDiscovery(_item->_file);
+        }
     }
 
     // Ensure errors that should eventually reset the chunked upload are tracked.

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -87,7 +87,7 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
         for (const auto &it : deleted) {
             if (!it.first.startsWith(propagator()->localPath()))
                 continue;
-            if (!deletedDir.isEmpty() && it.first.startsWith(deletedDir))
+            if (isPathInsideDeletedDir(it.first, deletedDir))
                 continue;
             if (it.second) {
                 deletedDir = it.first;

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -547,6 +547,8 @@ void PropagateLocalRename::start()
 
             const auto newItem = SyncFileItem::fromSyncJournalFileRecord(oldRecord);
             newItem->_file = newFileNameString;
+            newItem->_lockToken.clear();
+            newItem->_locked = SyncFileItem::LockStatus::UnlockedItem;
             const auto result = propagator()->updateMetadata(*newItem);
             if (!result) {
                 return;

--- a/src/libsync/propagatorjobs.h
+++ b/src/libsync/propagatorjobs.h
@@ -20,6 +20,19 @@ constexpr auto contentMd5HeaderC = "Content-MD5";
 constexpr auto checksumRecalculateOnServerHeaderC = "X-Recalculate-Hash";
 
 /**
+ * Whether @p path sits inside the already removed directory @p deletedDir.
+ * Compares with a trailing slash so a sibling such as "A/BC" is not mistaken
+ * for a child of "A/B".
+ */
+[[nodiscard]] inline bool isPathInsideDeletedDir(const QString &path, const QString &deletedDir)
+{
+    return !deletedDir.isEmpty()
+        && path.size() > deletedDir.size()
+        && path[deletedDir.size()] == QLatin1Char('/')
+        && path.startsWith(deletedDir);
+}
+
+/**
  * @brief Declaration of the other propagation jobs
  * @ingroup libsync
  */

--- a/test/syncenginetestutils.cpp
+++ b/test/syncenginetestutils.cpp
@@ -463,6 +463,9 @@ FakePropfindReply::FakePropfindReply(FileInfo &remoteRootFileInfo, QNetworkAcces
         xml.writeTextElement(ncUri, QStringLiteral("lock-owner-editor"), fileInfo.lockOwnerId);
         xml.writeTextElement(ncUri, QStringLiteral("lock-time"), QString::number(fileInfo.lockTime));
         xml.writeTextElement(ncUri, QStringLiteral("lock-timeout"), QString::number(fileInfo.lockTimeout));
+        if (!fileInfo.lockToken.isEmpty()) {
+            xml.writeTextElement(ncUri, QStringLiteral("lock-token"), fileInfo.lockToken);
+        }
         xml.writeTextElement(ncUri, QStringLiteral("is-encrypted"), fileInfo.isEncrypted ? QString::number(1) : QString::number(0));
         xml.writeTextElement(ncUri, QStringLiteral("metadata-files-live-photo"), fileInfo.isLivePhoto ? QString::number(1) : QString::number(0));
         buffer.write(fileInfo.extraDavProperties);

--- a/test/syncenginetestutils.h
+++ b/test/syncenginetestutils.h
@@ -223,6 +223,7 @@ public:
     char contentChar = 'W';
     LockState lockState = LockState::FileUnlocked;
     int lockType = 0;
+    QString lockToken;
     QString lockOwner;
     QString lockOwnerId;
     QString lockEditorId;

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -12,6 +12,7 @@
 #include "common/result.h"
 #include "syncenginetestutils.h"
 #include <syncengine.h>
+#include <propagatorjobs.h>
 
 using namespace OCC;
 
@@ -965,13 +966,17 @@ private slots:
         QTest::addColumn<Vfs::Mode>("vfsMode");
 
         QTest::newRow("Vfs::Off") << Vfs::Off;
-        QTest::newRow("Vfs::WithSuffix") << Vfs::WithSuffix;
+        if (isVfsPluginAvailable(Vfs::WithSuffix)) {
+            QTest::newRow("Vfs::WithSuffix") << Vfs::WithSuffix;
+        } else {
+            qWarning("Skipping Vfs::WithSuffix");
+        }
 #ifdef Q_OS_WIN32
         if (isVfsPluginAvailable(Vfs::WindowsCfApi))
         {
             QTest::newRow("Vfs::WindowsCfApi") << Vfs::WindowsCfApi;
         } else {
-            QWARN("Skipping Vfs::WindowsCfApi");
+            qWarning("Skipping Vfs::WindowsCfApi");
         }
 
 #endif
@@ -1422,6 +1427,138 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
 
         qDebug() << fakeFolder.currentLocalState();
+    }
+    // PropagateLocalRename must clear the lock token and locked state.
+    void testLockTokenClearedOnServerInitiatedRename()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.remoteModifier().mkdir("D");
+        fakeFolder.remoteModifier().insert("D/file.txt", 64);
+        QVERIFY(fakeFolder.syncOnce());
+
+        // Inject a stale lock token directly into the journal.
+        {
+            SyncJournalFileRecord record;
+            QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &record));
+            record._lockstate._locked = true;
+            record._lockstate._lockOwnerType = static_cast<qint64>(SyncFileItem::LockOwnerType::TokenLock);
+            record._lockstate._lockToken = QStringLiteral("stale-token");
+            QVERIFY(fakeFolder.syncJournal().setFileRecord(record));
+        }
+
+        // Server renames D -> D2, applied locally via PropagateLocalRename.
+        fakeFolder.remoteModifier().rename("D", "D2");
+        QVERIFY(fakeFolder.syncOnce());
+
+        // Child record at the new path must have its lock state cleared.
+        SyncJournalFileRecord moved;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D2/file.txt"), &moved));
+        QVERIFY(moved.isValid());
+        QVERIFY(moved._lockstate._lockToken.isEmpty());
+        QVERIFY(!moved._lockstate._locked);
+    }
+
+    // PropagateRemoteMove must clear the locked state.
+    void testLockedStateClearedOnClientInitiatedRename()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.remoteModifier().mkdir("D");
+        fakeFolder.remoteModifier().insert("D/file.txt", 64);
+        QVERIFY(fakeFolder.syncOnce());
+
+        // Mark the file as locked on the server so discovery reports it as locked.
+        fakeFolder.remoteModifier().modifyLockState(
+            QStringLiteral("D/file.txt"), FileModifier::LockState::FileLocked,
+            static_cast<int>(SyncFileItem::LockOwnerType::UserLock),
+            QStringLiteral("User"), QStringLiteral("userId"),
+            QStringLiteral("editor"), 1234567890, 3600);
+        QVERIFY(fakeFolder.syncOnce()); // Journal now has _locked = true for D/file.txt.
+
+        // Client renames D -> D2.
+        fakeFolder.localModifier().rename("D", "D2");
+        QVERIFY(fakeFolder.syncOnce());
+
+        // Locked state must be cleared in the new record.
+        SyncJournalFileRecord moved;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D2/file.txt"), &moved));
+        QVERIFY(moved.isValid());
+        QVERIFY(!moved._lockstate._locked);
+    }
+
+    // A 412 upload error must schedule rediscovery.
+    void testUpload412SchedulesRediscovery()
+    {
+        FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
+        QVERIFY(fakeFolder.syncOnce());
+
+        fakeFolder.localModifier().appendByte("D/file.txt");
+        fakeFolder.serverErrorPaths().append("D/file.txt", 412);
+        QVERIFY(!fakeFolder.syncOnce()); // Upload fails with 412.
+
+        // The 412 handler must invalidate the parent folder etag so the next sync
+        // rediscovers it instead of trusting the DB.
+        SyncJournalFileRecord parent;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D"), &parent));
+        QVERIFY(parent.isValid());
+        QCOMPARE(parent._etag, QByteArrayLiteral("_invalid_"));
+
+        // After clearing the error, the next sync must succeed.
+        fakeFolder.serverErrorPaths().clear();
+        [[maybe_unused]] const auto blacklistWiped = fakeFolder.syncJournal().wipeErrorBlacklist();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
+
+    // A 412 or 423 upload error must clear the whole lock state, not just the token.
+    void testUpload423ClearsStaleLockState()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.remoteModifier().mkdir("D");
+        fakeFolder.remoteModifier().insert("D/file.txt", 64);
+        fakeFolder.remoteModifier().modifyLockState(
+            QStringLiteral("D/file.txt"), FileModifier::LockState::FileLocked,
+            static_cast<int>(SyncFileItem::LockOwnerType::TokenLock),
+            QStringLiteral("user"), QStringLiteral("userId"),
+            QStringLiteral("editor"), 1234567890, 3600);
+        fakeFolder.remoteModifier().find(QStringLiteral("D/file.txt"))->lockToken = QStringLiteral("stale-token");
+        QVERIFY(fakeFolder.syncOnce());
+
+        // Discovery stored the lock token and locked state.
+        SyncJournalFileRecord locked;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &locked));
+        QVERIFY(locked._lockstate._locked);
+        QCOMPARE(locked._lockstate._lockToken, QStringLiteral("stale-token"));
+
+        // The lock made the local file read only on download; make it writable so a
+        // local change can trigger an upload the server then rejects with 423.
+        QVERIFY(QFile::setPermissions(fakeFolder.localPath() + QStringLiteral("D/file.txt"),
+                                      QFile::ReadOwner | QFile::WriteOwner));
+        fakeFolder.localModifier().appendByte("D/file.txt");
+        fakeFolder.serverErrorPaths().append("D/file.txt", 423);
+        QVERIFY(fakeFolder.syncOnce()); // 423 is a soft error, so the run completes.
+
+        // Both the token and the locked flag must be cleared.
+        SyncJournalFileRecord cleared;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &cleared));
+        QVERIFY(cleared.isValid());
+        QVERIFY(cleared._lockstate._lockToken.isEmpty());
+        QVERIFY(!cleared._lockstate._locked);
+    }
+
+    // The journal cleanup after a failed local remove must not treat a sibling as a
+    // child: "A/BC" is not inside "A/B".
+    void testDeletedDirPrefixDoesNotMatchSibling()
+    {
+        QVERIFY(isPathInsideDeletedDir(QStringLiteral("A/B/child.txt"), QStringLiteral("A/B")));
+        QVERIFY(isPathInsideDeletedDir(QStringLiteral("A/B/sub/child.txt"), QStringLiteral("A/B")));
+
+        // Sibling sharing the prefix must not be skipped.
+        QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/BC"), QStringLiteral("A/B")));
+        QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/BC/child.txt"), QStringLiteral("A/B")));
+
+        // The directory itself is not inside itself, and an empty deletedDir matches nothing.
+        QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/B"), QStringLiteral("A/B")));
+        QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/B/child.txt"), QString()));
     }
 };
 

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <QtTest>
+#include <QFile>
 #include "common/result.h"
 #include "syncenginetestutils.h"
 #include <syncengine.h>

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -1490,9 +1490,15 @@ private slots:
     // A 412 or 423 upload error must clear the whole lock state, not just the token.
     void testUpload423ClearsStaleLockState()
     {
+        // FakeFolder default-constructs with performInitialSync=true, so the DB is
+        // already populated with D/file.txt before seedStaleLock runs.
         FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
         seedStaleLock(fakeFolder, "D/file.txt");
         fakeFolder.localModifier().appendByte("D/file.txt");
+        fakeFolder.serverErrorPaths().append("D/file.txt", 423);
+        // 423 → FileLocked in commonErrorHandling (which clears the DB lock), but
+        // FileLocked is swallowed by PropagatorCompositeJob so the overall sync
+        // reports success.
         QVERIFY(fakeFolder.syncOnce());
 
         SyncJournalFileRecord cleared;

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -967,19 +967,14 @@ private slots:
         QTest::addColumn<Vfs::Mode>("vfsMode");
 
         QTest::newRow("Vfs::Off") << Vfs::Off;
-        if (isVfsPluginAvailable(Vfs::WithSuffix)) {
-            QTest::newRow("Vfs::WithSuffix") << Vfs::WithSuffix;
-        } else {
-            qWarning("Skipping Vfs::WithSuffix");
-        }
+        QTest::newRow("Vfs::WithSuffix") << Vfs::WithSuffix;
 #ifdef Q_OS_WIN32
         if (isVfsPluginAvailable(Vfs::WindowsCfApi))
         {
             QTest::newRow("Vfs::WindowsCfApi") << Vfs::WindowsCfApi;
         } else {
-            qWarning("Skipping Vfs::WindowsCfApi");
+            QWARN("Skipping Vfs::WindowsCfApi");
         }
-
 #endif
     }
 

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -1439,6 +1439,10 @@ private slots:
         QVERIFY(moved.isValid());
         QVERIFY(moved._lockstate._lockToken.isEmpty());
         QVERIFY(!moved._lockstate._locked);
+
+        const auto oldState = fakeFolder.currentRemoteState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), oldState);
     }
 
     // PropagateRemoteMove must clear the locked state.
@@ -1456,6 +1460,10 @@ private slots:
         QVERIFY(moved.isValid());
         QVERIFY(moved._lockstate._lockToken.isEmpty());
         QVERIFY(!moved._lockstate._locked);
+
+        const auto oldState = fakeFolder.currentRemoteState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), oldState);
     }
 
     // A 412 upload error must schedule rediscovery.
@@ -1480,6 +1488,10 @@ private slots:
         [[maybe_unused]] const auto blacklistWiped = fakeFolder.syncJournal().wipeErrorBlacklist();
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+
+        const auto oldState = fakeFolder.currentRemoteState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentLocalState(), oldState);
     }
 
     // A 412 or 423 upload error must clear the whole lock state, not just the token.
@@ -1501,6 +1513,11 @@ private slots:
         QVERIFY(cleared.isValid());
         QVERIFY(cleared._lockstate._lockToken.isEmpty());
         QVERIFY(!cleared._lockstate._locked);
+
+        fakeFolder.serverErrorPaths().clear();
+        const auto oldState = fakeFolder.currentLocalState();
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(fakeFolder.currentRemoteState(), oldState);
     }
 
     // The journal cleanup after a failed local remove must not treat a sibling as a

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -1403,7 +1403,7 @@ private slots:
         fakeFolder.remoteModifier().insert("FolderB/folderChild/FileA.txt");
         fakeFolder.remoteModifier().mkdir("FolderC");
 
-        const auto fileAFileInfo = fakeFolder.remoteModifier().find("FolderB/folderChild/FileA.txt");
+        const auto fileAFileInfo = fakeFolder.remoteModifier().find("FolderA/folderParent/FileA.txt");
         const auto fileAInFolderAFolderFileId = fileAFileInfo->fileId;
         const auto fileAInFolderAEtag = fileAFileInfo->etag;
         const auto duplicatedFileAFileInfo = fakeFolder.remoteModifier().find("FolderB/folderChild/FileA.txt");
@@ -1491,11 +1491,8 @@ private slots:
     void testUpload423ClearsStaleLockState()
     {
         FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
-        QVERIFY(fakeFolder.syncOnce());
         seedStaleLock(fakeFolder, "D/file.txt");
-
         fakeFolder.localModifier().appendByte("D/file.txt");
-        fakeFolder.serverErrorPaths().append("D/file.txt", 423);
         QVERIFY(fakeFolder.syncOnce());
 
         SyncJournalFileRecord cleared;

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -1431,26 +1431,13 @@ private slots:
     // PropagateLocalRename must clear the lock token and locked state.
     void testLockTokenClearedOnServerInitiatedRename()
     {
-        FakeFolder fakeFolder{FileInfo{}};
-        fakeFolder.remoteModifier().mkdir("D");
-        fakeFolder.remoteModifier().insert("D/file.txt", 64);
+        FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
         QVERIFY(fakeFolder.syncOnce());
+        seedStaleLock(fakeFolder, "D/file.txt");
 
-        // Inject a stale lock token directly into the journal.
-        {
-            SyncJournalFileRecord record;
-            QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &record));
-            record._lockstate._locked = true;
-            record._lockstate._lockOwnerType = static_cast<qint64>(SyncFileItem::LockOwnerType::TokenLock);
-            record._lockstate._lockToken = QStringLiteral("stale-token");
-            QVERIFY(fakeFolder.syncJournal().setFileRecord(record));
-        }
-
-        // Server renames D -> D2, applied locally via PropagateLocalRename.
         fakeFolder.remoteModifier().rename("D", "D2");
         QVERIFY(fakeFolder.syncOnce());
 
-        // Child record at the new path must have its lock state cleared.
         SyncJournalFileRecord moved;
         QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D2/file.txt"), &moved));
         QVERIFY(moved.isValid());
@@ -1461,27 +1448,17 @@ private slots:
     // PropagateRemoteMove must clear the locked state.
     void testLockedStateClearedOnClientInitiatedRename()
     {
-        FakeFolder fakeFolder{FileInfo{}};
-        fakeFolder.remoteModifier().mkdir("D");
-        fakeFolder.remoteModifier().insert("D/file.txt", 64);
+        FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
         QVERIFY(fakeFolder.syncOnce());
+        seedStaleLock(fakeFolder, "D/file.txt");
 
-        // Mark the file as locked on the server so discovery reports it as locked.
-        fakeFolder.remoteModifier().modifyLockState(
-            QStringLiteral("D/file.txt"), FileModifier::LockState::FileLocked,
-            static_cast<int>(SyncFileItem::LockOwnerType::UserLock),
-            QStringLiteral("User"), QStringLiteral("userId"),
-            QStringLiteral("editor"), 1234567890, 3600);
-        QVERIFY(fakeFolder.syncOnce()); // Journal now has _locked = true for D/file.txt.
-
-        // Client renames D -> D2.
         fakeFolder.localModifier().rename("D", "D2");
         QVERIFY(fakeFolder.syncOnce());
 
-        // Locked state must be cleared in the new record.
         SyncJournalFileRecord moved;
         QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D2/file.txt"), &moved));
         QVERIFY(moved.isValid());
+        QVERIFY(moved._lockstate._lockToken.isEmpty());
         QVERIFY(!moved._lockstate._locked);
     }
 
@@ -1512,32 +1489,14 @@ private slots:
     // A 412 or 423 upload error must clear the whole lock state, not just the token.
     void testUpload423ClearsStaleLockState()
     {
-        FakeFolder fakeFolder{FileInfo{}};
-        fakeFolder.remoteModifier().mkdir("D");
-        fakeFolder.remoteModifier().insert("D/file.txt", 64);
-        fakeFolder.remoteModifier().modifyLockState(
-            QStringLiteral("D/file.txt"), FileModifier::LockState::FileLocked,
-            static_cast<int>(SyncFileItem::LockOwnerType::TokenLock),
-            QStringLiteral("user"), QStringLiteral("userId"),
-            QStringLiteral("editor"), 1234567890, 3600);
-        fakeFolder.remoteModifier().find(QStringLiteral("D/file.txt"))->lockToken = QStringLiteral("stale-token");
+        FakeFolder fakeFolder{FileInfo{QString{}, {FileInfo{QStringLiteral("D"), {{"file.txt", 64}}}}}};
         QVERIFY(fakeFolder.syncOnce());
+        seedStaleLock(fakeFolder, "D/file.txt");
 
-        // Discovery stored the lock token and locked state.
-        SyncJournalFileRecord locked;
-        QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &locked));
-        QVERIFY(locked._lockstate._locked);
-        QCOMPARE(locked._lockstate._lockToken, QStringLiteral("stale-token"));
-
-        // The lock made the local file read only on download; make it writable so a
-        // local change can trigger an upload the server then rejects with 423.
-        QVERIFY(QFile::setPermissions(fakeFolder.localPath() + QStringLiteral("D/file.txt"),
-                                      QFile::ReadOwner | QFile::WriteOwner));
         fakeFolder.localModifier().appendByte("D/file.txt");
         fakeFolder.serverErrorPaths().append("D/file.txt", 423);
-        QVERIFY(fakeFolder.syncOnce()); // 423 is a soft error, so the run completes.
+        QVERIFY(fakeFolder.syncOnce());
 
-        // Both the token and the locked flag must be cleared.
         SyncJournalFileRecord cleared;
         QVERIFY(fakeFolder.syncJournal().getFileRecord(QByteArray("D/file.txt"), &cleared));
         QVERIFY(cleared.isValid());
@@ -1559,6 +1518,16 @@ private slots:
         // The directory itself is not inside itself, and an empty deletedDir matches nothing.
         QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/B"), QStringLiteral("A/B")));
         QVERIFY(!isPathInsideDeletedDir(QStringLiteral("A/B/child.txt"), QString()));
+    }
+
+private:
+    static void seedStaleLock(FakeFolder &folder, const QByteArray &path)
+    {
+        SyncJournalFileRecord record;
+        QVERIFY(folder.syncJournal().getFileRecord(path, &record));
+        record._lockstate._locked = true;
+        record._lockstate._lockToken = QStringLiteral("stale-token");
+        QVERIFY(folder.syncJournal().setFileRecord(record));
     }
 };
 


### PR DESCRIPTION
## Resolves
When a parent folder is renamed during sync, file changes inside it can be silently lost in 2 ways:

1. Stale lock tokens: renaming a parent copies child journal records to the new path but keeps the old WebDAV lock token. The next upload sends it at the new URL and the server rejects it with 412/423.
Clear _lockToken and _locked when writing a renamed child's journal record.
And No 412/423 recovery: the error handler didn't clear the stale token, so every retry failed the same way.
Clear the token from the journal on 412/423 and schedule rediscovery.
https://github.com/nextcloud/desktop/pull/10135

2. Path prefix bug: removeRecursively used startsWith(dir) instead of startsWith(dir + '/'), causing false prefix matches on sibling paths like A/BC when processing A/B.
Use startsWith(dir + '/').
See https://github.com/nextcloud/desktop/pull/10130

## Steps to test it
### Scenario 1 — Stale lock token after folder rename (the main symptom)
- What it tests: commits 5d8e64c757 and f1a60798a2 (lock token clearing + 412/423 recovery)
- Prerequisites: LibreOffice (or any WebDAV-locking editor), a Nextcloud server with file locking enabled, two clients or one client + the web UI.
1. Sync a folder containing an .odt or .xlsx file, e.g. Work/report.odt.
2. Open report.odt in LibreOffice — this acquires a WebDAV lock token stored in the journal.
3. From the web UI or a second client, rename the parent folder: Work → Work2.
4. Let the desktop client sync the rename (the folder appears as Work2 locally).
5. In LibreOffice, make a change and Save.
4. Save. LibreOffice may ask "The file has been changed since it was opened — save anyway?" Click Save anyway.
See https://github.com/nextcloud/desktop/pull/10135
  ✅ Expected (with fix): save succeeds, Work2/report.odt contents do not get lost.
  🔴 Regression (without fix): the upload fails with 412 or 423, LibreOffice shows a save error, and every subsequent save attempt fails identically because the stale token is never cleared.

### Scenario 2 — Path prefix matching (sibling folders not clobbered)
- What it tests: commit c1681866bc (slash-prefix fix in removeRecursively)
1. Create two sibling folders locally: D/ and D2/, each containing a file. Sync both.
2. Rename D → E locally.
3. Sync.
  ✅ Expected (with fix): D2/ and its contents remain fully intact after the sync.
  🔴 Regression (without fix): because "D2".startsWith("D") is true, the old logic could mark D2's entries as part of the renamed tree and remove them from the journal.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
