### PR TITLE
fix(TransifexStringCatalogSanitizer): Hardening to prevent data loss

### DIFF
--- a/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Package.swift
+++ b/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -18,6 +18,12 @@ let package = Package(
             name: "TransifexStringCatalogSanitizer",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .testTarget(
+            name: "TransifexStringCatalogSanitizerTests",
+            dependencies: [
+                "TransifexStringCatalogSanitizer",
             ]
         ),
     ]

--- a/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Sources/TransifexStringCatalogSanitizer/Sanitizer.swift
+++ b/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Sources/TransifexStringCatalogSanitizer/Sanitizer.swift
@@ -1,0 +1,85 @@
+//  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+///
+/// Pure sanitization logic for Xcode string catalogs (`.xcstrings`) pulled from Transifex.
+/// Contains no file I/O, no CLI argument handling, and no backup/dry-run concerns — those
+/// live in `TransifexStringCatalogSanitizer` (the `ParsableCommand`). Kept separate so it
+/// can be exercised directly by unit tests via `@testable import`, without touching disk
+/// or invoking ArgumentParser.
+///
+enum Sanitizer {
+    ///
+    /// Sanitize the string keys.
+    ///
+    static func sanitizeStrings(_ strings: inout [String: Any], sourceLanguage: String) throws {
+        for key in strings.keys.sorted() {
+            print("💬 \"\(key)\"")
+
+            guard var string = strings[key] as? [String: Any] else {
+                throw TransifexStringCatalogSanitizerError.missingString(key)
+            }
+
+            let extractionState = string["extractionState"] as? String
+
+            if extractionState == nil && string["localizations"] == nil {
+                print("\t🆕 This appears to be new because neither extraction state nor localization objects found.")
+                continue
+            }
+
+            if extractionState == "stale" {
+                print("\t❌ This is removed because it has been marked as stale.")
+                strings[key] = nil
+                continue
+            }
+
+            guard var localizations = string["localizations"] as? [String: Any] else {
+                throw TransifexStringCatalogSanitizerError.missingLocalizations(key)
+            }
+
+            try sanitizeLocalizations(&localizations, key: key, sourceLanguage: sourceLanguage)
+
+            // Update the string with modified localizations
+            string["localizations"] = localizations
+            strings[key] = string
+        }
+    }
+
+    ///
+    /// Sanitize the individual localizations of a key.
+    ///
+    static func sanitizeLocalizations(_ localizations: inout [String: Any], key: String, sourceLanguage: String) throws {
+        var localizationsToRemove: [String] = []
+
+        for localeCode in localizations.keys.sorted() {
+            guard let localization = localizations[localeCode] as? [String: Any] else {
+                throw TransifexStringCatalogSanitizerError.missingLocalization(localeCode)
+            }
+
+            guard let stringUnit = localization["stringUnit"] as? [String: Any] else {
+                throw TransifexStringCatalogSanitizerError.missingStringUnit(localeCode)
+            }
+
+            guard let value = stringUnit["value"] as? String else {
+                throw TransifexStringCatalogSanitizerError.missingValue
+            }
+
+            if value.isEmpty {
+                print("\t❌ \(localeCode): empty, will be removed")
+                localizationsToRemove.append(localeCode)
+            } else if value == key && localeCode.hasPrefix(sourceLanguage) == false {
+                print("\t❌ \(localeCode): same as key, will be removed")
+                localizationsToRemove.append(localeCode)
+            } else {
+                print("\t✅ \(localeCode): \"\(value)\"")
+            }
+        }
+
+        // Remove empty localizations
+        for localeCode in localizationsToRemove {
+            localizations.removeValue(forKey: localeCode)
+        }
+    }
+}

