### PR TITLE
Fix Open Local Folder

### DIFF
--- a/src/gui/tray/TrayFoldersMenuButton.qml
+++ b/src/gui/tray/TrayFoldersMenuButton.qml
@@ -17,7 +17,11 @@ HeaderButton {
     signal folderEntryTriggered(string fullFolderPath, bool isGroupFolder)
 
     required property var currentUser
-    property bool userHasGroupFolders: currentUser.groupFolders.length > 0
+    // Group folders are only navigable from this dropdown when the account has a
+    // classic-sync local folder — sandbox restrictions stop us revealing descendants
+    // of a file-provider domain in Finder, so file-provider accounts always use the
+    // folder button as a single-click "reveal root container" affordance instead.
+    property bool userHasGroupFolders: currentUser.hasLocalFolder && currentUser.groupFolders.length > 0
     property color parentBackgroundColor: "transparent"
 
     function openMenu() {


### PR DESCRIPTION
Offer local folder opening regardless of the presence of shared group folders which result in a dropdown menu item for classic synchronization folders.

As I found during development, due to sandbox restrictions it is not possible to provide a deep link popup menu for group folders, given there are some. Neither the main app nor the extension are allowed to delegate the revelation to Finder for different reasons due to the sandboxing.

This is a fix-up to #9857 and closes #9239.

No backport because it is part of a feature which will be delivered with release 34.0.0.