### PR TITLE
fix(UI): validate E2EE file names

### DIFF
--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -974,17 +974,17 @@ QByteArray FolderMetadata::prepareMetadataForSignature(const QJsonDocument &full
     return metdataModified.toJson(QJsonDocument::Compact);
 }
 
-void FolderMetadata::addEncryptedFile(const EncryptedFile &f) {
+bool FolderMetadata::addEncryptedFile(const EncryptedFile &f) {
     Q_ASSERT(_isMetadataValid);
     if (!_isMetadataValid) {
         qCWarning(lcCseMetadata()) << "Could not add encrypted file to non-initialized metadata!";
-        return;
+        return false;
     }
 
     if (!isOriginalFilenameValid(f.originalFilename)) {
         qCWarning(lcCseMetadata()) << "Could not add encrypted file with invalid original file name.";
         _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
-        return;
+        return false;
     }
 
     for (int i = 0; i < _files.size(); ++i) {
@@ -995,6 +995,7 @@ void FolderMetadata::addEncryptedFile(const EncryptedFile &f) {
     }
 
     _files.append(f);
+    return true;
 }
 
 const QByteArray FolderMetadata::binaryMetadataKeyForDecryption() const
@@ -1067,7 +1068,9 @@ bool FolderMetadata::moveFromFileDropToFiles()
             _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
             return false;
         }
-        addEncryptedFile(parsedEncryptedFile);
+        if (!addEncryptedFile(parsedEncryptedFile)) {
+            return false;
+        }
     }
 
     _fileDropEntries.clear();

--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -277,30 +277,39 @@ void FolderMetadata::setupExistingMetadata(const QByteArray &metadata)
         _counter = counterVariantFromJson.value<quint64>();
     }
 
+    QVector<EncryptedFile> parsedFiles;
+    parsedFiles.reserve(files.size() + folders.size());
+
     for (auto it = files.constBegin(), end = files.constEnd(); it != end; ++it) {
         const auto parsedEncryptedFile = parseEncryptedFileFromJson(it.key(), it.value());
-        if (!parsedEncryptedFile.originalFilename.isEmpty()) {
-            _files.push_back(parsedEncryptedFile);
+        if (parsedEncryptedFile.originalFilename.isEmpty()) {
+            qCWarning(lcCseMetadata()) << "Could not setup metadata. Encrypted file" << it.key() << "metadata is invalid.";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return;
         }
+        parsedFiles.push_back(parsedEncryptedFile);
     }
 
     for (auto it = folders.constBegin(); it != folders.constEnd(); ++it) {
         const auto folderName = it.value().toString();
         if (folderName.isEmpty()) {
-            continue;
+            qCWarning(lcCseMetadata()) << "Could not setup metadata. Encrypted folder" << it.key() << "metadata has an empty file name.";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return;
         }
 
         if (!isOriginalFilenameValid(folderName)) {
-            qCWarning(lcCseMetadata()) << "skipping encrypted folder" << it.key() << "metadata has an invalid file name";
+            qCWarning(lcCseMetadata()) << "Could not setup metadata. Encrypted folder" << it.key() << "metadata has an invalid file name.";
             _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
-            continue;
+            return;
         }
 
         EncryptedFile file;
         file.encryptedFilename = it.key();
         file.originalFilename = folderName;
-        _files.push_back(file);
+        parsedFiles.push_back(file);
     }
+    _files = parsedFiles;
     _isMetadataValid = true;
 }
 
