### PR TITLE
Updated API calls NextcloudKit dependency to breaking changes in 7.3.3

### DIFF
--- a/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bcf8f31d00a42fa9b91759ea772f7a38952c1a24478cfaa21b7ffb27634a0eed",
+  "originHash" : "a22e4492c8a7194a0ebcc9f9e61d4e85499c62f75841c7da69d00a900eaf544d",
   "pins" : [
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire",
       "state" : {
-        "revision" : "e938f8c66708e7352fc7e3512647fa54255b267a",
-        "version" : "5.11.2"
+        "revision" : "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+        "version" : "5.12.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nextcloud/NextcloudKit",
       "state" : {
-        "revision" : "6f25e101f5833d4d01961c5012acb37d526fffd2",
-        "version" : "7.2.8"
+        "revision" : "ef7b20a5dab6061d4139f943e824981369ef949e",
+        "version" : "7.3.3"
       }
     },
     {
@@ -58,10 +58,10 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
-        "version" : "2.97.1"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "397309e73621d6355d3a7fb832ca233ac9dd5254",
-        "version" : "0.61.0"
+        "revision" : "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
+        "version" : "0.61.1"
       }
     },
     {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/nextcloud/NextcloudCapabilitiesKit.git", from: "2.5.0"),
-        .package(url: "https://github.com/nextcloud/NextcloudKit", from: "7.2.3"),
+        .package(url: "https://github.com/nextcloud/NextcloudKit", from: "7.3.3"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
         .package(url: "https://github.com/realm/realm-swift.git", from: "20.0.4"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -502,7 +502,7 @@ import OSLog
 
     // MARK: - Helper functions
 
-    func signalEnumerator(completionHandler: @escaping (_ error: Error?) -> Void) {
+    func signalEnumerator(completionHandler: @Sendable @escaping (_ error: Error?) -> Void) {
         guard let manager else {
             logger.error("Cannot get file provider manager for domain. Cannot signal enumerator.")
             return

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
@@ -60,7 +60,17 @@ extension NextcloudKit: RemoteInterface {
                 requestHandler: requestHandler,
                 taskHandler: taskHandler,
                 progressHandler: progressHandler
-            ) { account, ocId, etag, date, size, response, nkError in
+            ) { account, response, nkError in
+                let allHeaderFields = response?.response?.allHeaderFields
+                let ocId = self.nkCommonInstance.findHeader("oc-fileid", allHeaderFields: allHeaderFields)
+                let etag = self.nkCommonInstance.normalizedETag(self.nkCommonInstance.findHeader("oc-etag", allHeaderFields: allHeaderFields))
+                let date = self.nkCommonInstance.findHeader("date", allHeaderFields: allHeaderFields)?.parsedDate(using: "EEE, dd MMM y HH:mm:ss zzz")
+                var size: Int64 = 0
+
+                if let value = allHeaderFields?["Content-Length"] as? String {
+                    size = Int64(value) ?? 0
+                }
+
                 continuation.resume(returning: (
                     account,
                     ocId,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -86,11 +86,7 @@ public protocol RemoteInterface: Sendable {
         progressHandler: @escaping (_ progress: Progress) -> Void
     ) async -> (
         account: String,
-        etag: String?,
-        date: Date?,
-        length: Int64,
-        headers: [AnyHashable: any Sendable]?,
-        afError: AFError?,
+        response: AFDownloadResponse<URL?>?,
         nkError: NKError
     )
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -66,7 +66,7 @@ public extension Item {
                 } else {
                     let identifier = NSFileProviderItemIdentifier(metadata.ocId)
 
-                    let (_, _, _, _, _, _, error) = await remoteInterface.downloadAsync(
+                    let (_, _, error) = await remoteInterface.downloadAsync(
                         serverUrlFileName: remotePath,
                         fileNameLocalPath: childLocalPath,
                         account: account.ncKitAccount,
@@ -176,7 +176,7 @@ public extension Item {
             }
 
         } else {
-            let (_, _, _, _, _, _, error) = await remoteInterface.downloadAsync(
+            let (_, _, error) = await remoteInterface.downloadAsync(
                 serverUrlFileName: serverUrlFileName,
                 fileNameLocalPath: localPath.path,
                 account: account.ncKitAccount,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
@@ -96,14 +96,10 @@ public struct TestableRemoteInterface: RemoteInterface, @unchecked Sendable {
         progressHandler _: @escaping (_ progress: Progress) -> Void
     ) async -> (
         account: String,
-        etag: String?,
-        date: Date?,
-        length: Int64,
-        headers: [AnyHashable: any Sendable]?,
-        afError: AFError?,
+        response: AFDownloadResponse<URL?>?,
         nkError: NKError
     ) {
-        ("", nil, nil, 0, nil, nil, .invalidResponseError)
+        ("", nil, .invalidResponseError)
     }
 
     public func enumerate(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -1034,23 +1034,19 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         progressHandler _: @escaping (_ progress: Progress) -> Void = { _ in }
     ) async -> (
         account: String,
-        etag: String?,
-        date: Date?,
-        length: Int64,
-        headers: [AnyHashable: any Sendable]?,
-        afError: AFError?,
+        response: AFDownloadResponse<URL?>?,
         nkError: NKError
     ) {
         guard let serverUrlFileName = serverUrlFileName as? String ?? (serverUrlFileName as? URL)?.absoluteString else {
-            return (account, nil, nil, 0, nil, nil, .urlError)
+            return (account, nil, .urlError)
         }
 
         guard let account = mockedAccounts[account] else {
-            return (account, nil, nil, 0, nil, nil, .urlError)
+            return (account, nil, .urlError)
         }
 
         guard let item = item(remotePath: serverUrlFileName, account: account.ncKitAccount) else {
-            return (account.ncKitAccount, nil, nil, 0, nil, nil, .urlError)
+            return (account.ncKitAccount, nil, .urlError)
         }
 
         let localUrl = URL(fileURLWithPath: fileNameLocalPath)
@@ -1066,18 +1062,10 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
             }
         } catch {
             print("Could not write item data: \(error)")
-            return (account.ncKitAccount, nil, nil, 0, nil, nil, .urlError)
+            return (account.ncKitAccount, nil, .urlError)
         }
 
-        return (
-            account.ncKitAccount,
-            item.versionIdentifier,
-            item.creationDate as Date,
-            item.size,
-            nil,
-            nil,
-            .success
-        )
+        return (account.ncKitAccount, nil, .success)
     }
 
     public func enumerate(


### PR DESCRIPTION
NextcloudKit 7.3.3 shipped breaking API changes due to [this pull request](https://github.com/nextcloud/NextcloudKit/pull/223). Some adaptions were required.