--- a/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Sources/TransifexStringCatalogSanitizer/TransifexStringCatalogSanitizer.swift
+++ b/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Sources/TransifexStringCatalogSanitizer/TransifexStringCatalogSanitizer.swift
@@ -8,7 +8,10 @@ import Foundation
 struct TransifexStringCatalogSanitizer: ParsableCommand {
     @Argument(help: "The string catalog file to sanitize.")
     var input: String
-    
+
+    @Flag(name: .long, help: "Report what would change without writing to disk or creating a backup file.")
+    var dryRun = false
+
     mutating func run() throws {
         let url = URL(fileURLWithPath: input).standardized
 
@@ -17,7 +20,7 @@ struct TransifexStringCatalogSanitizer: ParsableCommand {
         }
 
         let data = try Data(contentsOf: url)
-        
+
         guard var root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw TransifexStringCatalogSanitizerError.jsonObject
         }
@@ -29,86 +32,31 @@ struct TransifexStringCatalogSanitizer: ParsableCommand {
         guard var strings = root["strings"] as? [String: Any] else {
             throw TransifexStringCatalogSanitizerError.missingStrings
         }
-        
-        try sanitizeStrings(&strings, sourceLanguage: sourceLanguage)
+
+        if dryRun {
+            print("🔍 Dry run: no files will be written.\n")
+        }
+
+        try Sanitizer.sanitizeStrings(&strings, sourceLanguage: sourceLanguage)
 
         // Update the root with modified strings
         root["strings"] = strings
-        
+
         // Write the processed data back to the original file
         let processedData = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+
+        guard !dryRun else {
+            print("\n🔍 Dry run complete. Nothing was written to disk.")
+            return
+        }
+
+        // Preserve the pre-sanitize bytes so a bad run can be recovered from without
+        // re-pulling from Transifex. This must be the last thing before the real write:
+        // every guard/throw above has already succeeded by this point, so a crash during
+        // parsing or sanitizing never creates (or clobbers) a backup for a write that
+        // was never going to happen.
+        try data.write(to: url.appendingPathExtension("bak"))
+
         try processedData.write(to: url)
-    }
-
-    ///
-    /// Sanitize the string keys.
-    ///
-    private func sanitizeStrings(_ strings: inout [String: Any], sourceLanguage: String) throws {
-        for key in strings.keys.sorted() {
-            print("💬 \"\(key)\"")
-            
-            guard var string = strings[key] as? [String: Any] else {
-                throw TransifexStringCatalogSanitizerError.missingString(key)
-            }
-
-            let extractionState = string["extractionState"] as? String
-
-            if extractionState == nil && string["localizations"] == nil {
-                print("\t🆕 This appears to be new because neither extraction state nor localization objects found.")
-                continue
-            }
-
-            if extractionState == "stale" {
-                print("\t❌ This is removed because it has been marked as stale.")
-                strings[key] = nil
-                continue
-            }
-
-            guard var localizations = string["localizations"] as? [String: Any] else {
-                throw TransifexStringCatalogSanitizerError.missingLocalizations(key)
-            }
-            
-            try sanitizeLocalizations(&localizations, key: key, sourceLanguage: sourceLanguage)
-
-            // Update the string with modified localizations
-            string["localizations"] = localizations
-            strings[key] = string
-        }
-    }
-
-    ///
-    /// Sanitize the individual localizations of a key.
-    ///
-    private func sanitizeLocalizations(_ localizations: inout [String: Any], key: String, sourceLanguage: String) throws {
-        var localizationsToRemove: [String] = []
-        
-        for localeCode in localizations.keys.sorted() {
-            guard let localization = localizations[localeCode] as? [String: Any] else {
-                throw TransifexStringCatalogSanitizerError.missingLocalization(localeCode)
-            }
-            
-            guard let stringUnit = localization["stringUnit"] as? [String: Any] else {
-                throw TransifexStringCatalogSanitizerError.missingStringUnit(localeCode)
-            }
-            
-            guard let value = stringUnit["value"] as? String else {
-                throw TransifexStringCatalogSanitizerError.missingValue
-            }
-            
-            if value.isEmpty {
-                print("\t❌ \(localeCode): empty, will be removed")
-                localizationsToRemove.append(localeCode)
-            } else if value == key && localeCode.hasPrefix(sourceLanguage) == false {
-                print("\t❌ \(localeCode): same as key, will be removed")
-                localizationsToRemove.append(localeCode)
-            } else {
-                print("\t✅ \(localeCode): \"\(value)\"")
-            }
-        }
-        
-        // Remove empty localizations
-        for localeCode in localizationsToRemove {
-            localizations.removeValue(forKey: localeCode)
-        }
     }
 }