@@ -386,14 +395,15 @@ void FolderMetadata::setupExistingMetadataLegacy(const QByteArray &metadata)
 
         const auto originalFilename = decryptedFileObj["filename"].toString();
         if (originalFilename.isEmpty()) {
-            qCWarning(lcCseMetadata) << "decrypted metadata" << decryptedFileDoc.toJson(QJsonDocument::Compact) << "skipping encrypted file" << file.encryptedFilename << "metadata has an empty file name";
-            continue;
+            qCWarning(lcCseMetadata) << "decrypted metadata" << decryptedFileDoc.toJson(QJsonDocument::Compact) << "Could not setup legacy metadata. Encrypted file" << file.encryptedFilename << "metadata has an empty file name.";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return;
         }
 
         if (!isOriginalFilenameValid(originalFilename)) {
-            qCWarning(lcCseMetadata) << "skipping encrypted file" << file.encryptedFilename << "metadata has an invalid file name";
+            qCWarning(lcCseMetadata) << "Could not setup legacy metadata. Encrypted file" << file.encryptedFilename << "metadata has an invalid file name.";
             _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
-            continue;
+            return;
         }
 
         file.originalFilename = originalFilename;

--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -56,6 +56,11 @@ bool FolderMetadata::isOriginalFilenameValid(const QString &originalFilename)
         return false;
     }
 
+    if (originalFilename == QStringLiteral(".")
+        || originalFilename == QStringLiteral("..")) {
+        return false;
+    }
+
     if (originalFilename.contains(QLatin1Char('/'))
         || originalFilename.contains(QLatin1Char('\\'))
         || originalFilename.contains(QChar(0))) {

--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -9,6 +9,7 @@
 #include "clientsideencryption.h"
 #include "clientsideencryptionjobs.h"
 #include <common/checksums.h>
+#include <QDir>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QSslCertificate>
@@ -47,6 +48,22 @@ QString metadataStringFromOCsDocument(const QJsonDocument &ocsDoc)
     const auto &dataObj = ocsObj["data"].toObject();
     return dataObj["meta-data"].toString();
 }
+}
+
+bool FolderMetadata::isOriginalFilenameValid(const QString &originalFilename)
+{
+    if (originalFilename.isEmpty()) {
+        return false;
+    }
+
+    if (originalFilename.contains(QLatin1Char('/'))
+        || originalFilename.contains(QLatin1Char('\\'))
+        || originalFilename.contains(QChar(0))) {
+        return false;
+    }
+
+    const auto slashPrefixedName = QStringLiteral("/") + originalFilename;
+    return QDir::cleanPath(slashPrefixedName) == slashPrefixedName;
 }
 
 bool FolderMetadata::EncryptedFile::isDirectory() const
@@ -118,6 +135,11 @@ void FolderMetadata::setupExistingMetadata(const QByteArray &metadata)
 
     if (_existingMetadataVersion < MetadataVersion::Version1) {
         qCWarning(lcCseMetadata()) << "Could not setup metadata. Incorrect version" << _existingMetadataVersion;
+        _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+        return;
+    }
+    if (_existingMetadataVersion < MetadataVersion::Version2_0 && !_initialSignature.isEmpty()) {
+        qCWarning(lcCseMetadata()) << "Could not setup legacy metadata with a V2 signature.";
         _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
         return;
     }
@@ -259,12 +281,20 @@ void FolderMetadata::setupExistingMetadata(const QByteArray &metadata)
 
     for (auto it = folders.constBegin(); it != folders.constEnd(); ++it) {
         const auto folderName = it.value().toString();
-        if (!folderName.isEmpty()) {
-            EncryptedFile file;
-            file.encryptedFilename = it.key();
-            file.originalFilename = folderName;
-            _files.push_back(file);
+        if (folderName.isEmpty()) {
+            continue;
         }
+
+        if (!isOriginalFilenameValid(folderName)) {
+            qCWarning(lcCseMetadata()) << "skipping encrypted folder" << it.key() << "metadata has an invalid file name";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            continue;
+        }
+
+        EncryptedFile file;
+        file.encryptedFilename = it.key();
+        file.originalFilename = folderName;
+        _files.push_back(file);
     }
     _isMetadataValid = true;
 }
@@ -349,12 +379,19 @@ void FolderMetadata::setupExistingMetadataLegacy(const QByteArray &metadata)
 
         const auto decryptedFileObj = decryptedFileDoc.object();
 
