### PR TITLE
Reconciled file provider domain names

### DIFF
--- a/src/gui/macOS/fileproviderdomainmanager.h
+++ b/src/gui/macOS/fileproviderdomainmanager.h
@@ -47,6 +47,17 @@ public:
     void reconnectAll();
 
     /**
+     * @brief Reconcile registered file provider domain display names with the current account state.
+     *
+     * For every registered domain whose `displayName` no longer matches the owning account's
+     * `Account::shortcutName()` (e.g. the legacy U+2024-escaped form left over from the prior
+     * fix for #7979, or a stale `prettyName()` snapshot), re-register the domain in place so the
+     * macOS-side metadata catches up. Safe to call on every launch — a no-op when names already
+     * match.
+     */
+    void reconcileDomainDisplayNames();
+
+    /**
      * @brief Remove a file provider domain independent from an account.
      * @return The path to the location where preserved dirty user data is stored, or an empty QString if none.
      */

--- a/src/gui/macOS/fileproviderdomainmanager.mm
+++ b/src/gui/macOS/fileproviderdomainmanager.mm
@@ -309,6 +309,51 @@ public:
     }
 
     /**
+     * @brief Update every registered domain's display name to match its account's `shortcutName()`.
+     *
+     * Walks every registered `NSFileProviderDomain`, looks up its owning account, and if the
+     * domain's `displayName` differs from `account->shortcutName()` re-registers the domain
+     * in place by calling `addDomain:` again with the same identifier. macOS replaces the
+     * registration, keeping the on-disk data intact.
+     */
+    void reconcileDomainDisplayNames()
+    {
+        qCInfo(lcMacFileProviderDomainManager) << "Reconciling file provider domain display names...";
+
+        const auto domains = getDomains();
+        const auto accountManager = AccountManager::instance();
+
+        for (NSFileProviderDomain * const domain : domains) {
+            const auto domainId = QString::fromNSString(domain.identifier);
+            const auto accountState = accountManager->accountFromFileProviderDomainIdentifier(domainId);
+
+            if (!accountState || !accountState->account()) {
+                // Orphan domain — not owned by any current account. `removeOrphanedDomains()`
+                // in the settings controller is responsible for cleanup; nothing to do here.
+                continue;
+            }
+
+            const auto currentDisplayName = QString::fromNSString(domain.displayName);
+            const auto desiredDisplayName = accountState->account()->shortcutName();
+
+            if (currentDisplayName == desiredDisplayName) {
+                continue;
+            }
+
+            qCInfo(lcMacFileProviderDomainManager) << "Updating display name for domain"
+                                                   << domainId
+                                                   << "from" << currentDisplayName
+                                                   << "to" << desiredDisplayName;
+
+            NSFileProviderDomain * const updatedDomain = [[NSFileProviderDomain alloc] initWithIdentifier:domain.identifier displayName:desiredDisplayName.toNSString()];
+            updatedDomain.supportsSyncingTrash = YES;
+            addDomain(updatedDomain);
+        }
+
+        qCInfo(lcMacFileProviderDomainManager) << "Finished reconciling file provider domain display names.";
+    }
+
+    /**
      * @brief Remove all file provider domains one by one and also their associated data.
      */
     void removeAllDomains()
@@ -333,6 +378,13 @@ public:
 
         const auto accountId = account->userIdAtHostWithPort();
         const auto existingDomainId = account->fileProviderDomainIdentifier();
+        // Use `<server>[:port] - <user>` ordering so the trailing token is the user. This avoids
+        // LaunchServices treating the file provider root folder as a bundle when the server's TLD
+        // matches a recognised package extension like ".app" (see issues #7979 / #9684).
+        // Domains registered with a stale display name (e.g. the legacy U+2024-escaped form, or
+        // a name from before `prettyName()` was updated) are normalised on launch by
+        // `reconcileDomainDisplayNames()`.
+        const auto domainDisplayName = account->shortcutName();
 
         if (!existingDomainId.isEmpty()) {
             const auto domains = getDomains();
@@ -350,10 +402,6 @@ public:
         }
 
         const auto domainId = QUuid::createUuid().toString(QUuid::WithoutBraces);
-        // Replace dots with one-dot leader (U+2024) to prevent Finder from treating
-        // folders as bundles when the display name contains extensions like ".app"
-        auto domainDisplayName = account->displayName();
-        domainDisplayName.replace('.', QChar(0x2024));
         NSFileProviderDomain * const domain = [[NSFileProviderDomain alloc] initWithIdentifier:domainId.toNSString() displayName:domainDisplayName.toNSString()];
         domain.supportsSyncingTrash = YES;
         addDomain(domain);
@@ -475,6 +523,15 @@ void FileProviderDomainManager::reconnectAll()
     }
 
     d->reconnectAll();
+}
+
+void FileProviderDomainManager::reconcileDomainDisplayNames()
+{
+    if (!d) {
+        return;
+    }
+
+    d->reconcileDomainDisplayNames();
 }
 
 QString FileProviderDomainManager::removeDomain(NSFileProviderDomain *domain)

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -60,6 +60,7 @@ public:
 
         if (Mac::FileProvider::available()) {
             restoreMissingDomains();
+            Mac::FileProvider::instance()->domainManager()->reconcileDomainDisplayNames();
             Mac::FileProvider::instance()->domainManager()->reconnectAll();
             Mac::FileProvider::instance()->configureXPC();
         } else {


### PR DESCRIPTION
- No longer use the Unicode character `U+2024` to escape dots to work around the problem reported in #7979.
- File provider domains now have a canonical naming schema which is enforced on every app launch.
- File provider domains now are named in the pattern of `<server> - <pretty name>`.
- Fixes #9684.