### PR TITLE
fix(filedetails): use correct path for fetching file tags

### DIFF
--- a/src/gui/filedetails/filedetails.cpp
+++ b/src/gui/filedetails/filedetails.cpp
@@ -177,7 +177,6 @@ FileTagModel *FileDetails::fileTagModel() const
 void FileDetails::updateFileTagModel()
 {
     const auto localPath = _fileRecord.path();
-    const auto relPath = localPath.mid(_folder->cleanPath().length() + 1);
     QString serverPath = _folder->remotePathTrailingSlash() + _fileRecord.path();
  
     if (const auto vfsMode = _folder->vfs().mode(); _fileRecord.isVirtualFile() && vfsMode == Vfs::WithSuffix) {
@@ -186,7 +185,7 @@ void FileDetails::updateFileTagModel()
         }
     }
 
-    _fileTagModel = std::make_unique<FileTagModel>(relPath, _folder->accountState()->account());
+    _fileTagModel = std::make_unique<FileTagModel>(serverPath, _folder->accountState()->account());
     Q_EMIT fileTagModelChanged();
 }
 


### PR DESCRIPTION
Discovered in #9238, this was causing file tags to never appear in the file details window ...

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
