### PR TITLE
fix(networkjobs): move processEvents after reply reads in LsColJob

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -556,18 +556,16 @@ bool LsColJob::finished()
         connect(&parser, &LsColXMLParser::finishedWithoutError,
             this, &LsColJob::finishedWithoutError);
 
-        // bool LsColXMLParser::parse takes a while, let's process some events in attempt to make UI more responsive
-        // from https://doc.qt.io/qt-5/qcoreapplication.html#processEvents-1 
-        // "You can call this function occasionally when your program is busy doing a long operation (e.g. copying a file)."
-        // we should not abuse this function, as it affects QObject instances lifetime (when children are getting deleted or when deleteLater is called)
-        // one reason I had to remove ability for LsColJob to have parent, which, otherwise, leads to a crash later
-        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
-
-        QString expectedPath = reply()->request().url().path(); // something like "/owncloud/remote.php/dav/folder"
+        const auto expectedPath = reply()->request().url().path(); // something like "/owncloud/remote.php/dav/folder"
         if (!parser.parse(reply()->readAll(), &_folderInfos, expectedPath)) {
             // XML parse error
             emit finishedWithError(reply());
         }
+
+        // processEvents is called AFTER all reply() accesses. A pending deleteLater()
+        // processed inside it can zero the QPointer and caused a SIGSEGV when it was
+        // placed before the reply reads. Do not abuse: it affects QObject lifetimes.
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
     } else {
         // wrong content type, wrong HTTP code or any other network error
         emit finishedWithError(reply());

--- a/test/testremotediscovery.cpp
+++ b/test/testremotediscovery.cpp
@@ -37,6 +37,18 @@ struct MissingPermissionsPropfindReply : FakePropfindReply {
     }
 };
 
+// Reply that queues its own deletion so it fires inside LsColJob::finished()'s processEvents().
+struct FakePropfindReplyWithPendingDeletion : FakePropfindReply {
+    FakePropfindReplyWithPendingDeletion(FileInfo &remoteRootFileInfo, QNetworkAccessManager::Operation op,
+                                         const QNetworkRequest &request, QObject *parent)
+        : FakePropfindReply(remoteRootFileInfo, op, request, parent)
+    {
+        // respond() is queued before this timer, so it fires first; the deletion fires
+        // inside LsColJob::finished()'s processEvents() call.
+        QTimer::singleShot(0, this, &QObject::deleteLater);
+    }
+};
+
 
 enum ErrorKind : int {
     // Lower code are corresponding to HTML error code
@@ -240,6 +252,45 @@ private slots:
         rootFileIdSpy.clear();
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(rootFileIdSpy.size(), 0);
+    }
+
+    // Regression: processEvents() inside LsColJob::finished() must not run before reply()
+    // is read. A pending deleteLater() draining during processEvents() zeros the QPointer
+    // and caused a SIGSEGV at reply()->request().url().path() (address 0x8).
+    void testLsColJobDoesNotCrashWhenReplyIsDeletedDuringProcessEvents()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        fakeFolder.remoteModifier().mkdir("B/sub");
+
+        const auto errorFolder = QStringLiteral("dav/files/admin/B");
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op,
+                                         const QNetworkRequest &req,
+                                         QIODevice *) -> QNetworkReply * {
+            if (req.attribute(QNetworkRequest::CustomVerbAttribute).toString() == QStringLiteral("PROPFIND")
+                && req.url().path().endsWith(errorFolder)) {
+                return new FakePropfindReplyWithPendingDeletion(fakeFolder.remoteModifier(), op, req, nullptr);
+            }
+            return nullptr;
+        });
+
+        // The sync must complete without crashing. Discovery of B will fail gracefully
+        // because finishedWithoutError is still emitted before processEvents() runs.
+        QVERIFY(fakeFolder.syncOnce());
+        // Items under A and C must have synced normally.
+        QVERIFY(fakeFolder.currentLocalState().find("A"));
+        QVERIFY(fakeFolder.currentLocalState().find("C"));
+    }
+
+    // Verifies normal listing succeeds when the reply stays alive throughout.
+    void testLsColJobSucceedsNormally()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        fakeFolder.remoteModifier().insert("A/newfile.txt");
+
+        // Normal sync with no overrides: all PROPFIND replies remain alive.
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(fakeFolder.currentLocalState().find("A/newfile.txt"));
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
 };
 


### PR DESCRIPTION
## Resolves
Users on 4.0.9/4.0.10 started hitting a SIGSEGV at reply()->request().url().path() inside LsColJob::finished(). Crash address 0x8 (null pointer + 8 bytes) — the QPointer<QNetworkReply> was zeroed by the time that line ran.

## Summay
e9a0dbd16c (Jan 2024) added a QCoreApplication::processEvents() call inside LsColJob::finished() for UI responsiveness, placing it before the reply was read. The code even warned about this in a comment, but left the reply() access after processEvents() unguarded.

A pending deleteLater() on the reply — triggered by the network timeout timer — can be drained inside that processEvents() call, zeroing the QPointer. The function then crashes reading from null.

ee899a86b2 (March 2026) flipped enableTimeout = false → true, re-enabling the request timeout feature. With the timer active again, timeouts fire regularly during the 100 ms processEvents() window, making the race consistently reproducible in production.

This PR moves processEvents() to after all reply() accesses. The parse and signal emissions complete while the pointer is still valid. processEvents() still runs for UI responsiveness, just after parsing instead of before it.

## Tests
Added to testremotediscovery:
- testLsColJobDoesNotCrashWhenReplyIsDeletedDuringProcessEvents — uses a fake reply that schedules its own deleteLater() via a zero-timeout timer, reproducing the deletion-during-processEvents condition. Verifies no crash and that unaffected folders sync normally.
- testLsColJobSucceedsNormally — confirms the happy path (successful listing + local state matches remote) is unaffected by the change.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