-        if (decryptedFileObj["filename"].toString().isEmpty()) {
+        const auto originalFilename = decryptedFileObj["filename"].toString();
+        if (originalFilename.isEmpty()) {
             qCWarning(lcCseMetadata) << "decrypted metadata" << decryptedFileDoc.toJson(QJsonDocument::Compact) << "skipping encrypted file" << file.encryptedFilename << "metadata has an empty file name";
             continue;
         }
 
-        file.originalFilename = decryptedFileObj["filename"].toString();
+        if (!isOriginalFilenameValid(originalFilename)) {
+            qCWarning(lcCseMetadata) << "skipping encrypted file" << file.encryptedFilename << "metadata has an invalid file name";
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            continue;
+        }
+
+        file.originalFilename = originalFilename;
         file.encryptionKey = QByteArray::fromBase64(decryptedFileObj["key"].toString().toLocal8Bit());
         file.mimetype = decryptedFileObj["mimetype"].toString().toLocal8Bit();
 
@@ -508,8 +545,15 @@ bool FolderMetadata::isValid() const
 FolderMetadata::EncryptedFile FolderMetadata::parseEncryptedFileFromJson(const QString &encryptedFilename, const QJsonValue &fileJSON) const
 {
     const auto fileObj = fileJSON.toObject();
-    if (fileObj["filename"].toString().isEmpty()) {
+    const auto originalFilename = fileObj["filename"].toString();
+    if (originalFilename.isEmpty()) {
         qCWarning(lcCseMetadata()) << "skipping encrypted file" << encryptedFilename << "metadata has an empty file name";
+        return {};
+    }
+
+    if (!isOriginalFilenameValid(originalFilename)) {
+        qCWarning(lcCseMetadata()) << "skipping encrypted file" << encryptedFilename << "metadata has an invalid file name";
+        _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
         return {};
     }
     
@@ -521,7 +565,7 @@ FolderMetadata::EncryptedFile FolderMetadata::parseEncryptedFileFromJson(const Q
         nonce = QByteArray::fromBase64(fileObj[nonceKey].toString().toLocal8Bit());
     }
     file.initializationVector = nonce;
-    file.originalFilename = fileObj["filename"].toString();
+    file.originalFilename = originalFilename;
     file.encryptionKey = QByteArray::fromBase64(fileObj["key"].toString().toLocal8Bit());
     file.mimetype = fileObj["mimetype"].toString().toLocal8Bit();
 
@@ -535,6 +579,11 @@ FolderMetadata::EncryptedFile FolderMetadata::parseEncryptedFileFromJson(const Q
 
 QJsonObject FolderMetadata::convertFileToJsonObject(const EncryptedFile *encryptedFile) const
 {
+    if (!encryptedFile || !isOriginalFilenameValid(encryptedFile->originalFilename)) {
+        qCWarning(lcCseMetadata()) << "Metadata generation failed. Invalid original file name.";
+        return {};
+    }
+
     QJsonObject file;
     file.insert("key", QString(encryptedFile->encryptionKey.toBase64()));
     file.insert("filename", encryptedFile->originalFilename);
@@ -728,6 +777,12 @@ QByteArray FolderMetadata::encryptedMetadataLegacy()
 
     QJsonObject files;
     for (auto it = _files.constBegin(), end = _files.constEnd(); it != end; ++it) {
+        if (!isOriginalFilenameValid(it->originalFilename)) {
+            qCWarning(lcCseMetadata) << "Metadata generation failed. Invalid original file name for encrypted file" << it->encryptedFilename;
+            _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
+            return {};
+        }
+
         QJsonObject encrypted;
         encrypted.insert("key", QString(it->encryptionKey.toBase64()));
         encrypted.insert("filename", it->originalFilename);
@@ -923,6 +978,12 @@ void FolderMetadata::addEncryptedFile(const EncryptedFile &f) {
     Q_ASSERT(_isMetadataValid);
     if (!_isMetadataValid) {
         qCWarning(lcCseMetadata()) << "Could not add encrypted file to non-initialized metadata!";
+        return;
+    }
+
+    if (!isOriginalFilenameValid(f.originalFilename)) {
+        qCWarning(lcCseMetadata()) << "Could not add encrypted file with invalid original file name.";
+        _account->reportClientStatus(OCC::ClientStatusReportingStatus::E2EeError_GeneralError);
         return;
     }
 

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -147,7 +147,7 @@ public:
     static MetadataVersion setupVersionFromExistingMetadata(const QByteArray &metadata);
 
 public slots:
-    void addEncryptedFile(const OCC::FolderMetadata::EncryptedFile &f);
+    [[nodiscard]] bool addEncryptedFile(const OCC::FolderMetadata::EncryptedFile &f);
     void removeEncryptedFile(const OCC::FolderMetadata::EncryptedFile &f);
     void removeAllEncryptedFiles();
 

--- a/src/libsync/foldermetadata.h
+++ b/src/libsync/foldermetadata.h
@@ -172,6 +172,8 @@ private:
 
     [[nodiscard]] QJsonObject convertFileToJsonObject(const EncryptedFile *encryptedFile) const;
 
+    [[nodiscard]] static bool isOriginalFilenameValid(const QString &originalFilename);
+
     [[nodiscard]] MetadataVersion latestSupportedMetadataVersion() const;
 
     [[nodiscard]] bool parseFileDropPart(const QJsonDocument &doc);

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -210,7 +210,11 @@ void PropagateRemoteMkdir::slotMkdir()
     connect(_uploadEncryptedHelper, &PropagateUploadEncrypted::finalized,
       this, &PropagateRemoteMkdir::slotStartEncryptedMkcolJob);
     connect(_uploadEncryptedHelper, &PropagateUploadEncrypted::error,
-      []{ qCWarning(lcPropagateRemoteMkdir) << "Error setting up encryption."; });
+      this, [this] {
+          qCWarning(lcPropagateRemoteMkdir) << "Error setting up encryption.";
+          propagator()->_activeJobList.removeOne(this);
+          done(SyncFileItem::FatalError, tr("Failed to create encrypted folder."), ErrorCategory::GenericError);
+      });
     _uploadEncryptedHelper->start();
 }
 

--- a/src/libsync/propagateuploadencrypted.cpp
+++ b/src/libsync/propagateuploadencrypted.cpp
@@ -165,9 +165,6 @@ void PropagateUploadEncrypted::slotFetchMetadataJobFinished(int statusCode, cons
 
     if (!metadata->addEncryptedFile(encryptedFile)) {
         qCWarning(lcPropagateUploadEncrypted()) << "There was an error encrypting the file, aborting upload. Invalid metadata file name.";
-        if (!info.isDir()) {
-            QFile::remove(_completeFileName);
-        }
         emit error();
         return;
     }

--- a/src/libsync/propagateuploadencrypted.cpp
+++ b/src/libsync/propagateuploadencrypted.cpp
@@ -163,7 +163,14 @@ void PropagateUploadEncrypted::slotFetchMetadataJobFinished(int statusCode, cons
 
     qCDebug(lcPropagateUploadEncrypted) << "Creating the metadata for the encrypted file.";
 
-    metadata->addEncryptedFile(encryptedFile);
+    if (!metadata->addEncryptedFile(encryptedFile)) {
+        qCWarning(lcPropagateUploadEncrypted()) << "There was an error encrypting the file, aborting upload. Invalid metadata file name.";
+        if (!info.isDir()) {
+            QFile::remove(_completeFileName);
+        }
+        emit error();
+        return;
+    }
 
     qCDebug(lcPropagateUploadEncrypted) << "Metadata created, sending to the server.";
 

--- a/test/testclientsideencryptionv2.cpp
+++ b/test/testclientsideencryptionv2.cpp
@@ -296,6 +296,80 @@ private slots:
         QVERIFY(metadata->files().isEmpty());
     }
 
+    void testSetupExistingMetadataRejectsUnsafeOriginalFilename()
+    {
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/", FolderMetadata::FolderType::Root));
+        QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
+        metadataSetupCompleteSpy.wait();
+        QCOMPARE(metadataSetupCompleteSpy.count(), 1);
+        QVERIFY(metadata->isValid());
+
+        const auto initialEncryptedMetadata = metadata->encryptedMetadata();
+        QVERIFY(!initialEncryptedMetadata.isEmpty());
+
+        const auto encryptedFilename = QStringLiteral("encrypted-name");
+        const auto fileJson = QJsonObject{
+            {QStringLiteral("filename"), QStringLiteral("folder\\file.txt")},
+            {QStringLiteral("key"), QString::fromUtf8(EncryptionHelper::generateRandom(16).toBase64())},
+            {QStringLiteral("mimetype"), QStringLiteral("application/octet-stream")},
+            {QStringLiteral("nonce"), QString::fromUtf8(EncryptionHelper::generateRandom(16).toBase64())},
+            {QStringLiteral("authenticationTag"), QString::fromUtf8(EncryptionHelper::generateRandom(16).toBase64())},
+        };
+
+        QJsonArray keyChecksums;
+        for (auto it = metadata->_keyChecksums.constBegin(), end = metadata->_keyChecksums.constEnd(); it != end; ++it) {
+            keyChecksums.push_back(QJsonValue::fromVariant(*it));
+        }
+
+        const auto cipherText = QJsonObject{
+            {QStringLiteral("counter"), QJsonValue::fromVariant(metadata->newCounter())},
+            {QStringLiteral("files"), QJsonObject{{encryptedFilename, fileJson}}},
+            {QStringLiteral("folders"), QJsonObject{}},
+            {QStringLiteral("keyChecksums"), keyChecksums},
+        };
+        const auto cipherTextDoc = QJsonDocument(cipherText);
+
+        QByteArray authenticationTag;
+        const auto nonce = EncryptionHelper::generateRandom(16);
+        const auto encryptedCipherText = EncryptionHelper::gzipThenEncryptData(metadata->binaryMetadataKeyForEncryption(),
+                                                                               cipherTextDoc.toJson(QJsonDocument::Compact),
+                                                                               nonce,
+                                                                               authenticationTag).toBase64()
+            + QByteArrayLiteral("|") + nonce.toBase64();
+
+        auto metadataDoc = QJsonDocument::fromJson(initialEncryptedMetadata);
+        auto metaObject = metadataDoc.object();
+        auto metadataObject = metaObject[QStringLiteral("metadata")].toObject();
+        metadataObject.insert(QStringLiteral("ciphertext"), QString::fromUtf8(encryptedCipherText));
+        metadataObject.insert(QStringLiteral("nonce"), QString::fromUtf8(nonce.toBase64()));
+        metadataObject.insert(QStringLiteral("authenticationTag"), QString::fromUtf8(authenticationTag.toBase64()));
+        metaObject.insert(QStringLiteral("metadata"), metadataObject);
+        metadataDoc.setObject(metaObject);
+
+        const auto signature = _account->e2e()->generateSignatureCryptographicMessageSyntax(FolderMetadata::prepareMetadataForSignature(metadataDoc).toBase64()).toBase64();
+        QVERIFY(!signature.isEmpty());
+
+        const auto ocsDoc = QJsonDocument(QJsonObject{
+            {QStringLiteral("ocs"), QJsonObject{
+                {QStringLiteral("data"), QJsonObject{
+                    {QStringLiteral("meta-data"), QString::fromUtf8(metadataDoc.toJson(QJsonDocument::Compact))},
+                }},
+            }},
+        });
+
+        QScopedPointer<FolderMetadata> metadataFromJson(new FolderMetadata(_account,
+                                                                           "/",
+                                                                           ocsDoc.toJson(),
+                                                                           RootEncryptedFolderInfo::makeDefault(),
+                                                                           signature,
+                                                                           FolderMetadata::FolderType::Root));
+        QSignalSpy metadataSetupExistingCompleteSpy(metadataFromJson.data(), &FolderMetadata::setupComplete);
+        metadataSetupExistingCompleteSpy.wait();
+        QCOMPARE(metadataSetupExistingCompleteSpy.count(), 1);
+        QVERIFY(!metadataFromJson->isValid());
+        QVERIFY(metadataFromJson->files().isEmpty());
+    }
+
     void testE2EeFolderMetadataSharing()
     {
         // instantiate empty metadata, add a file, and share with a second user "sharee"

--- a/test/testclientsideencryptionv2.cpp
+++ b/test/testclientsideencryptionv2.cpp
@@ -104,7 +104,7 @@ private slots:
         encryptedFile.originalFilename = fakeFileName;
         encryptedFile.mimetype = "application/octet-stream";
         encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
-        metadata->addEncryptedFile(encryptedFile);
+        QVERIFY(metadata->addEncryptedFile(encryptedFile));
 
         const auto encryptedMetadata = metadata->encryptedMetadata();
         QVERIFY(!encryptedMetadata.isEmpty());
@@ -277,6 +277,25 @@ private slots:
         }
     }
 
+    void testAddEncryptedFileRejectsUnsafeOriginalFilename()
+    {
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/", FolderMetadata::FolderType::Root));
+        QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
+        metadataSetupCompleteSpy.wait();
+        QCOMPARE(metadataSetupCompleteSpy.count(), 1);
+        QVERIFY(metadata->isValid());
+
+        FolderMetadata::EncryptedFile encryptedFile;
+        encryptedFile.encryptionKey = EncryptionHelper::generateRandom(16);
+        encryptedFile.encryptedFilename = EncryptionHelper::generateRandomFilename();
+        encryptedFile.originalFilename = QStringLiteral("folder\\file.txt");
+        encryptedFile.mimetype = "application/octet-stream";
+        encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
+
+        QVERIFY(!metadata->addEncryptedFile(encryptedFile));
+        QVERIFY(metadata->files().isEmpty());
+    }
+
     void testE2EeFolderMetadataSharing()
     {
         // instantiate empty metadata, add a file, and share with a second user "sharee"
@@ -294,7 +313,7 @@ private slots:
         encryptedFile.originalFilename = fakeFileName;
         encryptedFile.mimetype = "application/octet-stream";
         encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
-        metadata->addEncryptedFile(encryptedFile);
+        QVERIFY(metadata->addEncryptedFile(encryptedFile));
 
         QVERIFY(metadata->addUser(_secondAccount->davUser(), _secondAccount->e2e()->getCertificate(), FolderMetadata::CertificateType::SoftwareNextcloudCertificate));
 
@@ -385,7 +404,7 @@ private slots:
         encryptedFile.originalFilename = fakeFileNameFromSecondUser;
         encryptedFile.mimetype = "application/octet-stream";
         encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
-        metadataFromJsonForSecondUser->addEncryptedFile(encryptedFile);
+        QVERIFY(metadataFromJsonForSecondUser->addEncryptedFile(encryptedFile));
 
         auto encryptedMetadataFromSecondUser = metadataFromJsonForSecondUser->encryptedMetadata();
         encryptedMetadataFromSecondUser.replace("\"", "\\\"");

--- a/test/testclientsideencryptionv2.cpp
+++ b/test/testclientsideencryptionv2.cpp
@@ -220,6 +220,63 @@ private slots:
         QVERIFY(!metadataFromJson->isValid());
     }
 
+    void testOriginalFilenameValidation_data()
+    {
+        QTest::addColumn<QString>("originalFilename");
+        QTest::addColumn<bool>("isValid");
+
+        QTest::newRow("plain file") << QStringLiteral("document.txt") << true;
+        QTest::newRow("plain folder") << QStringLiteral("Documents") << true;
+        QTest::newRow("hidden file") << QStringLiteral(".hidden") << true;
+        QTest::newRow("empty") << QString() << false;
+        QTest::newRow("current directory") << QStringLiteral(".") << false;
+        QTest::newRow("parent directory") << QStringLiteral("..") << false;
+        QTest::newRow("relative traversal") << QStringLiteral("../../poc_dir") << false;
+        QTest::newRow("embedded slash") << QStringLiteral("folder/file.txt") << false;
+        QTest::newRow("absolute path") << QStringLiteral("/tmp/poc") << false;
+        QTest::newRow("backslash") << QStringLiteral("folder\\file.txt") << false;
+        QTest::newRow("null byte") << QStringLiteral("file") + QChar(0) + QStringLiteral("name") << false;
+    }
+
+    void testOriginalFilenameValidation()
+    {
+        QFETCH(QString, originalFilename);
+        QFETCH(bool, isValid);
+
+        QCOMPARE(FolderMetadata::isOriginalFilenameValid(originalFilename), isValid);
+    }
+
+    void testParseEncryptedFileFromJsonRejectsUnsafeOriginalFilename_data()
+    {
+        testOriginalFilenameValidation_data();
+    }
+
+    void testParseEncryptedFileFromJsonRejectsUnsafeOriginalFilename()
+    {
+        QFETCH(QString, originalFilename);
+        QFETCH(bool, isValid);
+
+        QScopedPointer<FolderMetadata> metadata(new FolderMetadata(_account, "/", FolderMetadata::FolderType::Root));
+        QSignalSpy metadataSetupCompleteSpy(metadata.data(), &FolderMetadata::setupComplete);
+        metadataSetupCompleteSpy.wait();
+        QCOMPARE(metadataSetupCompleteSpy.count(), 1);
+        QVERIFY(metadata->isValid());
+
+        const auto fileJson = QJsonObject{
+            {QStringLiteral("filename"), originalFilename},
+            {QStringLiteral("key"), QString::fromUtf8(QByteArrayLiteral("key").toBase64())},
+            {QStringLiteral("mimetype"), QStringLiteral("application/octet-stream")},
+            {QStringLiteral("nonce"), QString::fromUtf8(QByteArrayLiteral("nonce").toBase64())},
+            {QStringLiteral("authenticationTag"), QString::fromUtf8(QByteArrayLiteral("tag").toBase64())},
+        };
+
+        const auto parsedEncryptedFile = metadata->parseEncryptedFileFromJson(QStringLiteral("encrypted-name"), fileJson);
+        QCOMPARE(!parsedEncryptedFile.originalFilename.isEmpty(), isValid);
+        if (isValid) {
+            QCOMPARE(parsedEncryptedFile.originalFilename, originalFilename);
+        }
+    }
+
     void testE2EeFolderMetadataSharing()
     {
         // instantiate empty metadata, add a file, and share with a second user "sharee"

--- a/test/testsecurefiledrop.cpp
+++ b/test/testsecurefiledrop.cpp
@@ -87,7 +87,7 @@ private slots:
             encryptedFile.originalFilename = fakeFileName;
             encryptedFile.mimetype = "application/octet-stream";
             encryptedFile.initializationVector = EncryptionHelper::generateRandom(16);
-            metadata->addEncryptedFile(encryptedFile);
+            QVERIFY(metadata->addEncryptedFile(encryptedFile));
         }
 
         QJsonObject fakeFileDropPart;


### PR DESCRIPTION
Make FolderMetadata enforce that every decrypted E2EE filename is a single path segment before it can enter discovery.
