### PR TITLE
Prevent crash on wake (Ticket#96101255)

### DIFF
--- a/src/gui/tray/asyncimageresponse.cpp
+++ b/src/gui/tray/asyncimageresponse.cpp
@@ -84,12 +84,17 @@ void AsyncImageResponse::processNextImage()
         if (iconUrl.isValid() && !iconUrl.scheme().isEmpty()) {
             // fetch the remote resource in the thread of the account (or rather its QNAM)
             // for some reason trying to use `accountInRequestedServer` causes clang 21 to crash for me :(
-            const auto accountQnam = accountInRequestedServer->networkAccessManager();
-            QMetaObject::invokeMethod(accountQnam, [this, accountInRequestedServer, iconUrl]() -> void {
+            // Hold the QNAM alive via its QSharedPointer for the whole request: resetNetworkAccessManager()
+            // (e.g. on wake from sleep) reassigns the account's QNAM and deleteLater()s the old one, which
+            // would otherwise take our in-flight reply with it and crash processNetworkReply() on another
+            // thread. reply->deleteLater() below breaks the resulting QNAM<->reply<->lambda ref cycle.
+            const auto accountQnam = accountInRequestedServer->sharedNetworkAccessManager();
+            QMetaObject::invokeMethod(accountQnam.data(), [this, accountInRequestedServer, accountQnam, iconUrl]() -> void {
                 const auto reply = accountInRequestedServer->sendRawRequest("GET"_ba, iconUrl);
-                connect(reply, &QNetworkReply::finished, this, [this, reply]() -> void {
-                    QMetaObject::invokeMethod(this, [this, reply]() -> void {
+                connect(reply, &QNetworkReply::finished, this, [this, reply, accountQnam]() -> void {
+                    QMetaObject::invokeMethod(this, [this, reply, accountQnam]() -> void {
                         processNetworkReply(reply);
+                        reply->deleteLater();
                     });
                 });
             });


### PR DESCRIPTION
## What

Fixes a crash in the desktop client that could happen right after the computer wakes from sleep.

## Why it crashed

The tray window shows avatars and file previews that are downloaded from the server. On wake, the client rebuilds its network connection and throws away any download that was still in progress. But a background thread was still holding on to that download and tried to read it - after it had already been deleted. Reading deleted memory = crash.

## The fix

`AsyncImageResponse` now keeps the account's network manager alive for the full duration of the image request (using the shared pointer the code already provides for exactly this), so the download can't be deleted out from under the thread that's reading it. It also explicitly cleans up the download when done, which additionally fixes a small leak.

One file changed: `src/gui/tray/asyncimageresponse.cpp` (~9 lines).

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
