### PR TITLE
Support Adobe InDesign safe save

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
@@ -50,6 +50,17 @@ public extension FilesDatabaseManager {
             return []
         }
 
+        // A soft-deleted incoming row is a tombstone, not an authoritative live
+        // occupant of its logical address, so it must never evict a live sibling.
+        // A deletion is authoritative only about its own ocId; if another live row
+        // shares the (account, serverUrl, fileName) it is the current truth and
+        // must survive. Without this, persisting the tombstone of a stale ocId
+        // after an app "safe save" (create -> delete -> recreate, which rotates the
+        // ocId) soft-deletes the freshly recreated live file. (Ticket 96101301)
+        if incoming.deleted {
+            return []
+        }
+
         let incomingOcId = incoming.ocId
         let incomingAccount = incoming.account
         let incomingServerUrl = incoming.serverUrl

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -1511,6 +1511,33 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         XCTAssertFalse(storedB.deleted, "Newly added row should not be deleted")
     }
 
+    func testDeletedIncomingDoesNotEvictLiveLogicalSibling() throws {
+        // Regression for ticket 96101301: an app "safe save" (create -> delete ->
+        // recreate) rotates the ocId, leaving a stale tombstone beside the live,
+        // server-confirmed row at the same logical path. Persisting that tombstone
+        // must NOT soft-delete the live sibling, or the freshly recreated file
+        // vanishes from Finder.
+        let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
+
+        // The live, server-confirmed row for the recreated file.
+        var live = SendableItemMetadata(ocId: "104", fileName: "TEST 1.pdf", account: account)
+        live.syncTime = Date(timeIntervalSince1970: 1000)
+        Self.dbManager.addItemMetadata(live)
+
+        // The tombstone of the stale ocId at the same logical address, being
+        // persisted by the working-set scan's deletion path with a bumped syncTime.
+        var tombstone = SendableItemMetadata(ocId: "99", fileName: "TEST 1.pdf", account: account)
+        tombstone.deleted = true
+        tombstone.syncTime = Date(timeIntervalSince1970: 2000)
+        Self.dbManager.addItemMetadata(tombstone)
+
+        let storedLive = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "104"))
+        XCTAssertFalse(storedLive.deleted, "A tombstone incoming must not soft-delete the live sibling")
+
+        let storedTombstone = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "99"))
+        XCTAssertTrue(storedTombstone.deleted, "The tombstone itself should remain recorded as deleted")
+    }
+
     func testAddItemMetadataSameOcIdSameLogicalPathIsNormalUpsert() throws {
         let account = Account(user: "test", id: "t", serverUrl: "https://example.com", password: "")
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -189,6 +189,70 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    /// Regression for ticket 96101301: an app "safe save" (create -> delete -> recreate) rotates the
+    /// ocId, so one logical path ends up with a stale ghost row (gone from the server) beside the live,
+    /// recreated file. During the working-set scan the parent depth-1 read reconciles the stale ocId as
+    /// gone and the scan persists that tombstone via `addItemMetadata`. Before the fix, the tombstone's
+    /// `evictLogicalDuplicates` soft-deleted the LIVE sibling, and both ocIds were reported deleted — so
+    /// the freshly saved file vanished from Finder even though it was live on the server. The live row
+    /// must survive and be reported updated (not deleted); the genuinely-gone ghost must still be
+    /// reported deleted.
+    func testAtomicSaveRecreateDoesNotDeleteLiveItemFromWorkingSet() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        // The live, recreated file that currently exists on the server at this path.
+        let liveFile = makeFile(name: "TEST 1.pdf", parent: folder, etag: "pdf-v1")
+
+        seed(folder, visitedDirectory: true)
+        seed(liveFile, downloaded: true) // materialized live file
+
+        // Seed a stale ghost row at the SAME logical address (same serverUrl + fileName) but a
+        // different ocId, NOT present on the mock server. `uploaded == true` so the depth-1 read's
+        // delete reconciliation considers it. This stands in for the first "safe save" write whose
+        // ocId the server rotated away.
+        let storedLive = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: liveFile.identifier))
+        let realm = Self.dbManager.ncDatabase()
+        let ghost = RealmItemMetadata()
+        ghost.ocId = "staleGhost"
+        ghost.account = Self.account.ncKitAccount
+        ghost.serverUrl = storedLive.serverUrl
+        ghost.fileName = storedLive.fileName
+        ghost.uploaded = true
+        ghost.syncTime = oldSyncTime
+        try realm.write { realm.add(ghost) }
+
+        // The live file also changed on the server (the recreate), so it is a genuine update.
+        liveFile.versionIdentifier = "pdf-v2"
+        liveFile.modificationDate = Date()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+
+        // The live row must NOT be soft-deleted by the ghost's eviction (primary regression guard).
+        let liveAfter = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: liveFile.identifier))
+        XCTAssertFalse(
+            liveAfter.deleted,
+            "The live recreated file must not be soft-deleted when the stale ghost's tombstone is persisted."
+        )
+
+        let deletedIds = Set(observer.deletedItemIdentifiers.map(\.rawValue))
+        XCTAssertFalse(
+            deletedIds.contains(liveFile.identifier),
+            "The live recreated file must not be reported deleted to the framework."
+        )
+        XCTAssertTrue(
+            reportedIds(observer).contains(liveFile.identifier),
+            "The live recreated file must be reported as an update."
+        )
+        XCTAssertTrue(
+            deletedIds.contains("staleGhost"),
+            "The genuinely-gone stale ocId must still be reported deleted."
+        )
+    }
+
     /// Scenario A (S1/S2 control): a NON-materialized file changed inside a visited (materialized)
     /// folder, AND the folder's ETag is bumped too (a well-behaved server propagates child changes
     /// up to the parent's ETag). Expected to PASS — the parent's bumped `syncTime` lets the child


### PR DESCRIPTION
## Resolves

Several customer support inquiries.

## Summary

This generic problem became obvious mostly in context of using Adobe software like InDesign. They perform something called "safe save" which first writes a temporary file, then deletes it again and then writes the actual file. This is not the standard behavior on macOS where atomic writes are the convention.

This resulted in files disappearing locally shortly after even though being uploaded successfully and related glitches.

Now, this is fixed by intercepting local changes and deletions for redundant items identified by `ocId`. This is another consequence of the misconception of that identifier as a unique key even though it is not.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
