### PR TITLE
[codex] fix: adjust file provider switch styling for stable-33

### DIFF
--- a/src/gui/macOS/ui/FileProviderSettings.qml
+++ b/src/gui/macOS/ui/FileProviderSettings.qml
@@ -54,8 +54,58 @@ Page {
             Switch {
                 id: vfsEnabledCheckBox
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                Layout.preferredWidth: 30
+                Layout.preferredHeight: 16
+                implicitWidth: 30
+                implicitHeight: 16
+                leftPadding: 0
+                rightPadding: 0
+                topPadding: 0
+                bottomPadding: 0
                 checked: root.controller.vfsEnabledForAccount(root.accountUserIdAtHost)
                 onClicked: root.controller.setVfsEnabledForAccount(root.accountUserIdAtHost, checked)
+
+                indicator: Rectangle {
+                    readonly property color enabledTrackColor: vfsEnabledCheckBox.checked ? "#00679e" : "#6b6b6b"
+                    readonly property real disabledTrackAlpha: vfsEnabledCheckBox.checked ? 0.45 : 0.35
+
+                    implicitWidth: 30
+                    implicitHeight: 16
+                    x: 0
+                    y: parent.height / 2 - height / 2
+                    radius: height / 2
+                    color: Qt.rgba(enabledTrackColor.r, enabledTrackColor.g, enabledTrackColor.b, vfsEnabledCheckBox.enabled ? 1.0 : disabledTrackAlpha)
+
+                    Rectangle {
+                        width: 10
+                        height: 10
+                        x: vfsEnabledCheckBox.checked ? parent.width - width - 3 : 3
+                        y: 3.6
+                        radius: width / 2
+                        color: vfsEnabledCheckBox.enabled ? "#26000000" : "#14000000"
+                    }
+
+                    Rectangle {
+                        width: 10
+                        height: 10
+                        x: vfsEnabledCheckBox.checked ? parent.width - width - 3 : 3
+                        y: 3
+                        radius: width / 2
+                        color: "#ffffff"
+                        opacity: vfsEnabledCheckBox.enabled ? 1.0 : 0.8
+                    }
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 1
+                        radius: height / 2
+                        color: "transparent"
+                        border.width: vfsEnabledCheckBox.activeFocus ? 2 : 0
+                        border.color: Qt.rgba(palette.highlight.r, palette.highlight.g, palette.highlight.b, 0.35)
+                    }
+                }
+
+                contentItem: Item {}
             }
         }
     }


### PR DESCRIPTION
Draft PR created at the user's request.

Summary:
- Backports the file provider virtual-files switch styling to `stable-33.0`.
- Keeps the change scoped to `src/gui/macOS/ui/FileProviderSettings.qml`, because `stable-33.0` does not contain the same `SettingsSwitch` source layout as the original branch.

Validation:
- `git diff --check origin/stable-33.0..HEAD`

AI disclosure:
- This draft was prepared with assistance from Codex. Please review the diff and rewrite this description in your own words before submitting upstream.