### PR TITLE
fix: Don't recursively call processEvents

### DIFF
--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -561,11 +561,6 @@ bool LsColJob::finished()
             // XML parse error
             emit finishedWithError(reply());
         }
-
-        // processEvents is called AFTER all reply() accesses. A pending deleteLater()
-        // processed inside it can zero the QPointer and caused a SIGSEGV when it was
-        // placed before the reply reads. Do not abuse: it affects QObject lifetimes.
-        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
     } else {
         // wrong content type, wrong HTTP code or any other network error
         emit finishedWithError(reply());


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
Fixes #10312

## Summary
Removes the re-entrant main QEventLoop handling caused by calling `QCoreApplication::processEvents()` which eventually causes a stack overflow. It's unclear what this call was supposed to do as the main QEventLoop is already handled by calling `QApplication::exec()` which is necessary anyway. This appears to be a remnant of someone not being well versed in asynchronous workloads, though that doesn't appear to be the only issue with the code in question.

### TODO
- [x] Verify if this actually fixes the issue as your build process does not work on Windows at all.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
