### PR TITLE
fix: double background in settings navigation

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -60,14 +60,6 @@
 
 using namespace Qt::StringLiterals;
 
-#ifdef Q_OS_WIN
-    // "light" looks too bright on dark mode on Windows only
-    #define BACKGROUND_PALETTE "alternate-base"
-#else
-    // ...and "alternate-base" looks too bright on macOS only.  On Linux/Plasma either one looked fine ...
-    #define BACKGROUND_PALETTE "light"
-#endif
-
 #ifdef BUILD_FILE_PROVIDER_MODULE
 #include "macOS/fileprovider.h"
 #endif
@@ -190,15 +182,14 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     const auto delegate = new FolderStatusDelegate;
     delegate->setParent(this);
 
-    setStyleSheet("QWidget#syncFoldersPanelContents, QWidget#connectionSettingsPanelContents, QWidget#fileProviderPanelContents { background: palette(" BACKGROUND_PALETTE "); }"_L1);
-    _ui->syncFoldersPanelContents->setAutoFillBackground(true);
-    _ui->syncFoldersPanelContents->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->syncFoldersPanelContents->setAutoFillBackground(false);
+    _ui->syncFoldersPanelContents->setAttribute(Qt::WA_StyledBackground, false);
     _ui->syncFoldersPanelContents->setContentsMargins(0, 0, 0, 0);
-    _ui->fileProviderPanelContents->setAutoFillBackground(true);
-    _ui->fileProviderPanelContents->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->fileProviderPanelContents->setAutoFillBackground(false);
+    _ui->fileProviderPanelContents->setAttribute(Qt::WA_StyledBackground, false);
     _ui->fileProviderPanelContents->setContentsMargins(0, 0, 0, 0);
-    _ui->connectionSettingsPanelContents->setAutoFillBackground(true);
-    _ui->connectionSettingsPanelContents->setAttribute(Qt::WA_StyledBackground, true);
+    _ui->connectionSettingsPanelContents->setAutoFillBackground(false);
+    _ui->connectionSettingsPanelContents->setAttribute(Qt::WA_StyledBackground, false);
     _ui->connectionSettingsPanelContents->setContentsMargins(0, 0, 0, 0);
 
     // Connect styleChanged events to our widgets, so they can adapt (Dark-/Light-Mode switching)
@@ -209,8 +200,6 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     _ui->_folderList->setAttribute(Qt::WA_StyledBackground, false);
     _ui->_folderList->viewport()->setAutoFillBackground(false);
     _ui->_folderList->viewport()->setAttribute(Qt::WA_StyledBackground, false);
-    _ui->_folderList->setStyleSheet(QStringLiteral("QTreeView { background: transparent; border: none; }"));
-    _ui->_folderList->viewport()->setStyleSheet(QStringLiteral("background: transparent;"));
     _ui->_folderList->setItemDelegate(delegate);
     _ui->_folderList->setModel(_model);
     _ui->_folderList->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -205,9 +205,12 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(this, &AccountSettings::styleChanged, delegate, &FolderStatusDelegate::slotStyleChanged);
 
     _ui->_folderList->header()->hide();
-    _ui->_folderList->setAutoFillBackground(true);
-    _ui->_folderList->setAttribute(Qt::WA_StyledBackground, true);
-    _ui->_folderList->setStyleSheet(QStringLiteral("QTreeView { background: palette(" BACKGROUND_PALETTE "); }"));
+    _ui->_folderList->setAutoFillBackground(false);
+    _ui->_folderList->setAttribute(Qt::WA_StyledBackground, false);
+    _ui->_folderList->viewport()->setAutoFillBackground(false);
+    _ui->_folderList->viewport()->setAttribute(Qt::WA_StyledBackground, false);
+    _ui->_folderList->setStyleSheet(QStringLiteral("QTreeView { background: transparent; border: none; }"));
+    _ui->_folderList->viewport()->setStyleSheet(QStringLiteral("background: transparent;"));
     _ui->_folderList->setItemDelegate(delegate);
     _ui->_folderList->setModel(_model);
     _ui->_folderList->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);

--- a/src/gui/networksettings.cpp
+++ b/src/gui/networksettings.cpp
@@ -21,15 +21,6 @@
 #include <QPalette>
 #include <type_traits>
 
-constexpr auto BACKGROUND_ROLE =
-#ifdef Q_OS_WIN
-    // "light" looks too bright on dark mode on Windows only
-    QPalette::AlternateBase;
-#else
-    // ...and "alternate-base" looks too bright on macOS only.  On Linux/Plasma either one looked fine ...
-    QPalette::Light;
-#endif
-
 namespace OCC {
 
 NetworkSettings::NetworkSettings(const AccountPtr &account, QWidget *parent)
@@ -38,14 +29,7 @@ NetworkSettings::NetworkSettings(const AccountPtr &account, QWidget *parent)
     , _account(account)
 {
     _ui->setupUi(this);
-    setAutoFillBackground(true);
-    setBackgroundRole(BACKGROUND_ROLE);
-    _ui->proxyGroupBox->setAutoFillBackground(true);
-    _ui->proxyGroupBox->setBackgroundRole(BACKGROUND_ROLE);
-    _ui->downloadBox->setAutoFillBackground(true);
-    _ui->downloadBox->setBackgroundRole(BACKGROUND_ROLE);
-    _ui->uploadBox->setAutoFillBackground(true);
-    _ui->uploadBox->setBackgroundRole(BACKGROUND_ROLE);
+    setAutoFillBackground(false);
 
     _ui->manualSettings->setVisible(_ui->manualProxyRadioButton->isChecked());
 

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -461,7 +461,8 @@ void SettingsDialog::customizeStyle()
         "#Settings { background: palette(window); border-radius: 0; }"
 
         /* Navigation */
-        "#settings_navigation, #settings_navigation_scroll { background: palette(" BACKGROUND_PALETTE "); border-radius: 12px; padding: 4px; }"
+        "#settings_navigation_scroll { background: palette(" BACKGROUND_PALETTE "); border-radius: 12px; padding: 4px; }"
+        "#settings_navigation { background: transparent; border: none; padding: 0px; }"
 
         /* Content area */
         "#settings_content, #settings_content_scroll { background: palette(window); border-radius: 12px; }"


### PR DESCRIPTION
fix the darker background in the inner nav container 
<img width="459" height="258" alt="Bildschirmfoto 2026-05-18 um 21 02 30" src="https://github.com/user-attachments/assets/d6c96ae6-a2b1-45a7-8eed-ddec1ba80aec" />

