### PR TITLE
chore: update craft cache

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     name: Linux Appimage Package
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.9.3-4
+    container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.9.3-5
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/craftmaster.ini
+++ b/craftmaster.ini
@@ -3,7 +3,7 @@
 [General]
 Branch = stable-4.0-qt-6.9.3
 CraftUrl = https://github.com/nextcloud/craft.git
-CraftRevision = 7a6af6465396c2271d3f4b49d5a4c13c052a3aeb
+CraftRevision = 22cf36e8e0b6d0091b6ced384650588ddd5ad0ea
 ShallowClone = False
 
 # Variables defined here override the default value
@@ -41,6 +41,7 @@ binary/mysql.useMariaDB = False
 libs/qt6.version = 6.9.3
 craft/craft-blueprints-kde.revision = stable-4.0
 libs/zlib.version = 1.3.1
+libs/openssl.version = 3.5.7
 
 [windows-msvc2022_64-cl]
 Packager/PackageType = NullsoftInstallerPackager
@@ -67,4 +68,4 @@ SIGN_PACKAGE = False
 
 [Custom_Variables_for_Brander]
 qtPath = /root/linux-gcc-x86_64
-dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.9.3-4
+dockerImage = ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.9.3-5


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
