### PR TITLE
chore(macOS): Removed obsolete SwiftNIO dependency

### DIFF
--- a/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a22e4492c8a7194a0ebcc9f9e61d4e85499c62f75841c7da69d00a900eaf544d",
+  "originHash" : "7cb1f4471610dcada5d7746883ed0a21f1993bafabc186c4814d4e3be4fcdfb5",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -62,42 +62,6 @@
       "state" : {
         "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
         "version" : "1.8.2"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
-        "version" : "1.6.0"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
-        "version" : "2.101.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
-        "version" : "1.6.5"
       }
     },
     {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Package.swift
@@ -23,8 +23,7 @@ let package = Package(
         .package(url: "https://github.com/nextcloud/NextcloudCapabilitiesKit.git", from: "2.5.0"),
         .package(url: "https://github.com/nextcloud/NextcloudKit", from: "7.3.3"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.55.0"),
-        .package(url: "https://github.com/realm/realm-swift.git", from: "20.0.4"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0")
+        .package(url: "https://github.com/realm/realm-swift.git", from: "20.0.4")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -56,11 +55,7 @@ let package = Package(
             name: "TestInterface",
             dependencies: [
                 "NextcloudFileProviderKit",
-                "NextcloudFileProviderKitMocks",
-                .product(name: "NIOCore", package: "swift-nio"),
-                .product(name: "NIOPosix", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIOWebSocket", package: "swift-nio")
+                "NextcloudFileProviderKitMocks"
             ],
             path: "Tests/Interface"
         ),


### PR DESCRIPTION
## Summary

This removes the already obsolete and unused SwiftNIO dependency which is heavy. Claude made me aware of it while I was working on something different. It was used for the push notification tests in the file provider extension before I completely refactored the remote change discovery for 33.0.0.

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
