### PR TITLE
fix: "dismiss" string and showing of chat message in tray preview

### DIFF
--- a/src/gui/macOS/trayaccountpopup/ncaccountactionspopup.mm
+++ b/src/gui/macOS/trayaccountpopup/ncaccountactionspopup.mm
@@ -266,7 +266,7 @@ static NSView *compactAccountActionsSeparator()
         [weakSelf hideAppsPopup];
     }]);
     if (assistantEnabled) {
-        addOwnedArrangedSubview(_stack, [[NCActionRow alloc] initWithTitle:QCoreApplication::translate("MainWindow", "Open Assistant").toNSString()
+        addOwnedArrangedSubview(_stack, [[NCActionRow alloc] initWithTitle:QCoreApplication::translate("MainWindow", "Assistant").toNSString()
                                                                       width:kAccountActionsPopupWidth
                                                                     enabled:YES
                                                                      action:^{
@@ -301,6 +301,7 @@ static NSView *compactAccountActionsSeparator()
             const auto activityIndex = notificationData.value(QStringLiteral("activityIndex")).toInt();
             addOwnedArrangedSubview(_stack, [[NCActionRow alloc] initWithTitle:title.toNSString()
                                                                           icon:systemSymbolImage(notificationData.value(QStringLiteral("systemIconName")).toString(), 14.0)
+                                                                      subtitle:notificationData.value(QStringLiteral("subtitle")).toString().toNSString()
                                                                       dateTime:notificationData.value(QStringLiteral("dateTime")).toString().toNSString()
                                                                          width:kAccountActionsPopupWidth
                                                                        enabled:YES

--- a/src/gui/tray/activitydata.cpp
+++ b/src/gui/tray/activitydata.cpp
@@ -298,14 +298,6 @@ QVariantList Activity::notificationPreviewActions() const
 {
     auto actions = QVariantList{};
 
-    if (isDismissableActivity()) {
-        actions.push_back(notificationPreviewAction(
-            QCoreApplication::translate("ActivityItemContent", "Confirm"),
-            QStringLiteral("dismiss"),
-            -1,
-            QByteArrayLiteral("DELETE")));
-    }
-
     const auto &actionsList = activityActionMetadata();
     for (const auto &action : actionsList) {
         const auto &link = action.link;
@@ -315,6 +307,14 @@ QVariantList Activity::notificationPreviewActions() const
             link._verb == QByteArrayLiteral("REPLY") ? QStringLiteral("openActivities") : QStringLiteral("trigger"),
             action.actionIndex,
             link._verb));
+    }
+
+    if (isDismissableActivity()) {
+        actions.push_back(notificationPreviewAction(
+            QCoreApplication::translate("ActivityItemContent", "Dismiss"),
+            QStringLiteral("dismiss"),
+            -1,
+            QByteArrayLiteral("DELETE")));
     }
 
     return actions;

--- a/src/gui/tray/activitylistmodel.cpp
+++ b/src/gui/tray/activitylistmodel.cpp
@@ -492,7 +492,21 @@ QVariantList ActivityListModel::buildNotificationPreviewData() const
 
     auto notifications = QVariantList{};
     for (const auto &candidate : std::as_const(candidates)) {
-        const auto title = candidate.activity.compactNotificationTitle();
+        auto title = candidate.activity.compactNotificationTitle();
+        auto subtitle = QString{};
+        auto systemIconName = candidate.activity.recentActivitySystemIconName();
+        if (candidate.activity._objectType == QStringLiteral("chat")
+            && candidate.activity._subjectRichParameters.contains(QStringLiteral("user"))) {
+            const auto user = candidate.activity._subjectRichParameters.value(QStringLiteral("user")).value<Activity::RichSubjectParameter>();
+            if (!user.name.isEmpty() && !candidate.activity._message.isEmpty()) {
+                title = user.name;
+                subtitle = candidate.activity._message;
+            }
+        }
+        if (candidate.activity._objectType == QStringLiteral("chat")
+            || candidate.activity._objectType == QStringLiteral("room")) {
+            systemIconName = QStringLiteral("message");
+        }
         if (title.isEmpty()) {
             continue;
         }
@@ -501,8 +515,9 @@ QVariantList ActivityListModel::buildNotificationPreviewData() const
         const auto actions = candidate.activity.notificationPreviewActions();
         notifications.push_back(QVariantMap{
             {QStringLiteral("title"), title},
+            {QStringLiteral("subtitle"), subtitle},
             {QStringLiteral("icon"), data(modelIndex, IconRole).toString()},
-            {QStringLiteral("systemIconName"), candidate.activity.recentActivitySystemIconName()},
+            {QStringLiteral("systemIconName"), systemIconName},
             {QStringLiteral("dateTime"), data(modelIndex, PointInTimeRole).toString()},
             {QStringLiteral("activityIndex"), candidate.row},
             {QStringLiteral("opensSettings"), candidate.activity._type == Activity::OpenSettingsNotificationType},

--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -627,15 +627,17 @@ void addNotifications(QMenu *menu, const int userId, const QVariantList &notific
         const auto activityIndex = notificationData.value(QStringLiteral("activityIndex")).toInt();
         const auto actions = notificationData.value(QStringLiteral("actions")).toList();
         const auto dateTime = notificationData.value(QStringLiteral("dateTime")).toString();
+        const auto subtitle = notificationData.value(QStringLiteral("subtitle")).toString();
+        const auto displayTitle = subtitle.isEmpty() ? title : QStringLiteral("%1: %2").arg(title, subtitle);
         if (actions.isEmpty()) {
-            const auto action = addTimedMenuAction(menu, activityIcon(notificationData), title, dateTime);
+            const auto action = addTimedMenuAction(menu, activityIcon(notificationData), displayTitle, dateTime);
             QObject::connect(action, &QAction::triggered, action, [userId, opensSettings] {
                 openNotification(userId, opensSettings);
             });
             continue;
         }
 
-        const auto notificationMenu = addTimedSubMenu(menu, activityIcon(notificationData), title, dateTime);
+        const auto notificationMenu = addTimedSubMenu(menu, activityIcon(notificationData), displayTitle, dateTime);
         setFixedMenuWidth(notificationMenu);
         const auto openAction = addMenuAction(notificationMenu, QIcon{}, QCoreApplication::translate("TrayAccountPopup", "Open"));
         QObject::connect(openAction, &QAction::triggered, openAction, [userId, opensSettings] {
@@ -738,7 +740,7 @@ void populateAccountMenu(QMenu *menu, const int userId, const bool fetchActivity
     if (assistantEnabled) {
         const auto assistantAction = addMenuAction(menu,
             templateBlackThemeIcon(QStringLiteral("nc-assistant-app.svg"), menuIconSize, menuIconPalette),
-            QCoreApplication::translate("MainWindow", "Open Assistant"));
+            QCoreApplication::translate("MainWindow", "Assistant"));
         QObject::connect(assistantAction, &QAction::triggered, assistantAction, [userId] {
             openAssistantForUser(userId);
         });


### PR DESCRIPTION
- tray-notifications now show name + text plus message icon
- the dismiss action was put to the bottom
- remove "Open" from Assistent tray menu row

<img width="511" height="106" alt="Unknown" src="https://github.com/user-attachments/assets/45f8c31c-38a9-4a4f-a211-9c7ff465bf48" />
