### PR TITLE
fix: add direct log when folder watcher detects changes

### DIFF
--- a/src/gui/folderwatcher.cpp
+++ b/src/gui/folderwatcher.cpp
@@ -284,6 +284,7 @@ void FolderWatcher::changeDetected(const QStringList &paths)
     }
 
     for (const auto &path : changedPaths) {
+        qCInfo(lcFolderWatcher) << "change on path" << path;
         emit pathChanged(path);
     }
 }


### PR DESCRIPTION
should enable better analyze of strange situations with local files disapearing

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
