### PR TITLE
Improve FinderSync Extension handling

### DIFF
--- a/admin/osx/post_install.sh.cmake
+++ b/admin/osx/post_install.sh.cmake
@@ -4,14 +4,57 @@
 # SPDX-FileCopyrightText: 2015 ownCloud GmbH
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-# Always enable the new 10.10 finder plugin if available
-if [ -x "$(command -v pluginkit)" ]; then
-    # add it to DB. This happens automatically too but we try to push it a bit harder for issue #3463
-    pluginkit -a  "/Applications/@APPLICATION_NAME@.app/Contents/PlugIns/FinderSyncExt.appex/"
-    # Since El Capitan we need to sleep #4650
-    sleep 10s
-    # enable it
-    pluginkit -e use -i @APPLICATION_REV_DOMAIN@.FinderSyncExt
+# Register and enable the Finder Sync extension.
+#
+# pluginkit manages the PlugInKit subsystem *per user*, but this postinstall script
+# runs as root. Running pluginkit directly here mutates root's registry and is a no-op
+# for the logged-in user — the extension then never appears/enables for them (issues
+# #8471, #10032). So we hop into the console user's context (launchctl asuser + sudo -u)
+# before calling pluginkit. Every step logs its result to /var/log/install.log so a
+# failed registration is recognisable from installer logs users provide.
+APPEX="/Applications/@APPLICATION_NAME@.app/Contents/PlugIns/FinderSyncExt.appex/"
+EXT_ID="@APPLICATION_REV_DOMAIN@.FinderSyncExt"
+LOG_PREFIX="Nextcloud FinderSync:"
+
+CONSOLE_USER=$(stat -f%Su /dev/console 2>/dev/null)
+CONSOLE_UID=$(id -u "$CONSOLE_USER" 2>/dev/null)
+
+run_as_console_user() {
+    launchctl asuser "$CONSOLE_UID" sudo -u "$CONSOLE_USER" "$@"
+}
+
+if [ -z "$CONSOLE_USER" ] || [ "$CONSOLE_USER" = "root" ] || [ -z "$CONSOLE_UID" ] || [ "$CONSOLE_UID" -eq 0 ]; then
+    echo "$LOG_PREFIX no console user logged in; skipping pluginkit registration (extension will register on first launch of the app by the user)"
+elif [ ! -x "$(command -v pluginkit)" ]; then
+    echo "$LOG_PREFIX pluginkit not found; cannot register extension for user '$CONSOLE_USER'"
+else
+    echo "$LOG_PREFIX registering extension for user '$CONSOLE_USER' (uid $CONSOLE_UID)"
+
+    # Add it to the DB. This happens automatically too, but we push a bit harder (#3463).
+    run_as_console_user pluginkit -a "$APPEX"; rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "$LOG_PREFIX pluginkit -a succeeded for $APPEX"
+    else
+        echo "$LOG_PREFIX WARNING pluginkit -a failed (rc $rc) for $APPEX"
+    fi
+
+    # Since El Capitan we need to wait for discovery before electing (#4650).
+    sleep 10
+
+    # Enable (elect) it for the console user.
+    run_as_console_user pluginkit -e use -i "$EXT_ID"; rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "$LOG_PREFIX pluginkit -e use succeeded for $EXT_ID"
+    else
+        echo "$LOG_PREFIX WARNING pluginkit -e use failed (rc $rc) for $EXT_ID"
+    fi
+
+    # Record the resulting election state for support diagnostics.
+    if run_as_console_user pluginkit -m -i "$EXT_ID" -v; then
+        echo "$LOG_PREFIX extension present in pluginkit database after registration (see line above for election state)"
+    else
+        echo "$LOG_PREFIX WARNING extension NOT present in pluginkit database after registration for $EXT_ID"
+    fi
 fi
 
 # Remove legacy LaunchAgent plist from all users if present, became obsolete with version 33.0.0

