### PR TITLE
Fix initial menu bar extra sync status

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+NSXPCListenerDelegate.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+NSXPCListenerDelegate.swift
@@ -33,8 +33,13 @@ extension FileProviderExtension: NSXPCListenerDelegate {
             logger.info("Succeeded to cast remote object proxy, adopting it!")
             app = appService
 
-            // Initial status report as soon as the app service is available.
-            updatedSyncStateReporting(oldActions: Set<UUID>())
+            // Force a fresh status report as soon as the app service is available. The app needs
+            // the current state on launch (typically idle, i.e. "all good"); without it the tray
+            // popover falls back to the misleading "Some files could not be synced!" message.
+            // This must NOT go through `updatedSyncStateReporting(oldActions:)`: that is
+            // edge-triggered and bails when sync activity has not changed, which is precisely the
+            // idle case we need to report here. See https://github.com/nextcloud/desktop/issues/10053.
+            reportCurrentSyncState()
         } else {
             logger.error("Failed to cast remote object proxy to AppProtocol!")
             app = nil

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -813,4 +813,31 @@ import OSLog
 
         app?.reportSyncStatus(argument, forDomainIdentifier: domain.identifier.rawValue)
     }
+
+    /// Reports the extension's current synchronization state to the app unconditionally.
+    ///
+    /// Unlike ``updatedSyncStateReporting(oldActions:)``, which is edge-triggered and deliberately
+    /// bails when sync activity has not changed, this always emits a report. The main app opens an
+    /// XPC connection to the extension on launch; at that point it needs the current resting state
+    /// — typically idle, i.e. "all good" — otherwise it falls back to the misleading
+    /// "Some files could not be synced!" message. See
+    /// https://github.com/nextcloud/desktop/issues/10053.
+    func reportCurrentSyncState() {
+        actionsLock.lock()
+        let syncing = !syncActions.isEmpty
+        let failed = !errorActions.isEmpty
+        actionsLock.unlock()
+
+        let argument = if syncing {
+            "SYNC_STARTED"
+        } else if failed {
+            "SYNC_FAILED"
+        } else {
+            "SYNC_FINISHED"
+        }
+
+        logger.debug("Reporting current synchronization state on request.", [.name: argument])
+
+        app?.reportSyncStatus(argument, forDomainIdentifier: domain.identifier.rawValue)
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ReportCurrentSyncStateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ReportCurrentSyncStateTests.swift
@@ -1,0 +1,88 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderXPC
+import XCTest
+
+/// Captures `reportSyncStatus(_:forDomainIdentifier:)` so the unconditional connect-time report can
+/// be exercised without a real XPC connection.
+private final class SyncStatusCapturingAppProxy: NSObject, AppProtocol {
+    var reportedSyncStatuses: [String] = []
+
+    func reportSyncStatus(_ status: String, forDomainIdentifier _: String) {
+        reportedSyncStatuses.append(status)
+    }
+
+    // The following are unused by these tests but required for protocol conformance.
+    func presentFileActions(_: String, path _: String, remoteItemPath _: String, withDomainIdentifier _: String) {}
+    func openItemInBrowser(_: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
+    func copyInternalLink(forItem _: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
+    func reportItemExcluded(fromSync _: String, fileName _: String, reason _: String, forDomainIdentifier _: String) {}
+    func reportInsufficientQuota(
+        forItem _: String,
+        fileName _: String,
+        fileBytes _: NSNumber?,
+        availableBytes _: NSNumber?,
+        forDomainIdentifier _: String
+    ) {}
+    func reportInsufficientQuotaSummary(forDomainIdentifier _: String) {}
+}
+
+/// Regression coverage for https://github.com/nextcloud/desktop/issues/10053.
+///
+/// When the main app connects on launch, the extension must report its *current* state — even when
+/// it is idle — so the app starts from an accurate status instead of falling back to the misleading
+/// "Some files could not be synced!" message. The connect-time report previously went through the
+/// edge-triggered `updatedSyncStateReporting(oldActions:)`, which deliberately bails when sync
+/// activity has not changed; an idle extension therefore reported nothing at all. `reportCurrentSyncState()`
+/// must instead always emit a report.
+final class ReportCurrentSyncStateTests: NextcloudFileProviderKitTestCase {
+    private func makeExtension() -> FileProviderExtension {
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("test-domain-10053"),
+            displayName: "Test"
+        )
+        return FileProviderExtension(domain: domain)
+    }
+
+    /// The fresh-launch case from the bug report: no sync activity, so the resting state is "all good".
+    func testReportsFinishedWhenIdle() {
+        let ext = makeExtension()
+        let proxy = SyncStatusCapturingAppProxy()
+        ext.app = proxy
+
+        ext.reportCurrentSyncState()
+
+        XCTAssertEqual(proxy.reportedSyncStatuses, ["SYNC_FINISHED"])
+    }
+
+    func testReportsStartedWhileSyncing() {
+        let ext = makeExtension()
+        let proxy = SyncStatusCapturingAppProxy()
+        ext.app = proxy
+        ext.syncActions.insert(UUID())
+
+        ext.reportCurrentSyncState()
+
+        XCTAssertEqual(proxy.reportedSyncStatuses, ["SYNC_STARTED"])
+    }
+
+    func testReportsFailedWhenOnlyErrorsPending() {
+        let ext = makeExtension()
+        let proxy = SyncStatusCapturingAppProxy()
+        ext.app = proxy
+        ext.errorActions.insert(UUID())
+
+        ext.reportCurrentSyncState()
+
+        XCTAssertEqual(proxy.reportedSyncStatuses, ["SYNC_FAILED"])
+    }
+
+    /// A missing app proxy (main app not running) must be a silent no-op, never a crash.
+    func testWithoutProxyDoesNotCrash() {
+        let ext = makeExtension()
+        ext.reportCurrentSyncState()
+    }
+}

--- a/src/gui/tray/syncstatussummary.cpp
+++ b/src/gui/tray/syncstatussummary.cpp
@@ -207,6 +207,15 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
     switch (state) {
     case SyncResult::Success:
     case SyncResult::SyncPrepare:
+    case SyncResult::Undefined:
+        // `Undefined` reaches this point only via the file provider path, before the extension has
+        // reported a concrete state (e.g. right after a fresh launch). It means "no status yet",
+        // not "a sync failed", so render it as the optimistic resting state rather than the
+        // misleading "Some files could not be synced!". This mirrors how the menu bar icon
+        // (`ownCloudGui::slotComputeOverallSyncStatus`) and the per-account icons (`UserModel`)
+        // already bucket `Undefined` as idle. The extension is additionally forced to report its
+        // real state once the app connects. See https://github.com/nextcloud/desktop/issues/10053.
+        //
         // Success should only be shown if all folders were fine
         if (!folderErrors()
 #ifdef BUILD_FILE_PROVIDER_MODULE
@@ -248,7 +257,6 @@ void SyncStatusSummary::setSyncState(const SyncResult::Status state)
         setSyncIcon(Theme::instance()->pause());
         break;
     case SyncResult::Problem:
-    case SyncResult::Undefined:
         setSyncing(false);
         setTotalFiles(0);
         setSyncStatusString(tr("Some files could not be synced!"));
@@ -288,7 +296,6 @@ void SyncStatusSummary::onFileProviderDomainSyncStateChanged(const AccountPtr &a
     case SyncResult::Error:
     case SyncResult::SetupError:
     case SyncResult::Problem:
-    case SyncResult::Undefined:
         // Mark this domain as failing so `setSyncState`'s `Success` branch correctly gates
         // the "All synced!" header on `_fileProviderDomainsWithErrors.empty()`. The previous
         // inversion erased the domain and forced `state = Success`, which is why the header
@@ -300,6 +307,13 @@ void SyncStatusSummary::onFileProviderDomainSyncStateChanged(const AccountPtr &a
     case SyncResult::NotYetStarted:
     case SyncResult::Paused:
     case SyncResult::SyncAbortRequested:
+    case SyncResult::Undefined:
+        // `Undefined` means the extension has not reported a concrete state yet (e.g. right after
+        // launch). It is not an error, so leave `_fileProviderDomainsWithErrors` untouched: a
+        // previously reported real error stays recorded, while a freshly configured domain simply
+        // stays out of the error set. The matching `setSyncState` branch then renders it as the
+        // optimistic resting state instead of the misleading warning. See
+        // https://github.com/nextcloud/desktop/issues/10053.
         break;
     }
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

Fixes #10053.

## Summary

The menu bar extra used to present a warning state, even though everything was fine.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
