### PR TITLE
fix(UI): drag and drop of account wizard

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -233,8 +233,12 @@ void ownCloudGui::slotTrayClicked(QSystemTrayIcon::ActivationReason reason)
     if (reason == QSystemTrayIcon::DoubleClick && currentUser && currentUser->hasLocalFolder()) {
         currentUser->openLocalFolder();
     } else if (reason == QSystemTrayIcon::Trigger) {
-        if (OwncloudSetupWizard::bringWizardToFrontIfVisible()) {
-            // brought wizard to front
+        if (OwncloudSetupWizard::isWizardVisible()) {
+            if (_tray->isOpen()) {
+                _tray->hideWindow();
+            } else {
+                _tray->showWindow();
+            }
         } else if (AccountManager::instance()->accounts().isEmpty()) {
             slotNewAccountWizard();
         } else if (_tray->raiseDialogs()) {

--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -17,6 +17,7 @@
 
 #include <QDialog>
 #include <QLoggingCategory>
+#include <QMouseEvent>
 #include <QQmlApplicationEngine>
 #include <QQmlComponent>
 #include <QQuickWindow>
@@ -25,6 +26,40 @@
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcWizard, "nextcloud.gui.wizard", QtInfoMsg)
+
+#if defined(Q_OS_MACOS) && QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+class AccountWizardWindowDragHandle : public QObject
+{
+public:
+    explicit AccountWizardWindowDragHandle(QQuickWindow *window, QObject *parent = nullptr)
+        : QObject(parent)
+        , _window(window)
+    {
+    }
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override
+    {
+        if (!_window || event->type() != QEvent::MouseButtonPress) {
+            return QObject::eventFilter(watched, event);
+        }
+
+        const auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        if (mouseEvent->button() == Qt::LeftButton && mouseEvent->position().y() <= dragHandleHeight) {
+            if (_window->startSystemMove()) {
+                return true;
+            }
+        }
+
+        return QObject::eventFilter(watched, event);
+    }
+
+private:
+    static constexpr auto dragHandleHeight = 28.0;
+
+    QPointer<QQuickWindow> _window;
+};
+#endif
 
 OwncloudSetupWizard::OwncloudSetupWizard(QObject *parent)
     : QObject(parent)
@@ -71,6 +106,18 @@ void OwncloudSetupWizard::runWizard(QObject *obj, const char *amember, QWidget *
 
 bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
 {
+    if (!isWizardVisible()) {
+        return false;
+    }
+
+    owncloudSetupWizard->_qmlWizardWindow->show();
+    owncloudSetupWizard->_qmlWizardWindow->raise();
+    owncloudSetupWizard->_qmlWizardWindow->requestActivate();
+    return true;
+}
+
+bool OwncloudSetupWizard::isWizardVisible()
+{
     if (owncloudSetupWizard.isNull()
         || !owncloudSetupWizard->_qmlWizardWindow
         || owncloudSetupWizard->_finished) {
@@ -82,9 +129,6 @@ bool OwncloudSetupWizard::bringWizardToFrontIfVisible()
         return false;
     }
 
-    owncloudSetupWizard->_qmlWizardWindow->show();
-    owncloudSetupWizard->_qmlWizardWindow->raise();
-    owncloudSetupWizard->_qmlWizardWindow->requestActivate();
     return true;
 }
 
@@ -126,6 +170,7 @@ bool OwncloudSetupWizard::startQmlWizard()
 #if defined(Q_OS_MACOS) && QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
     _qmlWizardWindow->setFlag(Qt::ExpandedClientAreaHint, true);
     _qmlWizardWindow->setFlag(Qt::NoTitleBarBackgroundHint, true);
+    _qmlWizardWindow->installEventFilter(new AccountWizardWindowDragHandle(_qmlWizardWindow, this));
 #endif
 
     connect(_qmlController, &AccountWizardController::finished, this, &OwncloudSetupWizard::finish);

--- a/src/gui/owncloudsetupwizard.h
+++ b/src/gui/owncloudsetupwizard.h
@@ -27,6 +27,7 @@ class OwncloudSetupWizard : public QObject
 public:
     /** Run the wizard */
     static void runWizard(QObject *obj, const char *amember, QWidget *parent = nullptr, bool forceRestart = false);
+    static bool isWizardVisible();
     static bool bringWizardToFrontIfVisible();
 
 signals:

--- a/src/gui/wizard/qml/AccountWizardWindow.qml
+++ b/src/gui/wizard/qml/AccountWizardWindow.qml
@@ -24,9 +24,9 @@ ApplicationWindow {
     LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    width: 500
+    width: 560
     height: compactHeight
-    minimumWidth: 480
+    minimumWidth: 540
     minimumHeight: compactHeight
     title: ""
     flags: Qt.Window
@@ -302,6 +302,7 @@ ApplicationWindow {
                 textSuffix: "\u2197"
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
+                Layout.minimumWidth: implicitWidth
                 onClicked: root.controller.openSignup()
             },
 
@@ -312,6 +313,7 @@ ApplicationWindow {
                 textSuffix: "\u2197"
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
+                Layout.minimumWidth: implicitWidth
                 onClicked: root.controller.openSelfHostedServerGuide()
             },
 
@@ -324,8 +326,8 @@ ApplicationWindow {
                 text: qsTr("Proxy settings")
                 font.pixelSize: Style.pixelSize + 3
                 font.weight: Font.Medium
-                Layout.fillWidth: true
-                Layout.preferredWidth: 1
+                Layout.preferredWidth: implicitWidth
+                Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 36
                 onClicked: root.controller.openProxySettings()
             },

--- a/src/gui/wizard/qml/AccountWizardWindow.qml
+++ b/src/gui/wizard/qml/AccountWizardWindow.qml
@@ -24,9 +24,9 @@ ApplicationWindow {
     LayoutMirroring.enabled: Application.layoutDirection === Qt.RightToLeft
     LayoutMirroring.childrenInherit: true
 
-    width: 560
+    width: 600
     height: compactHeight
-    minimumWidth: 540
+    minimumWidth: 600
     minimumHeight: compactHeight
     title: ""
     flags: Qt.Window

--- a/src/gui/wizard/qml/ServerPage.qml
+++ b/src/gui/wizard/qml/ServerPage.qml
@@ -177,7 +177,6 @@ Item {
 
                 WizardButton {
                     primary: true
-                    Layout.preferredWidth: implicitWidth
                     Layout.minimumWidth: implicitWidth
                     enabled: !root.controller.busy
                     text: qsTr("Log in")

--- a/src/gui/wizard/qml/ServerPage.qml
+++ b/src/gui/wizard/qml/ServerPage.qml
@@ -177,7 +177,8 @@ Item {
 
                 WizardButton {
                     primary: true
-                    Layout.preferredWidth: 76
+                    Layout.preferredWidth: implicitWidth
+                    Layout.minimumWidth: implicitWidth
                     enabled: !root.controller.busy
                     text: qsTr("Log in")
                     onClicked: root.controller.submitServerUrl()


### PR DESCRIPTION
- drag & drop of account wizard on macOS
- size of the account wizard and button margins
- blocking tray click when wizard is open

closes #10178 
closes #10177