### PR TITLE
fix(tray): show correct sync status icon in macOS account popup.

### DIFF
--- a/src/gui/macOS/trayaccountpopup_mac.mm
+++ b/src/gui/macOS/trayaccountpopup_mac.mm
@@ -59,54 +59,6 @@ static NSImage *nsImageFromQImage(const QImage &qimg)
     return img;
 }
 
-static NSImage *whiteSymbolImage(NSString *symbolName, CGFloat pointSize)
-{
-    NSImage *symbol = [[NSImage imageWithSystemSymbolName:symbolName accessibilityDescription:nil]
-        imageWithSymbolConfiguration:[NSImageSymbolConfiguration configurationWithPointSize:pointSize weight:NSFontWeightBold]];
-    NSImage *tintedSymbol = [[NSImage alloc] initWithSize:symbol.size];
-
-    [tintedSymbol lockFocus];
-    const NSRect symbolRect = NSMakeRect(0.0, 0.0, symbol.size.width, symbol.size.height);
-    [symbol drawInRect:symbolRect
-              fromRect:NSZeroRect
-             operation:NSCompositingOperationSourceOver
-              fraction:1.0
-        respectFlipped:YES
-                 hints:nil];
-    [NSColor.whiteColor set];
-    NSRectFillUsingOperation(symbolRect, NSCompositingOperationSourceIn);
-    [tintedSymbol unlockFocus];
-
-    return tintedSymbol;
-}
-
-static NSImage *syncStatusImage(BOOL syncOk)
-{
-    const CGFloat imageSize = 18.0;
-    const CGFloat circleSize = 16.0;
-    const NSRect imageRect = NSMakeRect(0.0, 0.0, imageSize, imageSize);
-    const NSRect circleRect = NSMakeRect((imageSize - circleSize) / 2.0,
-                                         (imageSize - circleSize) / 2.0,
-                                         circleSize,
-                                         circleSize);
-    NSImage *image = [[NSImage alloc] initWithSize:imageRect.size];
-
-    [image lockFocus];
-    [(syncOk ? NSColor.systemGreenColor : NSColor.systemBlueColor) setFill];
-    [[NSBezierPath bezierPathWithOvalInRect:circleRect] fill];
-
-    NSString *symbolName = syncOk ? @"checkmark" : @"arrow.triangle.2.circlepath";
-    NSImage *symbol = whiteSymbolImage(symbolName, 10);
-    [symbol drawInRect:NSMakeRect(4.0, 4.0, 10.0, 10.0)
-              fromRect:NSZeroRect
-             operation:NSCompositingOperationSourceOver
-              fraction:1.0
-        respectFlipped:YES
-                 hints:nil];
-    [image unlockFocus];
-
-    return image;
-}
 
 @interface NCHoverView : NSView
 @end
@@ -349,7 +301,7 @@ static NSImage *syncStatusImage(BOOL syncOk)
                              name:(NSString *)name
                            server:(NSString *)server
                            avatar:(NSImage *)avatar
-                           syncOk:(BOOL)syncOk
+                  syncStatusImage:(NSImage *)syncStatusImage
 {
     NSImageView *avatarView = [[NSImageView alloc] init];
     avatarView.image = avatar != nil ? avatar : [NSImage imageWithSystemSymbolName:@"person.circle.fill"
@@ -377,7 +329,7 @@ static NSImage *syncStatusImage(BOOL syncOk)
     row.popupDelegate = self;
 
     NSImageView *statusView = [[NSImageView alloc] init];
-    statusView.image = syncStatusImage(syncOk);
+    statusView.image = syncStatusImage;
     statusView.translatesAutoresizingMaskIntoConstraints = NO;
 
     NSImageView *chevron = [[NSImageView alloc] init];
@@ -436,9 +388,9 @@ static NSImage *syncStatusImage(BOOL syncOk)
         const QModelIndex idx = model->index(i);
         NSString *name   = model->data(idx, OCC::UserModel::NameRole).toString().toNSString();
         NSString *server = model->data(idx, OCC::UserModel::ServerRole).toString().toNSString();
-        const bool syncOk = model->data(idx, OCC::UserModel::SyncStatusOkRole).toBool();
         NSImage *avatar = nsImageFromQImage(model->avatarForRow(i));
-        [_stack addArrangedSubview:[self makeRowForIndex:i name:name server:server avatar:avatar syncOk:syncOk]];
+        NSImage *syncStatus = nsImageFromQImage(model->syncStatusIconForRow(i));
+        [_stack addArrangedSubview:[self makeRowForIndex:i name:name server:server avatar:avatar syncStatusImage:syncStatus]];
     }
 
     NSBox *sep = [[NSBox alloc] init];

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -2205,6 +2205,16 @@ QImage UserModel::avatarForRow(const int row) const
     return _users[row]->avatar();
 }
 
+QImage UserModel::syncStatusIconForRow(const int row) const
+{
+    if (row < 0 || row >= _users.size()) {
+        return {};
+    }
+    const auto url = _users[row]->syncStatusIcon();
+    const auto resourcePath = QStringLiteral(":") + url.path();
+    return QIcon(resourcePath).pixmap(18, 18).toImage();
+}
+
 QString UserModel::currentUserServer()
 {
     if (_currentUserId < 0 || _currentUserId >= _users.size())

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -340,6 +340,7 @@ public:
 
     [[nodiscard]]  QImage avatarById(const int id) const;
     [[nodiscard]] QImage avatarForRow(int row) const;
+    [[nodiscard]] QImage syncStatusIconForRow(int row) const;
 
     [[nodiscard]] User *currentUser() const;
     [[nodiscard]] User *findUserForAccount(AccountState *account) const;


### PR DESCRIPTION
## Resolves
The macOS account switcher popup was only checking a boolean (syncStatusOk) to decide what to draw, so all non-ok states (error, warning, paused, offline) looked identical to the syncing state — a blue spinning arrow. Only "all good" and "something is happening" were visually distinct.

## Summary
This replaces the custom drawn circle with the actual theme icon, the same one already used in the QML version of the popup. Now error, warning, paused and offline each show their correct icon - in the example bellow `admin` doesn't have a sync folder:

<img width="316" height="233" alt="Screenshot 2026-06-01 at 16 32 07" src="https://github.com/user-attachments/assets/0eeb1126-231e-4a91-97aa-8990d2e5a140" /> <img width="316" height="233" alt="Screenshot 2026-06-01 at 16 36 09" src="https://github.com/user-attachments/assets/160ed62e-583d-49d1-bd6d-657e7afe2e1a" />

`admin` with a sync folder:

<img width="309" height="234" alt="Screenshot 2026-06-01 at 18 55 42" src="https://github.com/user-attachments/assets/f2285099-5c0a-4927-84d6-6d15c4de94f0" /> <img width="309" height="234" alt="Screenshot 2026-06-01 at 18 56 18" src="https://github.com/user-attachments/assets/6268fc63-5ccd-4bf2-bf2e-a788207cd038" />



## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
