### PR TITLE
Disable file provider on macOS 13 Ventura

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -216,21 +216,27 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     new ToolTipUpdater(_ui->_folderList);
 
 #if defined(BUILD_FILE_PROVIDER_MODULE)
-    const auto fileProviderPanelContents = _ui->fileProviderPanelContents;
-    const auto fpSettingsLayout = new QVBoxLayout(fileProviderPanelContents);
-    const auto fpAccountUserIdAtHost = _accountState->account()->userIdAtHostWithPort();
-    const auto fpSettingsController = Mac::FileProviderSettingsController::instance();
-    const auto fpSettingsWidget = fpSettingsController->settingsViewWidget(fpAccountUserIdAtHost, fileProviderPanelContents,
-                                                                           QQuickWidget::SizeRootObjectToView);
-    fpSettingsLayout->setContentsMargins(0, 0, 0, 0);
-    fpSettingsLayout->setSpacing(0);
-    
-    fpSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    if (const auto fpSettingsWidgetLayout = fpSettingsWidget->layout()) {
-        fpSettingsWidgetLayout->setContentsMargins(0, 0, 0, 0);
+    if (Mac::FileProvider::available()) {
+        const auto fileProviderPanelContents = _ui->fileProviderPanelContents;
+        const auto fpSettingsLayout = new QVBoxLayout(fileProviderPanelContents);
+        const auto fpAccountUserIdAtHost = _accountState->account()->userIdAtHostWithPort();
+        const auto fpSettingsController = Mac::FileProviderSettingsController::instance();
+        const auto fpSettingsWidget = fpSettingsController->settingsViewWidget(fpAccountUserIdAtHost, fileProviderPanelContents,
+                                                                               QQuickWidget::SizeRootObjectToView);
+        fpSettingsLayout->setContentsMargins(0, 0, 0, 0);
+        fpSettingsLayout->setSpacing(0);
+
+        fpSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        if (const auto fpSettingsWidgetLayout = fpSettingsWidget->layout()) {
+            fpSettingsWidgetLayout->setContentsMargins(0, 0, 0, 0);
+        }
+        fpSettingsLayout->addWidget(fpSettingsWidget, 1);
+        fileProviderPanelContents->setLayout(fpSettingsLayout);
+    } else {
+        // macOS 13 Ventura: the file provider feature is unsupported there.
+        // This branch can be removed once Ventura is no longer supported.
+        _ui->fileProviderPanel->setVisible(false);
     }
-    fpSettingsLayout->addWidget(fpSettingsWidget, 1);
-    fileProviderPanelContents->setLayout(fpSettingsLayout);
 #else
     _ui->fileProviderPanel->setVisible(false);
 #endif

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -39,6 +39,7 @@
 #include "shellextensionsserver.h"
 #elif defined(Q_OS_MACOS)
 #include "macOS/fileprovider.h"
+#include "macOS/fileprovidersettingscontroller.h"
 #include "macOS/findersyncxpc.h"
 #include "macOS/findersyncservice.h"
 #endif
@@ -497,7 +498,15 @@ Application::Application(int &argc, char **argv)
 
 #if defined(BUILD_FILE_PROVIDER_MODULE)
     Mac::FileProvider::instance();
-    Mac::FileProvider::instance()->configureXPC();
+    if (Mac::FileProvider::available()) {
+        Mac::FileProvider::instance()->configureXPC();
+    } else {
+        // macOS 13 Ventura: instantiating the settings controller triggers the
+        // one-time cleanup that gracefully tears down any pre-existing VFS
+        // domains. The check (and this branch) can be removed once Ventura is
+        // no longer supported.
+        Mac::FileProviderSettingsController::instance();
+    }
 #endif
 
 #if defined(Q_OS_MACOS)

--- a/src/gui/macOS/fileprovider.h
+++ b/src/gui/macOS/fileprovider.h
@@ -28,6 +28,15 @@ public:
     static FileProvider *instance();
     ~FileProvider() override;
 
+    /**
+     * @brief Whether the macOS file provider feature is usable on the current OS.
+     *
+     * Returns false on macOS 13 Ventura, where the extension is incompatible
+     * (see nextcloud/desktop#9927). This runtime check can be removed once
+     * macOS 13 Ventura is no longer supported.
+     */
+    [[nodiscard]] static bool available();
+
     void configureXPC();
     [[nodiscard]] FileProviderXPC *xpc() const;
     [[nodiscard]] FileProviderDomainManager *domainManager() const;

--- a/src/gui/macOS/fileprovider_mac.mm
+++ b/src/gui/macOS/fileprovider_mac.mm
@@ -6,6 +6,7 @@
 #include "fileprovider.h"
 
 #include <QLoggingCategory>
+#include <QOperatingSystemVersion>
 
 #include "libsync/configfile.h"
 #include "gui/macOS/fileproviderxpc.h"
@@ -48,6 +49,11 @@ FileProvider *FileProvider::instance()
     return _instance;
 }
 
