### PR TITLE
Prevent duplicate database records for the same file provider item

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
@@ -1,0 +1,204 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+import RealmSwift
+
+public extension FilesDatabaseManager {
+    ///
+    /// Soft-delete any other non-deleted rows at the same logical address as
+    /// `incoming` whose `ocId` differs.
+    ///
+    /// Realm uses `ocId` as the primary key of ``RealmItemMetadata``. An
+    /// `update: .all` or `update: .modified` upsert therefore dedupes by
+    /// `ocId` only. When the server returns the same logical path with a
+    /// fresh `ocId` (restore-from-trash, another client recreating the item
+    /// during reconnect, an upload finalizer assigning a server-issued
+    /// `ocId`), the upsert inserts a second row beside the first. macOS can
+    /// only represent one sibling per logical name and renames the second
+    /// with a `" 2"` suffix when this surfaces in Finder.
+    ///
+    /// Call this from inside an active write transaction. The function
+    /// mutates the supplied Realm and assumes the caller will commit.
+    ///
+    /// In-flight rows (whose ``ItemMetadata/status`` is not ``Status/normal``)
+    /// and lock files of local origin are skipped: soft-deleting an
+    /// in-flight row would yank the file out from under a pending
+    /// `NSURLSession` task, and lock files of local origin must mirror the
+    /// existing exclusion in the materialised-deletions code path.
+    /// In-flight collisions are logged at `error` level for support
+    /// visibility.
+    ///
+    /// - Parameters:
+    ///   - incoming: The metadata about to be persisted; its `(account,
+    ///     serverUrl, fileName)` defines the logical address used for the
+    ///     collision query, while its `ocId` is excluded from candidates so
+    ///     that the normal same-`ocId` upsert is unaffected.
+    ///   - database: The Realm holding the open write transaction.
+    ///   - now: Timestamp stamped on every evicted row so the change
+    ///     surfaces through ``pendingWorkingSetChanges(since:)``.
+    ///
+    /// - Returns: The `ocId` values of rows that were soft-deleted.
+    ///
+    @discardableResult
+    func evictLogicalDuplicates(of incoming: any ItemMetadata, in database: Realm, now: Date = Date()) -> [String] {
+        // A lock file created by the local OS should never trigger eviction:
+        // it is not authoritative about the server-side state at its logical
+        // address and could otherwise soft-delete a legitimate server row.
+        if incoming.isLockFileOfLocalOrigin {
+            return []
+        }
+
+        let incomingOcId = incoming.ocId
+        let incomingAccount = incoming.account
+        let incomingServerUrl = incoming.serverUrl
+        let incomingFileName = incoming.fileName
+
+        let candidates = database
+            .objects(RealmItemMetadata.self)
+            .where {
+                $0.account == incomingAccount
+                    && $0.serverUrl == incomingServerUrl
+                    && $0.fileName == incomingFileName
+                    && $0.ocId != incomingOcId
+                    && !$0.deleted
+                    && !$0.isLockFileOfLocalOrigin
+            }
+
+        var evicted: [String] = []
+
+        for candidate in candidates {
+            if candidate.status != Status.normal.rawValue {
+                logger.error("Skipping eviction of in-flight logical duplicate.", [
+                    .item: candidate.ocId,
+                    .name: candidate.fileName,
+                    .url: candidate.serverUrl,
+                    .syncTime: candidate.syncTime
+                ])
+
+                continue
+            }
+
+            candidate.deleted = true
+            candidate.syncTime = now
+            evicted.append(candidate.ocId)
+
+            logger.info("Evicted logical duplicate.", [
+                .item: candidate.ocId,
+                .name: candidate.fileName,
+                .url: candidate.serverUrl,
+                .syncTime: candidate.syncTime
+            ])
+        }
+
+        return evicted
+    }
+
+    ///
+    /// One-shot startup pass that heals pre-existing logical duplicates
+    /// already persisted in the database.
+    ///
+    /// Buckets all non-deleted, non-lock-file rows (except the synthetic
+    /// root-container row) by `(account, serverUrl, fileName)`. Within each
+    /// bucket containing more than one row, picks a winner among the
+    /// settled (non-in-flight) rows by greatest ``ItemMetadata/syncTime``
+    /// — with the lexicographically greater `ocId` breaking ties — and
+    /// soft-deletes every other settled row. In-flight rows are never
+    /// touched (the still-running NSURLSession task references the
+    /// specific `ocId`) and an `error`-level log records each skip. If a
+    /// bucket is entirely in-flight, the whole bucket is left intact; the
+    /// next run-time eviction will heal it once the row settles.
+    ///
+    /// A write transaction is opened only when at least one bucket has
+    /// more than one row, so clean databases pay no transaction cost.
+    ///
+    func cleanupPreexistingLogicalDuplicates() {
+        let database = ncDatabase()
+        let rootContainerOcId = NSFileProviderItemIdentifier.rootContainer.rawValue
+
+        let candidates = database
+            .objects(RealmItemMetadata.self)
+            .where {
+                !$0.deleted
+                    && !$0.isLockFileOfLocalOrigin
+                    && $0.ocId != rootContainerOcId
+            }
+
+        struct LogicalKey: Hashable {
+            let account: String
+            let serverUrl: String
+            let fileName: String
+        }
+
+        var buckets: [LogicalKey: [RealmItemMetadata]] = [:]
+
+        for candidate in candidates {
+            let key = LogicalKey(account: candidate.account, serverUrl: candidate.serverUrl, fileName: candidate.fileName)
+            buckets[key, default: []].append(candidate)
+        }
+
+        let collisions = buckets.values.filter { $0.count > 1 }
+
+        guard !collisions.isEmpty else {
+            return
+        }
+
+        let now = Date()
+
+        do {
+            try database.write {
+                for group in collisions {
+                    let settled = group.filter { $0.status == Status.normal.rawValue }
+
+                    guard let winner = settled.max(by: { lhs, rhs in
+                        if lhs.syncTime != rhs.syncTime {
+                            return lhs.syncTime < rhs.syncTime
+                        }
+
+                        return lhs.ocId < rhs.ocId
+                    }) else {
+                        logger.info("Startup deduplication: all candidates are in-flight, leaving bucket intact.", [
+                            .name: group.first?.fileName,
+                            .url: group.first?.serverUrl
+                        ])
+
+                        continue
+                    }
+
+                    logger.info("Startup deduplication: kept canonical row.", [
+                        .item: winner.ocId,
+                        .name: winner.fileName,
+                        .url: winner.serverUrl,
+                        .syncTime: winner.syncTime
+                    ])
+
+                    for candidate in group where candidate.ocId != winner.ocId {
+                        if candidate.status != Status.normal.rawValue {
+                            logger.error("Startup deduplication: skipped in-flight logical duplicate.", [
+                                .item: candidate.ocId,
+                                .name: candidate.fileName,
+                                .url: candidate.serverUrl,
+                                .syncTime: candidate.syncTime
+                            ])
+
+                            continue
+                        }
+
+                        candidate.deleted = true
+                        candidate.syncTime = now
+
+                        logger.info("Startup deduplication: evicted duplicate.", [
+                            .item: candidate.ocId,
+                            .name: candidate.fileName,
+                            .url: candidate.serverUrl,
+                            .syncTime: candidate.syncTime
+                        ])
+                    }
+                }
+            }
+        } catch {
+            logger.error("Startup deduplication: write transaction failed.", [.error: error])
+        }
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -97,6 +97,7 @@ public final class FilesDatabaseManager: Sendable {
         do {
             _ = try Realm()
             logger.info("Successfully created Realm.")
+            cleanupPreexistingLogicalDuplicates()
         } catch {
             logger.fault("Error creating Realm: \(error)")
         }
@@ -378,6 +379,17 @@ public final class FilesDatabaseManager: Sendable {
             }
 
             try database.write {
+                // Evict any logical-address duplicates before persisting fresh
+                // payloads, so an ocId rotation (or rename whose target collides
+                // with a third row) does not leave two non-deleted siblings at
+                // the same `(account, serverUrl, fileName)`.
+                for metadata in metadatasToCreate {
+                    evictLogicalDuplicates(of: metadata, in: database)
+                }
+                for metadata in metadatasToUpdate {
+                    evictLogicalDuplicates(of: metadata, in: database)
+                }
+
                 // Do not delete the metadatas that have been deleted
                 database.add(metadatasToDelete.map { RealmItemMetadata(value: $0) }, update: .modified)
                 database.add(metadatasToUpdate.map { RealmItemMetadata(value: $0) }, update: .modified)
@@ -439,6 +451,7 @@ public final class FilesDatabaseManager: Sendable {
 
         do {
             try database.write {
+                evictLogicalDuplicates(of: metadata, in: database)
                 database.add(RealmItemMetadata(value: metadata), update: .all)
                 logger.debug("Added item metadata.", [.item: metadata.ocId, .name: metadata.fileName, .url: metadata.serverUrl])
             }
@@ -478,7 +491,9 @@ public final class FilesDatabaseManager: Sendable {
     public func addItemMetadataPreservingLocalState(_ metadata: SendableItemMetadata, preserveVisitedDirectory: Bool = true) -> SendableItemMetadata {
         var toWrite = metadata
 
-        if let existing = itemMetadatas.where({ $0.ocId == metadata.ocId }).first {
+        let metadatas = ncDatabase().objects(RealmItemMetadata.self)
+
+        if let existing = metadatas.where({ $0.ocId == metadata.ocId }).first {
             toWrite.downloaded = existing.downloaded
             toWrite.keepDownloaded = existing.keepDownloaded
 
@@ -487,6 +502,36 @@ public final class FilesDatabaseManager: Sendable {
             }
 
             toWrite.lockToken = existing.lockToken
+        } else {
+            // The ocId lookup missed. Before falling back to defaults from the
+            // server payload, look for a single non-deleted, non-local-lock row
+            // at the same logical address — an ocId rotation (restore-from-
+            // trash, recreate during reconnect, upload finalizer assigning a
+            // new server-side ocId) leaves the local-only state on the previous
+            // row, and #9923's preservation contract would otherwise silently
+            // drop `keepDownloaded`, `downloaded`, `visitedDirectory`, and
+            // `lockToken`. Only carry over when exactly one candidate exists:
+            // multiple candidates mean the DB is already in the duplicated
+            // state and choosing one would risk merging from the row about to
+            // be evicted. Eviction in `addItemMetadata` will then prune the
+            // prior row in the same write that persists the fresh one.
+            let logicalCandidates = metadatas.where {
+                $0.account == metadata.account
+                    && $0.serverUrl == metadata.serverUrl
+                    && $0.fileName == metadata.fileName
+                    && !$0.deleted
+                    && !$0.isLockFileOfLocalOrigin
+            }
+            if logicalCandidates.count == 1, let existing = logicalCandidates.first {
+                toWrite.downloaded = existing.downloaded
+                toWrite.keepDownloaded = existing.keepDownloaded
+
+                if preserveVisitedDirectory {
+                    toWrite.visitedDirectory = existing.visitedDirectory
+                }
+
+                toWrite.lockToken = existing.lockToken
+            }
         }
 
         addItemMetadata(toWrite)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -1391,4 +1391,405 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(updatedIds.count, expectedUpdatedCount, "Should have \(expectedUpdatedCount) updated items, got \(updatedIds.count): \(updatedIds)")
         XCTAssertEqual(deletedIds.count, expectedDeletedCount, "Should have \(expectedDeletedCount) deleted items, got \(deletedIds.count): \(deletedIds)")
     }
+
+    // MARK: - Logical-address deduplication
+
+    func testAddItemMetadataEvictsLogicalDuplicateWithDifferentOcId() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        var rowA = SendableItemMetadata(ocId: "A", fileName: "shared.txt", account: account)
+        rowA.syncTime = Date(timeIntervalSince1970: 1000)
+        Self.dbManager.addItemMetadata(rowA)
+
+        var rowB = SendableItemMetadata(ocId: "B", fileName: "shared.txt", account: account)
+        rowB.syncTime = Date(timeIntervalSince1970: 2000)
+        Self.dbManager.addItemMetadata(rowB)
+
+        let storedA = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "A"))
+        XCTAssertTrue(storedA.deleted, "Logical duplicate with different ocId should be soft-deleted")
+        XCTAssertGreaterThan(storedA.syncTime, rowA.syncTime, "Eviction should bump syncTime")
+
+        let storedB = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "B"))
+        XCTAssertFalse(storedB.deleted, "Newly added row should not be deleted")
+    }
+
+    func testAddItemMetadataSameOcIdSameLogicalPathIsNormalUpsert() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        var rowA = SendableItemMetadata(ocId: "A", fileName: "shared.txt", account: account)
+        rowA.etag = "v1"
+        Self.dbManager.addItemMetadata(rowA)
+
+        rowA.etag = "v2"
+        Self.dbManager.addItemMetadata(rowA)
+
+        let stored = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "A"))
+        XCTAssertFalse(stored.deleted, "Same-ocId upsert should not soft-delete the row")
+        XCTAssertEqual(stored.etag, "v2", "etag should be updated by the upsert")
+    }
+
+    func testDepth1ReadEvictsStaleLogicalSiblingOnFreshOcId() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        var rootMetadata = SendableItemMetadata(ocId: "root", fileName: "", account: account)
+        rootMetadata.directory = true
+        rootMetadata.uploaded = true
+        Self.dbManager.addItemMetadata(rootMetadata)
+
+        // Seed an existing row at the target logical path with `uploaded == false`
+        // so the depth-1-read delete-on-update path will not consider it; only
+        // the new eviction code can remove it.
+        let realm = Self.dbManager.ncDatabase()
+        let oldRow = RealmItemMetadata()
+        oldRow.ocId = "oldOcId"
+        oldRow.account = account.ncKitAccount
+        oldRow.serverUrl = account.davFilesUrl
+        oldRow.fileName = "TOOLS and WORKFLOWS"
+        oldRow.directory = true
+        oldRow.uploaded = false
+        oldRow.syncTime = Date(timeIntervalSince1970: 1000)
+        try realm.write { realm.add(oldRow) }
+
+        var freshDir = SendableItemMetadata(ocId: "freshOcId", fileName: "TOOLS and WORKFLOWS", account: account)
+        freshDir.directory = true
+        freshDir.uploaded = true
+
+        _ = Self.dbManager.depth1ReadUpdateItemMetadatas(
+            account: account.ncKitAccount,
+            serverUrl: account.davFilesUrl,
+            updatedMetadatas: [rootMetadata, freshDir],
+            keepExistingDownloadState: true
+        )
+
+        let storedOld = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "oldOcId"))
+        XCTAssertTrue(storedOld.deleted, "Stale logical sibling should be soft-deleted by eviction")
+
+        let storedFresh = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "freshOcId"))
+        XCTAssertFalse(storedFresh.deleted, "Fresh ocId row should be persisted")
+    }
+
+    func testDepth1ReadDoesNotEvictInFlightSibling() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        var rootMetadata = SendableItemMetadata(ocId: "root", fileName: "", account: account)
+        rootMetadata.directory = true
+        rootMetadata.uploaded = true
+        Self.dbManager.addItemMetadata(rootMetadata)
+
+        let realm = Self.dbManager.ncDatabase()
+        let inFlightRow = RealmItemMetadata()
+        inFlightRow.ocId = "uploading"
+        inFlightRow.account = account.ncKitAccount
+        inFlightRow.serverUrl = account.davFilesUrl
+        inFlightRow.fileName = "upload-in-progress.bin"
+        inFlightRow.uploaded = false
+        inFlightRow.status = Status.uploading.rawValue
+        try realm.write { realm.add(inFlightRow) }
+
+        var fresh = SendableItemMetadata(ocId: "freshOcId", fileName: "upload-in-progress.bin", account: account)
+        fresh.uploaded = true
+
+        _ = Self.dbManager.depth1ReadUpdateItemMetadatas(
+            account: account.ncKitAccount,
+            serverUrl: account.davFilesUrl,
+            updatedMetadatas: [rootMetadata, fresh],
+            keepExistingDownloadState: true
+        )
+
+        let storedInFlight = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "uploading"))
+        XCTAssertFalse(storedInFlight.deleted, "In-flight sibling should not be soft-deleted")
+
+        let storedFresh = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "freshOcId"))
+        XCTAssertFalse(storedFresh.deleted, "Fresh row should be inserted alongside the in-flight one")
+    }
+
+    func testStartupCleanupDeduplicatesSeededDuplicate() throws {
+        let testAccount = "TestAccount"
+        let testServerUrl = "https://example.com"
+        let fileName = "dup.txt"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let older = RealmItemMetadata()
+            older.ocId = "older"
+            older.account = testAccount
+            older.serverUrl = testServerUrl
+            older.fileName = fileName
+            older.syncTime = Date(timeIntervalSince1970: 1000)
+            realm.add(older)
+
+            let newer = RealmItemMetadata()
+            newer.ocId = "newer"
+            newer.account = testAccount
+            newer.serverUrl = testServerUrl
+            newer.fileName = fileName
+            newer.syncTime = Date(timeIntervalSince1970: 2000)
+            realm.add(newer)
+        }
+
+        let configuration = Realm.Configuration.defaultConfiguration
+        let manager = FilesDatabaseManager(
+            realmConfiguration: configuration,
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+
+        let storedOlder = try XCTUnwrap(manager.itemMetadata(ocId: "older"))
+        XCTAssertTrue(storedOlder.deleted, "Older duplicate should be soft-deleted at startup")
+
+        let storedNewer = try XCTUnwrap(manager.itemMetadata(ocId: "newer"))
+        XCTAssertFalse(storedNewer.deleted, "Newer duplicate should be kept")
+    }
+
+    func testStartupCleanupTiebreakOnEqualSyncTime() throws {
+        let testAccount = "TestAccount"
+        let testServerUrl = "https://example.com"
+        let fileName = "tie.txt"
+        let sameTime = Date(timeIntervalSince1970: 5000)
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let a = RealmItemMetadata()
+            a.ocId = "aa"
+            a.account = testAccount
+            a.serverUrl = testServerUrl
+            a.fileName = fileName
+            a.syncTime = sameTime
+            realm.add(a)
+
+            let b = RealmItemMetadata()
+            b.ocId = "bb"
+            b.account = testAccount
+            b.serverUrl = testServerUrl
+            b.fileName = fileName
+            b.syncTime = sameTime
+            realm.add(b)
+        }
+
+        let configuration = Realm.Configuration.defaultConfiguration
+        let manager = FilesDatabaseManager(
+            realmConfiguration: configuration,
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+
+        let storedA = try XCTUnwrap(manager.itemMetadata(ocId: "aa"))
+        XCTAssertTrue(storedA.deleted, "Lexicographically smaller ocId loses the tiebreak")
+
+        let storedB = try XCTUnwrap(manager.itemMetadata(ocId: "bb"))
+        XCTAssertFalse(storedB.deleted, "Lexicographically greater ocId wins the tiebreak")
+    }
+
+    func testStartupCleanupNoOpWhenNoDuplicates() throws {
+        let testAccount = "TestAccount"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let a = RealmItemMetadata()
+            a.ocId = "one"
+            a.account = testAccount
+            a.serverUrl = "https://example.com"
+            a.fileName = "one.txt"
+            realm.add(a)
+
+            let b = RealmItemMetadata()
+            b.ocId = "two"
+            b.account = testAccount
+            b.serverUrl = "https://example.com"
+            b.fileName = "two.txt"
+            realm.add(b)
+
+            // Same fileName but different serverUrl — not a logical duplicate.
+            let c = RealmItemMetadata()
+            c.ocId = "three"
+            c.account = testAccount
+            c.serverUrl = "https://example.com/folder"
+            c.fileName = "one.txt"
+            realm.add(c)
+        }
+
+        let configuration = Realm.Configuration.defaultConfiguration
+        let manager = FilesDatabaseManager(
+            realmConfiguration: configuration,
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertFalse(try XCTUnwrap(manager.itemMetadata(ocId: "one")).deleted)
+        XCTAssertFalse(try XCTUnwrap(manager.itemMetadata(ocId: "two")).deleted)
+        XCTAssertFalse(try XCTUnwrap(manager.itemMetadata(ocId: "three")).deleted)
+    }
+
+    func testStartupCleanupSkipsInTransitDuplicate() throws {
+        let testAccount = "TestAccount"
+        let testServerUrl = "https://example.com"
+        let fileName = "in-flight.bin"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let uploading = RealmItemMetadata()
+            uploading.ocId = "uploading"
+            uploading.account = testAccount
+            uploading.serverUrl = testServerUrl
+            uploading.fileName = fileName
+            uploading.status = Status.uploading.rawValue
+            uploading.syncTime = Date(timeIntervalSince1970: 5000)
+            realm.add(uploading)
+
+            let settled = RealmItemMetadata()
+            settled.ocId = "settled"
+            settled.account = testAccount
+            settled.serverUrl = testServerUrl
+            settled.fileName = fileName
+            settled.status = Status.normal.rawValue
+            settled.syncTime = Date(timeIntervalSince1970: 1000)
+            realm.add(settled)
+        }
+
+        let configuration = Realm.Configuration.defaultConfiguration
+        let manager = FilesDatabaseManager(
+            realmConfiguration: configuration,
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+
+        let storedUploading = try XCTUnwrap(manager.itemMetadata(ocId: "uploading"))
+        XCTAssertFalse(storedUploading.deleted, "In-flight row must remain intact")
+
+        let storedSettled = try XCTUnwrap(manager.itemMetadata(ocId: "settled"))
+        XCTAssertFalse(storedSettled.deleted, "Settled row remains because it is the only writable winner")
+    }
+
+    func testEvictionRespectsLockFileOfLocalOrigin() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+        let fileName = "~$doc.docx"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let localLock = RealmItemMetadata()
+            localLock.ocId = "local-lock"
+            localLock.account = account.ncKitAccount
+            localLock.serverUrl = account.davFilesUrl
+            localLock.fileName = fileName
+            localLock.isLockFileOfLocalOrigin = true
+            realm.add(localLock)
+        }
+
+        let serverRow = SendableItemMetadata(ocId: "server-row", fileName: fileName, account: account)
+        Self.dbManager.addItemMetadata(serverRow)
+
+        let storedLocalLock = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "local-lock"))
+        XCTAssertFalse(storedLocalLock.deleted, "Lock file of local origin must not be evicted")
+
+        let storedServer = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "server-row"))
+        XCTAssertFalse(storedServer.deleted, "Server-side row is inserted alongside the lock file")
+    }
+
+    func testEvictedRowSurfacesInPendingWorkingSetChanges() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+        let anchor = Date()
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let preExisting = RealmItemMetadata()
+            preExisting.ocId = "preExisting"
+            preExisting.account = account.ncKitAccount
+            preExisting.serverUrl = account.davFilesUrl
+            preExisting.fileName = "materialized.txt"
+            preExisting.downloaded = true // materialised
+            preExisting.syncTime = anchor.addingTimeInterval(-3600)
+            realm.add(preExisting)
+        }
+
+        var fresh = SendableItemMetadata(ocId: "fresh", fileName: "materialized.txt", account: account)
+        fresh.downloaded = true
+        fresh.syncTime = anchor.addingTimeInterval(60)
+        Self.dbManager.addItemMetadata(fresh)
+
+        let changes = Self.dbManager.pendingWorkingSetChanges(since: anchor)
+        XCTAssertTrue(
+            changes.deleted.contains { $0.ocId == "preExisting" },
+            "Evicted materialized row should surface in working-set deletions"
+        )
+    }
+
+    func testAddItemMetadataPreservingLocalStateFallsBackOnOcIdRotation() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        var original = SendableItemMetadata(ocId: "originalOcId", fileName: "rotated.txt", account: account)
+        original.keepDownloaded = true
+        original.downloaded = true
+        Self.dbManager.addItemMetadata(original)
+
+        var rotated = SendableItemMetadata(ocId: "rotatedOcId", fileName: "rotated.txt", account: account)
+        rotated.keepDownloaded = false // fresh from server, no local state
+        rotated.downloaded = false
+
+        let merged = Self.dbManager.addItemMetadataPreservingLocalState(rotated)
+
+        XCTAssertTrue(merged.keepDownloaded, "Should carry over keepDownloaded across the ocId rotation")
+        XCTAssertTrue(merged.downloaded, "Should carry over downloaded across the ocId rotation")
+
+        let storedOriginal = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "originalOcId"))
+        XCTAssertTrue(storedOriginal.deleted, "Original row should be soft-deleted after rotation")
+
+        let storedRotated = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "rotatedOcId"))
+        XCTAssertFalse(storedRotated.deleted)
+        XCTAssertTrue(storedRotated.keepDownloaded, "Persisted row should reflect the merged state")
+        XCTAssertTrue(storedRotated.downloaded)
+    }
+
+    func testAddItemMetadataPreservingLocalStateFallbackDoesNotMergeWhenAlreadyDuplicated() throws {
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+        let fileName = "duped.txt"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            let a1 = RealmItemMetadata()
+            a1.ocId = "A1"
+            a1.account = account.ncKitAccount
+            a1.serverUrl = account.davFilesUrl
+            a1.fileName = fileName
+            a1.keepDownloaded = true
+            a1.downloaded = true
+            a1.syncTime = Date(timeIntervalSince1970: 1000)
+            realm.add(a1)
+
+            let a2 = RealmItemMetadata()
+            a2.ocId = "A2"
+            a2.account = account.ncKitAccount
+            a2.serverUrl = account.davFilesUrl
+            a2.fileName = fileName
+            a2.keepDownloaded = true
+            a2.downloaded = true
+            a2.syncTime = Date(timeIntervalSince1970: 2000)
+            realm.add(a2)
+        }
+
+        var fresh = SendableItemMetadata(ocId: "B", fileName: fileName, account: account)
+        fresh.keepDownloaded = false
+        fresh.downloaded = false
+
+        let merged = Self.dbManager.addItemMetadataPreservingLocalState(fresh)
+
+        XCTAssertFalse(merged.keepDownloaded, "Should not merge state when the database is already duplicated")
+        XCTAssertFalse(merged.downloaded, "Should not merge state when the database is already duplicated")
+
+        let storedA1 = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "A1"))
+        XCTAssertTrue(storedA1.deleted, "Pre-existing duplicate A1 should be soft-deleted by eviction")
+
+        let storedA2 = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "A2"))
+        XCTAssertTrue(storedA2.deleted, "Pre-existing duplicate A2 should be soft-deleted by eviction")
+
+        let storedB = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "B"))
+        XCTAssertFalse(storedB.deleted)
+    }
 }


