### PR TITLE
fix: AppToken was not removed

### DIFF
--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -785,6 +785,8 @@ void AccountManager::removeAccountState(OCC::AccountState *account, AccountRemov
     _accounts.erase(it);
 
     if (removalMode == AccountRemovalMode::ForgetSensitiveData) {
+        account->account()->deleteAppToken();
+
         // Forget account credentials, cookies
         account->account()->credentials()->forgetSensitiveData();
         QFile::remove(account->account()->cookieJarPath());
@@ -796,8 +798,6 @@ void AccountManager::removeAccountState(OCC::AccountState *account, AccountRemov
     if (removalMode == AccountRemovalMode::ForgetSensitiveData) {
         // Forget E2E keys
         account->account()->e2e()->forgetSensitiveData();
-
-        account->account()->deleteAppToken();
     }
 
     // clean up config from subscriptions and enterprise channel

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -2512,7 +2512,6 @@ void UserModel::removeAccount(const int id)
         return;
     }
 
-    _users[id]->logout();
     _users[id]->removeAccount();
 
     beginRemoveRows(QModelIndex(), id, id);

--- a/src/libsync/account.cpp
+++ b/src/libsync/account.cpp
@@ -20,7 +20,6 @@
 #include "updatechannel.h"
 #include "version.h"
 
-#include "deletejob.h"
 #include "lockfilejobs.h"
 
 #include "common/syncjournaldb.h"
@@ -960,18 +959,13 @@ void Account::deleteAppPassword()
 
 void Account::deleteAppToken()
 {
-    const auto deleteAppTokenJob = new DeleteJob(sharedFromThis(), QStringLiteral("/ocs/v2.php/core/apppassword"));
-    connect(deleteAppTokenJob, &DeleteJob::finishedSignal, this, [this]() {
-        if (const auto deleteJob = qobject_cast<DeleteJob *>(QObject::sender())) {
-            const auto httpCode = deleteJob->reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-            if (httpCode != 200) {
-                qCWarning(lcAccount) << "AppToken remove failed for user: " << displayName() << " with code: " << httpCode;
-            } else {
-                qCInfo(lcAccount) << "AppToken for user: " << displayName() << " has been removed.";
-            }
+    const auto deleteAppTokenJob = new SimpleApiJob(sharedFromThis(), QStringLiteral("/ocs/v2.php/core/apppassword"));
+    deleteAppTokenJob->setVerb(SimpleApiJob::Verb::Delete);
+    connect(deleteAppTokenJob, &SimpleApiJob::resultReceived, this, [this](const int httpCode) {
+        if (httpCode != 200) {
+            qCWarning(lcAccount) << "AppToken remove failed for user: " << displayName() << " with code: " << httpCode;
         } else {
-            Q_ASSERT(false);
-            qCWarning(lcAccount) << "The sender is not a DeleteJob instance.";
+            qCInfo(lcAccount) << "AppToken for user: " << displayName() << " has been removed.";
         }
     });
     deleteAppTokenJob->start();


### PR DESCRIPTION
AppTokens were never removed from the server.

- wrong OCS url was called
- OCS endpoint was called after the local account was removed => 401 because the OCS could not authenticate anymore => sequence to be changed

closes #10148 