### PR TITLE
fix: Refactor visitedDirectory handling in MaterializedEnumerationObserver

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
@@ -97,7 +97,16 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
             logger.info("Updating item state to dataless.", [.name: metadata.fileName, .item: evictedItemIdentifier])
 
             metadata.downloaded = false
-            metadata.visitedDirectory = false
+
+            // Being absent from enumeratorForMaterializedItems only means the item has no
+            // local materialized content. For directories, visitedDirectory is our refresh
+            // subscription: if Finder has enumerated a folder before, keep watching it for
+            // remote child changes even when macOS reports it as dataless. This matters for
+            // shared mount roots, which may be omitted from materialized items after browsing.
+            if !metadata.directory {
+                metadata.visitedDirectory = false
+            }
+
             dbManager.addItemMetadata(metadata)
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
@@ -130,7 +130,7 @@ final class MaterialisedEnumerationObserverTests: NextcloudFileProviderKitTestCa
             XCTAssertTrue(finalItemC?.downloaded ?? false, "itemC should remain downloaded.")
 
             let finalDirD = dbManager.itemMetadata(ocId: "dirD")
-            XCTAssertFalse(
+            XCTAssertTrue(
                 finalDirD?.visitedDirectory ?? false, "dirD should be marked as visited."
             )
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
@@ -131,7 +131,7 @@ final class MaterialisedEnumerationObserverTests: NextcloudFileProviderKitTestCa
 
             let finalDirD = dbManager.itemMetadata(ocId: "dirD")
             XCTAssertFalse(
-                finalDirD?.visitedDirectory ?? true, "dirD should now be marked as not visited."
+                finalDirD?.visitedDirectory ?? false, "dirD should be marked as visited."
             )
 
             expect.fulfill()


### PR DESCRIPTION
visitedDirectory is what keeps a browsed folder in materialisedItemMetadatas() in FilesDatabaseManager.swift (line 591). That list drives checkMaterializedItemsOnServer() in Enumerator.swift (line 423). Preserving visitedDirectory means shared folders gets scanned again when its eTag changes, so the newly added child is discovered and reported.

Test change: update MaterialisedEnumerationObserverTests.swift (line 80) so an evicted directory remains visitedDirectory == true. The existing mixed-state test currently expects the opposite, and that expectation is the bug.