### PR TITLE
fix(file-provider): invalidate lock tokens when file paths change. 

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -151,6 +151,7 @@ public extension FilesDatabaseManager {
                         of: oldDirectoryServerUrl, with: newDirectoryServerUrl
                     )
                     childItem.serverUrl = movedServerUrl
+                    childItem.lockToken = nil
                     database.add(childItem, update: .all)
                     logger.debug(
                         """

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -277,10 +277,11 @@ public final class FilesDatabaseManager: Sendable {
         for var updatedMetadata in updatedMetadatas {
             if let existingMetadata = existingMetadatas.first(where: { $0.ocId == updatedMetadata.ocId }) {
                 if existingMetadata.status == Status.normal.rawValue, !existingMetadata.isInSameDatabaseStoreableRemoteState(updatedMetadata) {
-                    if updatedMetadata.directory,
-                       updatedMetadata.serverUrl != existingMetadata.serverUrl ||
-                       updatedMetadata.fileName != existingMetadata.fileName
-                    {
+                    let pathChanged =
+                        updatedMetadata.serverUrl != existingMetadata.serverUrl ||
+                        updatedMetadata.fileName != existingMetadata.fileName
+
+                    if updatedMetadata.directory, pathChanged {
                         directoriesNeedingRename.append(updatedMetadata)
                     }
 
@@ -290,7 +291,7 @@ public final class FilesDatabaseManager: Sendable {
 
                     updatedMetadata.visitedDirectory = existingMetadata.visitedDirectory
                     updatedMetadata.keepDownloaded = existingMetadata.keepDownloaded
-                    updatedMetadata.lockToken = existingMetadata.lockToken
+                    updatedMetadata.lockToken = pathChanged ? nil : existingMetadata.lockToken
 
                     returningUpdatedMetadatas.append(updatedMetadata)
 
@@ -651,6 +652,7 @@ public final class FilesDatabaseManager: Sendable {
                 itemMetadata.fileName = newFileName
                 itemMetadata.fileNameView = newFileName
                 itemMetadata.serverUrl = newServerUrl
+                itemMetadata.lockToken = nil
 
                 database.add(itemMetadata, update: .all)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extensions/NKError+Extensions.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extensions/NKError+Extensions.swift
@@ -28,6 +28,14 @@ extension NKError {
         errorCode == 404
     }
 
+    var isPreconditionFailedError: Bool {
+        errorCode == 412
+    }
+
+    var isLockedError: Bool {
+        errorCode == 423
+    }
+
     var isNoChangesError: Bool {
         errorCode == NKError.noChangesErrorCode
     }
@@ -49,7 +57,6 @@ extension NKError {
         } else if isNotFoundError {
             NSFileProviderError(.noSuchItem)
         } else if isCouldntConnectError {
-            // Provide something the file provider can do something with
             NSFileProviderError(.serverUnreachable)
         } else if isUnauthenticatedError || isUnauthorizedError {
             NSFileProviderError(.notAuthenticated)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -168,6 +168,37 @@ public extension Item {
                 """
             )
 
+            if error.isPreconditionFailedError || error.isLockedError {
+                logger.info("Clearing stale lock token after lock/precondition error.", [.item: itemIdentifier])
+                metadata.lockToken = nil
+                // Signal re-enumeration: if the parent was also renamed (causing the
+                // precondition failure), the working set check will update the path
+                // before the system retries.
+                if let domain, let manager = NSFileProviderManager(for: domain) {
+                    Task {
+                        try? await manager.signalEnumerator(for: .workingSet)
+                    }
+                }
+            }
+
+            // Remote path gone — parent renamed on another client while the file was
+            // open. Clear any stale lock token and signal the working set enumerator
+            // so the system discovers the new path before retrying. Return
+            // cannotSynchronize rather than noSuchItem: the file still exists on the
+            // server at a different location.
+            if error.isNotFoundError {
+                metadata.lockToken = nil
+                metadata.status = Status.uploadError.rawValue
+                metadata.sessionError = error.errorDescription
+                dbManager.addItemMetadata(metadata)
+                if let domain, let manager = NSFileProviderManager(for: domain) {
+                    Task {
+                        try? await manager.signalEnumerator(for: .workingSet)
+                    }
+                }
+                return (nil, NSFileProviderError(.cannotSynchronize))
+            }
+
             metadata.status = Status.uploadError.rawValue
             metadata.sessionError = error.errorDescription
             dbManager.addItemMetadata(metadata)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -587,6 +587,10 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// exercising the locally-known-mtime fallback in the production code.
     public var uploadReturnsNilDate: Bool = false
 
