### PR TITLE
Check Quota before File Provider Item Upload

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
@@ -27,7 +27,7 @@ extension Enumerator {
                 dbManager.addItemMetadataPreservingLocalState(metadata)
             }
         }
-        
+
         // Persist children — including those on follow-up pages — while
         // carrying over any local-only state previously set on existing rows
         // (e.g. `keepDownloaded` from a recursive "Always keep downloaded"

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -124,6 +124,7 @@ public extension Item {
         forcedChunkSize: Int?,
         progress: Progress,
         dbManager: FilesDatabaseManager,
+        appProxy: (any AppProtocol)? = nil,
         log: any FileProviderLogging
     ) async -> (Item?, Error?) {
         let logger = FileProviderLogger(category: "Item", log: log)
@@ -162,13 +163,23 @@ public extension Item {
                     received ocId: \(ocId ?? "empty")
                 """
             )
-            return await (nil, error.fileProviderError(
-                handlingCollisionAgainstItemInRemotePath: remotePath,
-                dbManager: dbManager,
-                remoteInterface: remoteInterface,
-                log: log
-            ))
+
+            // Surface the quota refusal in the main app's activity view (per-item entry +
+            // per-folder summary with a "Retry all uploads" button), matching the parity
+            // classic sync provides via `User::slotAddError(InsufficientRemoteStorage)` and
+            // `User::slotAddErrorToGui`. See nextcloud/desktop#9598.
+            if error.isGoingOverQuotaError {
+                let relativePath = remotePath.replacingOccurrences(of: account.davFilesUrl, with: "")
+                let fileBytes = (try? FileManager.default.attributesOfItem(atPath: localPath)[.size] as? Int64) ?? itemTemplate.documentSize??.int64Value
+                InsufficientQuotaReporter.reportItem(relativePath: relativePath, fileName: itemTemplate.filename, fileBytes: fileBytes, availableBytes: nil, domainIdentifier: domain?.identifier, appProxy: appProxy, log: log)
+                await InsufficientQuotaReporter.reportSummary(domainIdentifier: domain?.identifier, appProxy: appProxy, log: log)
+            }
+
+            return await (nil, error.fileProviderError(handlingCollisionAgainstItemInRemotePath: remotePath, dbManager: dbManager, remoteInterface: remoteInterface, log: log))
         }
+
+        // Re-arm the per-domain dedup so a future quota event can surface a fresh summary.
+        await InsufficientQuotaReporter.clearSummaryDedup(domainIdentifier: domain?.identifier)
 
         logger.info(
             """
@@ -401,6 +412,7 @@ public extension Item {
             forcedChunkSize: forcedChunkSize,
             progress: progress,
             dbManager: dbManager,
+            appProxy: appProxy,
             log: log
         )
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -102,7 +102,8 @@ public extension Item {
         forcedChunkSize: Int?,
         domain: NSFileProviderDomain?,
         progress: Progress,
-        dbManager: FilesDatabaseManager
+        dbManager: FilesDatabaseManager,
+        appProxy: (any AppProtocol)? = nil
     ) async -> (Item?, Error?) {
         let ocId = itemIdentifier.rawValue
 
@@ -170,15 +171,25 @@ public extension Item {
             metadata.status = Status.uploadError.rawValue
             metadata.sessionError = error.errorDescription
             dbManager.addItemMetadata(metadata)
+
+            // Surface the quota refusal in the main app's activity view (per-item entry +
+            // per-folder summary with a "Retry all uploads" button), matching the parity
+            // classic sync provides via `User::slotAddError(InsufficientRemoteStorage)` and
+            // `User::slotAddErrorToGui`. See nextcloud/desktop#9598.
+            if error.isGoingOverQuotaError {
+                let relativePath = remotePath.replacingOccurrences(of: account.davFilesUrl, with: "")
+                let fileBytes = (try? FileManager.default.attributesOfItem(atPath: newContents.path)[.size] as? Int64) ?? documentSize?.int64Value
+                InsufficientQuotaReporter.reportItem(relativePath: relativePath, fileName: filename, fileBytes: fileBytes, availableBytes: nil, domainIdentifier: domain?.identifier, appProxy: appProxy, log: logger.log)
+                await InsufficientQuotaReporter.reportSummary(domainIdentifier: domain?.identifier, appProxy: appProxy, log: logger.log)
+            }
+
             // Moving should be done before uploading and should catch collisions already, but,
             // it is painless to check here too just in case
-            return await (nil, error.fileProviderError(
-                handlingCollisionAgainstItemInRemotePath: remotePath,
-                dbManager: dbManager,
-                remoteInterface: remoteInterface,
-                log: logger.log
-            ))
+            return await (nil, error.fileProviderError(handlingCollisionAgainstItemInRemotePath: remotePath, dbManager: dbManager, remoteInterface: remoteInterface, log: logger.log))
         }
+
+        // Re-arm the per-domain dedup so a future quota event can surface a fresh summary.
+        await InsufficientQuotaReporter.clearSummaryDedup(domainIdentifier: domain?.identifier)
 
         logger.info(
             """
@@ -484,7 +495,8 @@ public extension Item {
                 forcedChunkSize: forcedChunkSize,
                 domain: domain,
                 progress: progress,
-                dbManager: dbManager
+                dbManager: dbManager,
+                appProxy: appProxy
             )
 
             guard contentError == nil, let contentModifiedItem else {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Services/BundleExclusionReporter.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Services/BundleExclusionReporter.swift
@@ -19,11 +19,11 @@ import NextcloudFileProviderXPC
 /// provider boundary and the user is informed politely instead of being left with a partial
 /// sync.
 ///
-public enum BundleExclusionReporter {
+enum BundleExclusionReporter {
     ///
     /// Localized human-readable reason shown to the user in the activity view.
     ///
-    public static func reasonText() -> String {
+    static func reasonText() -> String {
         NSLocalizedString(
             "BundleExclusion.Reason",
             bundle: .module,
@@ -43,7 +43,7 @@ public enum BundleExclusionReporter {
     ///   - appProxy: The cached `id<AppProtocol>` proxy held by the running `FileProviderExtension`. May be `nil` (e.g. main app not running) — in which case the report is dropped silently.
     ///   - log: The logger used for diagnostic output.
     ///
-    public static func report(
+    static func report(
         relativePath: String,
         fileName: String,
         domainIdentifier: NSFileProviderDomainIdentifier,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Services/InsufficientQuotaReporter.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Services/InsufficientQuotaReporter.swift
@@ -1,0 +1,138 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+import Foundation
+import NextcloudFileProviderXPC
+
+///
+/// Reports an upload that was refused due to insufficient server-side quota to the main app
+/// over the existing extension-to-app XPC channel.
+///
+/// The main app surfaces TWO entries in the systray's activity view:
+///
+/// - One per refused item (subject "“X” was not synchronized" / message describing the quota
+///   shortfall). Driven by `reportItem(...)`.
+/// - One per affected domain, with a "Retry all uploads" primary button. Driven by
+///   `reportSummary(...)` and deduped per-domain by this reporter so a 50-file paste produces
+///   a single summary, not 50.
+///
+/// This mirrors the per-item activity entry that classic sync produces via
+/// `User::slotAddErrorToGui` and the per-folder summary that classic sync produces via
+/// `SyncEngine::slotInsufficientRemoteStorage` → `User::slotAddError(InsufficientRemoteStorage)`.
+/// See nextcloud/desktop#9598.
+///
+enum InsufficientQuotaReporter {
+    ///
+    /// Per-domain dedup state for the summary report. Cleared by `clearSummaryDedup(...)` once
+    /// any subsequent upload in the same domain succeeds, so the next quota event re-arms the
+    /// summary message.
+    ///
+    private actor SummaryDedupState {
+        static let shared = SummaryDedupState()
+
+        private var reportedDomains = Set<String>()
+
+        ///
+        /// Atomically check-and-set: returns `true` if this is the first call for `domain`
+        /// since the last reset (i.e. the caller should send the summary), `false` otherwise.
+        ///
+        func shouldReport(domain: String) -> Bool {
+            guard !reportedDomains.contains(domain) else {
+                return false
+            }
+
+            reportedDomains.insert(domain)
+            return true
+        }
+
+        ///
+        /// Clear dedup state for a domain so the next quota event for it re-emits the summary.
+        ///
+        func clear(domain: String) {
+            reportedDomains.remove(domain)
+        }
+    }
+
+    ///
+    /// Send a per-item insufficient-quota report to the main app. Best-effort: errors are
+    /// logged and never thrown.
+    ///
+    /// - Parameters:
+    ///    - relativePath: The item's path relative to the file provider domain root.
+    ///    - fileName: The display name of the item, e.g. `huge-video.mov`.
+    ///    - fileBytes: Size of the file the user tried to upload, in bytes. `nil` if not known.
+    ///    - availableBytes: Available server quota at the upload's parent, in bytes. `nil` if
+    ///      not known (e.g. when the refusal came from a server 507 rather than a pre-flight
+    ///      PROPFIND).
+    ///    - domainIdentifier: The file provider domain identifier for the affected account.
+    ///    - appProxy: The cached `id<AppProtocol>` proxy held by the running
+    ///      `FileProviderExtension`. May be `nil` (e.g. main app not running) — in which case
+    ///      the report is dropped silently.
+    ///    - log: The logger used for diagnostic output.
+    ///
+    static func reportItem(relativePath: String, fileName: String, fileBytes: Int64?, availableBytes: Int64?, domainIdentifier: NSFileProviderDomainIdentifier?, appProxy: (any AppProtocol)?, log: any FileProviderLogging) {
+        let logger = FileProviderLogger(category: "InsufficientQuotaReporter", log: log)
+
+        guard let appProxy else {
+            logger.info("Quota item report dropped because of missing XPC proxy.", [.name: fileName])
+            return
+        }
+
+        guard let domainIdentifier else {
+            logger.info("Quota item report dropped because of missing domain identifier.", [.name: fileName])
+            return
+        }
+
+        logger.info("Reporting insufficient quota item to main app.", [.name: fileName])
+
+        appProxy.reportInsufficientQuota(forItem: relativePath, fileName: fileName, fileBytes: fileBytes.map { NSNumber(value: $0) }, availableBytes: availableBytes.map { NSNumber(value: $0) }, forDomainIdentifier: domainIdentifier.rawValue)
+    }
+
+    ///
+    /// Send a per-domain insufficient-quota *summary* report to the main app, at most once per
+    /// domain until `clearSummaryDedup(...)` is called. Safe to call repeatedly during a burst
+    /// of quota refusals.
+    ///
+    /// - Parameters:
+    ///   - domainIdentifier: The file provider domain identifier for the affected account.
+    ///   - appProxy: The cached `id<AppProtocol>` proxy. May be `nil`; the report is dropped
+    ///     silently in that case.
+    ///   - log: The logger used for diagnostic output.
+    ///
+    static func reportSummary(domainIdentifier: NSFileProviderDomainIdentifier?, appProxy: (any AppProtocol)?, log: any FileProviderLogging) async {
+        let logger = FileProviderLogger(category: "InsufficientQuotaReporter", log: log)
+
+        guard let appProxy else {
+            logger.info("Quota summary report dropped because of missing XPC proxy.")
+            return
+        }
+
+        guard let domainIdentifier else {
+            logger.info("Quota summary report dropped because of missing domain identifier.")
+            return
+        }
+
+        let shouldReport = await SummaryDedupState.shared.shouldReport(domain: domainIdentifier.rawValue)
+
+        guard shouldReport else {
+            logger.debug("Quota summary already reported for domain.", [.name: domainIdentifier.rawValue])
+            return
+        }
+
+        logger.info("Reporting insufficient quota summary to main app.", [.name: domainIdentifier.rawValue])
+        appProxy.reportInsufficientQuotaSummary(forDomainIdentifier: domainIdentifier.rawValue)
+    }
+
+    ///
+    /// Reset summary dedup state for the given domain. Called from upload-success paths so
+    /// the next quota event re-arms the summary entry.
+    ///
+    static func clearSummaryDedup(domainIdentifier: NSFileProviderDomainIdentifier?) async {
+        guard let domainIdentifier else {
+            return
+        }
+
+        await SummaryDedupState.shared.clear(domain: domainIdentifier.rawValue)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -37,6 +37,27 @@ func upload(
     let fileSize =
         (try? FileManager.default.attributesOfItem(atPath: localFilePath)[.size] as? Int64) ?? 0
 
+    // Pre-flight quota check: a depth-0 PROPFIND on the destination's parent picks up
+    // the user-level quota plus any tighter per-folder quota (group folders, external
+    // shares). Failing fast here keeps multi-GB chunked uploads from running for minutes
+    // before being rejected by a final 507. See nextcloud/desktop#9598.
+
+    if let lastSlash = remotePath.lastIndex(of: "/") {
+        let parentRemotePath = String(remotePath[..<lastSlash])
+
+        if !parentRemotePath.isEmpty {
+            let (_, files, _, propfindError) = await remoteInterface.enumerate(remotePath: parentRemotePath, depth: .target, showHiddenFiles: true, includeHiddenFiles: [], requestBody: nil, account: account, options: options, taskHandler: taskHandler)
+
+            if propfindError == .success, let availableBytes = files.first?.quotaAvailableBytes, availableBytes >= 0, fileSize > availableBytes {
+                uploadLogger.info("Refusing upload: file size \(fileSize) bytes exceeds available server quota of \(availableBytes) bytes.", [.url: remotePath])
+
+                return (nil, nil, nil, nil, NKError(statusCode: 507, fallbackDescription: "Insufficient quota on the server."))
+            } else if propfindError != .success {
+                uploadLogger.info("Could not check available quota. Proceeding with upload anyway.", [.error: propfindError, .url: parentRemotePath])
+            }
+        }
+    }
+
     let chunkSize = await {
         if let chunkSize {
             uploadLogger.info("Using provided chunkSize: \(chunkSize)")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderXPC/include/AppProtocol.h
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderXPC/include/AppProtocol.h
@@ -45,6 +45,32 @@ NS_ASSUME_NONNULL_BEGIN
                             reason:(NSString *)reason
                forDomainIdentifier:(NSString *)domainIdentifier;
 
+/**
+ * @brief The file provider extension reports a single item that the server refused with HTTP 507 (or that the pre-flight quota check refused).
+ *
+ * The main app surfaces an entry per item in its activity view, identical in shape to the per-item error entries the classic sync engine produces (e.g. "“X” was not synchronized — Insufficient storage on the server."). See nextcloud/desktop#9598.
+ *
+ * @param relativePath The item's path relative to the file provider domain root.
+ * @param fileName The display name of the item.
+ * @param fileBytes Size of the local file the user tried to upload, in bytes. May be `nil` if not known at report time.
+ * @param availableBytes Available quota the server reported via PROPFIND, in bytes. May be `nil` (e.g. when the refusal came from the server's 507 response rather than a pre-flight PROPFIND).
+ * @param domainIdentifier The file provider domain identifier for the affected account.
+ */
+- (void)reportInsufficientQuotaForItem:(NSString *)relativePath
+                              fileName:(NSString *)fileName
+                             fileBytes:(NSNumber * _Nullable)fileBytes
+                        availableBytes:(NSNumber * _Nullable)availableBytes
+                   forDomainIdentifier:(NSString *)domainIdentifier;
+
+/**
+ * @brief The file provider extension reports that one or more uploads were refused by the server's quota for the given domain.
+ *
+ * The main app surfaces a single per-folder summary entry in its activity view with a "Retry all uploads" button — analogous to the entry the classic sync engine produces via `SyncEngine::slotInsufficientRemoteStorage`. The main app dedupes this report per domain.
+ *
+ * @param domainIdentifier The file provider domain identifier for the affected account.
+ */
+- (void)reportInsufficientQuotaSummaryForDomainIdentifier:(NSString *)domainIdentifier;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteItem.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteItem.swift
@@ -34,6 +34,12 @@ public class MockRemoteItem: Equatable {
     public var serverUrl: String
     public var trashbinOriginalLocation: String?
 
+    // Defaults to -1 ("unknown / unlimited") so existing tests stay on the
+    // pre-quota-check code path. Tests that exercise the pre-flight quota
+    // gate set this on the upload's parent directory.
+    public var quotaAvailableBytes: Int64 = -1
+    public var quotaUsedBytes: Int64 = 0
+
     public static func == (lhs: MockRemoteItem, rhs: MockRemoteItem) -> Bool {
         lhs.parent == rhs.parent &&
             lhs.children == rhs.children &&
@@ -141,6 +147,8 @@ public class MockRemoteItem: Equatable {
         file.lockTimeOut = lockTimeOut
         file.trashbinFileName = name
         file.trashbinOriginalLocation = trashbinOriginalLocation ?? ""
+        file.quotaAvailableBytes = quotaAvailableBytes
+        file.quotaUsedBytes = quotaUsedBytes
         return file
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/BundleExclusionReporterTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/BundleExclusionReporterTests.swift
@@ -49,6 +49,18 @@ private final class CapturingAppProxy: NSObject, AppProtocol {
             )
         )
     }
+
+    /// Unused by these tests but required for protocol conformance — see
+    /// `InsufficientQuotaReporterTests` for the dedicated coverage.
+    func reportInsufficientQuota(
+        forItem _: String,
+        fileName _: String,
+        fileBytes _: NSNumber?,
+        availableBytes _: NSNumber?,
+        forDomainIdentifier _: String
+    ) {}
+
+    func reportInsufficientQuotaSummary(forDomainIdentifier _: String) {}
 }
 
 final class BundleExclusionReporterTests: XCTestCase {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/InsufficientQuotaReporterTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/InsufficientQuotaReporterTests.swift
@@ -1,0 +1,187 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudFileProviderXPC
+import XCTest
+
+/// Captures `AppProtocol` calls in-memory so the reporter can be exercised without a real XPC
+/// connection. Mirrors the helper used by `BundleExclusionReporterTests`, but with capture
+/// arrays for the new quota-specific methods.
+private final class CapturingAppProxy: NSObject, AppProtocol {
+    struct ItemCapture: Equatable {
+        let relativePath: String
+        let fileName: String
+        let fileBytes: Int64?
+        let availableBytes: Int64?
+        let domainIdentifier: String
+    }
+
+    var capturedItems: [ItemCapture] = []
+    var capturedSummaryDomains: [String] = []
+
+    func presentFileActions(
+        _: String, path _: String, remoteItemPath _: String, withDomainIdentifier _: String
+    ) {}
+
+    func reportSyncStatus(_: String, forDomainIdentifier _: String) {}
+
+    func reportItemExcluded(
+        fromSync _: String,
+        fileName _: String,
+        reason _: String,
+        forDomainIdentifier _: String
+    ) {}
+
+    func reportInsufficientQuota(
+        forItem relativePath: String,
+        fileName: String,
+        fileBytes: NSNumber?,
+        availableBytes: NSNumber?,
+        forDomainIdentifier domainIdentifier: String
+    ) {
+        capturedItems.append(
+            ItemCapture(
+                relativePath: relativePath,
+                fileName: fileName,
+                fileBytes: fileBytes?.int64Value,
+                availableBytes: availableBytes?.int64Value,
+                domainIdentifier: domainIdentifier
+            )
+        )
+    }
+
+    func reportInsufficientQuotaSummary(forDomainIdentifier domainIdentifier: String) {
+        capturedSummaryDomains.append(domainIdentifier)
+    }
+}
+
+final class InsufficientQuotaReporterTests: XCTestCase {
+    private let domainA = NSFileProviderDomainIdentifier("domain-a")
+    private let domainB = NSFileProviderDomainIdentifier("domain-b")
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // Reset shared dedup state between tests so order doesn't matter.
+        await InsufficientQuotaReporter.clearSummaryDedup(domainIdentifier: domainA)
+        await InsufficientQuotaReporter.clearSummaryDedup(domainIdentifier: domainB)
+    }
+
+    func testReportItemForwardsArguments() {
+        let proxy = CapturingAppProxy()
+        InsufficientQuotaReporter.reportItem(
+            relativePath: "/folder/huge.bin",
+            fileName: "huge.bin",
+            fileBytes: 50_000_000,
+            availableBytes: 1024,
+            domainIdentifier: domainA,
+            appProxy: proxy,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertEqual(proxy.capturedItems.count, 1)
+        XCTAssertEqual(
+            proxy.capturedItems.first,
+            CapturingAppProxy.ItemCapture(
+                relativePath: "/folder/huge.bin",
+                fileName: "huge.bin",
+                fileBytes: 50_000_000,
+                availableBytes: 1024,
+                domainIdentifier: "domain-a"
+            )
+        )
+    }
+
+    func testReportItemWithNilSizesPassesNilThrough() {
+        let proxy = CapturingAppProxy()
+        InsufficientQuotaReporter.reportItem(
+            relativePath: "/x",
+            fileName: "x",
+            fileBytes: nil,
+            availableBytes: nil,
+            domainIdentifier: domainA,
+            appProxy: proxy,
+            log: FileProviderLogMock()
+        )
+        XCTAssertEqual(proxy.capturedItems.first?.fileBytes, nil)
+        XCTAssertEqual(proxy.capturedItems.first?.availableBytes, nil)
+    }
+
+    func testReportItemWithoutProxyDropsSilently() {
+        // No assertion crash, no exception, just an info-level log line.
+        InsufficientQuotaReporter.reportItem(
+            relativePath: "/x",
+            fileName: "x",
+            fileBytes: nil,
+            availableBytes: nil,
+            domainIdentifier: domainA,
+            appProxy: nil,
+            log: FileProviderLogMock()
+        )
+    }
+
+    /// The summary is the per-folder activity entry that carries the "Retry all uploads"
+    /// button. Multiple refusals in the same domain must NOT pile up summaries.
+    func testSummaryDedupesPerDomain() async {
+        let proxy = CapturingAppProxy()
+        for _ in 0 ..< 5 {
+            await InsufficientQuotaReporter.reportSummary(
+                domainIdentifier: domainA,
+                appProxy: proxy,
+                log: FileProviderLogMock()
+            )
+        }
+        XCTAssertEqual(proxy.capturedSummaryDomains, ["domain-a"])
+    }
+
+    func testSummaryRearmsAfterClear() async {
+        let proxy = CapturingAppProxy()
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: proxy, log: FileProviderLogMock()
+        )
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: proxy, log: FileProviderLogMock()
+        )
+        await InsufficientQuotaReporter.clearSummaryDedup(domainIdentifier: domainA)
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: proxy, log: FileProviderLogMock()
+        )
+        XCTAssertEqual(proxy.capturedSummaryDomains, ["domain-a", "domain-a"])
+    }
+
+    func testSummaryDedupIsPerDomain() async {
+        let proxy = CapturingAppProxy()
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: proxy, log: FileProviderLogMock()
+        )
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainB, appProxy: proxy, log: FileProviderLogMock()
+        )
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: proxy, log: FileProviderLogMock()
+        )
+        XCTAssertEqual(proxy.capturedSummaryDomains, ["domain-a", "domain-b"])
+    }
+
+    func testSummaryWithoutProxyDropsSilently() async {
+        await InsufficientQuotaReporter.reportSummary(
+            domainIdentifier: domainA, appProxy: nil, log: FileProviderLogMock()
+        )
+    }
+
+    func testReportItemWithoutDomainDropsSilently() {
+        let proxy = CapturingAppProxy()
+        InsufficientQuotaReporter.reportItem(
+            relativePath: "/x",
+            fileName: "x",
+            fileBytes: nil,
+            availableBytes: nil,
+            domainIdentifier: nil,
+            appProxy: proxy,
+            log: FileProviderLogMock()
+        )
+        XCTAssertTrue(proxy.capturedItems.isEmpty)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -136,6 +136,82 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         XCTAssertTrue(createdItem.isUploaded)
     }
 
+    /// Pre-flight quota gate: when the parent's `quotaAvailableBytes` is below the local
+    /// file size, refuse the upload up-front with `.insufficientQuota` and never call
+    /// the remote upload endpoint. See nextcloud/desktop#9598.
+    func testCreateFileBlockedByInsufficientQuota() async throws {
+        rootItem.quotaAvailableBytes = 4 // less than the file we're about to upload
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        var fileItemMetadata = SendableItemMetadata(
+            ocId: "file-id", fileName: "file", account: Self.account
+        )
+        fileItemMetadata.classFile = NKTypeClassFile.document.rawValue
+
+        let tempUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-blocked-create")
+        try Data("Hello world".utf8).write(to: tempUrl) // 11 bytes > 4 bytes available
+
+        let fileItemTemplate = Item(
+            metadata: fileItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let (createdItem, error) = await Item.create(
+            basedOn: fileItemTemplate,
+            contents: tempUrl,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertNil(createdItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .insufficientQuota)
+        // No upload was attempted: the file did not appear under the remote root.
+        XCTAssertNil(rootItem.children.first { $0.name == fileItemMetadata.fileName })
+    }
+
+    /// Negative `quotaAvailableBytes` (the default for accounts with no quota set) must
+    /// not trigger the new pre-flight gate; the upload proceeds normally.
+    func testCreateFileWithUnknownQuotaProceeds() async throws {
+        XCTAssertEqual(rootItem.quotaAvailableBytes, -1) // default sentinel
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        var fileItemMetadata = SendableItemMetadata(
+            ocId: "file-id", fileName: "file-no-quota", account: Self.account
+        )
+        fileItemMetadata.classFile = NKTypeClassFile.document.rawValue
+
+        let tempUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-unknown-create")
+        try Data("Hello world".utf8).write(to: tempUrl)
+
+        let fileItemTemplate = Item(
+            metadata: fileItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let (createdItemMaybe, error) = await Item.create(
+            basedOn: fileItemTemplate,
+            contents: tempUrl,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertNil(error)
+        let createdItem = try XCTUnwrap(createdItemMaybe)
+        XCTAssertNotNil(rootItem.children.first { $0.identifier == createdItem.itemIdentifier.rawValue })
+    }
+
     func testCreateFileIntoFolder() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -4,11 +4,51 @@
 @preconcurrency import FileProvider
 @testable import NextcloudFileProviderKit
 import NextcloudFileProviderKitMocks
+import NextcloudFileProviderXPC
 import NextcloudKit
 import RealmSwift
 import TestInterface
 import UniformTypeIdentifiers
 import XCTest
+
+/// Captures the quota XPC calls so tests can verify the extension informs the main app on
+/// quota refusals (per-item + per-folder summary). See nextcloud/desktop#9598.
+final class QuotaCapturingAppProxy: NSObject, AppProtocol {
+    struct ItemCapture: Equatable {
+        let fileName: String
+        let fileBytes: Int64?
+        let availableBytes: Int64?
+        let domainIdentifier: String
+    }
+
+    var capturedItems: [ItemCapture] = []
+    var capturedSummaryDomains: [String] = []
+
+    func presentFileActions(_: String, path _: String, remoteItemPath _: String, withDomainIdentifier _: String) {}
+    func reportSyncStatus(_: String, forDomainIdentifier _: String) {}
+    func reportItemExcluded(fromSync _: String, fileName _: String, reason _: String, forDomainIdentifier _: String) {}
+
+    func reportInsufficientQuota(
+        forItem _: String,
+        fileName: String,
+        fileBytes: NSNumber?,
+        availableBytes: NSNumber?,
+        forDomainIdentifier domainIdentifier: String
+    ) {
+        capturedItems.append(
+            ItemCapture(
+                fileName: fileName,
+                fileBytes: fileBytes?.int64Value,
+                availableBytes: availableBytes?.int64Value,
+                domainIdentifier: domainIdentifier
+            )
+        )
+    }
+
+    func reportInsufficientQuotaSummary(forDomainIdentifier domainIdentifier: String) {
+        capturedSummaryDomains.append(domainIdentifier)
+    }
+}
 
 final class ItemCreateTests: NextcloudFileProviderKitTestCase {
     static let account = Account(
@@ -173,6 +213,59 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual((error as? NSFileProviderError)?.code, .insufficientQuota)
         // No upload was attempted: the file did not appear under the remote root.
         XCTAssertNil(rootItem.children.first { $0.name == fileItemMetadata.fileName })
+    }
+
+    /// When an upload is refused by the pre-flight quota gate, the extension must inform the
+    /// main app via XPC so it can surface a per-item activity entry plus a per-folder summary
+    /// entry with a "Retry all uploads" button. See nextcloud/desktop#9598.
+    func testCreateFileRefusedByQuotaReportsToMainApp() async throws {
+        rootItem.quotaAvailableBytes = 4
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        var fileItemMetadata = SendableItemMetadata(
+            ocId: "file-id", fileName: "file-quota-report", account: Self.account
+        )
+        fileItemMetadata.classFile = NKTypeClassFile.document.rawValue
+
+        let tempUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-report-create")
+        try Data("Hello world".utf8).write(to: tempUrl) // 11 bytes > 4 bytes available
+
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("test-domain-create"),
+            displayName: "test"
+        )
+        let proxy = QuotaCapturingAppProxy()
+
+        let fileItemTemplate = Item(
+            metadata: fileItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let (createdItem, error) = await Item.create(
+            basedOn: fileItemTemplate,
+            contents: tempUrl,
+            domain: domain,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            appProxy: proxy,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertNil(createdItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .insufficientQuota)
+
+        XCTAssertEqual(proxy.capturedItems.count, 1)
+        let itemCapture = try XCTUnwrap(proxy.capturedItems.first)
+        XCTAssertEqual(itemCapture.fileName, "file-quota-report")
+        XCTAssertEqual(itemCapture.domainIdentifier, "test-domain-create")
+        XCTAssertEqual(itemCapture.fileBytes, 11)
+
+        XCTAssertEqual(proxy.capturedSummaryDomains, ["test-domain-create"])
     }
 
     /// Negative `quotaAvailableBytes` (the default for accounts with no quota set) must

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -4,6 +4,7 @@
 @preconcurrency import FileProvider
 @testable import NextcloudFileProviderKit
 import NextcloudFileProviderKitMocks
+import NextcloudFileProviderXPC
 import NextcloudKit
 import RealmSwift
 import TestInterface
@@ -154,6 +155,62 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(
             remoteItem.remotePath, targetItemMetadata.serverUrl + "/" + targetItemMetadata.fileName
         )
+    }
+
+    /// Modify-path counterpart of `testCreateFileRefusedByQuotaReportsToMainApp`: the extension
+    /// must surface a per-item + per-folder summary report to the main app over XPC when an
+    /// already-uploaded file is rewritten with content the server can no longer accept.
+    func testModifyFileRefusedByQuotaReportsToMainApp() async throws {
+        rootItem.quotaAvailableBytes = 4
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContents = "Hello, much bigger New World!".data(using: .utf8)!
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-report-modify")
+        try newContents.write(to: newContentsUrl)
+
+        var targetItemMetadata = SendableItemMetadata(value: itemMetadata)
+        targetItemMetadata.size = Int64(newContents.count)
+
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("test-domain-modify"),
+            displayName: "test"
+        )
+        let proxy = QuotaCapturingAppProxy()
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: targetItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            domain: domain,
+            dbManager: Self.dbManager,
+            appProxy: proxy
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .insufficientQuota)
+        XCTAssertEqual(proxy.capturedItems.count, 1)
+        XCTAssertEqual(proxy.capturedItems.first?.fileName, "item.txt")
+        XCTAssertEqual(proxy.capturedItems.first?.fileBytes, Int64(newContents.count))
+        XCTAssertEqual(proxy.capturedSummaryDomains, ["test-domain-modify"])
     }
 
     /// Pre-flight quota gate on the modify path: when the parent's `quotaAvailableBytes`

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -156,6 +156,54 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    /// Pre-flight quota gate on the modify path: when the parent's `quotaAvailableBytes`
+    /// is below the new local content size, refuse the upload up-front with
+    /// `.insufficientQuota` and leave the remote item untouched.
+    /// See nextcloud/desktop#9598.
+    func testModifyFileBlockedByInsufficientQuota() async throws {
+        rootItem.quotaAvailableBytes = 4 // less than the new content we're about to push
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let originalRemoteData = remoteItem.data
+        let newContents = "Hello, much bigger New World!".data(using: .utf8)!
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("quota-blocked-modify")
+        try newContents.write(to: newContentsUrl)
+
+        var targetItemMetadata = SendableItemMetadata(value: itemMetadata)
+        targetItemMetadata.size = Int64(newContents.count)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: targetItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .insufficientQuota)
+        // The remote bytes must not have been touched by the refused upload.
+        XCTAssertEqual(remoteItem.data, originalRemoteData)
+    }
+
     func testModifyFolder() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
 

--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -79,6 +79,19 @@ public:
      */
     void openFileViewerForDomainIdentifier(const QString &domainIdentifier) const;
 
+    /**
+     * @brief Tell the system that the previously-returned `NSFileProviderError.insufficientQuota` error no longer applies and signal an enumeration of the working set so the system retries refused uploads.
+     *
+     * Implements the documented contract of
+     * `NSFileProviderManager.signalErrorResolved(_:completionHandler:)` followed by
+     * `signalEnumerator(for: .workingSet)`. Called from `User::slotFileProviderRetryUploads`
+     * when the user clicks the "Retry all uploads" button on the per-folder summary entry
+     * surfaced for nextcloud/desktop#9598.
+     *
+     * @param domainIdentifier The identifier of the affected file provider domain.
+     */
+    void clearInsufficientQuotaErrorAndEnumerate(const QString &domainIdentifier) const;
+
 public slots:
     /**
      * @brief Handle file ID changes from push notifications

--- a/src/gui/macOS/fileproviderdomainmanager.mm
+++ b/src/gui/macOS/fileproviderdomainmanager.mm
@@ -552,6 +552,67 @@ void FileProviderDomainManager::openFileViewerForDomainIdentifier(const QString 
     [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:@[[NSURL fileURLWithPath:url.toNSString()]]];
 }
 
+void FileProviderDomainManager::clearInsufficientQuotaErrorAndEnumerate(const QString &domainIdentifier) const
+{
+    if (!d || domainIdentifier.isEmpty()) {
+        return;
+    }
+
+    NSFileProviderDomain *targetDomain = nil;
+
+    for (NSFileProviderDomain * const domain : d->getDomains()) {
+        if (domainIdentifier == QString::fromNSString(domain.identifier)) {
+            targetDomain = domain;
+            break;
+        }
+    }
+
+    if (!targetDomain) {
+        qCWarning(lcMacFileProviderDomainManager) << "No file provider domain found with identifier"
+                                                  << domainIdentifier
+                                                  << "— cannot clear insufficient-quota error.";
+        return;
+    }
+
+    NSFileProviderManager * const manager = [NSFileProviderManager managerForDomain:targetDomain];
+
+    if (!manager) {
+        qCWarning(lcMacFileProviderDomainManager) << "No NSFileProviderManager for domain"
+                                                  << domainIdentifier
+                                                  << "— cannot clear insufficient-quota error.";
+        return;
+    }
+
+    NSError * const insufficientQuotaError = [NSError errorWithDomain:NSFileProviderErrorDomain
+                                                                 code:NSFileProviderErrorInsufficientQuota
+                                                             userInfo:nil];
+
+    qCInfo(lcMacFileProviderDomainManager) << "Clearing insufficient-quota error and signalling working-set enumerator for domain"
+                                           << domainIdentifier;
+
+    // Per Apple's documentation for `signalErrorResolved(_:completionHandler:)`, calling it
+    // tells the system that the previously-returned error no longer applies; the system may
+    // then retry the failed operation. Signalling the working set enumerator afterwards
+    // nudges the system to actually re-evaluate pending non-uploaded items, mirroring the
+    // pattern already used for `.notAuthenticated` in `FileProviderExtension.swift`.
+    [manager signalErrorResolved:insufficientQuotaError completionHandler:^(NSError * const resolveError) {
+        if (resolveError) {
+            qCWarning(lcMacFileProviderDomainManager) << "Failed to clear insufficient-quota error for domain"
+                                                      << domainIdentifier
+                                                      << ":" << QString::fromNSString(resolveError.localizedDescription);
+        }
+        
+        [manager signalEnumeratorForContainerItemIdentifier:NSFileProviderWorkingSetContainerItemIdentifier
+                                          completionHandler:^(NSError * const enumerateError) {
+            if (enumerateError) {
+                qCWarning(lcMacFileProviderDomainManager) << "Failed to signal working-set enumerator for domain"
+                                                          << domainIdentifier
+                                                          << ":" << QString::fromNSString(enumerateError.localizedDescription);
+            }
+        }];
+    }];
+}
+
 void FileProviderDomainManager::slotHandleFileIdsChanged(const OCC::Account * const account, const QList<qint64> &fileIds)
 {
     // NOTE: The fileIds argument is ignored for now but retained in the signature for future use.

--- a/src/gui/macOS/fileproviderservice.h
+++ b/src/gui/macOS/fileproviderservice.h
@@ -82,6 +82,34 @@ signals:
      */
     void itemExcludedFromSync(const QString &domainIdentifier, const QString &relativePath, const QString &fileName, const QString &reason);
 
+    /**
+     * @brief Emitted when a file provider extension reports a single item it refused to upload because of insufficient server-side quota.
+     *
+     * Consumers surface a per-item entry in the activity view — the same shape the classic
+     * sync engine produces via `User::slotAddErrorToGui`. See
+     * https://github.com/nextcloud/desktop/issues/9598.
+     *
+     * @param domainIdentifier The file provider domain identifier for the affected account.
+     * @param relativePath The path of the item relative to the file provider domain root.
+     * @param fileName The display name of the item.
+     * @param fileBytes The size of the file the user tried to upload, in bytes. -1 if unknown.
+     * @param availableBytes Available quota at the upload's parent at the time of refusal, in bytes. -1 if unknown.
+     */
+    void insufficientQuotaForItem(const QString &domainIdentifier, const QString &relativePath, const QString &fileName, qint64 fileBytes, qint64 availableBytes);
+
+    /**
+     * @brief Emitted when a file provider extension reports that one or more uploads were refused by the server quota for the given domain.
+     *
+     * Consumers surface a per-folder summary entry in the activity view with a "Retry all
+     * uploads" button — the same shape `SyncEngine::slotInsufficientRemoteStorage` →
+     * `User::slotAddError(InsufficientRemoteStorage)` produces for classic sync.
+     *
+     * The extension dedupes the report per domain; consumers do not need to dedupe again.
+     *
+     * @param domainIdentifier The file provider domain identifier for the affected account.
+     */
+    void insufficientQuotaSummary(const QString &domainIdentifier);
+
 private:
     class MacImplementation;
     std::unique_ptr<MacImplementation> d;

--- a/src/gui/macOS/fileproviderservice.mm
+++ b/src/gui/macOS/fileproviderservice.mm
@@ -78,6 +78,41 @@ Q_LOGGING_CATEGORY(lcMacFileProviderService, "nextcloud.gui.macfileproviderservi
                               Q_ARG(QString, qReason));
 }
 
+- (void)reportInsufficientQuotaForItem:(NSString *)relativePath
+                              fileName:(NSString *)fileName
+                             fileBytes:(NSNumber *)fileBytes
+                        availableBytes:(NSNumber *)availableBytes
+                   forDomainIdentifier:(NSString *)domainIdentifier
+{
+    const auto qDomainIdentifier = QString::fromNSString(domainIdentifier);
+    const auto qRelativePath = QString::fromNSString(relativePath);
+    const auto qFileName = QString::fromNSString(fileName);
+    const qint64 qFileBytes = fileBytes ? fileBytes.longLongValue : -1;
+    const qint64 qAvailableBytes = availableBytes ? availableBytes.longLongValue : -1;
+
+    qCInfo(OCC::lcMacFileProviderService) << "File provider extension reported insufficient-quota item:"
+                                          << qFileName
+                                          << "for domain:" << qDomainIdentifier;
+
+    QMetaObject::invokeMethod(_service, "insufficientQuotaForItem", Qt::QueuedConnection,
+                              Q_ARG(QString, qDomainIdentifier),
+                              Q_ARG(QString, qRelativePath),
+                              Q_ARG(QString, qFileName),
+                              Q_ARG(qint64, qFileBytes),
+                              Q_ARG(qint64, qAvailableBytes));
+}
+
+- (void)reportInsufficientQuotaSummaryForDomainIdentifier:(NSString *)domainIdentifier
+{
+    const auto qDomainIdentifier = QString::fromNSString(domainIdentifier);
+
+    qCInfo(OCC::lcMacFileProviderService) << "File provider extension reported insufficient-quota summary for domain:"
+                                          << qDomainIdentifier;
+
+    QMetaObject::invokeMethod(_service, "insufficientQuotaSummary", Qt::QueuedConnection,
+                              Q_ARG(QString, qDomainIdentifier));
+}
+
 - (void)reportSyncStatus:(NSString *)status forDomainIdentifier:(NSString *)domainIdentifier
 {
     const auto statusString = QString::fromNSString(status);
@@ -112,7 +147,14 @@ Q_LOGGING_CATEGORY(lcMacFileProviderService, "nextcloud.gui.macfileproviderservi
     } else if (statusString == QStringLiteral("SYNC_FINISHED")) {
         syncState = OCC::SyncResult::Status::Success;
     } else if (statusString == QStringLiteral("SYNC_FAILED")) {
-        syncState = OCC::SyncResult::Status::Problem;
+        // Map to `Error` (red icon) rather than `Problem` (yellow). Classic sync paints the
+        // tray icon red whenever any item-level error blocks an upload (see e.g.
+        // `SyncEngine::slotInsufficientRemoteStorage` → folder `Error` state); we want the
+        // file provider domain path to drive the same red state. Yellow `Problem` is reserved
+        // for soft warnings (e.g. unresolved conflicts coexisting with a successful sync) and
+        // does not match the semantics of the FPE's `errorActions` set, which only fills when
+        // an actual operation has failed. Reported on https://github.com/nextcloud/desktop/issues/9598.
+        syncState = OCC::SyncResult::Status::Error;
     } else if (statusString == QStringLiteral("SYNC_PAUSED")) {
         syncState = OCC::SyncResult::Status::Paused;
     } else {

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -315,6 +315,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
     QList<QString> problemFileProviderAccounts;
+    QList<QString> errorFileProviderAccounts;
     QList<QString> syncingFileProviderAccounts;
     QList<QString> successFileProviderAccounts;
     QList<QString> idleFileProviderAccounts;
@@ -334,6 +335,9 @@ void ownCloudGui::slotComputeOverallSyncStatus()
         const auto accountTooltipLabel = displayName.isEmpty() ? userIdAtHostWithPort : displayName;
 
         if (!fileProvider->xpc()->fileProviderDomainReachable(accountFpId)) {
+            // Unreachable XPC stays in the yellow "Problem" bucket (legacy behavior); the
+            // domain might just be coming up. Only proper failure states (`Error`/`SetupError`)
+            // earn the red icon.
             problemFileProviderAccounts.append(accountTooltipLabel);
         } else {
             switch (fileProvider->service()->latestReceivedSyncStatusForAccount(accountState->account())) {
@@ -350,9 +354,19 @@ void ownCloudGui::slotComputeOverallSyncStatus()
                 successFileProviderAccounts.append(accountTooltipLabel);
                 break;
             case SyncResult::Problem:
+                // Yellow tray icon — soft warning. Reserve for cases like unresolved
+                // conflicts coexisting with an otherwise successful sync.
+                problemFileProviderAccounts.append(accountTooltipLabel);
+                break;
             case SyncResult::Error:
             case SyncResult::SetupError:
-                problemFileProviderAccounts.append(accountTooltipLabel);
+                // Red tray icon — an actual operation failed (e.g. quota refusal). Tracked
+                // separately from Problem so the icon below can correctly map to
+                // `SyncResult::Error` rather than `Problem`. Without this split, every
+                // `SYNC_FAILED` from the FPE — including insufficient-quota refusals —
+                // landed in the same bucket as soft warnings and showed the yellow icon.
+                // See https://github.com/nextcloud/desktop/issues/9598.
+                errorFileProviderAccounts.append(accountTooltipLabel);
                 break;
             case SyncResult::Paused: // This is not technically possible with VFS
                 break;
@@ -407,7 +421,9 @@ void ownCloudGui::slotComputeOverallSyncStatus()
     FolderMan::trayOverallStatus(map.values(), &overallStatus, &hasUnresolvedConflicts, &overallProgressInfo);
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
-    if (!problemFileProviderAccounts.isEmpty()) {
+    if (!errorFileProviderAccounts.isEmpty()) {
+        overallStatus = SyncResult::Error;
+    } else if (!problemFileProviderAccounts.isEmpty()) {
         overallStatus = SyncResult::Problem;
     } else if (!syncingFileProviderAccounts.isEmpty() &&
                overallStatus != SyncResult::SyncRunning &&
@@ -415,7 +431,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
                overallStatus != SyncResult::Error &&
                overallStatus != SyncResult::SetupError) {
         overallStatus = SyncResult::SyncRunning;
-    } else if ((!successFileProviderAccounts.isEmpty() || (problemFileProviderAccounts.isEmpty() && syncingFileProviderAccounts.isEmpty() && !idleFileProviderAccounts.isEmpty())) &&
+    } else if ((!successFileProviderAccounts.isEmpty() || (problemFileProviderAccounts.isEmpty() && errorFileProviderAccounts.isEmpty() && syncingFileProviderAccounts.isEmpty() && !idleFileProviderAccounts.isEmpty())) &&
                overallStatus != SyncResult::SyncRunning &&
                overallStatus != SyncResult::Problem &&
                overallStatus != SyncResult::Error &&
@@ -441,7 +457,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
 
     // create the tray blob message, check if we have an defined state
 #ifdef BUILD_FILE_PROVIDER_MODULE
-    if (!map.isEmpty() || !syncingFileProviderAccounts.isEmpty() || !successFileProviderAccounts.isEmpty() || !problemFileProviderAccounts.isEmpty()) {
+    if (!map.isEmpty() || !syncingFileProviderAccounts.isEmpty() || !successFileProviderAccounts.isEmpty() || !problemFileProviderAccounts.isEmpty() || !errorFileProviderAccounts.isEmpty()) {
 #else
     if (map.count() > 0) {
 #endif
@@ -468,6 +484,9 @@ void ownCloudGui::slotComputeOverallSyncStatus()
         }
         for (const auto &accountId : problemFileProviderAccounts) {
             allStatusStrings += tr("macOS VFS for %1: A problem was encountered.").arg(accountId);
+        }
+        for (const auto &accountId : errorFileProviderAccounts) {
+            allStatusStrings += tr("macOS VFS for %1: An error was encountered.").arg(accountId);
         }
 #endif
         trayMessage = allStatusStrings.join(QLatin1String("\n"));

--- a/src/gui/tray/activitydata.h
+++ b/src/gui/tray/activitydata.h
@@ -39,6 +39,12 @@ public:
 
     static constexpr auto WhitelistFolderVerb = "WHITELIST_FOLDER";
     static constexpr auto BlacklistFolderVerb = "BLACKLIST_FOLDER";
+    /// Verb for the per-folder summary entry the file provider extension surfaces when an
+    /// upload is refused for insufficient server-side quota. The link payload is the file
+    /// provider domain identifier; `ActivityListModel::slotTriggerAction` dispatches this
+    /// verb to `User::slotFileProviderRetryUploads` and clears the quota entries for the
+    /// domain. See https://github.com/nextcloud/desktop/issues/9598.
+    static constexpr auto FileProviderRetryUploadsVerb = "FILE_PROVIDER_RETRY_UPLOADS";
 
 public:
     QString _imageSource;

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -673,6 +673,54 @@ void ActivityListModel::removeActivityFromActivityList(const Activity &activity)
     }
 }
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+qint64 ActivityListModel::fileProviderQuotaSummaryActivityId(const QString &domainIdentifier)
+{
+    return -static_cast<qint64>(qHash(QStringLiteral("fp-quota-summary:") + domainIdentifier));
+}
+
+qint64 ActivityListModel::fileProviderQuotaItemActivityId(
+    const QString &domainIdentifier, const QString &relativePath, const QString &fileName)
+{
+    return -static_cast<qint64>(qHash(QStringLiteral("fp-quota-item:") + domainIdentifier + relativePath + fileName));
+}
+
+void ActivityListModel::removeFileProviderQuotaActivitiesForDomain(const QString &domainIdentifier)
+{
+    if (domainIdentifier.isEmpty()) {
+        return;
+    }
+
+    const auto summaryId = fileProviderQuotaSummaryActivityId(domainIdentifier);
+
+    // Both the per-folder summary (constructed by `User::slotFileProviderInsufficientQuotaSummary`)
+    // and each per-item entry (constructed by `slotFileProviderInsufficientQuotaForItem`) stamp
+    // the file provider domain identifier into `_folder` for exactly this reason: the retry
+    // sweep can match by it without parsing subjects. A summary entry is identified by its
+    // stable id; per-item entries are identified by `_folder == domainIdentifier` plus the
+    // `DetailError` status (the only status we ever publish for these item entries).
+    ActivityList toRemove;
+    for (const auto &activity : std::as_const(_finalList)) {
+        if (activity._id == summaryId) {
+            toRemove.append(activity);
+            continue;
+        }
+        if (activity._type == Activity::SyncFileItemType
+            && activity._syncFileItemStatus == SyncFileItem::DetailError
+            && activity._folder == domainIdentifier) {
+            toRemove.append(activity);
+        }
+    }
+
+    for (const auto &activity : std::as_const(toRemove)) {
+        removeActivityFromActivityList(activity);
+    }
+
+    qCInfo(lcActivity) << "Removed" << toRemove.size()
+                       << "file provider quota activities for domain" << domainIdentifier;
+}
+#endif
+
 void ActivityListModel::removeOutdatedNotifications(const OCC::ActivityList &receivedNotifications)
 {
     ActivityList activitiesToRemove;
@@ -855,6 +903,17 @@ void ActivityListModel::slotTriggerAction(const int activityIndex, const int act
         removeActivityFromActivityList(activity);
         return;
     }
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    else if (action._verb == ActivityLink::FileProviderRetryUploadsVerb) {
+        const auto domainIdentifier = action._link;
+        // Tell the system to drop the cached `.insufficientQuota` error and re-enumerate
+        // (handled by `OCC::User::slotFileProviderRetryUploads`), then sweep the related
+        // activity entries from the list so the user gets immediate feedback.
+        emit fileProviderRetryUploadsRequested(domainIdentifier);
+        removeFileProviderQuotaActivitiesForDomain(domainIdentifier);
+        return;
+    }
+#endif
 
     emit sendNotificationRequest(activity._accName, action._link, action._verb, activityIndex);
 }

--- a/src/gui/tray/activitylistmodel.h
+++ b/src/gui/tray/activitylistmodel.h
@@ -134,6 +134,23 @@ public slots:
     void setReplyMessageSent(const int activityIndex, const QString &message);
     void setCurrentItem(const int currentItem);
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    /// Stable activity `_id` for the per-domain insufficient-quota summary entry. Used by
+    /// both `OCC::User` (when constructing the entry) and this model (when removing it on
+    /// retry). See https://github.com/nextcloud/desktop/issues/9598.
+    [[nodiscard]] static qint64 fileProviderQuotaSummaryActivityId(const QString &domainIdentifier);
+
+    /// Stable activity `_id` for a per-item insufficient-quota entry. Identical hashing on
+    /// both producer and consumer keeps `removeFileProviderQuotaActivitiesForDomain(...)`
+    /// able to find rows it didn't author.
+    [[nodiscard]] static qint64 fileProviderQuotaItemActivityId(const QString &domainIdentifier, const QString &relativePath, const QString &fileName);
+
+    /// Remove the per-folder summary entry plus every per-item quota entry that belongs to
+    /// the given domain from the activity list. Called when the user clicks "Retry all
+    /// uploads" so the UI gives immediate feedback that the click did something.
+    void removeFileProviderQuotaActivitiesForDomain(const QString &domainIdentifier);
+#endif
+
 signals:
     void accountStateChanged();
     void hasSyncConflictsChanged();
@@ -145,6 +162,16 @@ signals:
     void interactiveActivityReceived();
 
     void showSettingsDialog();
+
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    /**
+     * @brief Emitted when the user clicks the "Retry all uploads" button on a file provider
+     * insufficient-quota summary entry. The argument is the file provider domain identifier;
+     * the slot in `OCC::User` calls `signalErrorResolved` + `signalEnumerator` for that domain.
+     * See https://github.com/nextcloud/desktop/issues/9598.
+     */
+    void fileProviderRetryUploadsRequested(const QString &domainIdentifier);
+#endif
 
 protected:
     [[nodiscard]] bool currentlyFetching() const;

--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -281,15 +281,20 @@ void SyncStatusSummary::onFileProviderDomainSyncStateChanged(const AccountPtr &a
     switch (state) {
     case SyncResult::Success:
     case SyncResult::SyncPrepare:
-        // Success should only be shown if all folders were fine
+        // The domain is healthy again, so it no longer counts towards the "some files
+        // couldn't be synced" header.
         _fileProviderDomainsWithErrors.erase(account->userIdAtHostWithPort());
         break;
     case SyncResult::Error:
     case SyncResult::SetupError:
     case SyncResult::Problem:
     case SyncResult::Undefined:
-        _fileProviderDomainsWithErrors.erase(account->userIdAtHostWithPort());
-        state = SyncResult::Success;
+        // Mark this domain as failing so `setSyncState`'s `Success` branch correctly gates
+        // the "All synced!" header on `_fileProviderDomainsWithErrors.empty()`. The previous
+        // inversion erased the domain and forced `state = Success`, which is why the header
+        // showed "Everything synchronized!" while the tray icon was red. See
+        // https://github.com/nextcloud/desktop/issues/9598.
+        _fileProviderDomainsWithErrors.insert(account->userIdAtHostWithPort());
         break;
     case SyncResult::SyncRunning:
     case SyncResult::NotYetStarted:
@@ -297,7 +302,7 @@ void SyncStatusSummary::onFileProviderDomainSyncStateChanged(const AccountPtr &a
     case SyncResult::SyncAbortRequested:
         break;
     }
-        
+
     setSyncState(state);
 }
 #endif

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -336,6 +336,12 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
 #ifdef BUILD_FILE_PROVIDER_MODULE
     connect(Mac::FileProvider::instance()->service(), &Mac::FileProviderService::itemExcludedFromSync,
             this, &User::slotFileProviderItemExcludedFromSync);
+    connect(Mac::FileProvider::instance()->service(), &Mac::FileProviderService::insufficientQuotaForItem,
+            this, &User::slotFileProviderInsufficientQuotaForItem);
+    connect(Mac::FileProvider::instance()->service(), &Mac::FileProviderService::insufficientQuotaSummary,
+            this, &User::slotFileProviderInsufficientQuotaSummary);
+    connect(_activityModel, &ActivityListModel::fileProviderRetryUploadsRequested,
+            this, &User::slotFileProviderRetryUploads);
 #endif
 }
 
@@ -609,6 +615,9 @@ void User::slotCheckExpiredActivities()
     // Bundle-exclusion entries inherit the same expiration cycle as other activity errors. Once
     // their entries are pruned above, allow the same paths to surface again on the next drop.
     _reportedExcludedBundles.clear();
+    // Same lifecycle for quota dedup state: once the per-item activity rows have aged out of
+    // the list, allow the same files to re-surface on the next quota event.
+    _reportedQuotaItems.clear();
 #endif
 }
 
@@ -645,6 +654,124 @@ void User::slotFileProviderItemExcludedFromSync(const QString &domainIdentifier,
     }
 
     qCInfo(lcActivity) << "Surfaced bundle-exclusion in activity view for" << fileName << "in domain" << domainIdentifier;
+}
+
+void User::slotFileProviderInsufficientQuotaForItem(const QString &domainIdentifier, const QString &relativePath, const QString &fileName, qint64 fileBytes, qint64 availableBytes)
+{
+    const auto reportedAccount = AccountManager::instance()->accountFromFileProviderDomainIdentifier(domainIdentifier);
+    if (!reportedAccount || reportedAccount != _account) {
+        return;
+    }
+
+    // The system retries failing createItem/modifyItem operations transparently, so a single
+    // user-visible refusal can produce many `reportInsufficientQuotaForItem` calls. Dedupe
+    // per (domain, relativePath) so the activity list shows one row per affected file rather
+    // than one per retry. See https://github.com/nextcloud/desktop/issues/9598.
+    const auto dedupKey = domainIdentifier + QLatin1Char('|') + relativePath;
+    if (_reportedQuotaItems.contains(dedupKey)) {
+        qCDebug(lcActivity) << "Suppressing duplicate quota-item entry for" << relativePath << "in domain" << domainIdentifier;
+        return;
+    }
+    _reportedQuotaItems.insert(dedupKey);
+
+    Activity activity;
+    activity._type = Activity::SyncFileItemType;
+    activity._syncFileItemStatus = SyncFileItem::DetailError;
+    activity._subject = tr("“%1” was not synchronized").arg(fileName);
+    if (fileBytes >= 0 && availableBytes >= 0) {
+        activity._message = tr("Insufficient storage on the server. The file requires %1 but only %2 are available.")
+            .arg(Utility::octetsToString(fileBytes), Utility::octetsToString(availableBytes));
+    } else if (fileBytes >= 0) {
+        activity._message = tr("Insufficient storage on the server. The file requires %1.")
+            .arg(Utility::octetsToString(fileBytes));
+    } else {
+        activity._message = tr("Insufficient storage on the server.");
+    }
+    activity._link = relativePath;
+    activity._file = fileName; // also stashed so the retry sweep can recompute the activity id
+    const auto currentDateTime = QDateTime::currentDateTime();
+    activity._dateTime = QDateTime::fromString(currentDateTime.toString(), Qt::ISODate);
+    activity._expireAtMsecs = currentDateTime.addMSecs(activityDefaultExpirationTimeMsecs).toMSecsSinceEpoch();
+    activity._accName = _account->account()->displayName();
+    activity._folder = domainIdentifier; // payload used by the per-domain sweep on retry click
+    activity._id = ActivityListModel::fileProviderQuotaItemActivityId(domainIdentifier, relativePath, fileName);
+
+    _activityModel->addErrorToActivityList(activity, ActivityListModel::ErrorType::SyncError);
+
+    if (!_expiredActivitiesCheckTimer.isActive()) {
+        _expiredActivitiesCheckTimer.start(expiredActivitiesCheckIntervalMsecs);
+    }
+
+    qCInfo(lcActivity) << "Surfaced insufficient-quota item in activity view for" << fileName << "in domain" << domainIdentifier;
+}
+
+void User::slotFileProviderInsufficientQuotaSummary(const QString &domainIdentifier)
+{
+    const auto reportedAccount = AccountManager::instance()->accountFromFileProviderDomainIdentifier(domainIdentifier);
+    if (!reportedAccount || reportedAccount != _account) {
+        return;
+    }
+
+    if (_reportedQuotaSummaryDomains.contains(domainIdentifier)) {
+        qCDebug(lcActivity) << "Suppressing duplicate quota-summary entry for domain" << domainIdentifier;
+        return;
+    }
+    _reportedQuotaSummaryDomains.insert(domainIdentifier);
+
+    Activity activity;
+    activity._type = Activity::SyncResultType;
+    activity._syncResultStatus = SyncResult::Error;
+    activity._subject = tr("There is insufficient space available on the server for some uploads.");
+    // Surface the file provider domain's user-visible root path so the activity entry shows
+    // the affected folder, matching the layout classic sync produces in `User::slotAddError`
+    // where `activity._message = folderInstance->shortGuiLocalPath()`.
+    const auto domainPath = Mac::FileProvider::instance()->domainManager()->userVisibleUrlForDomainIdentifier(domainIdentifier);
+    activity._message = !domainPath.isEmpty() ? domainPath : domainIdentifier;
+    activity._link = domainIdentifier; // payload for the retry handler
+
+    const auto currentDateTime = QDateTime::currentDateTime();
+    activity._dateTime = QDateTime::fromString(currentDateTime.toString(), Qt::ISODate);
+    activity._expireAtMsecs = currentDateTime.addMSecs(activityDefaultExpirationTimeMsecs).toMSecsSinceEpoch();
+    activity._accName = _account->account()->displayName();
+    activity._folder = domainIdentifier; // makes the summary sweepable by the same per-domain key
+    activity._id = ActivityListModel::fileProviderQuotaSummaryActivityId(domainIdentifier);
+
+    ActivityLink retry;
+    retry._label = tr("Retry all uploads");
+    retry._link = domainIdentifier;
+    retry._verb = ActivityLink::FileProviderRetryUploadsVerb;
+    retry._primary = true;
+    activity._links.append(retry);
+
+    _activityModel->addErrorToActivityList(activity, ActivityListModel::ErrorType::SyncError);
+
+    if (!_expiredActivitiesCheckTimer.isActive()) {
+        _expiredActivitiesCheckTimer.start(expiredActivitiesCheckIntervalMsecs);
+    }
+
+    qCInfo(lcActivity) << "Surfaced insufficient-quota summary in activity view for domain" << domainIdentifier;
+}
+
+void User::slotFileProviderRetryUploads(const QString &domainIdentifier)
+{
+    qCInfo(lcActivity) << "User requested retry of file provider uploads for domain" << domainIdentifier;
+
+    // Ask the system to drop the cached `.insufficientQuota` error against affected items
+    // and re-enumerate the working set so retries kick in. Per Apple's documentation for
+    // `signalErrorResolved(_:completionHandler:)`, this is the correct way to clear a
+    // previously-returned error before requesting a re-evaluation.
+    Mac::FileProvider::instance()->domainManager()->clearInsufficientQuotaErrorAndEnumerate(domainIdentifier);
+
+    // Re-arm dedupe so the next quota event for this domain produces a fresh summary entry
+    // and fresh per-item entries (one per affected file, not one per retry).
+    _reportedQuotaSummaryDomains.remove(domainIdentifier);
+    const auto domainPrefix = domainIdentifier + QLatin1Char('|');
+    QMutableSetIterator<QString> it(_reportedQuotaItems);
+    while (it.hasNext()) {
+        if (it.next().startsWith(domainPrefix)) {
+            it.remove();
+        }
+    }
 }
 #endif
 

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -202,6 +202,22 @@ public slots:
     /// account's activity view. Connected from `Mac::FileProviderService::itemExcludedFromSync`.
     /// Tracked at https://github.com/nextcloud/desktop/issues/9827.
     void slotFileProviderItemExcludedFromSync(const QString &domainIdentifier, const QString &relativePath, const QString &fileName, const QString &reason);
+
+    /// Surface a single item refused by the server quota as a per-item entry in the activity
+    /// view. Connected from `Mac::FileProviderService::insufficientQuotaForItem`.
+    /// See https://github.com/nextcloud/desktop/issues/9598.
+    void slotFileProviderInsufficientQuotaForItem(const QString &domainIdentifier, const QString &relativePath, const QString &fileName, qint64 fileBytes, qint64 availableBytes);
+
+    /// Surface a per-folder summary entry for an insufficient-quota event in the activity
+    /// view. Carries a "Retry all uploads" button. Connected from
+    /// `Mac::FileProviderService::insufficientQuotaSummary`.
+    void slotFileProviderInsufficientQuotaSummary(const QString &domainIdentifier);
+
+    /// Trigger when the user clicks "Retry all uploads" on a per-folder quota summary.
+    /// Calls `NSFileProviderManager.signalErrorResolved(_:)` followed by
+    /// `signalEnumerator(for: .workingSet)` for the affected domain so the system retries
+    /// previously refused uploads.
+    void slotFileProviderRetryUploads(const QString &domainIdentifier);
 #endif
 
 private slots:
@@ -259,6 +275,18 @@ private:
     /// Rate-limit per relativePath so repeated bundle drops don't spam the activity view.
     /// Cleared by the existing `_expiredActivitiesCheckTimer` tick.
     QSet<QString> _reportedExcludedBundles;
+
+    /// Per-domain dedup for the file provider quota summary entry. Cleared on
+    /// "Retry all uploads" click so a fresh quota event re-emits the summary.
+    QSet<QString> _reportedQuotaSummaryDomains;
+
+    /// Per-(domain, relativePath) dedup for the file provider quota item entries. Without
+    /// this, every system-driven retry of the failing createItem/modifyItem produces a new
+    /// "X was not synchronized" row in the activity list. Keys are
+    /// `domainIdentifier + "|" + relativePath`. Cleared wholesale on the existing expiry
+    /// timer tick (so once an entry naturally expires it can re-surface) and per-domain on
+    /// "Retry all uploads" click.
+    QSet<QString> _reportedQuotaItems;
 #endif
     QMimeDatabase _mimeDb;
 


### PR DESCRIPTION
The actual pre-flight quota check for the file provider extension was implemented in a few lines. 😌 All the rest is the handling in our Qt/C++ main app. 😳 I know, it appears unreasonably complicated. 🤷🏻‍♀️ Hence the core fix and the rest to replicate the classic sync error reporting are two distinct commits.

Closes #9598.