### PR TITLE
fix(file-provider): prevent data loss when parent folder moves during sync.

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -94,7 +94,17 @@ public extension FilesDatabaseManager {
                 ($0.serverUrl == directoryUrlPath || $0.serverUrl.starts(with: directoryUrlPath + "/"))
         }
 
+        // TODO: Parent is deleted even when a child upload is pending. The child will
+        // orphan after upload. Follow-up: defer parent deletion or re-parent after upload.
         for result in results {
+            if result.status >= Status.inUpload.rawValue {
+                logger.info("Skipping deletion of child with pending upload.", [.item: result.ocId])
+                continue
+            }
+            if result.isLockFileOfLocalOrigin {
+                logger.info("Skipping deletion of local-origin lock file during directory delete.", [.item: result.ocId, .name: result.fileName])
+                continue
+            }
             let inactiveItemMetadata = SendableItemMetadata(value: result)
             do {
                 try database.write { result.deleted = true }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -474,13 +474,8 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             if readError?.errorCode == 404 {
                 allDeletedMetadatas.append(materializedItem)
                 examinedItemIds.insert(materializedItem.ocId)
-
-                materializedItems.filter {
-                    $0.serverUrl.hasPrefix(itemRemoteUrl)
-                }.forEach {
-                    allDeletedMetadatas.append($0)
-                    examinedItemIds.insert($0.ocId)
-                }
+                // Children are not marked deleted here — they may have moved with their parent.
+                logger.debug("Parent returned 404; children will be checked individually.", [.url: itemRemoteUrl])
             } else if let readError, readError != .success {
                 logger.error("Finished remote change enumeration of materialized items with error.", [.error: readError])
                 return
@@ -531,21 +526,18 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             }
         }
 
-        // Run a check to ensure files deleted in one location are not updated in another (e.g. when moved).
-        // The recursive scan provides us with updated/deleted metadatas only on a folder by folder basis; so we need to check we are not simultaneously marking a moved file as deleted and updated.
-        var checkedDeletedMetadatas = allDeletedMetadatas
+        // Catches moves across directories: items found at a new location (updated or new)
+        // should not be marked deleted at the old location.
+        let survivingOcIds = Set(allUpdatedMetadatas.map(\.ocId))
+            .union(allNewMetadatas.map(\.ocId))
 
-        for updatedMetadata in allUpdatedMetadatas {
-            guard let matchingDeletedMetadataIdx = checkedDeletedMetadatas.firstIndex(where: { $0.ocId == updatedMetadata.ocId }) else {
-                continue
-            }
-
-            checkedDeletedMetadatas.remove(at: matchingDeletedMetadataIdx)
-        }
-
-        allDeletedMetadatas = checkedDeletedMetadatas
+        allDeletedMetadatas.removeAll { survivingOcIds.contains($0.ocId) }
 
         for deletedMetadata in allDeletedMetadatas {
+            if deletedMetadata.status >= Status.inUpload.rawValue {
+                logger.info("Skipping deletion of item with pending upload.", [.item: deletedMetadata.ocId])
+                continue
+            }
             var deleteMarked = deletedMetadata
             deleteMarked.deleted = true
             deleteMarked.syncTime = Date()
@@ -662,7 +654,12 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         }
 
         // The file provider framework does not differentiate between newly added and updated items, hence the collections are merged.
-        let newAndUpdatedMetadatas: [SendableItemMetadata] = newMetadatas + updatedMetadatas
+        // Sort by remote path length (ascending) so parent directories are always reported before
+        // their children. Without this ordering, macOS may create the rename-destination folder to
+        // house a child item before it processes the parent directory rename, leaving both the old
+        // and new folder name visible on disk simultaneously.
+        let newAndUpdatedMetadatas: [SendableItemMetadata] = (newMetadatas + updatedMetadatas)
+            .sorted { $0.remotePath().count < $1.remotePath().count }
 
         let deletedFileProviderItemIdentifiers = Array(deletedMetadatas.map {
             NSFileProviderItemIdentifier($0.ocId)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -26,6 +26,12 @@ public extension Item {
     ) async -> (Item?, Error?) {
         let logger = FileProviderLogger(category: "Item", log: log)
 
+        // Note: when a parent folder is renamed on another client and an editor has a file open
+        // inside it, the editor may recreate the old folder here, producing a server-side duplicate.
+        // NSFilePresenter callbacks are only delivered when the writer uses NSFileCoordinator.
+        // It is not confirmed whether the File Provider daemon already does this internally when
+        // processing didUpdate renames. If it does not, wrapping rename propagation in an
+        // NSFileCoordinator coordinated write would notify registered presenters.
         let (_, _, _, createError) = await remoteInterface.createFolder(
             remotePath: remotePath, account: account, options: .init(), taskHandler: { task in
                 if let domain, let itemTemplate {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
@@ -1,0 +1,370 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudKit
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+// MARK: - Move-safe deletion
+
+final class MoveSafeDeletionTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    static let dbManager = FilesDatabaseManager(
+        account: account,
+        databaseDirectory: makeDatabaseDirectory(),
+        fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+        log: FileProviderLogMock()
+    )
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+    }
+
+    func testDeleteDirectorySkipsChildrenWithPendingUpload() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "upload-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "uploads"
+        dir.directory = true
+
+        let normalChild = RealmItemMetadata()
+        normalChild.ocId = "normal-child"
+        normalChild.account = "TestAccount"
+        normalChild.serverUrl = "https://cloud.example.com/files/uploads"
+        normalChild.fileName = "synced.txt"
+        normalChild.status = Status.normal.rawValue
+
+        let uploadingChild = RealmItemMetadata()
+        uploadingChild.ocId = "uploading-child"
+        uploadingChild.account = "TestAccount"
+        uploadingChild.serverUrl = "https://cloud.example.com/files/uploads"
+        uploadingChild.fileName = "uploading.txt"
+        uploadingChild.status = Status.uploading.rawValue
+
+        let inUploadChild = RealmItemMetadata()
+        inUploadChild.ocId = "inupload-child"
+        inUploadChild.account = "TestAccount"
+        inUploadChild.serverUrl = "https://cloud.example.com/files/uploads"
+        inUploadChild.fileName = "queued.txt"
+        inUploadChild.status = Status.inUpload.rawValue
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(dir)
+            realm.add(normalChild)
+            realm.add(uploadingChild)
+            realm.add(inUploadChild)
+        }
+
+        let deleted = Self.dbManager.deleteDirectoryAndSubdirectoriesMetadata(
+            ocId: "upload-dir"
+        )
+
+        XCTAssertNotNil(deleted)
+        let deletedOcIds = deleted?.map(\.ocId) ?? []
+        XCTAssertTrue(deletedOcIds.contains("upload-dir"), "Directory itself should be deleted")
+        XCTAssertTrue(deletedOcIds.contains("normal-child"), "Normal child should be deleted")
+        XCTAssertFalse(
+            deletedOcIds.contains("uploading-child"),
+            "Child with uploading status should be skipped"
+        )
+        XCTAssertFalse(
+            deletedOcIds.contains("inupload-child"),
+            "Child with inUpload status should be skipped"
+        )
+
+        let uploadingItem = Self.dbManager.itemMetadata(ocId: "uploading-child")
+        XCTAssertNotNil(uploadingItem)
+        XCTAssertFalse(
+            uploadingItem?.deleted ?? true,
+            "Uploading child should not be marked as deleted"
+        )
+    }
+
+    /// `uploadError (4)` satisfies `status >= inUpload (2)`, so items that failed
+    /// to upload are preserved just like items that are actively uploading.
+    /// This keeps the upload-error state visible to the user rather than losing it silently.
+    func testDeleteDirectorySkipsChildrenWithUploadError() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "uperr-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "work"
+        dir.directory = true
+
+        let uploadErrorChild = RealmItemMetadata()
+        uploadErrorChild.ocId = "uperr-child"
+        uploadErrorChild.account = "TestAccount"
+        uploadErrorChild.serverUrl = "https://cloud.example.com/files/work"
+        uploadErrorChild.fileName = "failed.txt"
+        uploadErrorChild.status = Status.uploadError.rawValue
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(dir)
+            realm.add(uploadErrorChild)
+        }
+
+        let deleted = Self.dbManager.deleteDirectoryAndSubdirectoriesMetadata(ocId: "uperr-dir")
+
+        XCTAssertNotNil(deleted)
+        let deletedOcIds = deleted?.map(\.ocId) ?? []
+        XCTAssertFalse(
+            deletedOcIds.contains("uperr-child"),
+            "Child with uploadError status must be skipped — status >= inUpload protects it."
+        )
+
+        let survivingChild = Self.dbManager.itemMetadata(ocId: "uperr-child")
+        XCTAssertNotNil(survivingChild)
+        XCTAssertFalse(survivingChild?.deleted ?? true)
+    }
+
+    func testDeleteDirectoryDeletesChildrenWithDownloadError() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "dl-err-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "errors"
+        dir.directory = true
+
+        let dlErrorChild = RealmItemMetadata()
+        dlErrorChild.ocId = "dl-err-child"
+        dlErrorChild.account = "TestAccount"
+        dlErrorChild.serverUrl = "https://cloud.example.com/files/errors"
+        dlErrorChild.fileName = "broken.pdf"
+        dlErrorChild.status = Status.downloadError.rawValue
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(dir)
+            realm.add(dlErrorChild)
+        }
+
+        let deleted = Self.dbManager.deleteDirectoryAndSubdirectoriesMetadata(
+            ocId: "dl-err-dir"
+        )
+
+        XCTAssertNotNil(deleted)
+        let deletedOcIds = deleted?.map(\.ocId) ?? []
+        XCTAssertTrue(
+            deletedOcIds.contains("dl-err-child"),
+            "Download-error items should still be deleted (only upload-status items are protected)"
+        )
+    }
+
+    func testDeleteDirectorySkipsLocalOriginLockFile() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "lock-del-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "work"
+        dir.directory = true
+
+        let normalChild = RealmItemMetadata()
+        normalChild.ocId = "lock-del-normal"
+        normalChild.account = "TestAccount"
+        normalChild.serverUrl = "https://cloud.example.com/files/work"
+        normalChild.fileName = "report.docx"
+        normalChild.status = Status.normal.rawValue
+
+        let lockFile = RealmItemMetadata()
+        lockFile.ocId = "lock-del-lockfile"
+        lockFile.account = "TestAccount"
+        lockFile.serverUrl = "https://cloud.example.com/files/work"
+        lockFile.fileName = ".~lock.report.docx#"
+        lockFile.isLockFileOfLocalOrigin = true
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(dir)
+            realm.add(normalChild)
+            realm.add(lockFile)
+        }
+
+        let deleted = Self.dbManager.deleteDirectoryAndSubdirectoriesMetadata(ocId: "lock-del-dir")
+
+        XCTAssertNotNil(deleted)
+        let deletedOcIds = deleted?.map(\.ocId) ?? []
+        XCTAssertTrue(deletedOcIds.contains("lock-del-dir"), "Directory itself must be deleted.")
+        XCTAssertTrue(deletedOcIds.contains("lock-del-normal"), "Normal child must be deleted.")
+        XCTAssertFalse(
+            deletedOcIds.contains("lock-del-lockfile"),
+            "Local-origin lock file must be preserved — the editor still has it open."
+        )
+
+        let survivingLock = Self.dbManager.itemMetadata(ocId: "lock-del-lockfile")
+        XCTAssertNotNil(survivingLock)
+        XCTAssertFalse(survivingLock?.deleted ?? true)
+    }
+
+    /// Item 404s at old path but is discovered at a new location by a separate
+    /// enumeration pass. The deconfliction step must recognise the item as
+    /// surviving (via allNewMetadatas) and NOT mark it deleted.
+    func testDeconflictionPreventsDeleteWhenItemFoundAtNewLocation() async throws {
+        let rootItem = MockRemoteItem.rootItem(account: Self.account)
+
+        // "doc.txt" exists locally at root — it is checked before the destination folder.
+        var oldMetadata = SendableItemMetadata(
+            ocId: "moved-item", fileName: "doc.txt", account: Self.account
+        )
+        oldMetadata.serverUrl = Self.account.davFilesUrl
+        oldMetadata.downloaded = true
+        oldMetadata.uploaded = true
+        oldMetadata.etag = "V1"
+        oldMetadata.syncTime = Date()
+        Self.dbManager.addItemMetadata(oldMetadata)
+
+        // "destination" is a visited folder — longer path, checked second.
+        var destFolderMeta = SendableItemMetadata(
+            ocId: "destination", fileName: "destination", account: Self.account
+        )
+        destFolderMeta.directory = true
+        destFolderMeta.visitedDirectory = true
+        destFolderMeta.etag = "OLD"
+        destFolderMeta.syncTime = Date()
+        Self.dbManager.addItemMetadata(destFolderMeta)
+
+        // On the server: root has only "destination", no "doc.txt".
+        // "destination" contains "doc.txt" (moved there).
+        let destRemote = MockRemoteItem(
+            identifier: "destination",
+            versionIdentifier: "V1",
+            name: "destination",
+            remotePath: Self.account.davFilesUrl + "/destination",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        let movedDocRemote = MockRemoteItem(
+            identifier: "moved-item",
+            versionIdentifier: "V2",
+            name: "doc.txt",
+            remotePath: Self.account.davFilesUrl + "/destination/doc.txt",
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+
+        rootItem.children = [destRemote]
+        destRemote.parent = rootItem
+        destRemote.children = [movedDocRemote]
+        movedDocRemote.parent = destRemote
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        try await observer.enumerateChanges(from: anchor)
+
+        let deletedIds = Set(observer.deletedItemIdentifiers.map(\.rawValue))
+        XCTAssertFalse(
+            deletedIds.contains("moved-item"),
+            "Item found at new location must not be reported as deleted"
+        )
+    }
+
+    func testParent404ReportsParentAsDeleted() async throws {
+        let rootItem = MockRemoteItem.rootItem(account: Self.account)
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // Parent folder that no longer exists on the server.
+        var parentMetadata = SendableItemMetadata(
+            ocId: "parent404", fileName: "movedFolder", account: Self.account
+        )
+        parentMetadata.directory = true
+        parentMetadata.visitedDirectory = true
+        parentMetadata.syncTime = Date()
+        Self.dbManager.addItemMetadata(parentMetadata)
+
+        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        try await observer.enumerateChanges(from: anchor)
+
+        let parentDeleted = observer.deletedItemIdentifiers.contains {
+            $0.rawValue == "parent404"
+        }
+        XCTAssertTrue(parentDeleted, "Folder that 404ed should be reported as deleted")
+    }
+
+    /// When a folder rename and its children are both pending in the working-set change
+    /// list, macOS processes items in the order the extension reports them. If a child
+    /// arrives before its parent's rename, macOS creates the destination folder to house
+    /// the child — then cannot complete the parent rename because the destination already
+    /// exists, leaving both the old and new folder name visible on disk simultaneously.
+    ///
+    /// Regression test: verify that pendingWorkingSetChanges output, when sorted by the
+    /// fix applied in completeChangesObserver, places parent directories before children.
+    func testPendingChangesAreSortedParentBeforeChild() throws {
+        let now = Date()
+        let recentSync = now.addingTimeInterval(-60)
+        let anchorDate = now.addingTimeInterval(-300)
+
+        // Parent directory and child file both have syncTime newer than the anchor so
+        // they appear in pendingWorkingSetChanges.
+        var dirMeta = SendableItemMetadata(
+            ocId: "sort-dir", fileName: "2026-renamed", account: Self.account
+        )
+        dirMeta.serverUrl = Self.account.davFilesUrl + "/container"
+        dirMeta.directory = true
+        dirMeta.visitedDirectory = true
+        dirMeta.etag = "V2"
+        dirMeta.uploaded = true
+        dirMeta.syncTime = recentSync
+        Self.dbManager.addItemMetadata(dirMeta)
+
+        var fileMeta = SendableItemMetadata(
+            ocId: "sort-file", fileName: "Spreadsheet.xlsx", account: Self.account
+        )
+        fileMeta.serverUrl = Self.account.davFilesUrl + "/container/2026-renamed"
+        fileMeta.downloaded = true
+        fileMeta.uploaded = true
+        fileMeta.etag = "V2"
+        fileMeta.syncTime = recentSync
+        Self.dbManager.addItemMetadata(fileMeta)
+
+        let pending = Self.dbManager.pendingWorkingSetChanges(since: anchorDate)
+
+        // Both items must be in the pending list.
+        XCTAssertTrue(pending.updated.contains(where: { $0.ocId == "sort-dir" }))
+        XCTAssertTrue(pending.updated.contains(where: { $0.ocId == "sort-file" }))
+
+        // Apply the same sort that completeChangesObserver uses before reporting to macOS.
+        let sorted = pending.updated.sorted { $0.remotePath().count < $1.remotePath().count }
+
+        let dirIndex = try XCTUnwrap(sorted.firstIndex(where: { $0.ocId == "sort-dir" }))
+        let fileIndex = try XCTUnwrap(sorted.firstIndex(where: { $0.ocId == "sort-file" }))
+
+        XCTAssertLessThan(
+            dirIndex, fileIndex,
+            "Parent directory must sort before its children to prevent duplicate folders on rename."
+        )
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
This PR is related to #10130, better to merge it afterwards.

Moving a folder on another client could silently wipe its contents from the device. An in-flight upload through a deleted parent would lose data permanently. Reporting children before the parent causes macOS to create a duplicate folder.

## Summary
Items found at a new location are not deleted; pending uploads and open lock files are protected — the enumerator now waits until the full sync pass completes before deciding what is deleted, using a survivingOcIds set to spare anything found at a new path. Items mid-upload and local-origin lock files are excluded from deletion even when their parent is removed. Items are also sorted parent-before-child before being reported to macOS to prevent duplicate folders caused by ordering.

### Steps to test it
Scenario A — Moved item is not deleted:
1. Create doc.txt in FolderA. Let it sync. 
2. Move doc.txt into FolderB from the web UI. 
3. Wait for next sync cycle. 
✅ doc.txt must appear inside FolderB in Finder. 
✅ doc.txt must not appear as deleted anywhere. 

Scenario B — Upload protection: 
1. Start uploading a large file (500 MB+) into FolderA. 
2. While uploading, delete FolderA from the web UI. 
✅ The upload must complete and the file must appear on the server. 
✅ The uploading file must not be silently lost. 

Scenario C — No duplicate folder on rename (no editor open):
1. Create FolderA with a file inside. Let it sync and open the file in an editor. 
2. Rename FolderA → FolderA-renamed from the web UI. 
✅ Only FolderA-renamed must appear in Finder — no duplicate FolderA.
  
  When pendingWorkingSetChanges returns items in undefined Realm order, a child item at its new path (FolderA-renamed/file.txt) can arrive in the didUpdate list before the parent rename (FolderA → FolderA-renamed).

  macOS processes the child first: "file.txt belongs in FolderA-renamed/ but that folder doesn't exist yet" → macOS creates FolderA-renamed/ as a new folder. Then it processes the rename: "rename FolderA → FolderA-renamed" but FolderA-renamed already exists → macOS can't complete the rename → both FolderA and FolderA-renamed remain.

Sorting parent directories before their children guarantees macOS sees FolderA renamed to FolderA-renamed first, renames the folder on disk, and then places children inside it without creating a duplicate.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