### PR DESCRIPTION
  Iron out logical-path duplicates in `RealmItemMetadata` and prevent them from re-accumulating.

  Customers on unstable connections see arbitrary folders in the file provider appear renamed with a " 2" suffix. macOS does this when the file provider returns two siblings with identical names — the file system can only represent one. A customer Realm confirms the cause: two non-deleted rows at the same `(account,
   serverUrl, fileName)` but different `ocId` and `syncTime` ~2h apart. `RealmItemMetadata` uses `ocId` as its primary key, so Realm's `update: .all` / `.modified` upserts dedupe by `ocId` alone. When the server returns the same logical path with a fresh `ocId` (restore-from-trash, another client recreating the item
   during reconnect, the upload finalizer assigning a server-issued `ocId`), a second row is inserted beside the first.
  
  No schema changes — Realm is being replaced medium-term. This is a focused code-only hotfix.

  ### Changes
  
  - **New `FilesDatabaseManager+Deduplication.swift`** — two helpers:
    - `evictLogicalDuplicates(of:in:now:)` — within an active write transaction, soft-deletes every non-deleted row at the incoming row's logical address with a different `ocId`. Skips in-flight rows (status ≠ normal) and lock files of local origin. Bumps `syncTime` on evicted rows so `pendingWorkingSetChanges`
  signals the framework.
    - `cleanupPreexistingLogicalDuplicates()` — one-shot startup pass: buckets every non-deleted, non-lock row by `(account, serverUrl, fileName)`, keeps the row with the most recent `syncTime` per bucket (lexicographically greater `ocId` breaks ties), soft-deletes the rest. Opens a write transaction only when
  collisions exist — zero cost for clean databases.
  - **`FilesDatabaseManager.swift`**
    - `addItemMetadata` runs `evictLogicalDuplicates` inside its existing write transaction, so every caller of the function (Item create/modify/fetch/trash/lockfile, materialised observer, paginated enumeration via `addItemMetadataPreservingLocalState`, the trash-marking pass in `Enumerator.swift`) is covered.
    - `depth1ReadUpdateItemMetadatas` pre-evicts for every item in `metadatasToCreate` and `metadatasToUpdate` inside its existing transaction; the update path is included defensively for rename targets that collide with a third row.
    - `addItemMetadataPreservingLocalState` falls back to a logical-address lookup when the `ocId` lookup misses, and carries over `keepDownloaded` / `downloaded` / `visitedDirectory` / `lockToken` if exactly one candidate exists. Without this, an `ocId` rotation would silently drop the user's "Always keep
  downloaded" state — the regression #9923 originally fixed for the non-rotation case. The merge is conservative: when multiple candidates exist (i.e. the DB is already in the duplicated state), no merge is performed and eviction prunes both prior rows.
    - `init` calls `cleanupPreexistingLogicalDuplicates()` after Realm initialisation succeeds.

  ### Edge cases

  - In-flight rows are never touched in either path; soft-deleting one would yank the file out from under a pending `NSURLSession` task. Skips are logged at `error` level for support visibility.
  - Lock files of local origin are excluded as both candidates and evictors, mirroring the existing exclusion in `pendingWorkingSetChanges`.
  - Same-`ocId` upserts remain a no-op for eviction (the upserted row is excluded from the collision query).
  - Working-set signalling fires only for rows the framework has previously been told about via enumeration. Duplicates that were never enumerated to the framework are still corrected in the database, but they don't surface as a "delete" event — which is correct, since the framework has no reference to delete.

  ### Out of scope

  Eviction inside `renameItemMetadata` and `renameDirectoryAndPropagateToChildren` is deliberately not part of this hotfix — the recursive directory rename has subtle correctness traps (children's destination addresses are computed in the same transaction) that aren't worth carrying here. Any rename-induced
  collision will heal on the next enumeration of the destination directory.

  ## Risks
  
  1. Soft-deletion signals the framework via `pendingWorkingSetChanges` only when the row has been previously enumerated to the framework. Duplicates that were never enumerated are healed in the DB but don't surface as a "delete" event.
  2. The transient window where `addItemMetadata` collides with an in-flight sibling leaves two live rows briefly; the next post-completion write heals it. Acceptable for a hotfix targeting *persistent* duplicates.
  3. The upload finalizer in `Item+Modify.swift` now correctly evicts the prior local-`ocId` row when the server assigns a new `ocId` — desired, but a behavioural change from the prior code that left both rows present.
  4. The medium-term Realm replacement should treat `(account, serverUrl, fileName)` as a unique constraint and handle `ocId` rotation at the schema level. This hotfix addresses the symptom, not the underlying race.