### PR TITLE
perf(db): WAL checkpoint when closing the journal

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -700,6 +700,7 @@ void SyncJournalDb::close()
     qCInfo(lcDb) << "Closing DB" << _dbFile;
 
     commitTransaction();
+    walCheckpoint();
 
     _db.close();
     clearEtagStorageFilter();


### PR DESCRIPTION
## Summary

`SyncJournalDb::close` commits the open transaction but does not checkpoint the WAL. The WAL file then keeps growing on subsequent opens until SQLite's automatic checkpoint heuristic eventually folds it back, which can take a long time on quiet accounts.

Added an explicit `walCheckpoint()` (which already exists in this class) after `commitTransaction()` in `close()`, so:

- The WAL is folded back into the main database file when the client shuts down or unmounts an account.
- On-disk journal size stays bounded across restarts.
- Next session startup has less WAL replay work to do.

One-line change. No behavioral risk: `walCheckpoint()` is the same function the existing periodic-checkpoint logic invokes; the only difference is one additional call at the well-defined "we are about to close" boundary.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no UI changes).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
