### PR TITLE
Port #10252 back manually to stable-33.0

### DIFF
--- a/.github/workflows/nextcloudfileproviderkit.yml
+++ b/.github/workflows/nextcloudfileproviderkit.yml
@@ -6,9 +6,9 @@ name: NextcloudFileProviderKit
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "stable-*" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "stable-*" ]
 
 jobs:
   Lint:

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncEngine.swift
@@ -27,7 +27,7 @@ extension Enumerator {
                 dbManager.addItemMetadataPreservingLocalState(metadata)
             }
         }
-        
+
         // Persist children — including those on follow-up pages — while
         // carrying over any local-only state previously set on existing rows
         // (e.g. `keepDownloaded` from a recursive "Always keep downloaded"

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -246,8 +246,25 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             }
 
             Task {
-                await checkMaterializedItemsOnServer()
+                let remoteChanges = await checkMaterializedItemsOnServer()
                 let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
+
+                // Merge the changes discovered directly against the server with the local pending
+                // changes re-derived from the database. `checkMaterializedItemsOnServer` returns the
+                // remote changes that the `syncTime`-based reconstruction in
+                // `pendingWorkingSetChanges` misses: non-materialized items, and items in subtrees
+                // whose own parent directory did not change. Deduplicate by ocId and make sure an
+                // item is never reported as both updated and deleted in the same pass.
+                let deletedById = Dictionary(
+                    (remoteChanges.deleted + pendingLocalChanges.deleted).map { ($0.ocId, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                var seenUpdates = Set<String>()
+                let mergedUpdates = (remoteChanges.updated + pendingLocalChanges.updated)
+                    .filter { metadata in
+                        guard deletedById[metadata.ocId] == nil else { return false }
+                        return seenUpdates.insert(metadata.ocId).inserted
+                    }
 
                 completeChangesObserver(
                     observer,
@@ -257,8 +274,8 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
                     remoteInterface: remoteInterface,
                     dbManager: dbManager,
                     newMetadatas: [],
-                    updatedMetadatas: pendingLocalChanges.updated,
-                    deletedMetadatas: pendingLocalChanges.deleted
+                    updatedMetadatas: mergedUpdates,
+                    deletedMetadatas: Array(deletedById.values)
                 )
             }
 
@@ -420,7 +437,21 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
 
     // MARK: - Helper methods
 
-    private func checkMaterializedItemsOnServer() async {
+    ///
+    /// Scan the materialized items (and any changed subtrees they reveal) on the server and return
+    /// the remote changes discovered, in addition to persisting them to the database.
+    ///
+    /// The returned changes are reported to the working-set change observer directly. Relying on
+    /// `pendingWorkingSetChanges(since:)` alone to re-derive the report from the database loses
+    /// changes to non-materialized items and to items in subtrees whose own parent directory did
+    /// not change, because that reconstruction is gated on the materialized set and `syncTime`.
+    ///
+    /// - Returns: The discovered new/updated metadata (merged into `updated`) and the metadata that
+    ///   were marked deleted.
+    ///
+    private func checkMaterializedItemsOnServer() async -> (
+        updated: [SendableItemMetadata], deleted: [SendableItemMetadata]
+    ) {
         logger.debug("Checking materialized items for changes on the server...")
 
         defer {
@@ -441,28 +472,42 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         var allDeletedMetadatas = [SendableItemMetadata]()
         var examinedItemIds = Set<String>()
 
-        for materializedItem in materializedItems where !examinedItemIds.contains(materializedItem.ocId) {
-            guard isLockFileName(materializedItem.fileName) == false else {
+        // Work queue seeded with the materialized items. A changed child directory discovered while
+        // scanning is appended so its descendants are visited too — otherwise a depth-1 read of a
+        // visited folder surfaces the changed subdirectory but never the changed items inside it.
+        // Unchanged subtrees are never enqueued, so the "skip unchanged directories" optimization
+        // is preserved.
+        var queue = materializedItems
+        var queuedDirectoryIds = Set(materializedItems.filter(\.directory).map(\.ocId))
+        var queueIndex = 0
+
+        while queueIndex < queue.count {
+            let workItem = queue[queueIndex]
+            queueIndex += 1
+
+            guard !examinedItemIds.contains(workItem.ocId) else { continue }
+            guard isLockFileName(workItem.fileName) == false else {
                 // Skip server requests for locally created lock files.
                 // They are not synchronized to the server for real.
                 // Thus they can be expected not to be found there.
                 // That would also cause their local deletion due to synchronization logic.
-                logger.debug("Skipping materialized item in working set check because the name hints a lock file.", [.item: materializedItem, .name: materializedItem.name])
+                logger.debug("Skipping materialized item in working set check because the name hints a lock file.", [.item: workItem, .name: workItem.name])
                 continue
             }
 
-            let itemRemoteUrl = materializedItem.remotePath()
+            let itemRemoteUrl = workItem.remotePath()
 
-            let (metadatas, newMetadatas, updatedMetadatas, deletedMetadatas, _, readError) = await Enumerator.readServerUrl(itemRemoteUrl, account: account, remoteInterface: remoteInterface, dbManager: dbManager, depth: materializedItem.directory ? .targetAndDirectChildren : .target, log: logger.log)
+            let (metadatas, newMetadatas, updatedMetadatas, deletedMetadatas, _, readError) = await Enumerator.readServerUrl(itemRemoteUrl, account: account, remoteInterface: remoteInterface, dbManager: dbManager, depth: workItem.directory ? .targetAndDirectChildren : .target, log: logger.log)
 
             if readError?.errorCode == 404 {
-                allDeletedMetadatas.append(materializedItem)
-                examinedItemIds.insert(materializedItem.ocId)
+                allDeletedMetadatas.append(workItem)
+                examinedItemIds.insert(workItem.ocId)
                 // Children are not marked deleted here — they may have moved with their parent.
                 logger.debug("Parent returned 404; children will be checked individually.", [.url: itemRemoteUrl])
             } else if let readError, readError != .success {
                 logger.error("Finished remote change enumeration of materialized items with error.", [.error: readError])
-                return
+                // Report what was discovered before the error rather than discarding it.
+                break
             } else {
                 allDeletedMetadatas += deletedMetadatas ?? []
                 allUpdatedMetadatas += updatedMetadatas ?? []
@@ -478,12 +523,23 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
                         examinedChildFilesAndDeletedItems.formUnion(metadatas[1...].filter { !$0.directory }.map(\.ocId))
                     }
 
-                    // Only skip unchanged child directories with no materialized descendants.
-                    // Lock changes don't propagate etags, so dirs with visible children must be enumerated.
                     if metadatas.count > 1 {
                         let childDirectories = metadatas[1...].filter(\.directory)
+                        let changedChildOcIds = Set((updatedMetadatas ?? []).map(\.ocId))
+                            .union((newMetadatas ?? []).map(\.ocId))
 
                         for childDir in childDirectories {
+                            // A changed child directory must be scanned so its descendants are
+                            // discovered, even when the directory itself is not materialized.
+                            if changedChildOcIds.contains(childDir.ocId) {
+                                if queuedDirectoryIds.insert(childDir.ocId).inserted {
+                                    queue.append(childDir)
+                                }
+                                continue
+                            }
+
+                            // Only skip unchanged child directories with no materialized descendants.
+                            // Lock changes don't propagate etags, so dirs with visible children must be enumerated.
                             guard let localItem = materializedItems.first(
                                 where: { $0.ocId == childDir.ocId }
                             ), localItem.isInSameDatabaseStoreableRemoteState(childDir) else {
@@ -517,6 +573,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
 
         allDeletedMetadatas.removeAll { survivingOcIds.contains($0.ocId) }
 
+        var reportedDeletions = [SendableItemMetadata]()
         for deletedMetadata in allDeletedMetadatas {
             if deletedMetadata.status >= Status.inUpload.rawValue {
                 logger.info("Skipping deletion of item with pending upload.", [.item: deletedMetadata.ocId])
@@ -526,11 +583,20 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
             deleteMarked.deleted = true
             deleteMarked.syncTime = Date()
             dbManager.addItemMetadata(deleteMarked)
+            reportedDeletions.append(deleteMarked)
         }
 
-        if allUpdatedMetadatas.isEmpty, allDeletedMetadatas.isEmpty {
+        // Deduplicate the discovered new/updated metadata by ocId, preserving order.
+        var seenUpdatedOcIds = Set<String>()
+        let discoveredUpdates = (allNewMetadatas + allUpdatedMetadatas).filter {
+            seenUpdatedOcIds.insert($0.ocId).inserted
+        }
+
+        if discoveredUpdates.isEmpty, reportedDeletions.isEmpty {
             logger.info("No remote changes found in materialized items.")
         }
+
+        return (updated: discoveredUpdates, deleted: reportedDeletions)
     }
 
     static func fileProviderPageforNumPage(_: Int) -> NSFileProviderPage? {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/ItemMetadata.swift
@@ -146,6 +146,7 @@ public extension ItemMetadata {
             && comparingMetadata.sharePermissionsCollaborationServices
             == sharePermissionsCollaborationServices
             && comparingMetadata.favorite == favorite
+            && comparingMetadata.size == size
     }
 
     /// Returns false if the user is lokced out of the file. I.e. The file is locked but by someone else

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -873,6 +873,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
             account: Self.account,
             remoteInterface: MockRemoteInterface(account: Self.account),
             dbManager: Self.dbManager,
+            displayFileActions: false,
             remoteSupportsTrash: true,
             log: FileProviderLogMock()
         )

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MoveSafeDeletionTests.swift
@@ -275,7 +275,9 @@ final class MoveSafeDeletionTests: NextcloudFileProviderKitTestCase {
 
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
 
-        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+        let anchor = try NSFileProviderSyncAnchor(
+            XCTUnwrap(ISO8601DateFormatter().string(from: Date().addingTimeInterval(-300)).data(using: .utf8))
+        )
 
         let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,
@@ -307,7 +309,9 @@ final class MoveSafeDeletionTests: NextcloudFileProviderKitTestCase {
         parentMetadata.syncTime = Date()
         Self.dbManager.addItemMetadata(parentMetadata)
 
-        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+        let anchor = try NSFileProviderSyncAnchor(
+            XCTUnwrap(ISO8601DateFormatter().string(from: Date().addingTimeInterval(-300)).data(using: .utf8))
+        )
 
         let enumerator = try Enumerator(
             enumeratedItemIdentifier: .workingSet,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -1,0 +1,331 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+//
+//  Reproducing tests for "server-side changes intermittently do not surface in the
+//  macOS File Provider domain". See the investigation plan
+//  (i-frequently-receive-reports-clever-karp).
+//
+//  Background
+//  ----------
+//  When the main app learns of a remote change (notify_push fileId / files signal, or
+//  root-ETag polling) it ultimately calls `notifyChange()`, which signals ONLY the
+//  `.workingSet` enumerator. So the working-set change path is the only extension code a
+//  push/poll signal drives. That path is:
+//
+//      enumerateChanges(.workingSet)
+//        -> checkMaterializedItemsOnServer()        // PROPFINDs every *materialized* item,
+//                                                    // writes fresh metadata + syncTime to the DB
+//        -> pendingWorkingSetChanges(since: anchor)  // re-derives the report from the DB by
+//                                                    // `syncTime > anchorDate` (+ a child scan)
+//        -> observer.didUpdate / didDeleteItems
+//
+//  These tests mutate the mock "server" and then run the *real* working-set path, asserting
+//  the change reaches `MockChangeObserver`. The header comment of each test records which
+//  suspect (S1/S2/S4) it probes.
+//
+//  Three of them reproduced real silent-drops in the enumerator/DB change-derivation logic and
+//  now pass after the fixes (see inline "Regression guard (Sx)" notes):
+//    - S1/S2: `checkMaterializedItemsOnServer` now returns the changes it discovers (reported
+//      directly) and recurses into changed subdirectories, instead of relying on the lossy
+//      `syncTime`-based reconstruction in `pendingWorkingSetChanges`.
+//    - S4: `isInSameDatabaseStoreableRemoteState` now also compares `size`.
+//
+//  None of these tests require any test-only mock changes.
+//
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudKit
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    static let dbManager = FilesDatabaseManager(
+        account: account,
+        databaseDirectory: makeDatabaseDirectory(),
+        fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+        log: FileProviderLogMock()
+    )
+
+    // Seeded rows are stamped well before the anchor so they do not spuriously match the
+    // `syncTime > anchorDate` window; the working-set scan stamps fresh rows at "now".
+    let oldSyncTime = Date(timeIntervalSinceNow: -600) // 10 minutes ago
+    let anchorDate = Date(timeIntervalSinceNow: -300) // 5 minutes ago
+
+    var rootItem: MockRemoteItem!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        rootItem = MockRemoteItem.rootItem(account: Self.account)
+    }
+
+    // MARK: - Helpers
+
+    /// Seed a DB row from `item`'s *current* state, with explicit materialization flags and a
+    /// pre-anchor `syncTime`. Call this BEFORE mutating the mock item's `versionIdentifier`, so the
+    /// DB holds the "old" state and the mock returns the "new" state on the next PROPFIND.
+    @discardableResult
+    private func seed(
+        _ item: MockRemoteItem,
+        downloaded: Bool = false,
+        visitedDirectory: Bool = false,
+        syncTime: Date? = nil
+    ) -> SendableItemMetadata {
+        var metadata = item.toItemMetadata(account: Self.account)
+        metadata.downloaded = downloaded
+        metadata.visitedDirectory = visitedDirectory
+        metadata.syncTime = syncTime ?? oldSyncTime
+        Self.dbManager.addItemMetadata(metadata)
+        return metadata
+    }
+
+    private func makeFolder(name: String, parent: MockRemoteItem, etag: String) -> MockRemoteItem {
+        let folder = MockRemoteItem(
+            identifier: name,
+            versionIdentifier: etag,
+            name: name,
+            remotePath: parent.remotePath + "/" + name,
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        folder.parent = parent
+        parent.children.append(folder)
+        return folder
+    }
+
+    private func makeFile(
+        name: String, parent: MockRemoteItem, etag: String, data: Data = Data([1, 2, 3])
+    ) -> MockRemoteItem {
+        let file = MockRemoteItem(
+            identifier: name,
+            versionIdentifier: etag,
+            name: name,
+            remotePath: parent.remotePath + "/" + name,
+            data: data,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        file.parent = parent
+        parent.children.append(file)
+        return file
+    }
+
+    private func runWorkingSetChanges(
+        _ remoteInterface: MockRemoteInterface
+    ) async throws -> MockChangeObserver {
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        // stable-33.0 uses a plain ISO8601 sync anchor (the version-tagged anchor from #10065 is not
+        // on this branch), so build the anchor the same way the enumerator and the other tests do.
+        let anchor = try NSFileProviderSyncAnchor(
+            XCTUnwrap(ISO8601DateFormatter().string(from: anchorDate).data(using: .utf8))
+        )
+        try await observer.enumerateChanges(from: anchor)
+        return observer
+    }
+
+    private func reportedIds(_ observer: MockChangeObserver) -> Set<String> {
+        Set(observer.changedItems.map(\.itemIdentifier.rawValue))
+    }
+
+    // MARK: - Tests
+
+    /// Baseline (sanity): a downloaded (materialized) file that changed on the server is reported.
+    /// Materialized files are PROPFIND'd at `.target` depth and re-stamped every scan, so this is
+    /// expected to PASS — it confirms the harness and the happy path.
+    func testMaterializedFileChangeIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let file = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true)
+        seed(file, downloaded: true) // materialized
+
+        // Server-side change to the materialized file.
+        file.versionIdentifier = "itemA-v2"
+        file.modificationDate = Date()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(file.identifier),
+            "A materialized file changed on the server must be reported as updated."
+        )
+    }
+
+    /// Scenario A (S1/S2 control): a NON-materialized file changed inside a visited (materialized)
+    /// folder, AND the folder's ETag is bumped too (a well-behaved server propagates child changes
+    /// up to the parent's ETag). Expected to PASS — the parent's bumped `syncTime` lets the child
+    /// scan in `pendingWorkingSetChanges` pick up the changed child.
+    func testChangedChildSurfacesWhenParentEtagAlsoBumped() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let file = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true)
+        seed(file, downloaded: false) // NOT materialized
+
+        // Child changed; parent ETag bumped to reflect it (well-behaved server).
+        file.versionIdentifier = "itemA-v2"
+        file.modificationDate = Date()
+        folder.versionIdentifier = "folder-v2"
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(file.identifier),
+            "A changed child in a visited folder should be reported when the parent ETag is bumped."
+        )
+    }
+
+    /// Scenario B (S1/S2): same as A but the parent folder's ETag is NOT bumped. This probes how
+    /// strongly the working-set report depends on the parent directory's `syncTime` being advanced.
+    /// The change is written to the DB by `checkMaterializedItemsOnServer` but
+    /// `pendingWorkingSetChanges` only scans children of directories that are themselves in the
+    /// materialized-and-changed set — so a non-materialized child whose parent did not change may be
+    /// dropped. Asserts the desired behaviour (child reported); a FAILURE documents the dependency.
+    func testChangedChildSurfacesWhenParentEtagUnchanged() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let file = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true)
+        seed(file, downloaded: false) // NOT materialized
+
+        // Child changed; parent ETag deliberately left unchanged.
+        file.versionIdentifier = "itemA-v2"
+        file.modificationDate = Date()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        // Regression guard (S1/S2): the changed child is now reported because
+        // checkMaterializedItemsOnServer returns it directly, rather than being gated on the
+        // parent folder's syncTime via pendingWorkingSetChanges.
+        XCTAssertTrue(
+            reportedIds(observer).contains(file.identifier),
+            "A changed non-materialized child should surface even if the parent folder ETag did not change."
+        )
+    }
+
+    /// Scenario C (S1 headline — depth-1 limitation): a change to a grandchild file that lives under
+    /// a NON-materialized subdirectory of a visited folder. `checkMaterializedItemsOnServer` reads
+    /// the visited folder only at depth 1, so it sees the changed subdirectory but never reads the
+    /// grandchild; the grandchild's `syncTime` is never advanced and it is never reported — even
+    /// with a perfectly well-behaved server that bumped every ancestor ETag. (Reachable when a prior
+    /// recursive enumeration populated the grandchild while the subdirectory was never opened.)
+    /// Asserts the desired behaviour; a FAILURE localizes the depth-1 drop.
+    func testDeepChangeUnderNonMaterializedSubfolderIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let childFolder = makeFolder(name: "childFolder", parent: folder, etag: "child-v1")
+        let grandchild = makeFile(name: "itemX", parent: childFolder, etag: "itemX-v1")
+
+        seed(folder, visitedDirectory: true) // materialized
+        seed(childFolder, visitedDirectory: false) // NOT materialized
+        seed(grandchild, downloaded: false) // NOT materialized, but known in DB
+
+        // Well-behaved server: every ancestor ETag bumped along with the grandchild's change.
+        grandchild.versionIdentifier = "itemX-v2"
+        grandchild.modificationDate = Date()
+        childFolder.versionIdentifier = "child-v2"
+        folder.versionIdentifier = "folder-v2"
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        // Regression guard (S1 headline): checkMaterializedItemsOnServer now enqueues the changed
+        // subfolder and scans it, so the grandchild's change is discovered, persisted and reported
+        // rather than dropped behind the depth-1 read of the visited folder.
+        XCTAssertTrue(
+            reportedIds(observer).contains(grandchild.identifier),
+            "A change to a grandchild under a non-materialized subfolder should surface in the working set."
+        )
+    }
+
+    /// S4: the change-detection predicate `isInSameDatabaseStoreableRemoteState` keys on ETag (+ a
+    /// fixed field set). If a file's content changes but its ETag is unchanged, the predicate treats
+    /// it as unchanged and the update is skipped. Real servers bump the ETag on content change, so
+    /// this documents the predicate's reliance on a correct ETag rather than a likely field bug.
+    func testSameEtagContentChangeIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let file = makeFile(name: "itemA", parent: folder, etag: "itemA-v1", data: Data([1, 2, 3]))
+
+        seed(folder, visitedDirectory: true)
+        seed(file, downloaded: false)
+
+        // Content (and parent ETag) change, but the file's own ETag and date are unchanged.
+        file.data = Data([9, 9, 9, 9, 9, 9])
+        folder.versionIdentifier = "folder-v2"
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        // Regression guard (S4): isInSameDatabaseStoreableRemoteState now also compares `size`, so a
+        // content change is detected even if the server returned a stale/unchanged ETag and date.
+        XCTAssertTrue(
+            reportedIds(observer).contains(file.identifier),
+            "A content change should surface; if it does not, the report depends entirely on a correct server ETag."
+        )
+    }
+
+    /// S3 (push gate): on notify_push servers `processFileIdsChanged` signals the working set when at
+    /// least one received fileId is locally known (`containsAnyItemMetadata`). The server propagates
+    /// a change's ETag up every ancestor to the user's root, so a `notify_file_id` for a newly-created
+    /// item also carries its PARENT folder's fileId (and ancestors) — all of which the client has
+    /// enumerated. The gate therefore matches and the new item triggers a refresh; it only ignores a
+    /// push whose ids are entirely outside the enumerated tree. See nextcloud/desktop#6430.
+    func testPushGateMatchesParentFolderOfNewItem() {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        // `MockRemoteItem.identifier` becomes both ocId and fileId; use a numeric id like the server.
+        folder.identifier = "1234"
+        seed(folder, visitedDirectory: true)
+
+        // A new child of folder 1234 has an id the client has never seen, but the server's parent-etag
+        // propagation means the push also carries the known parent folder id 1234 — so the gate matches
+        // and the new child is not dropped.
+        XCTAssertTrue(
+            Self.dbManager.containsAnyItemMetadata(fileIds: ["1234", "9001"]),
+            "A push carrying the (known) parent folder id must pass the gate so the new child surfaces."
+        )
+        // A push whose ids are all outside the enumerated tree affects nothing the working set tracks.
+        XCTAssertFalse(
+            Self.dbManager.containsAnyItemMetadata(fileIds: ["9001", "9002"]),
+            "A push with no locally known ids is correctly ignored."
+        )
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