--- a/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Tests/TransifexStringCatalogSanitizerTests/SanitizerTests.swift
+++ b/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Tests/TransifexStringCatalogSanitizerTests/SanitizerTests.swift
@@ -1,0 +1,161 @@
+//  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import Testing
+@testable import TransifexStringCatalogSanitizer
+
+struct SanitizerTests {
+    private func makeDictionary(_ json: String) throws -> [String: Any] {
+        try #require(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+    }
+
+    // MARK: - sanitizeStrings
+
+    @Test func staleExtractionState_removesWholeKey() throws {
+        var strings = try makeDictionary("""
+        {
+            "Hello": {
+                "extractionState": "stale",
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": "Hello"}}
+                }
+            }
+        }
+        """)
+
+        try Sanitizer.sanitizeStrings(&strings, sourceLanguage: "en")
+
+        #expect(strings["Hello"] == nil)
+    }
+
+    @Test func newKey_noExtractionStateNoLocalizations_passesThroughUnchanged() throws {
+        var strings = try makeDictionary("""
+        {
+            "Brand New": {
+                "comment": "Just extracted, not yet pulled from Transifex."
+            }
+        }
+        """)
+
+        try Sanitizer.sanitizeStrings(&strings, sourceLanguage: "en")
+
+        let entry = try #require(strings["Brand New"] as? [String: Any])
+        #expect(entry["comment"] as? String == "Just extracted, not yet pulled from Transifex.")
+        #expect(entry["localizations"] == nil)
+    }
+
+    @Test func missingString_throwsMissingString() throws {
+        var strings = try makeDictionary("""
+        { "Broken": "not a dictionary" }
+        """)
+
+        #expect {
+            try Sanitizer.sanitizeStrings(&strings, sourceLanguage: "en")
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingString(let key) = error else { return false }
+            return key == "Broken"
+        }
+    }
+
+    @Test func missingLocalizations_throwsMissingLocalizations() throws {
+        var strings = try makeDictionary("""
+        { "Untranslated": {"extractionState": "manual"} }
+        """)
+
+        #expect {
+            try Sanitizer.sanitizeStrings(&strings, sourceLanguage: "en")
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingLocalizations(let key) = error else { return false }
+            return key == "Untranslated"
+        }
+    }
+
+    // MARK: - sanitizeLocalizations
+
+    @Test func emptyLocalizationValue_isRemoved() throws {
+        var localizations = try makeDictionary("""
+        {
+            "en": {"stringUnit": {"state": "translated", "value": "Welcome"}},
+            "de": {"stringUnit": {"state": "translated", "value": ""}}
+        }
+        """)
+
+        try Sanitizer.sanitizeLocalizations(&localizations, key: "Welcome", sourceLanguage: "en")
+
+        #expect(localizations["de"] == nil)
+        #expect(localizations["en"] != nil)
+    }
+
+    @Test func nonSourceLocaleValueEqualsKey_isRemoved() throws {
+        var localizations = try makeDictionary("""
+        {
+            "de": {"stringUnit": {"state": "translated", "value": "Welcome"}}
+        }
+        """)
+
+        try Sanitizer.sanitizeLocalizations(&localizations, key: "Welcome", sourceLanguage: "en")
+
+        #expect(localizations["de"] == nil)
+    }
+
+    @Test(arguments: ["en", "en_GB", "en_US"])
+    func sourceLanguagePrefixedLocales_areExempt(locale: String) throws {
+        var localizations: [String: Any] = [
+            locale: ["stringUnit": ["state": "translated", "value": "Settings"]],
+        ]
+
+        try Sanitizer.sanitizeLocalizations(&localizations, key: "Settings", sourceLanguage: "en")
+
+        #expect(localizations[locale] != nil)
+    }
+
+    @Test func valueDifferentFromKey_isKept() throws {
+        var localizations = try makeDictionary("""
+        { "de": {"stringUnit": {"state": "translated", "value": "Willkommen"}} }
+        """)
+
+        try Sanitizer.sanitizeLocalizations(&localizations, key: "Welcome", sourceLanguage: "en")
+
+        let localization = try #require(localizations["de"] as? [String: Any])
+        let stringUnit = try #require(localization["stringUnit"] as? [String: Any])
+        #expect(stringUnit["value"] as? String == "Willkommen")
+    }
+
+    @Test func missingLocalization_throwsMissingLocalization() throws {
+        var localizations: [String: Any] = ["de": "unexpectedly not an object"]
+
+        #expect {
+            try Sanitizer.sanitizeLocalizations(&localizations, key: "AnyKey", sourceLanguage: "en")
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingLocalization(let localeCode) = error else { return false }
+            return localeCode == "de"
+        }
+    }
+
+    @Test func missingStringUnit_throwsMissingStringUnit() throws {
+        var localizations = try makeDictionary("""
+        { "de": {"notStringUnit": {}} }
+        """)
+
+        #expect {
+            try Sanitizer.sanitizeLocalizations(&localizations, key: "AnyKey", sourceLanguage: "en")
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingStringUnit(let localeCode) = error else { return false }
+            return localeCode == "de"
+        }
+    }
+
+    @Test func missingValue_throwsMissingValue() throws {
+        var localizations = try makeDictionary("""
+        { "de": {"stringUnit": {"state": "translated"}} }
+        """)
+
+        #expect {
+            try Sanitizer.sanitizeLocalizations(&localizations, key: "AnyKey", sourceLanguage: "en")
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingValue = error else { return false }
+            return true
+        }
+    }
+}

