### PR TITLE
Enable "Sync now" button

### DIFF
--- a/src/gui/tray/SyncStatus.qml
+++ b/src/gui/tray/SyncStatus.qml
@@ -103,7 +103,8 @@ RowLayout {
         visible: !activityModel.hasSyncConflicts &&
                  !syncStatus.syncing &&
                  !syncStatus.needsSandboxReapproval &&
-                 NC.UserModel.currentUser.hasLocalFolder &&
+                 (NC.UserModel.currentUser.hasLocalFolder ||
+                  (Qt.platform.os === "osx" && NC.UserModel.currentUser.hasFileProvider)) &&
                  NC.UserModel.currentUser.isConnected
         enabled: visible
         onClicked: {

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1903,7 +1903,28 @@ void User::slotAssistantRequestError(const QString &context, int statusCode)
 
 void User::forceSyncNow() const
 {
-    FolderMan::instance()->forceSyncForFolder(getFolder());
+    if (const auto folder = getFolder()) {
+        FolderMan::instance()->forceSyncForFolder(folder);
+        return;
+    }
+
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    if (hasFileProvider() && _account && _account->account()) {
+        const auto fileProvider = Mac::FileProvider::instance();
+        if (fileProvider && fileProvider->domainManager()) {
+            // No classic Folder exists for this account — it is managed by the macOS File
+            // Provider Extension. Per Apple's documented pattern, on-demand sync is requested
+            // by signalling the working-set enumerator; the OS then drives the extension's
+            // `enumerator(for: .workingSet)` → `enumerateChanges()` flow, which performs the
+            // actual remote reconciliation. See nextcloud/desktop#9909.
+            fileProvider->domainManager()->signalEnumeratorChanged(_account->account().data());
+            return;
+        }
+    }
+#endif
+
+    qCWarning(lcActivity) << "forceSyncNow: no folder and no file provider domain to sync for"
+                          << (_account ? _account->account()->displayName() : QStringLiteral("<no account>"));
 }
 
 void User::slotAccountCapabilitiesChangedRefreshGroupFolders()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,7 @@ nextcloud_add_benchmark(LargeSync)
 nextcloud_add_test(Account)
 nextcloud_add_test(Folder)
 nextcloud_add_test(FolderMan)
+nextcloud_add_test(ForceSyncNow)
 nextcloud_add_test(RemoteWipe)
 
 if(NOT BUILD_FILE_PROVIDER_MODULE)

--- a/test/testforcesyncnow.cpp
+++ b/test/testforcesyncnow.cpp
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QtTest>
+#include <QTemporaryDir>
+
+#include "account.h"
+#include "accountstate.h"
+#include "configfile.h"
+#include "folder.h"
+#include "folderman.h"
+#include "logger.h"
+#include "tray/usermodel.h"
+
+#include "foldermantestutils.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+
+using namespace OCC;
+
+/// Coverage for `User::forceSyncNow()`. Two cases:
+///
+///  - Classic-sync branch: a `Folder` exists for the account, so `forceSyncNow()` must route
+///    through `FolderMan::forceSyncForFolder()`, which unpauses the folder. We observe the
+///    state flip.
+///  - Folderless branch: no `Folder` and no File Provider domain. The pre-fix implementation
+///    crashed at `folderman.cpp:792` (dereferencing a null `Folder*`). The fix added an early
+///    return; we lock that in by verifying no crash.
+///
+/// The FPE branch (`hasFileProvider() && Mac::FileProvider::instance()->domainManager()...`) is
+/// only reachable when `BUILD_FILE_PROVIDER_MODULE` is on and an `NSFileProviderDomain` is
+/// registered with the OS. That requires macOS plus a configured account, so it is exercised
+/// via the manual verification steps in the issue rather than here.
+class TestForceSyncNow : public QObject
+{
+    Q_OBJECT
+
+    FolderManTestHelper _folderManHelper;
+
+private slots:
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogFlush(true);
+        OCC::Logger::instance()->setLogDebug(true);
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    void forceSyncNow_withClassicFolder_unpausesAndSchedules()
+    {
+        QTemporaryDir confDir;
+        ConfigFile::setConfDir(confDir.path()); // don't pollute the user's config
+
+        auto account = Account::create();
+        account->setCredentials(new HttpCredentialsTest("testuser", "secret"));
+        account->setUrl(QUrl("http://example.com"));
+
+        auto accountState = AccountStatePtr{new FakeAccountState{account}};
+
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        auto folderman = FolderMan::instance();
+        const auto folder = folderman->addFolder(accountState.data(), folderDefinition(fakeFolder.localPath()));
+        QVERIFY(folder);
+
+        // Put the folder in a state that `forceSyncForFolder` is supposed to clear.
+        folder->setSyncPaused(true);
+        QVERIFY(folder->syncPaused());
+
+        User user(accountState);
+        QVERIFY(user.hasLocalFolder());
+
+        user.forceSyncNow();
+
+        // `FolderMan::forceSyncForFolder` calls `setSyncPaused(false)` — observe the flip as
+        // proof that `User::forceSyncNow()` routed through the classic path.
+        QVERIFY(!folder->syncPaused());
+    }
+
+    void forceSyncNow_withoutFolderOrFileProvider_doesNotCrash()
+    {
+        QTemporaryDir confDir;
+        ConfigFile::setConfDir(confDir.path());
+
+        auto account = Account::create();
+        account->setCredentials(new HttpCredentialsTest("testuser", "secret"));
+        account->setUrl(QUrl("http://example.com"));
+
+        auto accountState = AccountStatePtr{new FakeAccountState{account}};
+
+        // No folder added to FolderMan for this account, and no File Provider domain is set
+        // (`fileProviderDomainIdentifier()` is empty by default), so `hasFileProvider()` is
+        // false. Pre-fix this would call `FolderMan::forceSyncForFolder(nullptr)` and crash.
+        User user(accountState);
+        QVERIFY(!user.hasLocalFolder());
+
+        user.forceSyncNow(); // must not crash
+
+        QVERIFY(true);
+    }
+};
+
+QTEST_MAIN(TestForceSyncNow)
+#include "testforcesyncnow.moc"


### PR DESCRIPTION
- Exposes the existing user interface already used for classic synchronization folders.
- Added a branch in the logic to signal the working set for the file provider domain of the currently selected account. The signaling happens in other code paths already, anyway.
- Basically, I just wired up a few things.
- Closes #9909.