### PR TITLE
fix(tray): Fix macOS material choice for tray menu background

### DIFF
--- a/src/gui/macOS/trayaccountpopup/trayaccountpopupviewutils.mm
+++ b/src/gui/macOS/trayaccountpopup/trayaccountpopupviewutils.mm
@@ -85,38 +85,59 @@ NSStackView *configurePopupPanel(NSPanel *panel)
     panel.backgroundColor = NSColor.clearColor;
     panel.opaque = NO;
 
-    auto container = [[[NSView alloc] init] autorelease];
-    container.wantsLayer = YES;
-    container.layer.cornerRadius = kCornerRadius;
-    container.layer.masksToBounds = YES;
-    panel.contentView = container;
-
-    auto visualEffectView = [[[NSVisualEffectView alloc] init] autorelease];
-    visualEffectView.material = NSVisualEffectMaterialMenu;
-    visualEffectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
-    visualEffectView.state = NSVisualEffectStateActive;
-    visualEffectView.wantsLayer = YES;
-    visualEffectView.layer.cornerRadius = kCornerRadius;
-    visualEffectView.layer.masksToBounds = YES;
-    visualEffectView.translatesAutoresizingMaskIntoConstraints = NO;
-    [container addSubview:visualEffectView];
-
     auto stack = [NSStackView stackViewWithViews:@[]];
     stack.orientation = NSUserInterfaceLayoutOrientationVertical;
     stack.spacing = 0;
     stack.translatesAutoresizingMaskIntoConstraints = NO;
-    [visualEffectView addSubview:stack];
 
-    [NSLayoutConstraint activateConstraints:@[
-        [visualEffectView.topAnchor constraintEqualToAnchor:container.topAnchor],
-        [visualEffectView.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
-        [visualEffectView.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
-        [visualEffectView.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
-        [stack.topAnchor constraintEqualToAnchor:visualEffectView.topAnchor],
-        [stack.leadingAnchor constraintEqualToAnchor:visualEffectView.leadingAnchor],
-        [stack.trailingAnchor constraintEqualToAnchor:visualEffectView.trailingAnchor],
-        [stack.bottomAnchor constraintEqualToAnchor:visualEffectView.bottomAnchor],
-    ]];
+    if (@available(macOS 26.0, *)) {
+        auto container = [[[NSView alloc] init] autorelease];
+        container.wantsLayer = YES;
+        container.layer.cornerRadius = kCornerRadius;
+        container.layer.masksToBounds = YES;
+        panel.contentView = container;
+
+        auto glassEffectView = [[[NSGlassEffectView alloc] init] autorelease];
+        glassEffectView.cornerRadius = kCornerRadius;
+        glassEffectView.contentView = stack;
+        glassEffectView.translatesAutoresizingMaskIntoConstraints = NO;
+        [container addSubview:glassEffectView];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [glassEffectView.topAnchor constraintEqualToAnchor:container.topAnchor],
+            [glassEffectView.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+            [glassEffectView.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+            [glassEffectView.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+        ]];
+    } else {
+        auto container = [[[NSView alloc] init] autorelease];
+        container.wantsLayer = YES;
+        container.layer.cornerRadius = kCornerRadius;
+        container.layer.masksToBounds = YES;
+        panel.contentView = container;
+
+        auto visualEffectView = [[[NSVisualEffectView alloc] init] autorelease];
+        visualEffectView.material = NSVisualEffectMaterialMenu;
+        visualEffectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
+        visualEffectView.state = NSVisualEffectStateActive;
+        visualEffectView.wantsLayer = YES;
+        visualEffectView.layer.cornerRadius = kCornerRadius;
+        visualEffectView.layer.masksToBounds = YES;
+        visualEffectView.translatesAutoresizingMaskIntoConstraints = NO;
+        [container addSubview:visualEffectView];
+        [visualEffectView addSubview:stack];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [visualEffectView.topAnchor constraintEqualToAnchor:container.topAnchor],
+            [visualEffectView.leadingAnchor constraintEqualToAnchor:container.leadingAnchor],
+            [visualEffectView.trailingAnchor constraintEqualToAnchor:container.trailingAnchor],
+            [visualEffectView.bottomAnchor constraintEqualToAnchor:container.bottomAnchor],
+            [stack.topAnchor constraintEqualToAnchor:visualEffectView.topAnchor],
+            [stack.leadingAnchor constraintEqualToAnchor:visualEffectView.leadingAnchor],
+            [stack.trailingAnchor constraintEqualToAnchor:visualEffectView.trailingAnchor],
+            [stack.bottomAnchor constraintEqualToAnchor:visualEffectView.bottomAnchor],
+        ]];
+    }
 
     return stack;
 }

--- a/src/gui/macOS/trayaccountpopup/trayaccountpopupviewutils.mm
+++ b/src/gui/macOS/trayaccountpopup/trayaccountpopupviewutils.mm
@@ -92,7 +92,7 @@ NSStackView *configurePopupPanel(NSPanel *panel)
     panel.contentView = container;
 
     auto visualEffectView = [[[NSVisualEffectView alloc] init] autorelease];
-    visualEffectView.material = NSVisualEffectMaterialHUDWindow;
+    visualEffectView.material = NSVisualEffectMaterialMenu;
     visualEffectView.blendingMode = NSVisualEffectBlendingModeBehindWindow;
     visualEffectView.state = NSVisualEffectStateActive;
     visualEffectView.wantsLayer = YES;


### PR DESCRIPTION
## Summary

### After (liquid glass, macOS 26+)

<img width="302" height="177" alt="Screenshot 2026-07-13 at 18 19 53" src="https://github.com/user-attachments/assets/d0129719-a6c3-4977-96c6-5ec59ebe666d" />

### Before (no liquid glass)

<img width="302" height="177" alt="Screenshot 2026-07-13 at 18 38 28" src="https://github.com/user-attachments/assets/35d50340-9cdd-43cb-845f-e81292312918" />

### After (visual effect material fix)

<img width="346" height="219" alt="Screenshot 2026-07-13 at 12 03 57" src="https://github.com/user-attachments/assets/9562357d-9ddd-4c31-b7ab-3624c057da5b" />

### Before

<img width="346" height="219" alt="Screenshot 2026-07-13 at 12 50 24" src="https://github.com/user-attachments/assets/2212f9d2-e0af-4119-9a77-13968fb8cd09" />

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [X] Uploaded screenshots from before and after for UI changes.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
