### PR TITLE
fix(logs): prints the Qt platform name at startup

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -881,7 +881,8 @@ void Application::setupLogging()
                           << "locale:" << QLocale::system().name()
                           << "ui_lang:" << property("ui_lang")
                           << "version:" << _theme->version()
-                          << "os:" << Utility::platformName();
+                          << "os:" << Utility::platformName()
+                          << "platform:" << QApplication::platformName();
     qCInfo(lcApplication) << "Arguments:" << qApp->arguments();
 }
 

--- a/src/gui/infosettings.cpp
+++ b/src/gui/infosettings.cpp
@@ -27,7 +27,6 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
-#include <QRegularExpression>
 #include <QSizePolicy>
 #include <QUrl>
 
@@ -38,7 +37,6 @@ QString aboutTextForInfoPanel()
 {
     auto aboutText = Theme::instance()->about();
     Theme::replaceLinkColorStringBackgroundAware(aboutText);
-    aboutText.replace(QRegularExpression(QStringLiteral(R"( \(([^()]*)\)$)")), QStringLiteral("<br>(\\1)"));
     return aboutText;
 }
 }

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -459,13 +459,8 @@ Theme::Theme()
 
 QString Theme::developerStringInfo() const
 {
-    // Shorten Qt's OS name: "macOS Mojave (10.14)" -> "macOS"
-    const auto osStringList = Utility::platformName().split(QLatin1Char(' '));
-    const auto osName = osStringList.at(0);
-
-    const auto devString = QString(tr("%1 Desktop Client Version %2 (%3 running on %4)", "%1 is application name. %2 is the human version string. %3 is the operating system name. %4 is the platform name (wayland, x11, …)"))
-    .arg(APPLICATION_NAME, QString::fromLatin1(MIRALL_HUMAN_VERSION_STRING), osName, qGuiApp->platformName());
-
+    const auto devString = QString(tr("%1 Desktop Client Version %2", "%1 is application name. %2 is the human version string."))
+    .arg(APPLICATION_NAME, QString::fromLatin1(MIRALL_HUMAN_VERSION_STRING));
     return devString;
 }
 


### PR DESCRIPTION
should enable to know when users have linux/wayland instead of linux/x11

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
