### PR TITLE
 fix(exclude): avoid trying to read patterns from file when reading failed

### DIFF
--- a/src/csync/csync_exclude.cpp
+++ b/src/csync/csync_exclude.cpp
@@ -302,12 +302,23 @@ void ExcludedFiles::loadExcludeFilePatterns(const QString &basePath, QFile &file
     QStringList patterns;
     while (!file.atEnd()) {
         QByteArray line = file.readLine().trimmed();
-        if (line.startsWith("#!version")) {
-            if (!versionDirectiveKeepNextLine(line))
-                file.readLine();
+        if (file.error()) {
+            // e.g. "Access to the cloud file is denied." when the exclude list is dehydrated on a VFS-enabled sync folder
+            qCWarning(lcCsyncExclude).nospace() << "failed to load exclude patterns from file, assume empty ignore list"
+                << " fileName=" << file.fileName()
+                << " error=" << file.error()
+                << " errorString=" << file.errorString();
+            break;
         }
-        if (line.isEmpty() || line.startsWith('#'))
+
+        if (line.startsWith("#!version")) {
+            if (!versionDirectiveKeepNextLine(line)) {
+                file.readLine();
+            }
+        }
+        if (line.isEmpty() || line.startsWith('#')) {
             continue;
+        }
         const auto patternStr = QString::fromUtf8(line);
         if (QStringView{patternStr}.trimmed() == QLatin1StringView("*")) {
             continue;

--- a/src/libsync/vfs/cfapi/vfs_cfapi.cpp
+++ b/src/libsync/vfs/cfapi/vfs_cfapi.cpp
@@ -553,7 +553,9 @@ int VfsCfApi::finalizeNewPlaceholders(const QList<PlaceholderCreateInfo> &newEnt
         folderRecord._isShared = entryInfo.parsedProperties.remotePerm.hasPermission(RemotePermissions::IsShared) || entryInfo.parsedProperties.sharedByMe;
         folderRecord._sharedByMe = entryInfo.parsedProperties.sharedByMe;
         folderRecord._lastShareStateFetchedTimestamp = QDateTime::currentMSecsSinceEpoch();
-        folderRecord._type = (entryInfo.parsedProperties.isDirectory ? ItemTypeVirtualDirectory : ItemTypeVirtualFile);
+        folderRecord._type =
+            (entryInfo.parsedProperties.isDirectory ? ItemTypeVirtualDirectory
+                                                    : (FileSystem::isExcludeFile(entryInfo.fullPath) ? ItemTypeVirtualFileDownload : ItemTypeVirtualFile));
         folderRecord._etag = entryInfo.parsedProperties.etag;
         folderRecord._e2eEncryptionStatus = static_cast<SyncJournalFileRecord::EncryptionStatus>(entryInfo.parsedProperties.isE2eEncrypted() ? SyncFileItem::EncryptionStatus::EncryptedMigratedV2_0 : SyncFileItem::EncryptionStatus::NotEncrypted);
         folderRecord._lockstate._locked = (entryInfo.parsedProperties.locked == SyncFileItemEnums::LockStatus::LockedItem);


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#10301

## Summary
The Windows on-demand VFS creates placeholder files while the folders are being navigated to.  This worked fine until a folder was opened which contains a folder-specific exclude patterns file: the sync engine would keep trying to read from the placeholder file forever.

--> resolve it by catching read errors in csync_exclude, and mark the exclude pattern file to be downloaded with the next sync while creating placeholders

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