+    /// When set, every upload call returns this error immediately without touching the mock tree.
+    /// Use this to simulate server-side upload rejections (e.g. 404 path gone, 507 quota).
+    public var uploadError: NKError?
+
     /// Handler to track enumerate calls
     public var enumerateCallHandler: ((String, EnumerateDepth, Bool, [String], Data?, Account, NKRequestOptions, @escaping (URLSessionTask) -> Void) -> Void)?
 
@@ -760,6 +764,10 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         response: HTTPURLResponse?,
         remoteError: NKError
     ) {
+        if let uploadError {
+            return (account.ncKitAccount, nil, nil, nil, 0, nil, uploadError)
+        }
+
         var itemName: String
         do {
             itemName = try name(from: remotePath)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -330,6 +330,144 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(remoteItem.data, originalRemoteData)
     }
 
+    /// When the server returns 404 during an upload (the parent folder was renamed
+    /// on another client while the file was open), the extension must:
+    ///   - clear the stale lock token so the next attempt goes without an If: header
+    ///   - return cannotSynchronize, not noSuchItem — the file still exists at a new path
+    ///
+    /// Regression test for the race condition described in nextcloud/desktop#9987.
+    func testModifyWith404ClearsLockTokenAndReturnsCannotSynchronize() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 404, fallbackDescription: "Not Found")
+
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.lockToken = "opaquelocktoken:stale-token-from-old-path"
+        itemMetadata.uploaded = true
+        itemMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-404-test")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual(
+            (error as? NSFileProviderError)?.code, .cannotSynchronize,
+            "404 during modify must surface as cannotSynchronize, not noSuchItem"
+        )
+        let updatedMetadata = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
+        XCTAssertNil(
+            updatedMetadata?.lockToken,
+            "Lock token must be cleared when the upload path is gone"
+        )
+    }
+
+    func testModifyWith412ClearsLockToken() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 412, fallbackDescription: "Precondition Failed")
+
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.lockToken = "opaquelocktoken:stale-token"
+        itemMetadata.uploaded = true
+        itemMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-412-test")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .cannotSynchronize)
+        let updatedMetadata = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
+        XCTAssertNil(updatedMetadata?.lockToken, "Stale lock token must be cleared on 412.")
+    }
+
+    func testModifyWith423ClearsLockToken() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 423, fallbackDescription: "Locked")
+
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.lockToken = "opaquelocktoken:stale-token"
+        itemMetadata.uploaded = true
+        itemMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-423-test")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .cannotSynchronize)
+        let updatedMetadata = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
+        XCTAssertNil(updatedMetadata?.lockToken, "Stale lock token must be cleared on 423.")
+    }
+
     func testModifyFolder() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LockTokenInvalidationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LockTokenInvalidationTests.swift