--- a/doc/macOS-FinderSync-extension.md
+++ b/doc/macOS-FinderSync-extension.md
@@ -1,0 +1,143 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+# macOS Finder Integration (FinderSync) Extension
+
+## Overview
+
+The Finder integration — the Nextcloud context-menu entries and the sync-status
+icons (badges) shown for folders under Finder's **Favorites** — is provided by a
+separate macOS app extension, `FinderSyncExt` (bundle identifier
+`com.nextcloud.desktopclient.FinderSyncExt` for the official build). It is
+distinct from the File Provider extension (`FileProviderExt`), which drives the
+**Locations** integration for virtual files. macOS allows only one of the two to
+be active at a time, by design.
+
+For the integration to work, three things must happen:
+
+1. **Registration** — macOS (LaunchServices / PlugInKit, `pluginkit`) must
+   discover and elect the extension for the logged-in user.
+2. **Enablement** — the user must have it enabled (this is the state a `+` in
+   `pluginkit -m` reflects).
+3. **Connection** — the extension process, launched by Finder, must connect back
+   to the running desktop client over XPC and complete a handshake.
+
+Historically the integration appeared "not loaded" (missing badges/menus after a
+reboot) even when steps 1 and 2 were fine, because step 3 could silently fail —
+see [#10032](https://github.com/nextcloud/desktop/issues/10032),
+[#8471](https://github.com/nextcloud/desktop/issues/8471) and
+[#8363](https://github.com/nextcloud/desktop/issues/8363). The extension now only
+reports itself connected after a real XPC **handshake** round-trip with the
+client succeeds, and both the installer and the runtime log every outcome so a
+failure is recognizable from logs alone. This document explains how to read them.
+
+## Verifying installation
+
+The installer's postinstall script ([`admin/osx/post_install.sh.cmake`](../admin/osx/post_install.sh.cmake))
+registers and enables the extension **for the logged-in console user**
+(`pluginkit` state is per-user, and the script itself runs as `root`, so it hops
+into the user's context with `launchctl asuser` + `sudo -u`). Every step is
+logged to `/var/log/install.log` with the prefix `Nextcloud FinderSync:`.
+
+```console
+grep "Nextcloud FinderSync" /var/log/install.log
+```
+
+A healthy installation ends with:
+
+```
+Nextcloud FinderSync: pluginkit -e use succeeded for com.nextcloud.desktopclient.FinderSyncExt
+Nextcloud FinderSync: extension present in pluginkit database after registration (see line above for election state)
+```
+
+Signals that registration did **not** happen:
+
+| Log line | Meaning |
+| --- | --- |
+| `WARNING pluginkit -a failed …` / `WARNING pluginkit -e use failed …` | The registration/election command returned non-zero. |
+| `WARNING extension NOT present in pluginkit database after registration …` | The extension is still not registered after the attempt. |
+| `no console user logged in; skipping pluginkit registration …` | Installed with no GUI user (e.g. MDM/remote). The extension is expected to register on the user's first launch of the app instead. |
+| `pluginkit not found; cannot register extension …` | `pluginkit` is unavailable on this system. |
+
+## Verifying at runtime
+
+### Is the extension registered and enabled?
+
+```console
+pluginkit -mvvv -i com.nextcloud.desktopclient.FinderSyncExt
+```
+
+A leading `+` means enabled, `-` means installed but disabled, `?` means
+registered without an explicit election, and empty output means it is not
+registered at all.
+
+### Does the extension reach the client? (the handshake)
+
+The extension logs its connection lifecycle to the unified system log under its
+own bundle identifier as subsystem. Watch it live while the client starts (or
+right after logging in):
+
+```console
+log stream --level info --predicate 'subsystem == "com.nextcloud.desktopclient.FinderSyncExt"'
+```
+
+Or inspect what already happened (info-level entries are not persisted forever,
+so keep the window short):
+
+```console
+log show --last 10m --info --predicate 'subsystem == "com.nextcloud.desktopclient.FinderSyncExt"'
+```
+
+Key messages and what they mean:
+
+| Message | Level | Meaning |
+| --- | --- | --- |
+| `FinderSync XPC handshake succeeded; connection to app is live` | info | **Working.** The extension confirmed the client is on the other end. |
+| `Performing XPC handshake with app (generation N)` | info | A connection attempt is in progress. |
+| `FinderSync XPC handshake timed out after 5 s` | error | The client was reachable but did not answer the handshake. A reconnect is scheduled. |
+| `FinderSync XPC message to app failed: …` | error | The client is not listening yet (e.g. extension started before the app). A reconnect is scheduled. |
+| `FinderSync XPC connection lost (<reason>); scheduling reconnect` | error | An established connection dropped (client quit, interrupted, …). |
+| `Scheduling reconnect in N seconds` | info | Backoff between retries (1 → 2 → 4 → 8 s). |
+
+Transient failures immediately after login are normal: the extension is
+typically launched by Finder before the client finishes starting, so you may see
+a `message to app failed` / reconnect or two followed by `handshake succeeded`.
+What indicates a real problem is `handshake succeeded` **never** appearing, or a
+previously-live connection producing repeated `connection lost` entries.
+
+The client side of the same handshake is logged in the **desktop client log**
+(not the system log), at info level under the categories
+`nextcloud.gui.macos.findersync.xpc` and `nextcloud.gui.macfindersyncservice`.
+The positive confirmation there is:
+
+```
+FinderSync extension handshake received; connection to app is live
+```
+
+## Remediation
+
+If the extension is registered and enabled (`+` above) but never completes the
+handshake, and the client is definitely running:
+
+1. Disable and re-enable **Nextcloud** in **System Settings** under **Login Items
+   & Extensions** (on older macOS: **Privacy & Security ▸ Extensions**).
+2. Relaunch Finder (`killall Finder`).
+
+These are workarounds for a stuck state, not a fix. When reporting a problem,
+attach the output of the `grep`, `pluginkit -m` and `log show` commands above.
+
+## Implementation references
+
+- Extension XPC client and handshake / reconnect logic:
+  [`shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncXPCManager.m`](../shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncXPCManager.m)
+- Extension principal object (badges, menus, bounded menu wait):
+  [`shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m`](../shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m)
+- Shared XPC protocol (`performHandshakeWithReply:`):
+  [`shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncAppProtocol.h`](../shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncAppProtocol.h)
+- Client-side XPC listener and service:
+  [`src/gui/macOS/findersyncxpc_mac.mm`](../src/gui/macOS/findersyncxpc_mac.mm),
+  [`src/gui/macOS/findersyncservice.mm`](../src/gui/macOS/findersyncservice.mm)
+- Installer registration:
+  [`admin/osx/post_install.sh.cmake`](../admin/osx/post_install.sh.cmake)

--- a/doc/macOS-development.md
+++ b/doc/macOS-development.md
@@ -179,4 +179,5 @@ The way Transifex handles Xcode string catalogs creates a high risk of accidenta
 
 - **Direct `mac-crafter` CLI usage / branding builds** → [`admin/osx/mac-crafter/README.md`](../admin/osx/mac-crafter/README.md)
 - **Qt + macOS App Sandbox internals** → [`doc/macOS-Sandbox-Qt.md`](./macOS-Sandbox-Qt.md)
+- **Finder integration (FinderSync) extension — verifying & troubleshooting loading** → [`doc/macOS-FinderSync-extension.md`](./macOS-FinderSync-extension.md)
 - **NextcloudFileProviderKit Swift package** → [`shell_integration/MacOSX/NextcloudFileProviderKit/README.md`](../shell_integration/MacOSX/NextcloudFileProviderKit/README.md)

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSync.m
@@ -15,9 +15,15 @@
     NSMutableDictionary *_strings;
     NSMutableArray *_menuItems;
     NSCondition *_menuIsComplete;
+    BOOL _menuReady;  // Predicate for _menuIsComplete; guards against lost NSCondition signals.
     os_log_t _log;
 }
 @end
+
+// Upper bound on how long -menuForMenuKind: blocks Finder's thread waiting for the app to
+// return menu items. A healthy connection replies in milliseconds; this only bites when the
+// app died mid-request, so we cap it rather than hang Finder indefinitely (issues #10032/#8363).
+static const NSTimeInterval kFinderSyncMenuWaitTimeoutSeconds = 5.0;
 
 static os_log_t getFinderSyncLogger(void) {
     static dispatch_once_t onceToken;
@@ -61,11 +67,12 @@ static os_log_t getFinderSyncLogger(void) {
         [syncController setBadgeImage:warning label:@"Ignored" forBadgeIdentifier:@"IGNORE+SWM"];
         [syncController setBadgeImage:error label:@"Error" forBadgeIdentifier:@"ERROR+SWM"];
 
-        // Initialize XPC manager instead of socket client
+        // Initialize XPC manager instead of socket client. The manager pulls the localized
+        // strings itself once the handshake with the app succeeds, so there is no point
+        // requesting them here — at init time the connection is never established yet.
         os_log_info(_log, "Initializing FinderSync XPC manager");
         self.xpcManager = [[FinderSyncXPCManager alloc] initWithDelegate:self];
         [self.xpcManager start];
-        [self.xpcManager askOnSocket:@"" query:@"GET_STRINGS"];
 
         _registeredDirectories = NSMutableSet.set;
         _strings = NSMutableDictionary.dictionary;
@@ -118,10 +125,20 @@ static os_log_t getFinderSyncLogger(void) {
 - (void)waitForMenuToArrive
 {
     os_log_debug(_log, "Waiting for menu to arrive");
+    NSDate *const deadline = [NSDate dateWithTimeIntervalSinceNow:kFinderSyncMenuWaitTimeoutSeconds];
     [self->_menuIsComplete lock];
-    [self->_menuIsComplete wait];
+    // Loop on a predicate rather than a bare -wait: an NSCondition signal is not sticky, so if
+    // -menuHasCompleted fired before we reached -wait the signal would be lost and we would block
+    // forever. The deadline additionally guarantees we never hang Finder if the reply never comes.
+    while (!self->_menuReady) {
+        if (![self->_menuIsComplete waitUntilDate:deadline]) {
+            os_log_error(_log, "Timed out waiting for menu items from app after %.0f s; returning what we have",
+                         (double)kFinderSyncMenuWaitTimeoutSeconds);
+            break;
+        }
+    }
     [self->_menuIsComplete unlock];
-    os_log_debug(_log, "Menu arrival wait completed");
+    os_log_debug(_log, "Menu arrival wait completed (ready=%d)", self->_menuReady);
 }
 
 - (NSMenu *)menuForMenuKind:(FIMenuKind)whichMenu
@@ -156,6 +173,13 @@ static os_log_t getFinderSyncLogger(void) {
 	os_log_debug(_log, "Root directories check: onlyRootsSelected = %d", onlyRootsSelected);
 
 	NSString *paths = [self selectedPathsSeparatedByRecordSeparator];
+
+    // Arm the predicate before issuing the async request so a reply that races back
+    // before -waitForMenuToArrive cannot be missed.
+    [self->_menuIsComplete lock];
+    self->_menuReady = NO;
+    [self->_menuIsComplete unlock];
+
 	[self.xpcManager askOnSocket:paths query:@"GET_MENU_ITEMS"];
 
     // Since the XPC communication is asynchronous, wait here until the menu
@@ -271,7 +295,10 @@ static os_log_t getFinderSyncLogger(void) {
 - (void)menuHasCompleted
 {
     os_log_debug(_log, "Menu completion signal received");
+    [self->_menuIsComplete lock];
+    self->_menuReady = YES;
     [self->_menuIsComplete signal];
+    [self->_menuIsComplete unlock];
     os_log_debug(_log, "Menu signal emitted");
 }
 

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncXPCManager.m
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/FinderSyncXPCManager.m
@@ -8,6 +8,11 @@
 #import "Services/FinderSyncAppProtocol.h"
 
 #import <os/log.h>
+#import <stdatomic.h>
+
+// If the app accepted the Mach lookup but never replies to the handshake (e.g. it is
+// still launching), no error handler fires — so we time the handshake out and retry.
+static const NSTimeInterval kFinderSyncHandshakeTimeoutSeconds = 5.0;
 
 static os_log_t getXPCManagerLogger(void) {
     static dispatch_once_t onceToken;
@@ -26,7 +31,14 @@ static os_log_t getXPCManagerLogger(void) {
 {
     NSXPCConnection *_connection;
     id<FinderSyncAppProtocol> _appProxy;
-    BOOL _isConnected;
+    // Only true after a handshake round-trip to the app succeeds. Atomic because it is
+    // written on _connectionQueue but read from Finder's thread via -isConnected.
+    atomic_bool _isConnected;
+    // Identifies the current connection attempt. Every asynchronous callback (handshake
+    // reply, handshake error, interruption, invalidation, timeout) captures the generation
+    // it belongs to and is ignored if a newer attempt has superseded it — so a late
+    // callback from a dead connection can never tear down a newer, healthy one.
+    NSUInteger _connectionGeneration;
     NSMutableDictionary *_statusCache;
     dispatch_queue_t _connectionQueue;
     NSUInteger _reconnectDelay;
@@ -44,7 +56,8 @@ static os_log_t getXPCManagerLogger(void) {
     if (self) {
         _log = getXPCManagerLogger();
         _delegate = delegate;
-        _isConnected = NO;
+        atomic_store(&_isConnected, false);
+        _connectionGeneration = 0;
         _statusCache = [NSMutableDictionary dictionary];
         _connectionQueue = dispatch_queue_create("com.nextcloud.FinderSync.XPCQueue", DISPATCH_QUEUE_SERIAL);
         _reconnectDelay = 1;
@@ -102,43 +115,110 @@ static os_log_t getXPCManagerLogger(void) {
         connection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(FinderSyncProtocol)];
         connection.exportedObject = self;
 
-        // Set up interruption and invalidation handlers
+        // Tag this attempt. Every callback below is guarded by this generation so a stale
+        // callback from a superseded connection cannot disturb a newer, healthy one.
+        const NSUInteger generation = ++self->_connectionGeneration;
+
         __weak FinderSyncXPCManager *weakSelf = self;
 
         connection.interruptionHandler = ^{
-            FinderSyncXPCManager *strongSelf = weakSelf;
-            if (strongSelf) {
-                os_log_info(strongSelf->_log, "XPC connection interrupted");
-                strongSelf->_isConnected = NO;
-                [strongSelf scheduleReconnect];
-            }
+            [weakSelf handleConnectionFailureForGeneration:generation reason:@"connection interrupted"];
         };
 
         connection.invalidationHandler = ^{
-            FinderSyncXPCManager *strongSelf = weakSelf;
-
-            if (strongSelf) {
-                os_log_info(strongSelf->_log, "XPC connection invalidated");
-                strongSelf->_isConnected = NO;
-                strongSelf->_connection = nil;
-                strongSelf->_appProxy = nil;
-                [strongSelf scheduleReconnect];
-            }
+            [weakSelf handleConnectionFailureForGeneration:generation reason:@"connection invalidated"];
         };
 
-        os_log_info(self->_log, "Resuming XPC connection");
+        os_log_info(self->_log, "Resuming XPC connection (generation %lu)", (unsigned long)generation);
         [connection resume];
 
         self->_connection = connection;
 
-        self->_appProxy = [connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
-            os_log_error(self->_log, "Error getting remote proxy: %{public}@", error.localizedDescription);
+        // NSXPCConnection is lazy: -resume and the proxy below succeed even when no peer has
+        // accepted the connection yet (e.g. the extension launched before the app at login).
+        // So we do NOT mark ourselves connected here — we withhold that until a real handshake
+        // round-trip to the app succeeds. This is the fix for the phantom-connected state
+        // behind issues #10032/#8471/#8363, where the extension believed it was connected to
+        // a dead peer and never recovered until the user toggled it or relaunched Finder.
+        id<FinderSyncAppProtocol> proxy = [connection remoteObjectProxyWithErrorHandler:^(NSError *error) {
+            os_log_error(self->_log, "FinderSync XPC message to app failed: %{public}@", error.localizedDescription);
+            [weakSelf handleConnectionFailureForGeneration:generation reason:@"remote proxy error"];
         }];
 
-        self->_isConnected = YES;
+        os_log_info(self->_log, "Performing XPC handshake with app (generation %lu)", (unsigned long)generation);
 
-        // Request initial localized strings
-        [self requestLocalizedStrings];
+        [proxy performHandshakeWithReply:^{
+            FinderSyncXPCManager *strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+
+            dispatch_async(strongSelf->_connectionQueue, ^{
+                if (generation != strongSelf->_connectionGeneration) {
+                    os_log_info(strongSelf->_log, "Ignoring stale handshake reply (generation %lu, current %lu)",
+                                (unsigned long)generation, (unsigned long)strongSelf->_connectionGeneration);
+                    return;
+                }
+
+                strongSelf->_appProxy = proxy;
+                atomic_store(&strongSelf->_isConnected, true);
+                strongSelf->_reconnectDelay = 1; // reset backoff after a healthy connection
+                os_log_info(strongSelf->_log, "FinderSync XPC handshake succeeded; connection to app is live (generation %lu)",
+                            (unsigned long)generation);
+
+                // Only now that the app is confirmed live do we pull the localized strings.
+                [strongSelf requestLocalizedStrings];
+            });
+        }];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kFinderSyncHandshakeTimeoutSeconds * NSEC_PER_SEC)), self->_connectionQueue, ^{
+            FinderSyncXPCManager *strongSelf = weakSelf;
+            if (!strongSelf) {
+                return;
+            }
+
+            if (generation == strongSelf->_connectionGeneration && !atomic_load(&strongSelf->_isConnected)) {
+                os_log_error(strongSelf->_log, "FinderSync XPC handshake timed out after %.0f s (generation %lu)",
+                             (double)kFinderSyncHandshakeTimeoutSeconds, (unsigned long)generation);
+                [strongSelf handleConnectionFailureForGeneration:generation reason:@"handshake timeout"];
+            }
+        });
+    });
+}
+
+- (void)handleConnectionFailureForGeneration:(NSUInteger)generation reason:(NSString *)reason
+{
+    dispatch_async(_connectionQueue, ^{
+        if (generation != self->_connectionGeneration) {
+            // A newer connection attempt already superseded this one; nothing to do.
+            return;
+        }
+
+        os_log_error(self->_log, "FinderSync XPC connection lost (%{public}@); scheduling reconnect", reason);
+
+        atomic_store(&self->_isConnected, false);
+
+        // Bump the generation so the invalidation handler we trigger below — and any
+        // in-flight handshake reply/timeout for this attempt — are recognised as stale.
+        self->_connectionGeneration++;
+
+        NSXPCConnection *deadConnection = self->_connection;
+        self->_connection = nil;
+        self->_appProxy = nil;
+        [deadConnection invalidate];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Release Finder's menu thread if it is blocked waiting for a reply that will
+            // never arrive, then let the extension drop its now-stale badges/registrations.
+            if ([self.delegate respondsToSelector:@selector(menuHasCompleted)]) {
+                [self.delegate menuHasCompleted];
+            }
+            if ([self.delegate respondsToSelector:@selector(connectionDidDie)]) {
+                [self.delegate connectionDidDie];
+            }
+        });
+
+        [self scheduleReconnect];
     });
 }
 
@@ -168,16 +248,19 @@ static os_log_t getXPCManagerLogger(void) {
 - (void)invalidateConnection
 {
     dispatch_sync(_connectionQueue, ^{
+        // Bump the generation so the invalidation handler for this connection is treated
+        // as stale and does not schedule a reconnect after we are being torn down.
+        self->_connectionGeneration++;
         [self->_connection invalidate];
         self->_connection = nil;
         self->_appProxy = nil;
-        self->_isConnected = NO;
+        atomic_store(&self->_isConnected, false);
     });
 }
 
 - (BOOL)isConnected
 {
-    return _isConnected;
+    return atomic_load(&_isConnected);
 }
 
 - (void)requestLocalizedStrings

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncAppProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncAppProtocol.h
@@ -56,6 +56,23 @@
                   forPaths:(NSArray<NSString *> *)paths
          completionHandler:(void(^)(NSError *error))completionHandler;
 
+/**
+ * @brief Handshake round-trip the extension uses to confirm the app is actually
+ * listening before it treats the XPC connection as usable.
+ *
+ * NSXPCConnection is lazy: -resume and -remoteObjectProxyWithErrorHandler: both
+ * succeed even when no peer has accepted the connection yet — e.g. the extension
+ * was launched by Finder at login before the main app finished starting. Treating
+ * that as "connected" is the phantom state behind issues #10032/#8471/#8363, where
+ * Finder shows the extension enabled but badges and menus never work after a reboot.
+ * Only a real round-trip proves the app is alive: on success this reply is invoked;
+ * if delivery fails the proxy's error handler fires instead, which the extension
+ * uses to detect the dead connection and reconnect.
+ *
+ * @param completionHandler Invoked by the app once it has received the handshake.
+ */
+- (void)performHandshakeWithReply:(void(^)(void))completionHandler;
+
 @end
 
 #endif /* FinderSyncAppProtocol_h */

--- a/src/gui/macOS/findersyncservice.mm
+++ b/src/gui/macOS/findersyncservice.mm
@@ -261,6 +261,18 @@ Q_LOGGING_CATEGORY(lcMacFinderSyncService, "nextcloud.gui.macfindersyncservice",
     }, Qt::QueuedConnection);
 }
 
+- (void)performHandshakeWithReply:(void(^)(void))completionHandler
+{
+    // Logged at info level so it appears in the client log bundle users attach to
+    // issues: this line is the positive proof that a FinderSync extension reached
+    // the app and completed the connection handshake (see issues #10032/#8471/#8363).
+    qCInfo(OCC::lcMacFinderSyncService) << "FinderSync extension handshake received; connection to app is live";
+
+    if (completionHandler) {
+        completionHandler();
+    }
+}
+
 @end
 
 namespace OCC {


### PR DESCRIPTION
Several changes to improve the loading of the FinderSync extension on macOS.

Note the developer documentation added, too.

Known issue: When one has Adobe Creative Cloud installed, the enablement of "Core Sync" and "Creative Cloud" file providers in macOS system settings breaks our FinderSync. I remember this class of problems from my previous job with another file provider and FinderSync extension. Other third party apps may break the own FinderSync extension loading for whatever reason. I think back then it was OneDrive. Probably related how macOS loads the extensions.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
