### PR TITLE
fix(file-provider): prevent duplicate folder when editor saves to renamed path.

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -123,6 +123,7 @@ public extension FilesDatabaseManager {
         }
 
         renameItemMetadata(ocId: ocId, newServerUrl: newServerUrl, newFileName: newFileName)
+        recentRenames.record(oldPath: oldDirectoryServerUrl, newOcId: ocId)
         logger.debug("Renamed root renaming directory from \"\(oldDirectoryServerUrl)\" to \"\(newDirectoryServerUrl)\".", [.item: ocId])
 
         do {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -34,6 +34,7 @@ public final class FilesDatabaseManager: Sendable {
     private static let schemaVersion = SchemaVersion.addedIsLockFileOfLocalOriginToRealmItemMetadata
     let logger: FileProviderLogger
     let account: Account
+    public let recentRenames = RecentRenameTracker()
 
     var itemMetadatas: Results<RealmItemMetadata> {
         ncDatabase().objects(RealmItemMetadata.self)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -26,6 +26,17 @@ public extension Item {
     ) async -> (Item?, Error?) {
         let logger = FileProviderLogger(category: "Item", log: log)
 
+        // If this path was recently renamed away, the creation request is most likely an
+        // editor (e.g. LibreOffice) that has not received the path-change notification and
+        // is trying to recreate the old folder. Refuse the creation so no duplicate folder
+        // appears on the server. Returning the renamed item here would cause macOS to treat
+        // that item as being at the old path, undoing the rename — so an error is correct.
+        // See nextcloud/desktop#9987.
+        if dbManager.recentRenames.ocId(for: remotePath) != nil {
+            logger.info("Path was recently renamed. Refusing creation to prevent duplicate folder.", [.url: remotePath])
+            return (nil, NSFileProviderError(.cannotSynchronize))
+        }
+
         let (_, _, _, createError) = await remoteInterface.createFolder(
             remotePath: remotePath, account: account, options: .init(), taskHandler: { task in
                 if let domain, let itemTemplate {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/RecentRenameTracker.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/RecentRenameTracker.swift
@@ -1,0 +1,64 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+
+///
+/// Thread-safe TTL cache mapping the old remote path of a renamed directory to the
+/// ocId of that directory at its new path.
+///
+/// When an editor (e.g. LibreOffice) holds a document open and the containing folder
+/// is renamed on another client, the editor may continue writing to the old path.
+/// macOS File Provider then calls ``FileProviderExtension.createItem`` for the old
+/// folder name. Without this cache the extension would issue a MKCOL for the old
+/// path, creating a duplicate folder on the server.
+///
+/// ``Item.createNewFolder`` consults this cache before calling MKCOL. If the
+/// requested path was recently renamed, the existing (renamed) ``Item`` is returned
+/// instead of creating a new folder. Entries expire after ``ttl`` seconds; beyond
+/// that, the request is treated as genuinely new content.
+///
+public final class RecentRenameTracker: @unchecked Sendable {
+    private struct Entry {
+        let ocId: String
+        let expiry: Date
+    }
+
+    private var entries: [String: Entry] = [:]
+    private let lock = NSLock()
+    let ttl: TimeInterval
+
+    public init(ttl: TimeInterval = 60) {
+        self.ttl = ttl
+    }
+
+    ///
+    /// Record that the directory previously at ``oldPath`` has been renamed.
+    ///
+    /// - Parameters:
+    ///   - oldPath: The full remote path the directory occupied before the rename.
+    ///   - newOcId: The ocId of the directory at its new path (unchanged by the rename).
+    ///
+    public func record(oldPath: String, newOcId: String) {
+        lock.withLock {
+            prune()
+            entries[oldPath] = Entry(ocId: newOcId, expiry: Date().addingTimeInterval(ttl))
+        }
+    }
+
+    ///
+    /// Return the ocId of the directory that was recently at ``oldPath``, or ``nil``
+    /// if no unexpired entry exists for that path.
+    ///
+    public func ocId(for oldPath: String) -> String? {
+        lock.withLock {
+            prune()
+            return entries[oldPath]?.ocId
+        }
+    }
+
+    private func prune() {
+        let now = Date()
+        entries = entries.filter { $0.value.expiry > now }
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/FileProviderLogMock.swift
@@ -11,7 +11,7 @@ public actor FileProviderLogMock: FileProviderLogging {
     let logger: Logger
 
     public init() {
-        logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "FileProviderLogMock")
+        logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.nextcloud.NextcloudFileProviderKit.tests", category: "FileProviderLogMock")
     }
 
     public func write(category _: String, level _: OSLogType, message: String, details _: [FileProviderLogDetailKey: (any Sendable)?], file _: StaticString, function _: StaticString, line _: UInt) {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -1221,4 +1221,97 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         let decoration = try XCTUnwrap(createdFileItem.decorations?.first)
         XCTAssertTrue(decoration.rawValue.hasSuffix(".keep-downloaded"))
     }
+
+    // MARK: - Duplicate-folder mitigation (nextcloud/desktop#9987)
+
+    func testRecentRenameTrackerRecordsAndReturnsOcId() {
+        let tracker = RecentRenameTracker(ttl: 60)
+        let path = "https://cloud.example.com/files/old-folder"
+        tracker.record(oldPath: path, newOcId: "folder-ocid")
+        XCTAssertEqual(tracker.ocId(for: path), "folder-ocid")
+    }
+
+    func testRecentRenameTrackerReturnsNilForUnknownPath() {
+        let tracker = RecentRenameTracker(ttl: 60)
+        XCTAssertNil(tracker.ocId(for: "https://cloud.example.com/files/unknown"))
+    }
+
+    func testRecentRenameTrackerExpiry() {
+        let tracker = RecentRenameTracker(ttl: -1) // already expired
+        tracker.record(oldPath: "https://cloud.example.com/files/old", newOcId: "some-id")
+        XCTAssertNil(tracker.ocId(for: "https://cloud.example.com/files/old"),
+                     "Expired entries must not be returned.")
+    }
+
+    func testRenameDirectoryAndPropagatePopulatesRecentRenames() throws {
+        let dir = RealmItemMetadata()
+        dir.ocId = "rrt-dir"
+        dir.account = "TestAccount"
+        dir.serverUrl = "https://cloud.example.com/files"
+        dir.fileName = "old-name"
+        dir.directory = true
+
+        let realm = Self.dbManager.ncDatabase()
+        try realm.write { realm.add(dir) }
+
+        _ = Self.dbManager.renameDirectoryAndPropagateToChildren(
+            ocId: "rrt-dir",
+            newServerUrl: "https://cloud.example.com/files",
+            newFileName: "new-name"
+        )
+
+        XCTAssertEqual(
+            Self.dbManager.recentRenames.ocId(for: "https://cloud.example.com/files/old-name"),
+            "rrt-dir",
+            "renameDirectoryAndPropagateToChildren must populate recentRenames with the old path."
+        )
+    }
+
+    /// When a folder is renamed on the server and an editor (e.g. LibreOffice) tries to
+    /// recreate the old folder name, createNewFolder must refuse the creation rather than
+    /// issue a MKCOL. Returning the existing renamed item would cause macOS to re-associate
+    /// its identifier with the old path, undoing the rename. An error is the correct response:
+    /// it prevents the duplicate without disturbing the renamed item's location.
+    func testCreateFolderRefusesWhenPathWasRecentlyRenamed() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // "2026" was renamed to "2026-renamed". Register the rename in the cache.
+        let oldPath = Self.account.davFilesUrl + "/2026"
+        Self.dbManager.recentRenames.record(oldPath: oldPath, newOcId: "dir-ocid")
+
+        // Editor tries to create "2026" (the old name).
+        var oldFolderMeta = SendableItemMetadata(
+            ocId: "tmp-create-id", fileName: "2026", account: Self.account
+        )
+        oldFolderMeta.directory = true
+        oldFolderMeta.classFile = NKTypeClassFile.directory.rawValue
+
+        let itemTemplate = Item(
+            metadata: oldFolderMeta,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (createdItem, error) = await Item.create(
+            basedOn: itemTemplate,
+            contents: nil,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertNil(createdItem, "No item must be returned for a recently renamed path.")
+        XCTAssertEqual(
+            (error as? NSFileProviderError)?.code, .cannotSynchronize,
+            "Creation at a recently renamed path must fail with cannotSynchronize."
+        )
+        XCTAssertFalse(
+            rootItem.children.contains(where: { $0.name == "2026" }),
+            "No '2026' folder must have been created on the server."
+        )
+    }
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
This PR is related to https://github.com/nextcloud/desktop/pull/10135, better to merge it afterwards.

LibreOffice and other cross-platform editors do not implement NSFilePresenter, so they get no path change notification when a parent folder is renamed. They keep using the old path while the parent folder was renamed and the user is editing a file. So the editor's save creates a brand-new folder on the server at the old name, uploads the file there, and the user silently ends up with both 2026/Spreadsheet.xlsx (stale copy) and 2026-renamed/Spreadsheet.xlsx (real file) on the server.

## Summary
Refuse folder creation at a recently renamed path. A 60-second TTL cache records the old path when a directory is renamed. If a createItem arrives for a cached path the extension returns .cannotSynchronize instead of issuing a server MKCOL.

## Steps to test it
1. Open Spreadsheet.xlsx from a folder in Finder using LibreOffice. 
2. While the file is open, rename the parent folder from the web UI or another client. 
3. Wait for the client to sync the rename (the folder name in Finder should update). 
4.  Without closing LibreOffice, save the file. 
✅ Before fix: a duplicate folder with the old name appears on the server. 
✅ After fix: no duplicate folder is created. LibreOffice may show a save error (expected — the old path is gone). 
✅ Only FolderA-renamed/Spreadsheet.xlsx exists on the server. 
5. Close and reopen the file from the renamed folder location and save again. 
✅ Second save succeeds normally (TTL has cleared or the path is now correct).

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
