### PR TITLE
Re-enumerate file provider items after app updates

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -18,7 +18,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     let domain: NSFileProviderDomain?
     let dbManager: FilesDatabaseManager
 
-    private let currentAnchor = NSFileProviderSyncAnchor(ISO8601DateFormatter().string(from: Date()).data(using: .utf8)!)
+    private let currentAnchor = Enumerator.syncAnchor(at: Date())
     private let pageItemCount: Int
     let logger: FileProviderLogger
     let account: Account
@@ -224,6 +224,30 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     public func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
         logger.debug("Enumerating changes (anchor: \(String(data: anchor.rawValue, encoding: .utf8) ?? "")).", [.url: serverUrl])
 
+        // Version-tagged anchor check — applies to every container, not just the working set.
+        // The framework persists per-container anchors and replays them on subsequent
+        // `enumerateChanges` calls. An anchor that doesn't parse as the version-tagged format
+        // (older builds wrote just the ISO8601 date) or whose embedded version doesn't match the
+        // running extension is treated as expired so the framework drops cached
+        // `NSFileProviderItem` snapshots in that container and re-enumerates them. The fresh
+        // `Item` objects then carry up-to-date `userInfo`, `contentPolicy`, etc.
+        //
+        // See nextcloud/desktop#10065.
+
+        guard let parsed = Self.parseSyncAnchor(anchor) else {
+            logger.info("Sync anchor is not in the expected version-tagged format. Returning syncAnchorExpired so the framework re-enumerates this container and refreshes cached NSFileProviderItem snapshots. See nextcloud/desktop#10065.", [.item: enumeratedItemIdentifier])
+            observer.finishEnumeratingWithError(NSFileProviderError(.syncAnchorExpired))
+            return
+        }
+
+        let runningVersion = Self.currentExtensionVersion()
+
+        guard parsed.version == runningVersion else {
+            logger.info("Sync anchor's embedded extension version \"\(parsed.version)\" does not match the running extension version \"\(runningVersion)\". Returning syncAnchorExpired so the framework re-enumerates this container and refreshes cached NSFileProviderItem snapshots. See nextcloud/desktop#10065.", [.item: enumeratedItemIdentifier])
+            observer.finishEnumeratingWithError(NSFileProviderError(.syncAnchorExpired))
+            return
+        }
+
         /*
          If this is an enumerator for the working set, then:
 
@@ -235,15 +259,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         if enumeratedItemIdentifier == .workingSet {
             logger.debug("Enumerating changes in working set.", [.account: account])
 
-            let formatter = ISO8601DateFormatter()
-
-            guard let anchorDateString = String(data: anchor.rawValue, encoding: .utf8),
-                  let date = formatter.date(from: anchorDateString)
-            else {
-                logger.error("Could not parse sync anchor \"\(anchor.rawValue)\".")
-                observer.finishEnumeratingWithError(NSFileProviderError(.syncAnchorExpired))
-                return
-            }
+            let date = parsed.date
 
             Task {
                 await checkMaterializedItemsOnServer()
@@ -751,5 +767,52 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         }
         // Provide it to the caller method so it can ingest it into the database and fix future errs
         return metadata
+    }
+
+    // MARK: - Version-tagged sync anchor
+
+    ///
+    /// Build a sync anchor that encodes the running extension bundle's `CFBundleShortVersionString` alongside the given timestamp.
+    ///
+    /// The same format is used for every container the extension enumerates (working set, root container, sub-directories, trash) so the framework's per-container persisted anchors all carry the version. On the next call to ``enumerateChanges(for:from:)`` the embedded version is compared against the running extension — any mismatch (including anchors persisted by builds older than this change, which carried only the ISO8601 date) is rejected with `NSFileProviderError(.syncAnchorExpired)`. That causes the framework to drop its cached sync state for that container and re-enumerate it via ``enumerateItems(for:startingAt:)``, so the fresh ``Item`` objects we hand back carry up-to-date `userInfo`, `contentPolicy`, and any other `NSFileProviderItem` properties whose derivation changed between app versions.
+    ///
+    /// See nextcloud/desktop#10065.
+    ///
+    public static func syncAnchor(at date: Date) -> NSFileProviderSyncAnchor {
+        let raw = "\(currentExtensionVersion())|\(ISO8601DateFormatter().string(from: date))"
+        // Force-unwrap is safe: an ASCII version string and an ISO8601 date both encode cleanly to UTF-8.
+        return NSFileProviderSyncAnchor(raw.data(using: .utf8)!)
+    }
+
+    ///
+    /// Parse a sync anchor produced by ``syncAnchor(at:)``.
+    ///
+    /// Returns `nil` for anchors that are not in the expected `"<version>|<ISO8601-date>"` format — including anchors persisted by builds older than #10065 that carried only the ISO8601 date. The caller treats `nil` as an expired anchor.
+    ///
+    private static func parseSyncAnchor(_ anchor: NSFileProviderSyncAnchor) -> (version: String, date: Date)? {
+        guard let raw = String(data: anchor.rawValue, encoding: .utf8) else {
+            return nil
+        }
+
+        let parts = raw.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+
+        guard parts.count == 2 else {
+            return nil
+        }
+
+        guard let date = ISO8601DateFormatter().date(from: String(parts[1])) else {
+            return nil
+        }
+
+        return (String(parts[0]), date)
+    }
+
+    ///
+    /// The running extension bundle's `CFBundleShortVersionString`, or the empty string when none is available — e.g. unit-test hosts without a versioned `Info.plist`.
+    ///
+    /// The empty-string fallback compares equal across calls inside the same process, so test anchors round-trip cleanly through ``syncAnchor(at:)`` and ``parseSyncAnchor(_:)`` without triggering the version-mismatch branch.
+    ///
+    private static func currentExtensionVersion() -> String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -527,6 +527,101 @@ import OSLog
 
         logger.debug("Signalling enumerators.")
         notifyChange()
+
+        // Also nudge the root container so its enumerator's `enumerateChanges(for:from:)` is
+        // invoked shortly after the extension starts. Best-effort: when no enumerator is
+        // active for the root container at signal time, the framework debounces the signal
+        // and the call is effectively a no-op. The reliable refresh of cached
+        // `NSFileProviderItem` snapshots after an extension version bump happens via
+        // ``refreshFrameworkCacheIfExtensionVersionChanged`` below; this signal just shortens
+        // the path on launches where Finder is already actively viewing the root.
+        manager.signalEnumerator(for: .rootContainer) { error in
+            if error != nil {
+                self.logger.error("Failed to signal root container enumerator after account setup.", [.error: error?.localizedDescription])
+            }
+        }
+
+        refreshFrameworkCacheIfExtensionVersionChanged()
+    }
+
+    ///
+    /// On the first launch after the extension bundle's `CFBundleShortVersionString` changes, walk every non-deleted item in the database and call `NSFileProviderManager.requestModification(of: [.lastUsedDate], forItemWithIdentifier:)` for each.
+    ///
+    /// Each `requestModification` schedules a `modifyItem(…)` call from the framework into this extension. Our `modifyItem` builds a fresh ``Item`` from the database row and returns it via the completion handler — and the fresh `Item`'s ``Item/itemVersion`` carries a `metadataVersion` that embeds the current extension version (see ``Item/itemVersion``). The framework compares that against its cached `metadataVersion` (which was derived under the previous extension version), detects the mismatch, and writes the fresh snapshot — including the freshly computed `userInfo` keys, `contentPolicy`, `fileSystemFlags`, etc. — into its cache.
+    ///
+    /// Without this iteration, only items in the working set get their cached snapshots refreshed after a version bump (via the version-tagged sync anchor in ``Enumerator``). Placeholder children of containers Finder isn't actively enumerating — the bulk of items in a fresh sync — would otherwise keep their pre-upgrade snapshots until the user actively interacts with them. The same `requestModification(of: [.lastUsedDate], …)` nudge is used by ``Item/signalKeepDownloaded`` for individual keep-downloaded toggles.
+    ///
+    /// The current bundle version is persisted to ``FileProviderDomainDefaults/lastSeenExtensionVersion`` only after the iteration has finished issuing every nudge, so an interrupted launch redoes the work on the next start rather than skipping items.
+    ///
+    /// See nextcloud/desktop#10065.
+    ///
+    private func refreshFrameworkCacheIfExtensionVersionChanged() {
+        guard let manager else {
+            logger.error("Cannot refresh framework cache because the file provider manager is not available.")
+            return
+        }
+
+        guard let dbManager else {
+            logger.error("Cannot refresh framework cache because the database manager is not available.")
+            return
+        }
+
+        guard let ncAccount else {
+            logger.error("Cannot refresh framework cache because the account is not set up.")
+            return
+        }
+
+        let bundle = Bundle(for: type(of: self))
+
+        guard let currentVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String, currentVersion.isEmpty == false else {
+            logger.error("Cannot refresh framework cache because the extension bundle has no CFBundleShortVersionString.")
+            return
+        }
+
+        let lastSeenVersion = config.lastSeenExtensionVersion
+
+        guard currentVersion != lastSeenVersion else {
+            logger.debug("Extension version \"\(currentVersion)\" unchanged since last launch. Skipping framework cache refresh.")
+            return
+        }
+
+        let items = dbManager
+            .itemMetadatas(account: ncAccount.ncKitAccount)
+            .filter { metadata in
+                !metadata.deleted
+                    && metadata.ocId != NSFileProviderItemIdentifier.rootContainer.rawValue
+                    && metadata.ocId != NSFileProviderItemIdentifier.trashContainer.rawValue
+            }
+
+        logger.info("Extension version changed from \"\(lastSeenVersion ?? "<nil>")\" to \"\(currentVersion)\". Requesting metadata refresh for \(items.count) item(s).")
+
+        // Fire-and-forget: each `requestModification` returns quickly after scheduling the
+        // framework's modifyItem call. Sequential awaits keep the request-queue throughput
+        // predictable and avoid spawning one Swift `Task` per database row (which for large
+        // synced sets would be wasteful even if the system-level queue would coalesce them).
+        Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            for metadata in items {
+                let identifier = NSFileProviderItemIdentifier(metadata.ocId)
+
+                do {
+                    try await manager.requestModification(of: [.lastUsedDate], forItemWithIdentifier: identifier)
+                } catch {
+                    logger.error("Failed to request modification on item for framework cache refresh after extension version bump.", [.item: identifier, .error: error.localizedDescription])
+                }
+            }
+
+            // Persist the new version once every nudge has been issued — even if some of
+            // them errored. The next launch under the same version will skip this work; the
+            // small subset of items that errored will refresh through normal user-interaction
+            // paths (item(for:), explicit enumeration) once Finder touches them, because the
+            // `metadataVersion` comparison still detects the mismatch on those paths.
+            config.lastSeenExtensionVersion = currentVersion
+            logger.info("Framework cache refresh completed after extension version bump.", [.account: ncAccount])
+        }
     }
 
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
@@ -20,6 +20,7 @@ public struct FileProviderDomainDefaults {
         case user
         case userId
         case serverUrl
+        case lastSeenExtensionVersion
         case debugLoggingEnabled
     }
 
@@ -143,6 +144,40 @@ public struct FileProviderDomainDefaults {
                 logger.error("Ignoring new value for \"userId\" because it is an empty string for file provider domain \"\(identifier)\"!")
             } else {
                 internalConfig[ConfigKey.userId.rawValue] = newValue
+            }
+        }
+    }
+
+    ///
+    /// The extension bundle's `CFBundleShortVersionString` as last seen for this domain.
+    ///
+    /// Used by ``FileProviderExtension`` to detect app updates and, on first launch after a bump, iterate the database to call `NSFileProviderManager.requestModification(of: [.lastUsedDate], …)` for every non-deleted item — which nudges the framework to refresh its cached `NSFileProviderItem` snapshots so newly derived `userInfo` / `contentPolicy` / fileSystemFlags reach the system. The value is only persisted after the iteration has issued every nudge, so a launch that's interrupted mid-iteration redoes the work on the next start.
+    ///
+    /// See nextcloud/desktop#10065.
+    ///
+    public var lastSeenExtensionVersion: String? {
+        get {
+            let identifier = identifier.rawValue
+
+            if let value = internalConfig[ConfigKey.lastSeenExtensionVersion.rawValue] as? String {
+                logger.debug("Returning existing value \"\(value)\" for \"lastSeenExtensionVersion\" for file provider domain \"\(identifier)\".")
+                return value
+            } else {
+                logger.debug("No existing value for \"lastSeenExtensionVersion\" for file provider domain \"\(identifier)\" found.")
+                return nil
+            }
+        }
+
+        set {
+            let identifier = identifier.rawValue
+
+            if newValue == nil {
+                logger.debug("Removing key \"lastSeenExtensionVersion\" for file provider domain \"\(identifier)\" because the new value is nil.")
+                internalConfig.removeValue(forKey: ConfigKey.lastSeenExtensionVersion.rawValue)
+            } else if newValue == "" {
+                logger.error("Ignoring new value for \"lastSeenExtensionVersion\" because it is an empty string for file provider domain \"\(identifier)\"!")
+            } else {
+                internalConfig[ConfigKey.lastSeenExtensionVersion.rawValue] = newValue
             }
         }
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -69,10 +69,23 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
     }
 
     public var itemVersion: NSFileProviderItemVersion {
-        NSFileProviderItemVersion(
-            contentVersion: metadata.etag.data(using: .utf8)!,
-            metadataVersion: metadata.etag.data(using: .utf8)!
-        )
+        // `metadataVersion` embeds the running extension's `CFBundleShortVersionString`
+        // alongside the server etag so the framework's cached snapshot is detected as stale
+        // after any extension update that changes how `userInfo` / `contentPolicy` /
+        // `fileSystemFlags` / etc. are derived from `metadata`. Without the extension-version
+        // component, an item whose server etag is unchanged would carry the same
+        // `metadataVersion` we previously handed the framework, the framework would treat
+        // its cached snapshot as still valid, and the new derivations would never reach the
+        // system — leaving e.g. the `displayOpenInBrowser` / `displayCopyInternalLink`
+        // userInfo keys missing on items enumerated by older builds. `contentVersion` stays
+        // bare-etag because the file content itself didn't change across the upgrade and
+        // bumping it would force the framework to re-download every materialised file.
+        //
+        // See nextcloud/desktop#10065.
+        let extensionVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        let metadataVersionString = "\(metadata.etag)|\(extensionVersion)"
+
+        return NSFileProviderItemVersion(contentVersion: metadata.etag.data(using: .utf8)!, metadataVersion: metadataVersionString.data(using: .utf8)!)
     }
 
     public var filename: String {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -151,6 +151,7 @@ public actor FileProviderLog: FileProviderLogging {
         }
 
         self.logsDirectory = logsDirectory
+
         debugLoggingObservation = UserDefaults.standard.observe(\.debugLoggingEnabled, options: [.new]) { [weak self] _, _ in
             Task { [weak self] in
                 await self?.reloadDebugLoggingEnabled()

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
@@ -3,6 +3,7 @@
 
 @preconcurrency import FileProvider
 import Foundation
+import NextcloudFileProviderKit
 
 public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
     public var changedItems: [any NSFileProviderItemProtocol] = []
@@ -33,11 +34,7 @@ public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
     }
 
     public func enumerateChanges(from anchor: NSFileProviderSyncAnchor =
-        .init(
-            ISO8601DateFormatter()
-                .string(from: Date(timeIntervalSince1970: 1))
-                .data(using: .utf8)!
-        )) async throws
+        Enumerator.syncAnchor(at: Date(timeIntervalSince1970: 1))) async throws
     {
         enumerator.enumerateChanges?(for: self, from: anchor)
         while !isComplete {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -622,9 +622,10 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let tenMinutesAgo = Date().addingTimeInterval(-600)
         let now = Date()
 
-        // Create a sync anchor from our date.
-        let formatter = ISO8601DateFormatter()
-        let anchor = try NSFileProviderSyncAnchor(XCTUnwrap(formatter.string(from: anchorDate).data(using: .utf8)))
+        // Build a version-tagged sync anchor at the chosen date. The same helper is used by the
+        // production code, so the anchor round-trips cleanly through `enumerateChanges` without
+        // tripping the syncAnchorExpired branch added for nextcloud/desktop#10065.
+        let anchor = Enumerator.syncAnchor(at: anchorDate)
 
         // Setup remote interface with the items we're testing
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
@@ -744,10 +745,10 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         childFolderMetadata.etag = remoteChildFolder.versionIdentifier
         Self.dbManager.addItemMetadata(childFolderMetadata)
 
-        // Create a sync anchor from before now
+        // Create a sync anchor from before now using the production helper so it carries the
+        // version prefix expected by the syncAnchorExpired check (nextcloud/desktop#10065).
         let anchorDate = Date().addingTimeInterval(-300) // 5 minutes ago
-        let formatter = ISO8601DateFormatter()
-        let anchor = try NSFileProviderSyncAnchor(XCTUnwrap(formatter.string(from: anchorDate).data(using: .utf8)))
+        let anchor = Enumerator.syncAnchor(at: anchorDate)
 
         // Update sync times to be after the anchor (so they would be checked)
         let now = Date()


### PR DESCRIPTION
- Fixes #10065.
- As it turned out, re-importing all file provider items is the completely wrong choice as in my first attempt. The extension did not loose track of the synchronization and the item identifiers are still stable.
- Telling the system to request the item information again is achieved by reporting an expired sync anchor.