### PR TITLE
perf(rename): cache fileExists results in PropagateLocalRename::start

### DIFF
--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -349,7 +349,10 @@ void PropagateLocalRename::start()
     const auto targetFile = propagator()->fullLocalPath(_item->_renameTarget);
     const auto originalFile = propagator()->fullLocalPath(_item->_originalFile);
 
-    const auto fileAlreadyMoved = (!FileSystem::fileExists(originalFile) || !FileSystem::fileExists(existingFile))&& FileSystem::fileExists(targetFile);
+    const auto origExists = FileSystem::fileExists(originalFile);
+    const auto existingExists = FileSystem::fileExists(existingFile);
+    const auto targetExists = FileSystem::fileExists(targetFile);
+    const auto fileAlreadyMoved = (!origExists || !existingExists) && targetExists;
     auto pinState = OCC::PinState::Unspecified;
     if (!fileAlreadyMoved) {
         auto pinStateResult = vfs->pinState(propagator()->adjustRenamedPath(_item->_file));
@@ -361,9 +364,9 @@ void PropagateLocalRename::start()
     // if the file is a file underneath a moved dir, the _item->file is equal
     // to _item->renameTarget and the file is not moved as a result.
     qCDebug(lcPropagateLocalRename) << _item->_file << _item->_renameTarget << _item->_originalFile << previousNameInDb << (fileAlreadyMoved ? "original file has already moved" : "original file is still there");
-    qCDebug(lcPropagateLocalRename()) << (FileSystem::fileExists(originalFile) ? "original file exists" : "original file is missing") << originalFile << _item->_originalFile;
-    qCDebug(lcPropagateLocalRename()) << (FileSystem::fileExists(existingFile) ? "existing file exists" : "existing file is missing") << existingFile << previousNameInDb;
-    Q_ASSERT(FileSystem::fileExists(propagator()->fullLocalPath(_item->_originalFile)) || FileSystem::fileExists(existingFile));
+    qCDebug(lcPropagateLocalRename()) << (origExists ? "original file exists" : "original file is missing") << originalFile << _item->_originalFile;
+    qCDebug(lcPropagateLocalRename()) << (existingExists ? "existing file exists" : "existing file is missing") << existingFile << previousNameInDb;
+    Q_ASSERT(origExists || existingExists);
     if (_item->_file != _item->_renameTarget) {
         propagator()->reportProgress(*_item, 0);
         qCDebug(lcPropagateLocalRename) << "MOVE " << existingFile << " => " << targetFile;


### PR DESCRIPTION
## Summary

`PropagateLocalRename::start` was calling `FileSystem::fileExists` repeatedly across the same three paths in a row:

- `originalFile`: 2 calls
- `existingFile`: 3 calls
- `targetFile`: 1 call

Each call is a filesystem `stat`. Cached the three results into local `bool`s at the top of the function and reused them throughout.

### Bonus consistency win

A side effect of caching is that the `Q_ASSERT` and the two `qCDebug` log lines below the `fileAlreadyMoved` check now use the **same** bool values that `fileAlreadyMoved` was computed from. Previously, if filesystem state changed between the original computation and the assert/log calls (unlikely but possible under aggressive renames), the log line and the assert could disagree. Now they're guaranteed consistent.

No behavioral change.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
