### PR TITLE
perf(tray): asynchronous Image loading for avatars and activity thumbnails

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -60,6 +60,7 @@ RowLayout {
                     fillMode: Image.PreserveAspectFit
                     source: model.thumbnail.source
                     visible: false
+                    asynchronous: true
                     sourceSize.height: 64
                     sourceSize.width: 64
                 }

--- a/src/gui/tray/UserLine.qml
+++ b/src/gui/tray/UserLine.qml
@@ -37,6 +37,7 @@ AbstractButton {
             source: model.avatar !== "" ? model.avatar : Style.darkMode ? "image://avatars/fallbackWhite" : "image://avatars/fallbackBlack"
             Layout.preferredHeight: Style.accountAvatarSize
             Layout.preferredWidth: Style.accountAvatarSize
+            asynchronous: true
 
             Rectangle {
                 id: accountStatusIndicatorBackground


### PR DESCRIPTION
## Summary

Two `Image` elements in the tray decoded their `source` synchronously on the GUI thread. When many of them appear at once — the activity list populating after sign-in, the user list refreshing, fast scrolling — the synchronous decode visibly stutters the tray.

This PR adds `asynchronous: true` to both, so decode happens on Qt's image loader thread and the GUI keeps painting while pixels are being fetched/decoded.

### `ActivityItemContent.qml` — `thumbnailImage`

The activity row thumbnail. Source is either a remote URL fetched through the Nextcloud server's preview API or a local image provider. Decode could take tens to hundreds of milliseconds, multiplied across however many activity rows are visible.

### `UserLine.qml` — `accountAvatar`

The per-account avatar in the user list. Source is either a remote avatar URL or a fallback image provider. Same blocking-decode behaviour was visible when the account list first populates.

### Behaviour during decode

Identical to Qt's existing late-source paint path: the `Image` element draws nothing for a frame or two while the source is being decoded, then paints normally. No flash of fallback content or visible flicker was observed.

This is a small, focused two-line change carved out of a larger PR (#9996) that bundled these together with rounded-corner clipping changes that turned out to be incorrect. This PR contains only the safe, validated portion.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes (no visual change — same images, same layout, same paint output once decoded).
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