+bool FileProvider::available()
+{
+    return QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSSonoma;
+}
+
 FileProvider::~FileProvider()
 {
     _instance = nullptr;
@@ -55,6 +61,11 @@ FileProvider::~FileProvider()
 
 void FileProvider::configureXPC()
 {
+    if (!available()) {
+        qCInfo(lcMacFileProvider) << "Skipping file provider XPC configuration on unsupported macOS version.";
+        return;
+    }
+
     _xpc = std::make_unique<FileProviderXPC>(new FileProviderXPC(this));
 
     if (_xpc) {

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -57,9 +57,14 @@ public:
 
         migrateToAppSandbox();
         removeOrphanedDomains();
-        restoreMissingDomains();
-        Mac::FileProvider::instance()->domainManager()->reconnectAll();
-        Mac::FileProvider::instance()->configureXPC();
+
+        if (Mac::FileProvider::available()) {
+            restoreMissingDomains();
+            Mac::FileProvider::instance()->domainManager()->reconnectAll();
+            Mac::FileProvider::instance()->configureXPC();
+        } else {
+            disableFileProviderForAllEnabledAccountsOnUnsupportedOS();
+        }
     };
 
     ~MacImplementation() override = default;
@@ -284,6 +289,32 @@ public:
         }
 
         qCInfo(lcFileProviderSettingsController) << "Finished removing orphaned domains.";
+    }
+
+    // macOS 13 Ventura cleanup: removes any pre-existing file provider domain
+    // gracefully (preserving dirty user data) for each account that still has
+    // VFS enabled. Can be deleted once Ventura is no longer supported.
+    void disableFileProviderForAllEnabledAccountsOnUnsupportedOS()
+    {
+        qCInfo(lcFileProviderSettingsController) << "macOS 13 Ventura: disabling file provider for all enabled accounts.";
+
+        const auto accountStates = AccountManager::instance()->accounts();
+
+        for (const auto &accountState : accountStates) {
+            const auto account = accountState->account();
+
+            if (!account) {
+                continue;
+            }
+
+            if (account->fileProviderDomainIdentifier().isEmpty()) {
+                continue;
+            }
+
+            const auto userIdAtHost = account->userIdAtHostWithPort();
+            qCInfo(lcFileProviderSettingsController) << "Disabling file provider for account" << userIdAtHost;
+            (void)setVfsEnabledForAccount(userIdAtHost, false);
+        }
     }
 
 private:

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -106,7 +106,7 @@ OwncloudAdvancedSetupPage::OwncloudAdvancedSetupPage(OwncloudWizard *wizard)
 #ifdef Q_OS_WIN
         bestAvailableVfsMode() == Vfs::WindowsCfApi
 #elif defined(BUILD_FILE_PROVIDER_MODULE)
-        true
+        Mac::FileProvider::available()
 #else
         false
 #endif
@@ -149,14 +149,14 @@ void OwncloudAdvancedSetupPage::initializePage()
 {
     WizardCommon::initErrorLabel(_ui.errorLabel);
 
-    if (Theme::instance()->disableVirtualFilesSyncFolder()
-            || !(Theme::instance()->showVirtualFilesOption()
+    const auto hideVfsOption = Theme::instance()->disableVirtualFilesSyncFolder()
 #ifdef BUILD_FILE_PROVIDER_MODULE
-                 || true
+        || !Mac::FileProvider::available();
 #else
-                 && bestAvailableVfsMode() != Vfs::Off
+        || !(Theme::instance()->showVirtualFilesOption() && bestAvailableVfsMode() != Vfs::Off);
 #endif
-    )) {
+
+    if (hideVfsOption) {
         // If the layout were wrapped in a widget, the auto-grouping of the
         // radio buttons no longer works and there are surprising margins.
         // Just manually hide the button and remove the layout.

--- a/src/gui/wizard/owncloudwizard.cpp
+++ b/src/gui/wizard/owncloudwizard.cpp
@@ -233,7 +233,7 @@ bool OwncloudWizard::needsToAcceptTermsOfService() const
 bool OwncloudWizard::useVirtualFileSyncByDefault() const
 {
 #ifdef BUILD_FILE_PROVIDER_MODULE
-    return true;
+    return Mac::FileProvider::available();
 #else
     return false;
 #endif


### PR DESCRIPTION
  Closes #10018.

  The file provider extension is completely incompatible with macOS 13 Ventura (see #9927). Until a code-level fix is possible, this PR stops exposing the feature on Ventura at runtime. macOS 14 Sonoma and later are unchanged.

  A single static gate `Mac::FileProvider::available()` (returns `false` on Ventura, `true` on Sonoma+) is wired in at every user-visible VFS entry point:

  - **Wizard default** — `OwncloudWizard::useVirtualFileSyncByDefault()` returns `false` on Ventura, so the wizard takes the classic-sync setup path; `useVirtualFileSync()`, the per-folder check in `slotCreateLocalAndRemoteFolders`, and the file-provider branch in `slotAssistantFinished` all naturally follow.
  - **Wizard VFS radio** — `OwncloudAdvancedSetupPage` no longer auto-selects `rVirtualFileSync` on Ventura, and `initializePage` unconditionally hides the radio + layout (even with experimental options enabled).
  - **Account settings** — `AccountSettings` skips constructing the file provider settings panel on Ventura and hides it.
  - **Startup cleanup** — `Application` instantiates `FileProviderSettingsController` on Ventura, which now branches in its constructor: skips `restoreMissingDomains` / `reconnectAll` / `configureXPC`, and instead calls a new helper that loops over accounts with a non-empty `fileProviderDomainIdentifier` and reuses
  the existing `setVfsEnabledForAccount(..., false)` path. `NSFileProviderDomainRemovalModePreserveDirtyUserData` keeps any dirty user data on disk, as the issue requires.
  - **Defensive guard** — `FileProvider::configureXPC()` early-returns on Ventura, so any code path that reaches it is a no-op.

  Each Ventura-only branch carries a comment noting it can be removed once Ventura is no longer supported (same precedent as `SingleInstanceManager`).