--- a/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Tests/TransifexStringCatalogSanitizerTests/TransifexStringCatalogSanitizerRunTests.swift
+++ b/shell_integration/MacOSX/TransifexStringCatalogSanitizer/Tests/TransifexStringCatalogSanitizerTests/TransifexStringCatalogSanitizerRunTests.swift
@@ -1,0 +1,137 @@
+//  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import ArgumentParser
+import Foundation
+import Testing
+@testable import TransifexStringCatalogSanitizer
+
+struct TransifexStringCatalogSanitizerRunTests {
+    private let sampleCatalog = """
+    { "sourceLanguage": "en", "version": "1.0", "strings": {
+        "Old": { "extractionState": "stale", "localizations": {
+            "en": {"stringUnit": {"state": "translated", "value": "Old"}}
+        }},
+        "Welcome": { "extractionState": "manual", "localizations": {
+            "en": {"stringUnit": {"state": "translated", "value": "Welcome"}},
+            "de": {"stringUnit": {"state": "translated", "value": "Willkommen"}}
+        }}
+    }}
+    """
+
+    private func makeTempFile(_ contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("xcstrings")
+        try Data(contents.utf8).write(to: url)
+        return url
+    }
+
+    private func removeTempFile(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(at: url.appendingPathExtension("bak"))
+    }
+
+    @Test func missingFile_throwsMissingFile() throws {
+        var command = try TransifexStringCatalogSanitizer.parse(["/nonexistent/path/x.xcstrings"])
+
+        #expect {
+            try command.run()
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingFile = error else { return false }
+            return true
+        }
+    }
+
+    @Test func nonJSONContent_throwsAnError() throws {
+        let url = try makeTempFile("this is not json")
+        defer { removeTempFile(url) }
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+
+        // Syntactically invalid JSON fails inside JSONSerialization.jsonObject itself,
+        // before the `guard ... as?` cast runs — so this is a Foundation decoding error,
+        // not TransifexStringCatalogSanitizerError.jsonObject.
+        #expect(throws: (any Error).self) {
+            try command.run()
+        }
+    }
+
+    @Test func jsonArrayInsteadOfObject_throwsJsonObjectError() throws {
+        let url = try makeTempFile("[]")
+        defer { removeTempFile(url) }
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+
+        #expect {
+            try command.run()
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.jsonObject = error else { return false }
+            return true
+        }
+    }
+
+    @Test func missingSourceLanguage_throwsMissingSourceLanguage() throws {
+        let url = try makeTempFile(#"{"strings": {}}"#)
+        defer { removeTempFile(url) }
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+
+        #expect {
+            try command.run()
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingSourceLanguage = error else { return false }
+            return true
+        }
+    }
+
+    @Test func missingStrings_throwsMissingStrings() throws {
+        let url = try makeTempFile(#"{"sourceLanguage": "en"}"#)
+        defer { removeTempFile(url) }
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+
+        #expect {
+            try command.run()
+        } throws: { error in
+            guard case TransifexStringCatalogSanitizerError.missingStrings = error else { return false }
+            return true
+        }
+    }
+
+    @Test func realRun_writesBackupAndSanitizesFile() throws {
+        let url = try makeTempFile(sampleCatalog)
+        defer { removeTempFile(url) }
+
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+        try command.run()
+
+        let backupURL = url.appendingPathExtension("bak")
+        #expect(FileManager.default.fileExists(atPath: backupURL.path))
+        #expect(try Data(contentsOf: backupURL) == Data(sampleCatalog.utf8))
+
+        let root = try #require(try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any])
+        let strings = try #require(root["strings"] as? [String: Any])
+        #expect(strings["Old"] == nil)
+        #expect(strings["Welcome"] != nil)
+    }
+
+    @Test func dryRun_doesNotWriteOrBackup() throws {
+        let url = try makeTempFile(sampleCatalog)
+        defer { removeTempFile(url) }
+
+        var command = try TransifexStringCatalogSanitizer.parse(["--dry-run", url.path])
+        try command.run()
+
+        #expect(try Data(contentsOf: url) == Data(sampleCatalog.utf8))
+        #expect(!FileManager.default.fileExists(atPath: url.appendingPathExtension("bak").path))
+    }
+
+    @Test func realRun_overwritesPreviousBackup() throws {
+        let url = try makeTempFile(sampleCatalog)
+        defer { removeTempFile(url) }
+        let backupURL = url.appendingPathExtension("bak")
+        try Data("stale sentinel backup content".utf8).write(to: backupURL)
+
+        var command = try TransifexStringCatalogSanitizer.parse([url.path])
+        try command.run()
+
+        #expect(try Data(contentsOf: backupURL) == Data(sampleCatalog.utf8))
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

Improve the tool to decrease risk of translation loss.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
