### PR TITLE
fix: parsing ] in ignore list in File Provider correctly

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/IgnoredFilesMatcher.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/IgnoredFilesMatcher.swift
@@ -8,8 +8,12 @@ public class IgnoredFilesMatcher {
     private let regexes: [NSRegularExpression]
 
     private static func patternToRegex(_ pattern: String, wildcardsMatchSlash: Bool) -> String {
-        let trimmed = pattern.trimmingCharacters(in: .whitespaces)
+        var trimmed = pattern.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return "a^" }
+        if trimmed.hasPrefix("]") {
+            trimmed.removeFirst()
+        }
+        guard !trimmed.isEmpty else { return "a^" }
 
         var regex = ""
         var i = trimmed.startIndex

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/IgnoredFilesMatcherTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/IgnoredFilesMatcherTests.swift
@@ -31,4 +31,12 @@ struct IgnoredFilesMatcherTests {
         #expect(!matcher.isExcluded("other/deep/file.txt"))
         #expect(!matcher.isExcluded("random.file"))
     }
+
+    @Test func excludeAndRemovePrefixMatchesDesktopTemporaryFiles() {
+        let matcher = IgnoredFilesMatcher(ignoreList: ["]*.~*"], log: FileProviderLogMock())
+
+        #expect(matcher.isExcluded(".testbestand.docx.~485bd8b"))
+        #expect(matcher.isExcluded("folder/.testbestand.docx.~485bd8b"))
+        #expect(!matcher.isExcluded("testbestand.docx"))
+    }
 }


### PR DESCRIPTION
The C++ forwarded that raw ignore pattern to Swift, but the Swift matcher treated the leading ] as a literal instead of the C++ meaning “exclude and remove”.

```
...
~*.tmp
]*.~*
...
```

this resulted in temporary office files like `.test.docx.~485bd8b` to be synced to the server.
Now they are ignored
<img width="394" height="79" alt="Bildschirmfoto 2026-06-29 um 14 05 13" src="https://github.com/user-attachments/assets/65661dc4-de86-4583-8e60-99a84c06419c" />
