### PR TITLE
fix(libsync): add NEXTCLOUD_BULK_UPLOAD env override to force-disable bulk upload

### DIFF
--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -232,6 +232,11 @@ int Capabilities::maxConcurrentChunkUploads() const
 
 bool Capabilities::bulkUpload() const
 {
+    static const auto bulkUploadEnv = qgetenv("OWNCLOUD_BULK_UPLOAD");
+    if (bulkUploadEnv == "0")
+        return false;
+    if (bulkUploadEnv == "1")
+        return true;
     return _capabilities["dav"].toMap()["bulkupload"].toByteArray() >= "1.0";
 }
 

--- a/src/libsync/capabilities.cpp
+++ b/src/libsync/capabilities.cpp
@@ -232,7 +232,7 @@ int Capabilities::maxConcurrentChunkUploads() const
 
 bool Capabilities::bulkUpload() const
 {
-    static const auto bulkUploadEnv = qgetenv("OWNCLOUD_BULK_UPLOAD");
+    static const auto bulkUploadEnv = qgetenv("NEXTCLOUD_BULK_UPLOAD");
     if (bulkUploadEnv == "0")
         return false;
     if (bulkUploadEnv == "1")


### PR DESCRIPTION
## Summary
Adds an `OWNCLOUD_BULK_UPLOAD` environment variable override to `Capabilities::bulkUpload()`, mirroring the existing `OWNCLOUD_CHUNKING_NG` pattern in the same file (`src/libsync/capabilities.cpp`).

## Problem
Bulk upload (`POST .../dav/bulk`) is enabled automatically whenever the server advertises the `dav.bulkupload` capability, with **no client-side way to opt out** if that endpoint is broken or blocked somewhere in the network path (reverse proxy, WAF, CDN, etc).

Observed against a self-hosted Nextcloud instance where every single bulk-upload POST failed immediately with `UnknownNetworkError`, while regular per-file uploads (`PropagateUploadFileNG`) succeeded without issue. Because the failure is deterministic and the in-memory per-file bulk-upload blacklist does not survive across the `--max-sync-retries` internal restarts (let alone separate `nextcloudcmd` invocations from a cron/systemd timer), affected files never converge — the sync stays permanently red for every file it decides to bulk-upload, run after run, with no recovery path short of patching the client.

## Fix
`OWNCLOUD_BULK_UPLOAD=0` forces bulk upload off regardless of server capabilities (falls back to the normal single-file upload path). `OWNCLOUD_BULK_UPLOAD=1` forces it on. Unset preserves current behavior exactly (server capability decides).

Verified locally: rebuilding `nextcloudcmd`/`libnextcloudsync` with this change and setting `OWNCLOUD_BULK_UPLOAD=0` took a sync from a reproducible ~630-file failure batch (100% of that sync's bulk-upload attempts failing with `UnknownNetworkError`, identical set of files failing across 3 consecutive runs) down to a clean run with zero bulk-related errors, using the regular upload path instead.

## Testing
- Local `dpkg-buildpackage` build against Debian 12 (bookworm) package `3.7.3-1+deb12u2`
- Confirmed `OWNCLOUD_BULK_UPLOAD=0` / `=1` / unset all behave as expected against a real server
- No existing tests cover `Capabilities::bulkUpload()`; behavior for the unset case is unchanged (same expression as before, now reached only after the two new early-return checks)
