### PR TITLE
Fix crash due to __FILEPROVIDER_OBSERVER_TOO_MANY_ITEMS__

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
@@ -1,0 +1,140 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+
+///
+/// A thread-safe FIFO buffer of change metadata still to be delivered to an
+/// `NSFileProviderChangeObserver` across the successive `enumerateChanges(for:from:)` invocations the
+/// framework drives with `moreComing: true`.
+///
+/// The framework asserts (`__FILEPROVIDER_OBSERVER_TOO_MANY_ITEMS__`) when a single batch reports more
+/// than 100× its suggested batch size — ≈20000 items for the default suggestion. Large change sets
+/// (especially the working set, which aggregates the whole reachable tree) must therefore be split
+/// across several batches, and the SDK resumes a split enumeration by *re-invoking* `enumerateChanges`
+/// with the anchor that the previous batch returned — there is one `finishEnumeratingChanges` per call.
+///
+/// The change derivation that feeds this buffer is **destructive**: the working-set scan
+/// (``Enumerator/scanMaterialisedItemsForRemoteChanges()``) and the depth-1 container read both persist
+/// the discovered creations and updates (matching etags) to the local database as they run, so
+/// re-deriving on a continuation invocation would surface (almost) no created/updated items and that
+/// undelivered remainder would be silently dropped. The buffer therefore holds the full derived change
+/// set after a single derivation and hands it out one batch at a time; the derivation never runs again
+/// while the buffer stays primed for the same sync anchor.
+///
+/// Durability: the buffer is in memory. Within a normal `moreComing` chain the framework reuses the same
+/// ``Enumerator`` instance, so the remainder survives. If the extension process is recycled mid-drain (only
+/// reachable for change sets larger than ``Enumerator/maxBatchSize``), a fresh instance re-derives from the
+/// original anchor: undelivered **deletions** are recovered (their soft-deleted rows persist with a fresh
+/// `syncTime` until ``FilesDatabaseManager/removeItemMetadata(ocId:)`` runs after delivery, and the
+/// working-set re-derivation re-surfaces them via `pendingWorkingSetChanges(since:)`), but undelivered
+/// **created/updated** items can be lost — for a regular container entirely, and for the working set when
+/// the item is not materialised. This replaces a guaranteed crash with a rare, bounded partial loss.
+///
+/// ``Enumerator`` is `Sendable` with only immutable members, so the mutable delivery state lives behind
+/// this `@unchecked Sendable`, `NSLock`-guarded box — the established concurrency idiom in this target
+/// (see `FileProviderExtension.actionsLock`). `Synchronization.Mutex` is unavailable because the
+/// deployment target is macOS 13.
+///
+final class ChangeDeliveryBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private let logger: FileProviderLogger
+    private var anchorKey: String?
+    private var remainingUpdated: [SendableItemMetadata] = []
+    private var remainingDeleted: [SendableItemMetadata] = []
+
+    init(log: any FileProviderLogging) {
+        logger = FileProviderLogger(category: "ChangeDeliveryBuffer", log: log)
+    }
+
+    ///
+    /// Whether a derivation has already filled the buffer for the given sync-anchor key and changes are
+    /// still waiting to be delivered. A continuation invocation that sees `true` must drain rather than
+    /// re-derive.
+    ///
+    func isPrimed(forKey key: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return anchorKey == key
+    }
+
+    ///
+    /// Store the full derived change set for a drain sequence, keyed by the originating sync anchor.
+    ///
+    /// `updated` must already be sorted parents-before-children (ascending remote-path length) so that
+    /// draining the single combined list front-to-back never reports a child in an earlier batch than
+    /// its parent.
+    ///
+    func prime(key: String, updated: [SendableItemMetadata], deleted: [SendableItemMetadata]) {
+        lock.lock()
+        defer { lock.unlock() }
+        anchorKey = key
+        remainingUpdated = updated
+        remainingDeleted = deleted
+        logger.debug(
+            "Primed change delivery buffer. anchor: \(key), updated: \(updated.count), deleted: \(deleted.count)"
+        )
+    }
+
+    ///
+    /// Pop the next batch, budgeting updates and deletions *together* against `maxItems` so the combined
+    /// `didUpdate` + `didDeleteItems` payload of a single `finishEnumeratingChanges` stays under the cap.
+    /// Updates are drained before deletions, preserving the parent-before-child ordering of the updates.
+    ///
+    /// `moreComing` reflects whether anything is still buffered *after* this batch (so an exactly-full
+    /// final batch does not provoke a spurious empty follow-up). The key is cleared once both lists drain,
+    /// so a later signal starts a fresh derivation.
+    ///
+    func takeBatch(
+        maxItems: Int
+    ) -> (updated: [SendableItemMetadata], deleted: [SendableItemMetadata], moreComing: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let key = anchorKey ?? "nil"
+        let budget = max(1, maxItems)
+
+        let updatedCount = Swift.min(remainingUpdated.count, budget)
+        let batchUpdated = Array(remainingUpdated.prefix(updatedCount))
+        remainingUpdated.removeFirst(updatedCount)
+
+        let deletedCount = Swift.min(remainingDeleted.count, budget - updatedCount)
+        let batchDeleted = Array(remainingDeleted.prefix(deletedCount))
+        remainingDeleted.removeFirst(deletedCount)
+
+        let moreComing = !remainingUpdated.isEmpty || !remainingDeleted.isEmpty
+        if !moreComing {
+            anchorKey = nil
+        }
+
+        logger.debug(
+            "Drained change batch. anchor: \(key), maxItems: \(budget), tookUpdated: \(updatedCount), tookDeleted: \(deletedCount), remainingUpdated: \(remainingUpdated.count), remainingDeleted: \(remainingDeleted.count), moreComing: \(moreComing)"
+        )
+
+        return (batchUpdated, batchDeleted, moreComing)
+    }
+
+    ///
+    /// Discard any buffered state. Used when a fresh enumeration arrives under a different anchor than
+    /// the one the buffer was primed for, so a stale remainder is never served against a new sync point.
+    ///
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        let previousKey = anchorKey
+        let discardedUpdated = remainingUpdated.count
+        let discardedDeleted = remainingDeleted.count
+
+        anchorKey = nil
+        remainingUpdated = []
+        remainingDeleted = []
+
+        // A non-empty discard means an in-progress drain was abandoned (a fresh enumeration arrived under
+        // a different anchor). Log it loudly enough to spot potential change loss from a debug archive.
+        if discardedUpdated > 0 || discardedDeleted > 0 {
+            logger.info(
+                "Reset change delivery buffer, discarding undelivered remainder. anchor: \(previousKey ?? "nil"), discardedUpdated: \(discardedUpdated), discardedDeleted: \(discardedDeleted)"
+            )
+        }
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ChangeEnumeration.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ChangeEnumeration.swift
@@ -23,12 +23,29 @@ extension Enumerator {
     ) {
         logger.info("Enumerating changes in item.", [.url: serverUrl])
 
+        let anchorKey = String(data: anchor.rawValue, encoding: .utf8) ?? ""
+
         // No matter what happens here we finish enumeration in some way, either from the error
-        // handling below or from the completeChangesObserver.
+        // handling below or from draining the change buffer.
         Task { [weak self] in
             guard let self else {
                 return
             }
+
+            // Continuation of an in-progress drain: serve the next buffered batch without re-reading
+            // the container (the depth-1 read is destructive, so re-deriving would lose the remainder).
+            // A regular container preserves its incoming anchor, so startAnchor and finalAnchor match.
+            if changeBuffer.isPrimed(forKey: anchorKey) {
+                logger.debug("Container change buffer primed for anchor \(anchorKey); draining next batch without re-reading.", [.url: serverUrl])
+                drainChangeBuffer(
+                    for: observer,
+                    startAnchor: anchor,
+                    finalAnchor: anchor,
+                    suggested: observer.suggestedBatchSize
+                )
+                return
+            }
+            changeBuffer.reset()
 
             let readResult = await Self.readServerUrl(
                 serverUrl,
@@ -61,14 +78,16 @@ extension Enumerator {
                         dbManager.deleteItemMetadata(ocId: itemMetadata.ocId)
                     }
 
-                    completeChangesObserver(
+                    // A single deletion — small enough to report directly without buffering.
+                    completeChangesBatch(
                         observer,
+                        updated: [],
+                        deleted: [itemMetadata],
                         anchor: anchor,
-                        enumeratedItemIdentifier: enumeratedItemIdentifier,
+                        moreComing: false,
                         account: account,
                         remoteInterface: remoteInterface,
-                        dbManager: dbManager,
-                        changes: ChangeSet(deleted: [itemMetadata])
+                        dbManager: dbManager
                     )
                     return
                 } else if readError!.isNoChangesError { // All is well, just no changed etags
@@ -92,14 +111,18 @@ extension Enumerator {
 
             logger.info("Finished reading remote changes.", [.account: account.ncKitAccount, .url: serverUrl])
 
-            completeChangesObserver(
-                observer,
-                anchor: anchor,
-                enumeratedItemIdentifier: enumeratedItemIdentifier,
-                account: account,
-                remoteInterface: remoteInterface,
-                dbManager: dbManager,
-                changes: changes
+            // Sort created+updated parents-before-children (see completeChangesBatch) and buffer the
+            // full set so it can be delivered one batch at a time across the framework's moreComing
+            // re-invocations without exceeding the per-batch limit.
+            let sortedUpdated = changes.createdAndUpdated
+                .sorted { $0.remotePath().count < $1.remotePath().count }
+            changeBuffer.prime(key: anchorKey, updated: sortedUpdated, deleted: changes.deleted)
+
+            drainChangeBuffer(
+                for: observer,
+                startAnchor: anchor,
+                finalAnchor: anchor,
+                suggested: observer.suggestedBatchSize
             )
         }
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ItemEnumeration.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ItemEnumeration.swift
@@ -14,17 +14,44 @@ extension Enumerator {
     /// Enumerate the working set: the items the system keeps track of, i.e. visited folders and
     /// downloaded files, read straight from the local database.
     ///
-    func enumerateWorkingSetItems(for observer: NSFileProviderEnumerationObserver) {
+    func enumerateWorkingSetItems(
+        for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage
+    ) {
         logger.info("Upcoming enumeration is of working set.")
-        // Visited folders and downloaded files.
+
+        // Visited folders and downloaded files, read straight from the local database. The materialised
+        // set can be large, so report it one page at a time to stay under the framework's per-page limit.
+        // Sort by a stable key (ocId) so the offset cursor stays consistent across the paginated
+        // re-invocations the framework drives; the read itself is non-destructive, so re-reading and
+        // slicing on each page needs no cross-call buffer.
         let materialisedItems = dbManager.materialisedItemMetadatas(account: account.ncKitAccount)
             .filter { !$0.deleted }
-        completeEnumerationObserver(observer, nextPage: nil, itemMetadatas: materialisedItems)
+            .sorted { $0.ocId < $1.ocId }
+
+        let offset = Self.itemPageOffset(from: page)
+        let pageSize = effectiveBatchSize(suggested: observer.suggestedPageSize)
+        let start = min(offset, materialisedItems.count)
+        let end = min(start + pageSize, materialisedItems.count)
+        let pageItems = Array(materialisedItems[start ..< end])
+        let nextPage = end < materialisedItems.count ? Self.itemPage(forOffset: end) : nil
+
+        logger.debug(
+            "Enumerating working-set items page. offset: \(offset), pageSize: \(pageSize), pageItems: \(pageItems.count), totalMaterialised: \(materialisedItems.count), hasNextPage: \(nextPage != nil)",
+            [.account: account.ncKitAccount]
+        )
+
+        completeEnumerationObserver(observer, nextPage: nextPage, itemMetadatas: pageItems)
     }
 
     ///
     /// Enumerate the direct children of a regular directory container by reading it from the server,
     /// paginating when the server supports it.
+    ///
+    /// - Note: On servers older than Nextcloud 31 the read is not server-paginated and all direct
+    ///   children are reported in one page. A single directory with more than ~100× the suggested page
+    ///   size of *direct* children could in theory still hit the framework's per-page limit there. This
+    ///   is left unhandled for now: the supported (Nextcloud 31+) path paginates, and the working-set
+    ///   item path — the realistic large-listing case — is paged in ``enumerateWorkingSetItems(for:startingAt:)``.
     ///
     func enumerateContainerItems(
         for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage
@@ -111,7 +138,18 @@ extension Enumerator {
                 """
             )
 
-            completeEnumerationObserver(observer, nextPage: nextPage, itemMetadatas: items)
+            // completeEnumerationObserver finishes on an already-encoded page, so serialise the server's
+            // pagination cursor here (nil ends the enumeration). Each server page is already bounded by
+            // pageItemCount, so it stays under the framework's per-page limit.
+            let rawNextPage: NSFileProviderPage?
+            if let nextPage, let nextPageData = try? JSONEncoder().encode(nextPage) {
+                logger.info("Next page: \(String(data: nextPageData, encoding: .utf8) ?? "?")")
+                rawNextPage = NSFileProviderPage(nextPageData)
+            } else {
+                rawNextPage = nil
+            }
+
+            completeEnumerationObserver(observer, nextPage: rawNextPage, itemMetadatas: items)
         }
     }
 
@@ -138,5 +176,32 @@ extension Enumerator {
         }
 
         return (index: response.index, total: response.total, page: page)
+    }
+
+    ///
+    /// The offset a client-paginated item enumeration should resume from.
+    ///
+    /// Used by the item paths that read the whole listing into memory and page over it locally (the
+    /// working set; see ``enumerateWorkingSetItems(for:startingAt:)``). The cursor is the decimal offset
+    /// encoded as UTF-8 — tiny (well under the 500-byte page limit) and never failing to encode. The
+    /// framework's opaque initial pages, and anything that is not a non-negative decimal, map to offset `0`.
+    ///
+    static func itemPageOffset(from page: NSFileProviderPage) -> Int {
+        guard page != NSFileProviderPage.initialPageSortedByName as NSFileProviderPage,
+              page != NSFileProviderPage.initialPageSortedByDate as NSFileProviderPage,
+              let text = String(data: page.rawValue, encoding: .utf8),
+              let offset = Int(text), offset >= 0
+        else {
+            return 0
+        }
+        return offset
+    }
+
+    ///
+    /// Encode a continuation page for a client-paginated item enumeration. Encoding a decimal offset
+    /// cannot fail, so this never silently truncates the enumeration.
+    ///
+    static func itemPage(forOffset offset: Int) -> NSFileProviderPage {
+        NSFileProviderPage(Data(String(offset).utf8))
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
@@ -10,9 +10,16 @@ import NextcloudKit
 /// when an item's parent identifier is not yet known locally.
 ///
 extension Enumerator {
+    ///
+    /// Report one page of items to the enumeration observer and finish on the given continuation page.
+    ///
+    /// Callers paginate: each invocation passes a single page's worth of `itemMetadatas` together with the
+    /// already-encoded `nextPage` to continue from (`nil` ends the enumeration). Keeping each page under
+    /// the framework's per-page limit is the caller's responsibility — see ``effectiveBatchSize(suggested:)``.
+    ///
     func completeEnumerationObserver(
         _ observer: NSFileProviderEnumerationObserver,
-        nextPage: EnumeratorPageResponse?,
+        nextPage: NSFileProviderPage?,
         itemMetadatas: [SendableItemMetadata],
         handleInvalidParent: Bool = true
     ) {
@@ -25,13 +32,7 @@ extension Enumerator {
                 Task { @MainActor in
                     observer.didEnumerate(items)
                     logger.info("Did enumerate \(items.count) items. Next page is nil: \(nextPage == nil)")
-
-                    if let nextPage, let nextPageData = try? JSONEncoder().encode(nextPage) {
-                        logger.info("Next page: \(String(data: nextPageData, encoding: .utf8) ?? "?")")
-                        observer.finishEnumerating(upTo: NSFileProviderPage(nextPageData))
-                    } else {
-                        observer.finishEnumerating(upTo: nil)
-                    }
+                    observer.finishEnumerating(upTo: nextPage)
                 }
             } catch let error as NSError { // This error can only mean a missing parent item identifier
                 guard handleInvalidParent else {
@@ -61,61 +62,123 @@ extension Enumerator {
         }
     }
 
-    func completeChangesObserver(
+    ///
+    /// Pop the next batch from ``changeBuffer`` and report it.
+    ///
+    /// Intermediate batches (`moreComing == true`) return `startAnchor` — the anchor the enumeration was
+    /// invoked with — so that if the drain is interrupted the framework resumes *behind* every
+    /// undelivered item rather than advancing the sync point past changes still sitting in the buffer.
+    /// Only the final batch returns `finalAnchor` (the working set advances to ``currentAnchor``; a
+    /// regular container preserves its incoming anchor).
+    ///
+    func drainChangeBuffer(
+        for observer: NSFileProviderChangeObserver,
+        startAnchor: NSFileProviderSyncAnchor,
+        finalAnchor: NSFileProviderSyncAnchor,
+        suggested: Int?
+    ) {
+        let batch = changeBuffer.takeBatch(maxItems: effectiveBatchSize(suggested: suggested))
+        logger.info(
+            "Reporting change batch. updated: \(batch.updated.count), deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)",
+            [.item: enumeratedItemIdentifier]
+        )
+        completeChangesBatch(
+            observer,
+            updated: batch.updated,
+            deleted: batch.deleted,
+            anchor: batch.moreComing ? startAnchor : finalAnchor,
+            moreComing: batch.moreComing,
+            account: account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
+        )
+    }
+
+    ///
+    /// Report one already-sized batch of changes to the change observer and finish the batch.
+    ///
+    /// `updated` and `deleted` are a single batch's worth of metadata (kept under the framework's per-batch
+    /// limit by the caller via ``effectiveBatchSize(suggested:)``). The file-provider framework does not
+    /// distinguish created from updated items, so both arrive through `updated`; it must already be sorted
+    /// parents-before-children. A deleted item's database row is removed only once *its* batch has been
+    /// delivered, so a batch still waiting in the ``changeBuffer`` keeps its rows for re-derivation should
+    /// the drain be interrupted. The missing-parent recovery mirrors ``completeEnumerationObserver`` and is
+    /// scoped to this batch.
+    ///
+    func completeChangesBatch(
         _ observer: NSFileProviderChangeObserver,
+        updated: [SendableItemMetadata],
+        deleted: [SendableItemMetadata],
         anchor: NSFileProviderSyncAnchor,
-        enumeratedItemIdentifier: NSFileProviderItemIdentifier,
+        moreComing: Bool,
         account: Account,
         remoteInterface: RemoteInterface,
-        dbManager: FilesDatabaseManager,
-        changes: ChangeSet,
-        handleInvalidParent: Bool = true
+        dbManager: FilesDatabaseManager
     ) {
-        logger.info("Completing change observation...")
+        let deletedFileProviderItemIdentifiers = deleted.map { NSFileProviderItemIdentifier($0.ocId) }
 
-        for metadata in changes.created {
-            logger.debug("Got added metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
+        // Per-item trace so a debug archive can reconstruct exactly which items each batch carried.
+        for metadata in updated {
+            logger.debug("Reporting updated item in change batch.", [.item: metadata.ocId, .name: metadata.fileName])
         }
 
-        for metadata in changes.updated {
-            logger.debug("Got updated metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
+        for metadata in deleted {
+            logger.debug("Reporting deleted item in change batch.", [.item: metadata.ocId, .name: metadata.fileName])
         }
 
-        for metadata in changes.deleted {
-            logger.debug("Got deleted metadata to report.", [.item: metadata.ocId, .name: metadata.fileName])
-        }
-
-        // The file provider framework does not differentiate between newly added and updated items, hence the collections are merged.
-        // Sort by remote path length (ascending) so parent directories are always reported before
-        // their children. Without this ordering, macOS may create the rename-destination folder to
-        // house a child item before it processes the parent directory rename, leaving both the old
-        // and new folder name visible on disk simultaneously.
-        let newAndUpdatedMetadatas: [SendableItemMetadata] = changes.createdAndUpdated
-            .sorted { $0.remotePath().count < $1.remotePath().count }
-
-        let deletedMetadatas = changes.deleted
-        let deletedFileProviderItemIdentifiers = Array(deletedMetadatas.map {
-            NSFileProviderItemIdentifier($0.ocId)
-        })
-
+        // Report deletions once, here — not inside the update path, so the invalid-parent retry below
+        // does not re-issue them.
         if deletedFileProviderItemIdentifiers.isEmpty == false {
             observer.didDeleteItems(withIdentifiers: deletedFileProviderItemIdentifiers)
         }
 
-        Task { [newAndUpdatedMetadatas, deletedMetadatas] in
+        reportBatchUpdates(
+            observer,
+            updated: updated,
+            deletedToRemove: deleted,
+            anchor: anchor,
+            moreComing: moreComing,
+            account: account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
+        )
+    }
+
+    ///
+    /// Convert this batch's `updated` metadata to items, report them, finish the batch, and hard-remove
+    /// the delivered deletions from the database. On a missing-parent error it recovers the parent and
+    /// retries the conversion once — deletions are already reported by ``completeChangesBatch`` and are
+    /// not re-issued here.
+    ///
+    private func reportBatchUpdates(
+        _ observer: NSFileProviderChangeObserver,
+        updated: [SendableItemMetadata],
+        deletedToRemove: [SendableItemMetadata],
+        anchor: NSFileProviderSyncAnchor,
+        moreComing: Bool,
+        account: Account,
+        remoteInterface: RemoteInterface,
+        dbManager: FilesDatabaseManager,
+        handleInvalidParent: Bool = true
+    ) {
+        Task { [updated, deletedToRemove] in
             do {
-                let updatedItems = try await newAndUpdatedMetadatas.toFileProviderItems(account: account, remoteInterface: remoteInterface, dbManager: dbManager, log: self.logger.log)
+                let updatedItems = try await updated.toFileProviderItems(account: account, remoteInterface: remoteInterface, dbManager: dbManager, log: self.logger.log)
 
                 Task { @MainActor in
                     if !updatedItems.isEmpty {
                         observer.didUpdate(updatedItems)
                     }
 
-                    observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
-
-                    for metadata in deletedMetadatas {
+                    // Hard-remove delivered deletions before finishing the batch: the items are already
+                    // reported (didDeleteItems ran in completeChangesBatch), and doing the DB write before
+                    // finishEnumeratingChanges keeps the database consistent with what the observer has
+                    // been told by the time the batch is acknowledged.
+                    for metadata in deletedToRemove {
                         dbManager.removeItemMetadata(ocId: metadata.ocId)
                     }
+
+                    observer.finishEnumeratingChanges(upTo: anchor, moreComing: moreComing)
                 }
             } catch let error as NSError { // This error can only mean a missing parent item identifier
                 guard handleInvalidParent else {
@@ -134,25 +197,23 @@ extension Enumerator {
                         dbManager: dbManager
                     )
 
-                    var recoveredChanges = changes
-                    recoveredChanges.created.append(metadata)
-
-                    completeChangesObserver(
+                    // Prepend the recovered parent so it keeps the parent-before-child ordering within
+                    // this batch, then retry once with recovery disabled.
+                    reportBatchUpdates(
                         observer,
+                        updated: [metadata] + updated,
+                        deletedToRemove: deletedToRemove,
                         anchor: anchor,
-                        enumeratedItemIdentifier: enumeratedItemIdentifier,
+                        moreComing: moreComing,
                         account: account,
                         remoteInterface: remoteInterface,
                         dbManager: dbManager,
-                        changes: recoveredChanges,
                         handleInvalidParent: false
                     )
                 } catch {
                     observer.finishEnumeratingWithError(error)
                 }
             }
-
-            logger.info("Completed change observation.")
         }
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
@@ -6,29 +6,37 @@ import NextcloudKit
 
 extension Enumerator {
     ///
-    /// Change enumeration completion.
+    /// Pop the next batch of trash deletions from ``changeBuffer`` and report it.
     ///
-    /// `NKTrash` items do not have an ETag. We assume they cannot be modified while they are in the trash. So we will just check by their `ocId`.
-    /// Newly added items by deletion on the server side or another client are not of interest and we do not want to display them in the local trash.
-    /// In the end, only the remotely and permanently deleted items are of interest.
+    /// `NKTrash` items have no ETag; the only trash change of interest is a *permanent* remote deletion,
+    /// detected as a local trash row absent from the remote listing. Those orphans are derived once (see
+    /// ``enumerateTrashChanges(for:anchor:)``) and drained here one capped batch per invocation so a large
+    /// permanent-purge cannot exceed the framework's per-batch limit. Trash preserves its incoming anchor
+    /// (like a regular container), so the same anchor is returned on every batch. Each delivered orphan is
+    /// soft-deleted (`deleteItemMetadata`) only after its batch finishes, so an interrupted drain keeps its
+    /// row — the reconciliation re-derives it (the row still carries a trash `serverUrl`) rather than
+    /// dropping it.
     ///
-    static func completeChangesObserver(_ observer: NSFileProviderChangeObserver, anchor: NSFileProviderSyncAnchor, account: Account, dbManager: FilesDatabaseManager, remoteTrashItems: [NKTrash], log: any FileProviderLogging) async {
-        let logger = FileProviderLogger(category: "Enumerator", log: log)
-        let localIdentifiers = dbManager.trashedItemMetadatas(account: account).map(\.ocId)
-        let localSet = Set(localIdentifiers)
-        let remoteIdentifiers = remoteTrashItems.map(\.ocId)
-        let remoteSet = Set(remoteIdentifiers)
-        let orphanedSet = localSet.subtracting(remoteSet)
-        let orphanedIdentifiers = orphanedSet.map { NSFileProviderItemIdentifier($0) }
+    private func drainTrashDeletions(
+        for observer: NSFileProviderChangeObserver, anchor: NSFileProviderSyncAnchor, suggested: Int?
+    ) {
+        let batch = changeBuffer.takeBatch(maxItems: effectiveBatchSize(suggested: suggested))
+        let orphanedIdentifiers = batch.deleted.map { NSFileProviderItemIdentifier($0.ocId) }
 
-        for identifier in orphanedSet {
-            logger.info("Permanently deleting remote trash item which could not be matched with a local one.", [.item: identifier])
-            dbManager.deleteItemMetadata(ocId: identifier)
+        if orphanedIdentifiers.isEmpty == false {
+            observer.didDeleteItems(withIdentifiers: orphanedIdentifiers)
         }
 
-        observer.didDeleteItems(withIdentifiers: orphanedIdentifiers)
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
-        logger.debug("Finished enumerating remote changes in trash.")
+        // Soft-delete delivered orphans before finishing the batch: they are already reported
+        // (didDeleteItems above), and writing the DB before finishEnumeratingChanges keeps the local
+        // state consistent with what the observer has been told by the time the batch is acknowledged.
+        for metadata in batch.deleted {
+            dbManager.deleteItemMetadata(ocId: metadata.ocId)
+        }
+
+        observer.finishEnumeratingChanges(upTo: anchor, moreComing: batch.moreComing)
+
+        logger.debug("Reported trash deletion batch. deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)")
     }
 
     ///
@@ -68,17 +76,28 @@ extension Enumerator {
     }
 
     ///
-    /// Change enumeration of the trash container: list the remote trash and let
-    /// ``completeChangesObserver(_:anchor:account:dbManager:remoteTrashItems:log:)`` reconcile it
-    /// against the local trash to report permanently-deleted items.
+    /// Change enumeration of the trash container: list the remote trash, reconcile it against the local
+    /// trash to find permanently-deleted (orphaned) items, buffer them, and drain them one capped batch
+    /// at a time via ``drainTrashDeletions(for:anchor:suggested:)``.
     ///
     func enumerateTrashChanges(for observer: NSFileProviderChangeObserver, anchor: NSFileProviderSyncAnchor) {
         logger.debug("Enumerating changes in trash.", [.account: account.ncKitAccount])
+
+        let anchorKey = String(data: anchor.rawValue, encoding: .utf8) ?? ""
 
         Task { [weak self] in
             guard let self else {
                 return
             }
+
+            // Continuation of an in-progress drain: serve the next buffered batch without re-listing the
+            // remote trash (re-deriving after per-batch soft-deletes would re-report the wrong subset).
+            if changeBuffer.isPrimed(forKey: anchorKey) {
+                logger.debug("Trash change buffer primed for anchor \(anchorKey); draining next batch without re-listing.", [.account: account.ncKitAccount])
+                drainTrashDeletions(for: observer, anchor: anchor, suggested: observer.suggestedBatchSize)
+                return
+            }
+            changeBuffer.reset()
 
             let (_, capabilities, _, error) = await remoteInterface.currentCapabilities(account: account)
 
@@ -122,14 +141,18 @@ extension Enumerator {
                 return
             }
 
-            await Self.completeChangesObserver(
-                observer,
-                anchor: anchor,
-                account: account,
-                dbManager: dbManager,
-                remoteTrashItems: trashedItems ?? [],
-                log: logger.log
-            )
+            // Orphans = local trash rows absent from the remote trash listing = permanently deleted
+            // remotely. Derive once, then drain in batches.
+            let remoteSet = Set((trashedItems ?? []).map(\.ocId))
+            let orphans = dbManager.trashedItemMetadatas(account: account)
+                .filter { !remoteSet.contains($0.ocId) }
+
+            for orphan in orphans {
+                logger.info("Permanently deleting remote trash item which could not be matched with a local one.", [.item: orphan.ocId])
+            }
+
+            changeBuffer.prime(key: anchorKey, updated: [], deleted: orphans)
+            drainTrashDeletions(for: observer, anchor: anchor, suggested: observer.suggestedBatchSize)
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -19,26 +19,50 @@ extension Enumerator {
     /// server scan is what surfaces remote changes the database-only reconstruction misses:
     /// non-materialised items, and items whose own parent directory did not itself change.
     ///
-    func enumerateWorkingSetChanges(for observer: NSFileProviderChangeObserver, since date: Date) {
+    func enumerateWorkingSetChanges(
+        for observer: NSFileProviderChangeObserver, since date: Date, anchor: NSFileProviderSyncAnchor
+    ) {
         logger.debug("Enumerating changes in working set.", [.account: account])
 
+        let anchorKey = String(data: anchor.rawValue, encoding: .utf8) ?? ""
+
         Task {
-            let serverChanges = await scanMaterialisedItemsForRemoteChanges()
-            let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
+            // Derive the change set once per drain sequence. The scan is destructive — it persists its
+            // discoveries to the database as it recurses — so on the framework's moreComing
+            // re-invocations we must drain the buffer rather than re-derive, or every change beyond the
+            // first batch is silently dropped.
+            if !changeBuffer.isPrimed(forKey: anchorKey) {
+                // A re-invocation under a *different* anchor is a fresh enumeration; drop any stale
+                // remainder before deriving anew.
+                changeBuffer.reset()
+                logger.debug("Working-set change buffer not primed for anchor \(anchorKey); deriving changes.", [.account: account])
 
-            let changes = ChangeSet(
-                mergingUpdated: [serverChanges.updated, pendingLocalChanges.updated],
-                deleted: [serverChanges.deleted, pendingLocalChanges.deleted]
-            )
+                let serverChanges = await scanMaterialisedItemsForRemoteChanges()
+                let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
 
-            completeChangesObserver(
-                observer,
-                anchor: currentAnchor,
-                enumeratedItemIdentifier: enumeratedItemIdentifier,
-                account: account,
-                remoteInterface: remoteInterface,
-                dbManager: dbManager,
-                changes: changes
+                let changes = ChangeSet(
+                    mergingUpdated: [serverChanges.updated, pendingLocalChanges.updated],
+                    deleted: [serverChanges.deleted, pendingLocalChanges.deleted]
+                )
+
+                // Sort created+updated by remote-path length (ascending) so parent directories are
+                // reported before their children. Draining the single combined list front-to-back
+                // preserves this across batches; without it macOS may create a rename-destination folder
+                // to house a child before it processes the parent rename, briefly leaving both the old
+                // and new folder names on disk.
+                let sortedUpdated = changes.createdAndUpdated
+                    .sorted { $0.remotePath().count < $1.remotePath().count }
+
+                changeBuffer.prime(key: anchorKey, updated: sortedUpdated, deleted: changes.deleted)
+            }
+
+            // Intermediate batches keep the original anchor so an interrupted drain resumes behind all
+            // undelivered items; the final batch advances the working-set sync point to currentAnchor.
+            drainChangeBuffer(
+                for: observer,
+                startAnchor: anchor,
+                finalAnchor: currentAnchor,
+                suggested: observer.suggestedBatchSize
             )
         }
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -51,6 +51,29 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     let remoteInterface: RemoteInterface
     let serverUrl: String
 
+    /// Holds the undelivered remainder of a large change set so it can be reported one batch at a time
+    /// across the framework's `moreComing` re-invocations without re-running the destructive derivation.
+    /// See ``ChangeDeliveryBuffer`` and ``drainChangeBuffer(for:startAnchor:finalAnchor:suggested:)``.
+    ///
+    /// Load-bearing assumption: the framework continues a `moreComing` chain on the *same* enumerator
+    /// instance, re-invoking `enumerateChanges(for:from:)` with the anchor the previous batch returned
+    /// (see `NSFileProviderEnumerating.h`, `currentSyncAnchorWithCompletionHandler`). The in-memory
+    /// buffer therefore survives the chain. If the extension process is recycled mid-drain, a fresh
+    /// instance re-derives from the original anchor; see ``ChangeDeliveryBuffer`` for the bounded
+    /// created/updated loss this can cause for change sets larger than ``maxBatchSize``.
+    let changeBuffer: ChangeDeliveryBuffer
+
+    /// Default number of items reported per page/batch when the system does not suggest one. Mirrors the
+    /// per-page item budget used for paginated item enumeration (``pageItemCount``).
+    static let defaultBatchSize = 1000
+
+    /// Hard ceiling on the items reported in a single page/batch. The framework asserts past 100× the
+    /// system's suggested size (≈20000 for the default suggestion of 200, which is the limit the
+    /// `__FILEPROVIDER_OBSERVER_TOO_MANY_ITEMS__` crash hit); staying well under that avoids the assertion
+    /// while keeping batch counts low. It also leaves headroom for the single recovered-parent item that
+    /// invalid-parent recovery may prepend to a batch.
+    static let maxBatchSize = 4000
+
     private static func isSystemIdentifier(_ identifier: NSFileProviderItemIdentifier) -> Bool {
         identifier == .rootContainer || identifier == .trashContainer || identifier == .workingSet
     }
@@ -71,6 +94,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         self.domain = domain
         pageItemCount = pageSize
         logger = FileProviderLogger(category: "Enumerator", log: log)
+        changeBuffer = ChangeDeliveryBuffer(log: log)
 
         if Self.isSystemIdentifier(enumeratedItemIdentifier) {
             logger.info("Providing enumerator for a system defined container.", [.item: enumeratedItemIdentifier])
@@ -96,6 +120,19 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         logger.debug("Enumerator is being invalidated.", [.item: enumeratedItemIdentifier, .name: enumeratedItemMetadata?.fileName])
     }
 
+    ///
+    /// Resolve how many items to report per page/batch from the observer's system-set suggestion,
+    /// falling back to ``defaultBatchSize`` when the system did not set one and clamping to
+    /// ``maxBatchSize``.
+    ///
+    /// `suggestedBatchSize` / `suggestedPageSize` are optional observer properties the system sets to the
+    /// value best suited to the current enumeration; they surface as `nil` (or `0`) when unset.
+    ///
+    func effectiveBatchSize(suggested: Int?) -> Int {
+        let base = suggested.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultBatchSize
+        return min(base, Self.maxBatchSize)
+    }
+
     // MARK: - Protocol methods
 
     public func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
@@ -104,7 +141,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         if enumeratedItemIdentifier == .trashContainer {
             enumerateTrashItems(for: observer)
         } else if enumeratedItemIdentifier == .workingSet {
-            enumerateWorkingSetItems(for: observer)
+            enumerateWorkingSetItems(for: observer, startingAt: page)
         } else {
             enumerateContainerItems(for: observer, startingAt: page)
         }
@@ -121,7 +158,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         }
 
         if enumeratedItemIdentifier == .workingSet {
-            enumerateWorkingSetChanges(for: observer, since: anchorDate)
+            enumerateWorkingSetChanges(for: observer, since: anchorDate, anchor: anchor)
         } else if enumeratedItemIdentifier == .trashContainer {
             enumerateTrashChanges(for: observer, anchor: anchor)
         } else {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
@@ -8,8 +8,19 @@ import NextcloudFileProviderKit
 public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
     public var changedItems: [any NSFileProviderItemProtocol] = []
     public var deletedItemIdentifiers: [NSFileProviderItemIdentifier] = []
+    /// Every `finishEnumeratingChanges` call recorded as `(anchor, moreComing)`, in order, so tests can
+    /// assert the batching behaviour (intermediate vs final anchors, batch count).
+    public private(set) var finishes: [(anchor: NSFileProviderSyncAnchor, moreComing: Bool)] = []
+    /// The cumulative number of reported items (updates + deletions) observed at each finish, so tests can
+    /// derive per-batch sizes and assert no batch exceeds the cap. `didUpdate`/`didDeleteItems` for a
+    /// batch are delivered before its `finishEnumeratingChanges`, so each entry includes that batch.
+    public private(set) var reportedCountsAtFinish: [Int] = []
+    /// Mirrors the system-set `suggestedBatchSize`. `@objc` so the optional protocol requirement is seen
+    /// by the production code through the protocol existential; set small to force multi-batch delivery.
+    @objc public var suggestedBatchSize: Int = 0
     var error: Error?
     var isComplete = false
+    private var batchComplete = false
     var enumerator: NSFileProviderEnumerator
 
     public init(enumerator: NSFileProviderEnumerator) {
@@ -24,31 +35,49 @@ public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
         self.deletedItemIdentifiers.append(contentsOf: deletedItemIdentifiers)
     }
 
-    public func finishEnumeratingChanges(upTo _: NSFileProviderSyncAnchor, moreComing _: Bool) {
-        isComplete = true
+    public func finishEnumeratingChanges(upTo anchor: NSFileProviderSyncAnchor, moreComing: Bool) {
+        finishes.append((anchor, moreComing))
+        reportedCountsAtFinish.append(changedItems.count + deletedItemIdentifiers.count)
+        // moreComing: the framework would re-invoke enumerateChanges from this anchor for the next batch.
+        isComplete = !moreComing
+        batchComplete = true
     }
 
     public func finishEnumeratingWithError(_ error: Error) {
         self.error = error
         isComplete = true
+        batchComplete = true
     }
 
     public func enumerateChanges(from anchor: NSFileProviderSyncAnchor =
         Enumerator.syncAnchor(at: Date(timeIntervalSince1970: 1))) async throws
     {
-        enumerator.enumerateChanges?(for: self, from: anchor)
-        while !isComplete {
-            try await Task.sleep(nanoseconds: 1_000_000)
-        }
-        if let error {
-            throw error
-        }
+        isComplete = false
+        var currentAnchor = anchor
+        // Drive the batches the way the framework does: re-invoke enumerateChanges from the anchor the
+        // previous batch returned until one finishes with moreComing == false.
+        repeat {
+            batchComplete = false
+            enumerator.enumerateChanges?(for: self, from: currentAnchor)
+            while !batchComplete {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            if let error {
+                throw error
+            }
+            if let latestAnchor = finishes.last?.anchor {
+                currentAnchor = latestAnchor
+            }
+        } while !isComplete
     }
 
     public func reset() {
         changedItems = []
         deletedItemIdentifiers = []
+        finishes = []
+        reportedCountsAtFinish = []
         error = nil
         isComplete = false
+        batchComplete = false
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockEnumerationObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockEnumerationObserver.swift
@@ -7,6 +7,9 @@ import Foundation
 public class MockEnumerationObserver: NSObject, NSFileProviderEnumerationObserver {
     public var items: [NSFileProviderItem] = []
     public var observedPages: [NSFileProviderPage] = []
+    /// Mirrors the system-set `suggestedPageSize`. `@objc` so the optional protocol requirement is seen
+    /// by the production code through the protocol existential; set small to force multi-page delivery.
+    @objc public var suggestedPageSize: Int = 0
     public private(set) var error: Error?
     public private(set) var page: NSFileProviderPage?
     private var isComplete = false

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -2112,4 +2112,391 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             "lockToken must be preserved across target-depth reads"
         )
     }
+
+    // MARK: - Batched enumeration (nextcloud/desktop #10266: >20000 items in one batch crash)
+
+    /// Seed `count` materialised files directly under the root, present unchanged on the server, all
+    /// synced just now so both the working-set scan and the pending-changes re-derivation report them.
+    @discardableResult
+    private func seedMaterialisedWorkingSetFiles(count: Int, syncTime: Date) -> Set<String> {
+        var expectedOcIds = Set<String>()
+        for i in 0 ..< count {
+            let item = MockRemoteItem(
+                identifier: "wsItem\(i)",
+                name: "wsItem\(i).txt",
+                remotePath: Self.account.davFilesUrl + "/wsItem\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            item.parent = rootItem
+            rootItem.children.append(item)
+
+            var metadata = item.toItemMetadata(account: Self.account)
+            metadata.downloaded = true // materialised
+            metadata.syncTime = syncTime
+            Self.dbManager.addItemMetadata(metadata)
+            expectedOcIds.insert(metadata.ocId)
+        }
+        return expectedOcIds
+    }
+
+    func testWorkingSetChangesDeliveredInBatchesRespectingSuggestedBatchSize() async throws {
+        // The crash this fixes: the working-set change set was reported in a single batch, which the
+        // framework rejects past 100× the suggested size (≈20000). It must now be split into batches no
+        // larger than the suggested size, with no change dropped or duplicated, and without re-running the
+        // destructive scan on the framework's moreComing re-invocations.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let anchorDate = Date().addingTimeInterval(-300)
+        let anchor = Enumerator.syncAnchor(at: anchorDate)
+        let itemCount = 10
+        let batchSize = 3
+
+        let expectedOcIds = seedMaterialisedWorkingSetFiles(count: itemCount, syncTime: Date())
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        observer.suggestedBatchSize = batchSize
+
+        try await observer.enumerateChanges(from: anchor)
+
+        XCTAssertNil(observer.error, "Enumeration should complete without error.")
+
+        // Every change delivered exactly once, none dropped, none duplicated.
+        let reportedOcIds = observer.changedItems.map(\.itemIdentifier.rawValue)
+        XCTAssertEqual(reportedOcIds.count, itemCount, "No change should be duplicated across batches.")
+        XCTAssertEqual(Set(reportedOcIds), expectedOcIds, "Every change must be delivered across the batches.")
+
+        // Split into more than one batch.
+        XCTAssertGreaterThan(observer.finishes.count, 1, "A change set larger than the batch size must be split.")
+
+        // No batch exceeds the suggested size — this is what keeps the framework from asserting.
+        var previousTotal = 0
+        for total in observer.reportedCountsAtFinish {
+            XCTAssertLessThanOrEqual(total - previousTotal, batchSize, "No single batch may exceed the suggested batch size.")
+            previousTotal = total
+        }
+
+        // Intermediate batches keep the original anchor; only the final batch advances the sync point.
+        for finish in observer.finishes.dropLast() {
+            XCTAssertTrue(finish.moreComing, "Non-final batches must report moreComing == true.")
+            XCTAssertEqual(finish.anchor.rawValue, anchor.rawValue, "Intermediate batches must return the original anchor.")
+        }
+        let finalFinish = try XCTUnwrap(observer.finishes.last)
+        XCTAssertFalse(finalFinish.moreComing, "The final batch must report moreComing == false.")
+        XCTAssertNotEqual(finalFinish.anchor.rawValue, anchor.rawValue, "The final batch must advance the working-set sync anchor.")
+
+        // The destructive scan ran once: one server read per materialised item, not once per batch.
+        XCTAssertLessThanOrEqual(
+            remoteInterface.readOperationCount,
+            itemCount + 2,
+            "Continuation batches must drain the buffer, not re-run the server scan."
+        )
+    }
+
+    func testWorkingSetChangesReportSingleBatchWhenUnderCap() async throws {
+        // With no system suggestion the default batch size applies, so a small change set is delivered in
+        // exactly one batch — preserving the pre-existing single-batch behaviour and the final anchor.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let anchorDate = Date().addingTimeInterval(-300)
+        let anchor = Enumerator.syncAnchor(at: anchorDate)
+        let expectedOcIds = seedMaterialisedWorkingSetFiles(count: 3, syncTime: Date())
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+
+        try await observer.enumerateChanges(from: anchor)
+
+        XCTAssertNil(observer.error)
+        XCTAssertEqual(Set(observer.changedItems.map(\.itemIdentifier.rawValue)), expectedOcIds)
+        XCTAssertEqual(observer.finishes.count, 1, "A change set under the cap must be a single batch.")
+        XCTAssertEqual(observer.finishes.first?.moreComing, false)
+    }
+
+    func testWorkingSetChangesEmptyReportsSingleFinalBatch() async throws {
+        // No materialised items, no changes: exactly one finish, moreComing == false, advancing the anchor.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+
+        try await observer.enumerateChanges(from: anchor)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(observer.changedItems.isEmpty)
+        XCTAssertTrue(observer.deletedItemIdentifiers.isEmpty)
+        XCTAssertEqual(observer.finishes.count, 1)
+        XCTAssertEqual(observer.finishes.first?.moreComing, false)
+    }
+
+    func testWorkingSetItemsArePaginatedUnderSuggestedPageSize() async throws {
+        // The working-set item enumeration read all materialised items in a single page. It must now be
+        // paged under the suggested page size, delivering every item exactly once across the pages.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let itemCount = 7
+        let expectedOcIds = seedMaterialisedWorkingSetFiles(count: itemCount, syncTime: Date())
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account, rootItem: rootItem),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockEnumerationObserver(enumerator: enumerator)
+        observer.suggestedPageSize = 2
+
+        try await observer.enumerateItems()
+
+        XCTAssertNil(observer.error)
+        let reportedOcIds = observer.items.map(\.itemIdentifier.rawValue)
+        XCTAssertEqual(reportedOcIds.count, itemCount, "No item should be duplicated across pages.")
+        XCTAssertEqual(Set(reportedOcIds), expectedOcIds, "Every materialised item must be delivered across the pages.")
+        XCTAssertGreaterThan(observer.observedPages.count, 1, "A materialised set larger than the page size must be paged.")
+        for page in observer.observedPages {
+            XCTAssertLessThanOrEqual(page.rawValue.count, 500, "Continuation pages must stay within the 500-byte limit.")
+        }
+    }
+
+    func testContainerChangesDeliveredInBatches() async throws {
+        // A regular container's change set must also batch under the suggested size.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        // Folder known locally (unchanged etag) with several brand-new children on the server.
+        var folderMetadata = remoteFolder.toItemMetadata(account: Self.account)
+        folderMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(folderMetadata)
+
+        let childCount = 8
+        let batchSize = 3
+        remoteFolder.children = []
+        var expectedChildIds = Set<String>()
+        for i in 0 ..< childCount {
+            let child = MockRemoteItem(
+                identifier: "newChild\(i)",
+                name: "newChild\(i).txt",
+                remotePath: Self.account.davFilesUrl + "/folder/newChild\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            child.parent = remoteFolder
+            remoteFolder.children.append(child)
+            expectedChildIds.insert(child.identifier)
+        }
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .init(remoteFolder.identifier),
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account, rootItem: rootItem),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        observer.suggestedBatchSize = batchSize
+
+        try await observer.enumerateChanges()
+
+        XCTAssertNil(observer.error)
+
+        // Every new child reported.
+        let reportedIds = Set(observer.changedItems.map(\.itemIdentifier.rawValue))
+        XCTAssertTrue(reportedIds.isSuperset(of: expectedChildIds), "Every new child must be reported.")
+
+        // Split into batches, none exceeding the cap.
+        XCTAssertGreaterThan(observer.finishes.count, 1, "A container change set larger than the batch size must be split.")
+        var previousTotal = 0
+        for total in observer.reportedCountsAtFinish {
+            XCTAssertLessThanOrEqual(total - previousTotal, batchSize, "No container-change batch may exceed the suggested batch size.")
+            previousTotal = total
+        }
+        XCTAssertEqual(observer.finishes.last?.moreComing, false)
+    }
+
+    func testWorkingSetChangesBatchMixingUpdatesAndDeletions() async throws {
+        // An overflowing change set containing BOTH updates and deletions: exercises takeBatch's combined
+        // update+delete budget, deletions landing in later batches, and the per-batch hard-removal of
+        // delivered deletions across batch boundaries.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let anchorDate = Date().addingTimeInterval(-300)
+        let anchor = Enumerator.syncAnchor(at: anchorDate)
+        let now = Date()
+        let batchSize = 3
+
+        // Updates: materialised files present unchanged on the server.
+        let expectedUpdated = seedMaterialisedWorkingSetFiles(count: 4, syncTime: now)
+
+        // Deletions: materialised files soft-deleted in the DB after the anchor. The scan skips deleted
+        // rows, so these surface only via pendingWorkingSetChanges; they need not exist on the server.
+        var expectedDeleted = Set<String>()
+        for i in 0 ..< 4 {
+            let item = MockRemoteItem(
+                identifier: "wsDel\(i)",
+                name: "wsDel\(i).txt",
+                remotePath: Self.account.davFilesUrl + "/wsDel\(i).txt",
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            var metadata = item.toItemMetadata(account: Self.account)
+            metadata.downloaded = true // materialised
+            metadata.deleted = true
+            metadata.syncTime = now
+            Self.dbManager.addItemMetadata(metadata)
+            expectedDeleted.insert(metadata.ocId)
+        }
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account, rootItem: rootItem),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        observer.suggestedBatchSize = batchSize
+
+        try await observer.enumerateChanges(from: anchor)
+
+        XCTAssertNil(observer.error)
+
+        // Updates and deletions both delivered in full, exactly once.
+        XCTAssertEqual(Set(observer.changedItems.map(\.itemIdentifier.rawValue)), expectedUpdated)
+        XCTAssertEqual(observer.changedItems.count, expectedUpdated.count, "No update duplicated across batches.")
+        XCTAssertEqual(Set(observer.deletedItemIdentifiers.map(\.rawValue)), expectedDeleted)
+        XCTAssertEqual(observer.deletedItemIdentifiers.count, expectedDeleted.count, "No deletion duplicated across batches.")
+
+        // Split into batches, each within the cap (combined updates + deletions).
+        XCTAssertGreaterThan(observer.finishes.count, 1)
+        var previousTotal = 0
+        for total in observer.reportedCountsAtFinish {
+            XCTAssertLessThanOrEqual(total - previousTotal, batchSize, "No batch may exceed the cap, counting updates and deletions together.")
+            previousTotal = total
+        }
+
+        // Every delivered deletion's row is hard-removed by the time its (possibly later) batch finishes.
+        for deletedOcId in expectedDeleted {
+            XCTAssertNil(Self.dbManager.itemMetadata(ocId: deletedOcId), "Delivered deletions must be hard-removed across batch boundaries.")
+        }
+
+        // Anchors stay within the framework's 500-byte page/anchor limit.
+        for finish in observer.finishes {
+            XCTAssertLessThanOrEqual(finish.anchor.rawValue.count, 500, "Sync anchors must stay under the 500-byte limit.")
+        }
+    }
+
+    func testEffectiveBatchSizeClampsAndFallsBack() throws {
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertEqual(enumerator.effectiveBatchSize(suggested: nil), 1000, "Unset falls back to the default.")
+        XCTAssertEqual(enumerator.effectiveBatchSize(suggested: 0), 1000, "Zero falls back to the default.")
+        XCTAssertEqual(enumerator.effectiveBatchSize(suggested: -5), 1000, "Negative falls back to the default.")
+        XCTAssertEqual(enumerator.effectiveBatchSize(suggested: 200), 200, "A sane suggestion is honoured verbatim.")
+        XCTAssertEqual(enumerator.effectiveBatchSize(suggested: 99999), 4000, "A huge suggestion is clamped below the framework ceiling.")
+    }
+
+    func testTrashChangesDeliveredInBatches() async throws {
+        // A large permanent purge of trash items must batch its deletions under the suggested size.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem
+        )
+        // Remote trash empty → every local trash row is orphaned (permanently deleted remotely).
+        rootTrashItem.children = []
+
+        let trashCount = 8
+        let batchSize = 3
+        var expectedOcIds = Set<String>()
+        for i in 0 ..< trashCount {
+            let item = MockRemoteItem(
+                identifier: "trashBatch\(i)",
+                name: "trashBatch\(i).txt",
+                remotePath: Self.account.trashUrl + "/trashBatch\(i).txt",
+                data: Data(repeating: 1, count: 8),
+                account: Self.account.ncKitAccount,
+                username: Self.account.username,
+                userId: Self.account.id,
+                serverUrl: Self.account.serverUrl
+            )
+            let metadata = item.toNKTrash().toItemMetadata(account: Self.account)
+            Self.dbManager.addItemMetadata(metadata)
+            expectedOcIds.insert(metadata.ocId)
+        }
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .trashContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        observer.suggestedBatchSize = batchSize
+
+        try await observer.enumerateChanges()
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(observer.changedItems.isEmpty, "Trash reports only deletions.")
+        XCTAssertEqual(Set(observer.deletedItemIdentifiers.map(\.rawValue)), expectedOcIds, "Every orphan must be reported.")
+        XCTAssertEqual(observer.deletedItemIdentifiers.count, trashCount, "No orphan duplicated across batches.")
+
+        XCTAssertGreaterThan(observer.finishes.count, 1, "A large purge must be split into batches.")
+        var previousTotal = 0
+        for total in observer.reportedCountsAtFinish {
+            XCTAssertLessThanOrEqual(total - previousTotal, batchSize, "No trash batch may exceed the suggested batch size.")
+            previousTotal = total
+        }
+        XCTAssertEqual(observer.finishes.last?.moreComing, false)
+
+        // Delivered orphans are soft-deleted by the time their batch finishes.
+        for ocId in expectedOcIds {
+            XCTAssertEqual(Self.dbManager.itemMetadata(ocId: ocId)?.deleted, true, "Delivered trash orphans must be soft-deleted.")
+        }
+    }
 }


### PR DESCRIPTION
Hopefully fixes the remaining problem in #9283.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).