### PR TITLE
fix: do not trigger false remote wipe message

### DIFF
--- a/src/gui/remotewipe.cpp
+++ b/src/gui/remotewipe.cpp
@@ -27,6 +27,10 @@ RemoteWipe::RemoteWipe(AccountPtr account, QObject *parent)
             return;
         }
 
+        if (!_account->isRemoteWipeRequested_HACK()) {
+            return;
+        }
+
         notifyServerSuccess();
     });
 


### PR DESCRIPTION
remote wipe confirmation was called by every accountRemoved
