### PR TITLE
fix(cmd,csync): don't silently ignore a missing --exclude file

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -547,6 +547,15 @@ restart_sync:
 
     // Always try to load the user-provided exclude list if one is specified
     if (hasUserExcludeFile) {
+        if (!QFile::exists(options.exclude)) {
+            // A user-supplied --exclude path that can't be found is a
+            // configuration error, not something to silently ignore:
+            // reloadExcludeFiles() below drops missing files without
+            // failing, which previously made the whole sync run with
+            // no exclusions and no diagnostic (see nextcloud/desktop#4621).
+            qFatal("Exclude list file supplied via --exclude does not exist: %s", qUtf8Printable(options.exclude));
+            return EXIT_FAILURE;
+        }
         engine.excludedFiles().addExcludeFilePath(options.exclude);
     }
     // Load the system list if available, or if there's no user-provided list

--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -346,6 +346,7 @@ bool ExcludedFiles::reloadExcludeFiles()
             const auto &excludeFile = *excludeFileIt;
             QFile file(excludeFile);
             if (!file.exists()) {
+                qWarning() << "Exclude list file does not exist, skipping:" << excludeFile;
                 excludeFileIt = excludeFiles.erase(excludeFileIt);
                 continue;
             }


### PR DESCRIPTION
## Summary
Fixes #4621.

`nextcloudcmd --exclude <path>` silently produced a full, unfiltered sync (no exclusions applied) whenever `<path>` couldn't be resolved at runtime — with **no warning or error anywhere**. This matches the original report in #4621 exactly: "It still syncs everything... doesn't respect the local exclude list", with nothing in the logs pointing at why.

## Root cause
`ExcludedFiles::reloadExcludeFiles()` in `src/csync/csync_exclude.cpp` iterates the registered exclude-file paths and, when `QFile::exists()` is `false` for one of them, just erases it from the list and moves on — `success` stays `true`, nothing is logged. This is inconsistent with the sibling branch a few lines below, which does `qWarning()` + `success = false` when a file exists but can't be *opened*.

Because `nextcloudcmd`'s CLI-level check in `src/cmd/cmd.cpp` only tests `!options.exclude.isEmpty()` (i.e. "was --exclude given at all"), not whether the path actually resolves, any path that doesn't exist at the moment `reloadExcludeFiles()` runs (typo, cron job with a different CWD than an interactive shell, file not yet materialized, etc.) is dropped without a trace, and the sync proceeds as if `--exclude` had never been passed.

## Fix
- `csync_exclude.cpp`: log a `qWarning()` when a registered exclude file can't be found, instead of silently erasing it — makes the situation visible in `--logdebug` output for all callers (GUI and CLI).
- `cmd.cpp`: since a user explicitly passing `--exclude <path>` clearly intends for that file to be used, fail fast with `qFatal()` right when parsing the CLI options if the path doesn't exist, rather than only discovering the problem three layers down with no way to tell "user typo" apart from "path was never wrong to begin with".

## Test plan
- [x] Read through `reloadExcludeFiles()` / `loadExcludeFilePatterns()` call paths to confirm the silent-drop behavior and that the fix doesn't change behavior for the legitimately-optional system exclude list (still no `qFatal`, only a `qWarning`).
- [ ] CI (Linux GCC/Clang compile + unit tests) — not run locally due to unavailable Qt6/ECM6/KDSingleApplication-qt6 toolchain in my environment; relying on this PR's CI run.
- [ ] Manual repro: run `nextcloudcmd --exclude /nonexistent/path ...` before/after the fix.