### PR TITLE
fix(ci): Use macOS 26 runners for GitHub actions.

### DIFF
--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Build nextcloud-client
     timeout-minutes: 60
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -76,7 +76,7 @@ jobs:
     name: Run tests
     needs: build
     timeout-minutes: 60
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Restore cached Craft directories containing the built client
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/nextcloudfileproviderkit.yml
+++ b/.github/workflows/nextcloudfileproviderkit.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   Lint:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     defaults:
       run:
@@ -25,7 +25,7 @@ jobs:
         run: swiftformat --lint . --reporter github-actions-log
 
   Tests:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     defaults:
       run:


### PR DESCRIPTION
Because "macos-latest" is far behind and still on macOS 15.

For reference: https://github.com/actions/runner-images#available-images