### PR TITLE
fix(#10216): Prevent app nap and silent kill

### DIFF
--- a/src/gui/cocoainitializer_mac.mm
+++ b/src/gui/cocoainitializer_mac.mm
@@ -7,6 +7,7 @@
 #include "cocoainitializer.h"
 
 #import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSProcessInfo.h>
 #import <AppKit/NSApplication.h>
 
 #include "application.h"
@@ -63,6 +64,7 @@ class CocoaInitializer::Private {
 public:
     NSAutoreleasePool* autoReleasePool;
     URLEventHandler* handler;
+    id<NSObject> appNapActivity = nil;
 };
 
 CocoaInitializer::CocoaInitializer() {
@@ -70,9 +72,22 @@ CocoaInitializer::CocoaInitializer() {
     d->handler = [[URLEventHandler alloc] init];
     NSApplicationLoad();
     d->autoReleasePool = [[NSAutoreleasePool alloc] init];
+
+    // As an LSUIElement agent we usually have no visible window, which makes macOS
+    // throttle us via App Nap and lets RunningBoard suspend (and later jetsam-reap)
+    // the process while it is idle in the background. Holding an NSActivityBackground
+    // assertion for our whole lifetime keeps the process out of App Nap so syncing
+    // continues; it still allows normal idle system/display sleep.
+    NSProcessInfo *const processInfo = [NSProcessInfo processInfo];
+    d->appNapActivity = [[processInfo beginActivityWithOptions:NSActivityBackground
+                                                        reason:@"Keep syncing while running in the background"] retain];
 }
 
 CocoaInitializer::~CocoaInitializer() {
+    if (d->appNapActivity) {
+        [[NSProcessInfo processInfo] endActivity:d->appNapActivity];
+        [d->appNapActivity release];
+    }
     [d->autoReleasePool release];
     delete d;
 }


### PR DESCRIPTION
Fixes #10216, hopefully. I could never reproduce the issue and also @Rello who experienced it could not provoke it.

Our app now pretends to have some activity going on to trick the system into not killing it for laziness.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
