### PR TITLE
fix(file-provider): use slash prefix for child item queries.

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -17,7 +17,10 @@ public extension FilesDatabaseManager {
     func childItems(directoryMetadata: SendableItemMetadata) -> [SendableItemMetadata] {
         let directoryServerUrl = fullServerPathUrl(for: directoryMetadata)
         return itemMetadatas
-            .where { $0.serverUrl.starts(with: directoryServerUrl) }
+            .where {
+                $0.serverUrl == directoryServerUrl ||
+                    $0.serverUrl.starts(with: directoryServerUrl + "/")
+            }
             .toUnmanagedResults()
     }
 
@@ -37,7 +40,10 @@ public extension FilesDatabaseManager {
     func childItemCount(directoryMetadata: SendableItemMetadata) -> Int {
         let directoryServerUrl = fullServerPathUrl(for: directoryMetadata)
         return itemMetadatas
-            .where { $0.serverUrl.starts(with: directoryServerUrl) }
+            .where {
+                $0.serverUrl == directoryServerUrl ||
+                    $0.serverUrl.starts(with: directoryServerUrl + "/")
+            }
             .count
     }
 
@@ -84,7 +90,8 @@ public extension FilesDatabaseManager {
         var deletedMetadatas: [SendableItemMetadata] = [directoryMetadataCopy]
 
         let results = itemMetadatas.where {
-            $0.account == directoryAccount && $0.serverUrl.starts(with: directoryUrlPath)
+            $0.account == directoryAccount &&
+                ($0.serverUrl == directoryUrlPath || $0.serverUrl.starts(with: directoryUrlPath + "/"))
         }
 
         for result in results {
@@ -119,7 +126,7 @@ public extension FilesDatabaseManager {
         let newDirectoryServerUrl = newServerUrl + "/" + newFileName
         let childItemResults = itemMetadatas.where {
             $0.account == directoryMetadata.account &&
-                $0.serverUrl.starts(with: oldDirectoryServerUrl)
+                ($0.serverUrl == oldDirectoryServerUrl || $0.serverUrl.starts(with: oldDirectoryServerUrl + "/"))
         }
 
         renameItemMetadata(ocId: ocId, newServerUrl: newServerUrl, newFileName: newFileName)
@@ -151,7 +158,7 @@ public extension FilesDatabaseManager {
         return itemMetadatas
             .where {
                 $0.account == directoryMetadata.account &&
-                    $0.serverUrl.starts(with: newDirectoryServerUrl)
+                    ($0.serverUrl == newDirectoryServerUrl || $0.serverUrl.starts(with: newDirectoryServerUrl + "/"))
             }
             .toUnmanagedResults()
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -213,7 +213,10 @@ public final class FilesDatabaseManager: Sendable {
         account: String, underServerUrl serverUrl: String
     ) -> [SendableItemMetadata] {
         itemMetadatas
-            .where { $0.account == account && $0.serverUrl.starts(with: serverUrl) }
+            .where {
+                $0.account == account &&
+                    ($0.serverUrl == serverUrl || $0.serverUrl.starts(with: serverUrl + "/"))
+            }
             .toUnmanagedResults()
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -513,7 +513,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
 
                             let hasMaterializedDescendants = materializedItems.contains {
                                 $0.ocId != localItem.ocId
-                                    && $0.serverUrl.hasPrefix(localItem.remotePath())
+                                    && $0.serverUrl.hasPrefix(localItem.remotePath() + "/")
                             }
 
                             if !hasMaterializedDescendants {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
@@ -11,7 +11,7 @@ public actor FileProviderLogMock: FileProviderLogging {
     let logger: Logger
 
     public init() {
-        logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "FileProviderLogMock")
+        logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.nextcloud.NextcloudFileProviderKit.tests", category: "FileProviderLogMock")
     }
 
     public func write(category _: String, level _: OSLogType, message: String, details _: [FileProviderLogDetailKey: (any Sendable)?], file _: StaticString, function _: StaticString, line _: UInt) {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/PathBoundaryPrefixTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/PathBoundaryPrefixTests.swift
@@ -1,0 +1,234 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudKit
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+// MARK: - Path boundary prefix matching
+
+final class PathBoundaryPrefixTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    static let dbManager = FilesDatabaseManager(
+        account: account,
+        databaseDirectory: makeDatabaseDirectory(),
+        fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+        log: FileProviderLogMock()
+    )
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+    }
+
+    func testChildItemsMatchesDirectChildButNotSiblingWithSharedPrefix() throws {
+        let directoryMetadata = RealmItemMetadata()
+        directoryMetadata.ocId = "dir-A"
+        directoryMetadata.account = "TestAccount"
+        directoryMetadata.serverUrl = "https://cloud.example.com/files"
+        directoryMetadata.fileName = "photos"
+        directoryMetadata.directory = true
+
+        let childMetadata = RealmItemMetadata()
+        childMetadata.ocId = "child-1"
+        childMetadata.account = "TestAccount"
+        childMetadata.serverUrl = "https://cloud.example.com/files/photos"
+        childMetadata.fileName = "pic.jpg"
+
+        let nestedChild = RealmItemMetadata()
+        nestedChild.ocId = "nested-1"
+        nestedChild.account = "TestAccount"
+        nestedChild.serverUrl = "https://cloud.example.com/files/photos/vacation"
+        nestedChild.fileName = "beach.jpg"
+
+        let siblingMetadata = RealmItemMetadata()
+        siblingMetadata.ocId = "sibling-1"
+        siblingMetadata.account = "TestAccount"
+        siblingMetadata.serverUrl = "https://cloud.example.com/files/photos-backup"
+        siblingMetadata.fileName = "old.jpg"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(directoryMetadata)
+            realm.add(childMetadata)
+            realm.add(nestedChild)
+            realm.add(siblingMetadata)
+        }
+
+        let children = Self.dbManager.childItems(
+            directoryMetadata: SendableItemMetadata(value: directoryMetadata)
+        )
+        let childOcIds = Set(children.map(\.ocId))
+        XCTAssertTrue(childOcIds.contains("child-1"), "Direct child should be matched")
+        XCTAssertTrue(childOcIds.contains("nested-1"), "Nested descendant should be matched")
+        XCTAssertFalse(childOcIds.contains("sibling-1"), "Sibling with shared prefix must not match")
+        XCTAssertEqual(children.count, 2)
+    }
+
+    func testChildItemCountExcludesSiblingWithSharedPrefix() throws {
+        let directoryMetadata = RealmItemMetadata()
+        directoryMetadata.ocId = "dir-B"
+        directoryMetadata.account = "TestAccount"
+        directoryMetadata.serverUrl = "https://cloud.example.com/files"
+        directoryMetadata.fileName = "docs"
+        directoryMetadata.directory = true
+
+        let childMetadata = RealmItemMetadata()
+        childMetadata.ocId = "child-2"
+        childMetadata.account = "TestAccount"
+        childMetadata.serverUrl = "https://cloud.example.com/files/docs"
+        childMetadata.fileName = "report.pdf"
+
+        let siblingMetadata = RealmItemMetadata()
+        siblingMetadata.ocId = "sibling-2"
+        siblingMetadata.account = "TestAccount"
+        siblingMetadata.serverUrl = "https://cloud.example.com/files/docs-archive"
+        siblingMetadata.fileName = "old-report.pdf"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(directoryMetadata)
+            realm.add(childMetadata)
+            realm.add(siblingMetadata)
+        }
+
+        let count = Self.dbManager.childItemCount(
+            directoryMetadata: SendableItemMetadata(value: directoryMetadata)
+        )
+        XCTAssertEqual(count, 1)
+    }
+
+    func testDeleteDirectoryDoesNotDeleteSiblingWithSharedPrefix() throws {
+        let directoryMetadata = RealmItemMetadata()
+        directoryMetadata.ocId = "dir-C"
+        directoryMetadata.account = "TestAccount"
+        directoryMetadata.serverUrl = "https://cloud.example.com/files"
+        directoryMetadata.fileName = "work"
+        directoryMetadata.directory = true
+
+        let childMetadata = RealmItemMetadata()
+        childMetadata.ocId = "child-3"
+        childMetadata.account = "TestAccount"
+        childMetadata.serverUrl = "https://cloud.example.com/files/work"
+        childMetadata.fileName = "task.txt"
+
+        let siblingMetadata = RealmItemMetadata()
+        siblingMetadata.ocId = "sibling-3"
+        siblingMetadata.account = "TestAccount"
+        siblingMetadata.serverUrl = "https://cloud.example.com/files/work-old"
+        siblingMetadata.fileName = "task-old.txt"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(directoryMetadata)
+            realm.add(childMetadata)
+            realm.add(siblingMetadata)
+        }
+
+        let deleted = Self.dbManager.deleteDirectoryAndSubdirectoriesMetadata(ocId: "dir-C")
+        XCTAssertNotNil(deleted)
+        XCTAssertEqual(deleted?.count, 2, "Should delete directory + direct child")
+
+        let survivingSibling = Self.dbManager.itemMetadata(ocId: "sibling-3")
+        XCTAssertNotNil(survivingSibling)
+        XCTAssertFalse(survivingSibling?.deleted ?? true)
+    }
+
+    func testRenameDirectoryDoesNotRenameSiblingWithSharedPrefix() throws {
+        let directoryMetadata = RealmItemMetadata()
+        directoryMetadata.ocId = "dir-D"
+        directoryMetadata.account = "TestAccount"
+        directoryMetadata.serverUrl = "https://cloud.example.com/files"
+        directoryMetadata.fileName = "alpha"
+        directoryMetadata.directory = true
+
+        let childMetadata = RealmItemMetadata()
+        childMetadata.ocId = "child-4"
+        childMetadata.account = "TestAccount"
+        childMetadata.serverUrl = "https://cloud.example.com/files/alpha"
+        childMetadata.fileName = "file.txt"
+
+        let siblingMetadata = RealmItemMetadata()
+        siblingMetadata.ocId = "sibling-4"
+        siblingMetadata.account = "TestAccount"
+        siblingMetadata.serverUrl = "https://cloud.example.com/files/alphabet"
+        siblingMetadata.fileName = "a.txt"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(directoryMetadata)
+            realm.add(childMetadata)
+            realm.add(siblingMetadata)
+        }
+
+        let updated = Self.dbManager.renameDirectoryAndPropagateToChildren(
+            ocId: "dir-D",
+            newServerUrl: "https://cloud.example.com/files",
+            newFileName: "beta"
+        )
+
+        XCTAssertNotNil(updated)
+        XCTAssertTrue(
+            updated?.contains(where: { $0.ocId == "child-4" }) ?? false,
+            "Direct child should be in the updated results"
+        )
+
+        let renamedChild = Self.dbManager.itemMetadata(ocId: "child-4")
+        XCTAssertEqual(
+            renamedChild?.serverUrl,
+            "https://cloud.example.com/files/beta",
+            "Direct child's serverUrl should be updated"
+        )
+
+        let sibling = Self.dbManager.itemMetadata(ocId: "sibling-4")
+        XCTAssertEqual(
+            sibling?.serverUrl,
+            "https://cloud.example.com/files/alphabet",
+            "Sibling with shared prefix should not have its serverUrl changed"
+        )
+    }
+
+    func testItemMetadatasUnderServerUrlExcludesSiblingPrefix() throws {
+        let directChild = RealmItemMetadata()
+        directChild.ocId = "under-1"
+        directChild.account = "TestAccount"
+        directChild.serverUrl = "https://cloud.example.com/files/project"
+        directChild.fileName = "readme.md"
+
+        let nestedChild = RealmItemMetadata()
+        nestedChild.ocId = "under-2"
+        nestedChild.account = "TestAccount"
+        nestedChild.serverUrl = "https://cloud.example.com/files/project/src"
+        nestedChild.fileName = "main.swift"
+
+        let siblingMetadata = RealmItemMetadata()
+        siblingMetadata.ocId = "under-3"
+        siblingMetadata.account = "TestAccount"
+        siblingMetadata.serverUrl = "https://cloud.example.com/files/project-v2"
+        siblingMetadata.fileName = "readme.md"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(directChild)
+            realm.add(nestedChild)
+            realm.add(siblingMetadata)
+        }
+
+        let results = Self.dbManager.itemMetadatas(
+            account: "TestAccount",
+            underServerUrl: "https://cloud.example.com/files/project"
+        )
+        let resultOcIds = Set(results.map(\.ocId))
+        XCTAssertTrue(resultOcIds.contains("under-1"), "Direct child should be included")
+        XCTAssertTrue(resultOcIds.contains("under-2"), "Nested child should be included")
+        XCTAssertFalse(resultOcIds.contains("under-3"), "Sibling with shared prefix must not match")
+        XCTAssertEqual(results.count, 2)
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
Slash prefix in path queries — starts(with: directoryUrl) without a trailing slash incorrectly matched sibling directories that share a name prefix (e.g. photos matched photos-backup). 

## Summary
Renaming or deleting a folder could silently affect any sibling whose name begins with the same string — data in unrelated folders gets corrupted or deleted during sync. 

## Solution
Adding + "/" restricts matches to true descendants only.

### Steps to test it
1. Create FolderA and FolderA-old on the server, each with at least one file inside. 
3. Wait for both to appear in Finder. 
4. Rename FolderA → FolderA-renamed from the web UI or another client. 
5. Wait for sync to settle. 
✅ FolderA-old and its contents must be untouched. 
6. Delete FolderA-renamed from the web UI. 
✅ FolderA-old must still appear and remain accessible.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).