### PR TITLE
fix: do not double translate string

### DIFF
--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -312,7 +312,7 @@ QString Utility::durationToDescriptiveString2(quint64 msecs)
         return firstPart;
     }
 
-    return QCoreApplication::translate("Utility", "%1 %2").arg(firstPart, periods[p + 1].description(secondPartNum));
+    return QStringLiteral("%1 %2").arg(firstPart, periods[p + 1].description(secondPartNum));
 }
 
 QString Utility::durationToDescriptiveString1(quint64 msecs)


### PR DESCRIPTION
do not double translate. The meaningful text is already translated in the unit strings like %n hour(s) and %n minute(s). Translating only %1 %2 gives translators almost no useful source text, and the placeholder order should stay stable for a compact duration.

description() already calls QCoreApplication::translate

closes #10147 