### PR TITLE
fix: Add missing icons to buttons on Plasma

### DIFF
--- a/src/gui/tray/ActivityItemContent.qml
+++ b/src/gui/tray/ActivityItemContent.qml
@@ -173,6 +173,7 @@ RowLayout {
                     width: Style.activityListButtonWidth
                     height: Style.activityListButtonHeight
 
+                    icon.name: 'view-more-symbolic'
                     icon.source: "image://svgimage-custom-color/more.svg/" + palette.buttonText
                     icon.width: Style.activityListButtonIconSize
                     icon.height: Style.activityListButtonIconSize
@@ -216,6 +217,7 @@ RowLayout {
                     width: Style.activityListButtonWidth
                     height: Style.activityListButtonHeight
 
+                    icon.name: 'dialog-close-symbolic'
                     icon.source: "image://svgimage-custom-color/clear.svg/" + palette.buttonText
                     icon.width: Style.activityListButtonIconSize
                     icon.height: Style.activityListButtonIconSize


### PR DESCRIPTION
## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
