### PR TITLE
fix(gui): prevent nullptr dereference when VFS mode is unavailable

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -769,7 +769,10 @@ void AccountSettings::slotCustomContextMenuRequested(const QPoint &pos)
 
     if (const auto mode = bestAvailableVfsMode();
         !Theme::instance()->disableVirtualFilesSyncFolder() &&
-        Theme::instance()->showVirtualFilesOption() && !folder->virtualFilesEnabled() && Vfs::checkAvailability(folder->path(), mode)) {
+        Theme::instance()->showVirtualFilesOption() &&
+        !folder->virtualFilesEnabled() &&
+        mode != Vfs::Off &&
+        Vfs::checkAvailability(folder->path(), mode)) {
         if (mode == Vfs::WindowsCfApi || ConfigFile().showExperimentalOptions()) {
             ac = menu->addAction(tr("Enable virtual file support %1 …").arg(mode == Vfs::WindowsCfApi ? QString() : tr("(experimental)")));
             // TODO: remove when UX decision is made


### PR DESCRIPTION
Prevent reaching a code path in Utility::askExperimentalVirtualFilesFeature that would cause a null pointer dereference when the necessary libraries are not available. Adding the check for Vfs::Off to AccountSettings::slotCustomContextMenuRequested stops the option to enable vfs to appear altogether in such cases.

Assisted-by: Qwen:qwen-3.6-35b-a3b

## Resolves
#10174

## Summary

OpenSUSE Tumbleweed has a separate package for VFS. If the user tries to enable VFS without it the previous code dereferenced a null pointer and segfaulted. This fix prevents the user from enabling the option in that case.

### TODO

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