@@ -1,0 +1,231 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudKit
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+// MARK: - Lock token invalidation
+
+final class LockTokenInvalidationTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    static let dbManager = FilesDatabaseManager(
+        account: account,
+        databaseDirectory: makeDatabaseDirectory(),
+        fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+        log: FileProviderLogMock()
+    )
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+    }
+
+    func testRenameItemMetadataClearsLockToken() throws {
+        let metadata = RealmItemMetadata()
+        metadata.ocId = "lock-1"
+        metadata.account = "TestAccount"
+        metadata.serverUrl = "https://cloud.example.com/files/old"
+        metadata.fileName = "doc.txt"
+        metadata.lockToken = "opaquelocktoken:abc123"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write { realm.add(metadata) }
+
+        Self.dbManager.renameItemMetadata(
+            ocId: "lock-1",
+            newServerUrl: "https://cloud.example.com/files/new",
+            newFileName: "doc.txt"
+        )
+
+        let updated = Self.dbManager.itemMetadata(ocId: "lock-1")
+        XCTAssertNotNil(updated)
+        XCTAssertNil(updated?.lockToken, "Lock token must be cleared after rename")
+    }
+
+    func testRenameDirectoryClearsLockTokenOnChildren() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "lock-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "folder"
+        dir.directory = true
+
+        let child = RealmItemMetadata()
+        child.ocId = "lock-child"
+        child.account = "TestAccount"
+        child.serverUrl = "https://cloud.example.com/files/folder"
+        child.fileName = "important.docx"
+        child.lockToken = "opaquelocktoken:xyz789"
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write {
+            realm.add(dir)
+            realm.add(child)
+        }
+
+        _ = Self.dbManager.renameDirectoryAndPropagateToChildren(
+            ocId: "lock-dir",
+            newServerUrl: "https://cloud.example.com/files",
+            newFileName: "renamed-folder"
+        )
+
+        let updatedChild = Self.dbManager.itemMetadata(ocId: "lock-child")
+        XCTAssertNotNil(updatedChild)
+        XCTAssertNil(
+            updatedChild?.lockToken,
+            "Lock token on child must be cleared when parent directory is renamed"
+        )
+        XCTAssertEqual(
+            updatedChild?.serverUrl,
+            "https://cloud.example.com/files/renamed-folder"
+        )
+    }
+
+    func testProcessUpdateClearsLockTokenWhenFileNameChanges() {
+        let account = Account(
+            user: "lockClear", id: "lc", serverUrl: "https://example.com", password: ""
+        )
+
+        var parentDir = SendableItemMetadata(
+            ocId: "lock-clear-parent", fileName: "parentDir", account: account
+        )
+        parentDir.serverUrl = account.davFilesUrl
+        parentDir.directory = true
+        parentDir.uploaded = true
+        parentDir.etag = "dir-etag-1"
+        Self.dbManager.addItemMetadata(parentDir)
+
+        var original = SendableItemMetadata(
+            ocId: "lock-update", fileName: "old-name.txt", account: account
+        )
+        original.serverUrl = account.davFilesUrl + "/parentDir"
+        original.lockToken = "opaquelocktoken:should-be-cleared"
+        original.uploaded = true
+        original.downloaded = true
+        original.etag = "etag-1"
+        Self.dbManager.addItemMetadata(original)
+
+        var updatedParent = parentDir
+        updatedParent.etag = "dir-etag-2"
+
+        var renamed = original
+        renamed.fileName = "new-name.txt"
+        renamed.fileNameView = "new-name.txt"
+        renamed.etag = "etag-2"
+
+        let result = Self.dbManager.depth1ReadUpdateItemMetadatas(
+            account: account.ncKitAccount,
+            serverUrl: account.davFilesUrl + "/parentDir",
+            updatedMetadatas: [updatedParent, renamed],
+            keepExistingDownloadState: true
+        )
+
+        let renamedResult = result.updatedMetadatas?.first(where: { $0.ocId == "lock-update" })
+        XCTAssertNotNil(renamedResult, "Renamed item should appear in updated metadatas")
+        XCTAssertNil(
+            renamedResult?.lockToken,
+            "Lock token must be cleared when file name changes during update"
+        )
+    }
+
+    func testProcessUpdatePreservesLockTokenWhenPathUnchanged() {
+        let account = Account(
+            user: "lockKeep", id: "lk", serverUrl: "https://example.com", password: ""
+        )
+
+        var parentDir = SendableItemMetadata(
+            ocId: "lock-keep-parent", fileName: "parentDir", account: account
+        )
+        parentDir.serverUrl = account.davFilesUrl
+        parentDir.directory = true
+        parentDir.uploaded = true
+        parentDir.etag = "dir-etag-1"
+        Self.dbManager.addItemMetadata(parentDir)
+
+        var original = SendableItemMetadata(
+            ocId: "lock-preserve", fileName: "file.txt", account: account
+        )
+        original.serverUrl = account.davFilesUrl + "/parentDir"
+        original.lockToken = "opaquelocktoken:keep-me"
+        original.uploaded = true
+        original.downloaded = true
+        original.etag = "etag-1"
+        Self.dbManager.addItemMetadata(original)
+
+        var updatedParent = parentDir
+        updatedParent.etag = "dir-etag-2"
+
+        var updated = original
+        updated.etag = "etag-2"
+
+        let result = Self.dbManager.depth1ReadUpdateItemMetadatas(
+            account: account.ncKitAccount,
+            serverUrl: account.davFilesUrl + "/parentDir",
+            updatedMetadatas: [updatedParent, updated],
+            keepExistingDownloadState: true
+        )
+
+        let preservedResult = result.updatedMetadatas?.first(where: { $0.ocId == "lock-preserve" })
+        XCTAssertNotNil(preservedResult, "Unchanged-path item should appear in updated metadatas")
+        XCTAssertEqual(
+            preservedResult?.lockToken,
+            "opaquelocktoken:keep-me",
+            "Lock token must be preserved when path has not changed"
+        )
+    }
+}
+
+// MARK: - NKError extensions (Fix 3)
+
+final class NKErrorExtensionsTests: XCTestCase {
+    func testPreconditionFailedError() {
+        let error = NKError(errorCode: 412, errorDescription: "Precondition Failed")
+        XCTAssertTrue(error.isPreconditionFailedError)
+        XCTAssertFalse(error.isLockedError)
+    }
+
+    func testLockedError() {
+        let error = NKError(errorCode: 423, errorDescription: "Locked")
+        XCTAssertTrue(error.isLockedError)
+        XCTAssertFalse(error.isPreconditionFailedError)
+    }
+
+    func testFileProviderErrorMapping() {
+        let success = NKError.success
+        XCTAssertNil(success.fileProviderError)
+
+        let notFound = NKError(errorCode: 404, errorDescription: "")
+        XCTAssertEqual(notFound.fileProviderError?.code, .noSuchItem)
+
+        let unauthorized = NKError(errorCode: 401, errorDescription: "")
+        XCTAssertEqual(unauthorized.fileProviderError?.code, .notAuthenticated)
+
+        let quota = NKError(errorCode: 507, errorDescription: "")
+        XCTAssertEqual(quota.fileProviderError?.code, .insufficientQuota)
+
+        let collision = NKError(errorCode: 405, errorDescription: "")
+        XCTAssertEqual(collision.fileProviderError?.code, .filenameCollision)
+
+        let precondition = NKError(errorCode: 412, errorDescription: "")
+        XCTAssertEqual(
+            precondition.fileProviderError?.code,
+            .cannotSynchronize,
+            "412 maps to generic cannotSynchronize, not a special branch"
+        )
+
+        let locked = NKError(errorCode: 423, errorDescription: "")
+        XCTAssertEqual(
+            locked.fileProviderError?.code,
+            .cannotSynchronize,
+            "423 maps to generic cannotSynchronize, not a special branch"
+        )
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
@@ -23,9 +23,20 @@ final class MoveSafeDeletionTests: NextcloudFileProviderKitTestCase {
         log: FileProviderLogMock()
     )
 
+    /// Retains the in-memory Realm for the whole test. Without a live reference the
+    /// store is deallocated once a synchronous write returns, so data written before
+    /// an `await` vanishes when the enumerator reopens the Realm on another thread.
+    private var keepAliveRealm: Realm?
+
     override func setUp() {
         super.setUp()
         Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        keepAliveRealm = Self.dbManager.ncDatabase()
+    }
+
+    override func tearDown() {
+        keepAliveRealm = nil
+        super.tearDown()
     }
 
     func testDeleteDirectorySkipsChildrenWithPendingUpload() throws {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
This PR is related to https://github.com/nextcloud/desktop/pull/10134, better to merge it afterwards.

Stale WebDAV lock token cleared on path change — when an editor locks a file the server issues a token bound to that file's path. If the parent folder is renamed the token becomes invalid. 

The next save attempt sends a stale If: header. The server rejects it with 412/423, and the user cannot save — they must manually copy the file elsewhere. 

## Summary
The code now clears it whenever a rename is detected: during sync, in the DB rename functions, and on upload errors 412 and 423.

## Steps to test it
1. Open Spreadsheet.xlsx from a group folder via Finder (server issues a WebDAV lock).
2. While the file is open, rename its parent folder from another client or the web UI.
3. Edit the file content.
4. Save. LibreOffice may ask "The file has been changed since it was opened — save anyway?" Click Save anyway.
  ✅ Save succeeds — no further error dialog.
  ✅ The updated file appears in the web UI with the new content.
5. Edit and save a second time.
  ✅ The second save also succeeds.

> [!WARNING]   
*Known limitation*
...
  When a folder is renamed on another client and LibreOffice has a file open inside it, saving may create a duplicate folder on the server at the old path. The File Provider extension does not coordinate renames through NSFileCoordinator, so macOS cannot notify open applications of the path change even if they implement NSFilePresenter. A proper fix requires the extension to wrap rename operations in NSFileCoordinator writes.
...
  Our extension calls remoteInterface.move(...) (a WebDAV call) and then updates the local database. It does not go through NSFileCoordinator. So even if LibreOffice correctly registered as an NSFilePresenter, it still would not be notified — because our side isn't coordinating.
...
Our extension needs to use NSFileCoordinator when renaming items. 

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
