### PR TITLE
feat(fileprovider): Handle AutoCAD lock files

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -18,13 +18,16 @@ NextcloudFileProviderKit is a Swift package designed to simplify the development
 
 ### Lock File Support
 
-Some applications like Microsoft Office and LibreOffice create hidden lock files in the same directory a file opened by them is located in.
-They usually equal the name of the opened file with prefixes like `~$` or suffixes like `#`.
+Some applications like Microsoft Office, LibreOffice, Adobe and AutoCAD create hidden lock files in the same directory a file opened by them is located in.
+Office and LibreOffice lock files usually equal the name of the opened file with prefixes like `~$` or suffixes like `#`.
+Adobe applications (InDesign, InCopy, Premiere Pro) use dedicated lock file extensions (`.idlk`, `.prlock`) that carry only the document's base name — not its extension — so the guarded document is resolved by matching a sibling file.
+AutoCAD creates `.dwl` and `.dwl2` lock files that share the document's base name, so the guarded `.dwg` document is resolved by replacing the extension.
 These are recognized by the file provider extension and not synchronized to the server.
 However, the capabilities of the `files_lock` server app are used to lock the file for editing remotely on the server.
 
 - ``isLockFileName(_:)``
 - ``originalFileName(fromLockFileName:dbManager:)``
+- ``lockFileTargetName(forLockFileName:parentServerUrl:dbManager:)``
 
 ### Logging
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
@@ -252,6 +252,14 @@ extension Item {
             return nil
         }
 
+        // (Newer versions of) AutoCAD creates .dwl and .dwl2 as a pair. Only unlock when both are gone.
+        if isAutoCADLockFileName(metadata.fileName),
+           autoCADSiblingLockFileExists(lockFilename: metadata.fileName, parentServerUrl: metadata.serverUrl, dbManager: dbManager)
+        {
+            logger.info("AutoCAD sibling lock file still present; keeping document locked.", [.name: originalFileName])
+            return nil
+        }
+
         let originalFileServerFileNameUrl = metadata.serverUrl + "/" + originalFileName
 
         do {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -21,6 +21,18 @@ let adobeLockFileDocumentExtensions: [String: [String]] = [
     "prlock": ["prproj"]
 ]
 
+/// Lock file extensions created by AutoCAD.
+///
+/// AutoCAD creates `.dwl` (plain text) and `.dwl2` (XML) lock files when a `.dwg` drawing is
+/// opened. Unlike Adobe lock files, the lock file shares the exact same base name as the
+/// document — only the extension differs — so the guarded document is resolved by simply
+/// replacing the lock extension with `.dwg`. Both lock files are deleted when the drawing
+/// is closed.
+let autoCADLockFileExtensions: Set<String> = ["dwl", "dwl2"]
+
+/// The document extension guarded by AutoCAD lock files.
+let autoCADDocumentExtension = "dwg"
+
 ///
 /// Determine whether the given filename is a lock file as created by Adobe applications like InDesign or Premiere Pro.
 ///
@@ -34,7 +46,19 @@ public func isAdobeLockFileName(_ filename: String) -> Bool {
 }
 
 ///
-/// Determine whether the given filename is a lock file as created by certain applications like Microsoft Office, LibreOffice or Adobe.
+/// Determine whether the given filename is a lock file as created by AutoCAD.
+///
+/// - Parameters:
+///     - filename: The filename to check.
+///
+/// - Returns: `true` if the filename is an AutoCAD lock file, `false` otherwise.
+///
+public func isAutoCADLockFileName(_ filename: String) -> Bool {
+    autoCADLockFileExtensions.contains((filename as NSString).pathExtension.lowercased())
+}
+
+///
+/// Determine whether the given filename is a lock file as created by certain applications like Microsoft Office, LibreOffice, Adobe or AutoCAD.
 ///
 /// - Parameters:
 ///     - filename: The filename to check.
@@ -47,7 +71,9 @@ public func isLockFileName(_ filename: String) -> Bool {
         // LibreOffice lock files
         (filename.hasPrefix(".~lock.") && filename.hasSuffix("#")) ||
         // Adobe lock files
-        isAdobeLockFileName(filename)
+        isAdobeLockFileName(filename) ||
+        // AutoCAD lock files
+        isAutoCADLockFileName(filename)
 }
 
 ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -219,6 +219,42 @@ func autoCADLockFileTargetName(_ lockFilename: String) -> String? {
 }
 
 ///
+/// Check whether any other AutoCAD lock file for the same document still exists in the
+/// database, apart from the one being deleted.
+///
+/// AutoCAD creates `.dwl` and `.dwl2` as a pair. The guarded document must only be
+/// unlocked on the server when **both** are gone. This helper is used by
+/// ``Item/deleteLockFile(domain:dbManager:)`` to avoid prematurely unlocking when
+/// only one of the two lock files is removed.
+///
+/// - Parameters:
+///     - lockFilename: The lock file name being deleted.
+///     - parentServerUrl: The server URL of the directory containing the lock file.
+///     - dbManager: The database manager to use for looking up files.
+///
+/// - Returns: `true` if at least one other AutoCAD lock file for the same base name
+///   still exists in the database, `false` otherwise.
+///
+func autoCADSiblingLockFileExists(lockFilename: String, parentServerUrl: String, dbManager: FilesDatabaseManager) -> Bool {
+    let baseName = (lockFilename as NSString).deletingPathExtension
+    guard !baseName.isEmpty else { return false }
+
+    let otherLockExtensions = autoCADLockFileExtensions.subtracting([(lockFilename as NSString).pathExtension.lowercased()])
+    for ext in otherLockExtensions {
+        let siblingName = baseName + "." + ext
+        if let sibling = dbManager.itemMetadatas
+            .where({ $0.serverUrl.equals(parentServerUrl) })
+            .where({ $0.fileName.equals(siblingName) })
+            .first,
+           !sibling.deleted
+        {
+            return true
+        }
+    }
+    return false
+}
+
+///
 /// Resolve the document guarded by a lock file, regardless of the application that created it.
 ///
 /// Office and LibreOffice lock file names fully encode the document name, so it is decoded

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -201,12 +201,32 @@ func adobeLockFileTargetName(lockFilename: String, parentServerUrl: String, dbMa
 }
 
 ///
+/// Resolve the document guarded by an AutoCAD lock file.
+///
+/// AutoCAD lock files (`.dwl` / `.dwl2`) share the exact same base name as the guarded
+/// `.dwg` document — only the extension differs — so the document name is derived by
+/// replacing the lock extension with `.dwg`. No sibling lookup is needed.
+///
+/// - Parameters:
+///     - lockFilename: The AutoCAD lock file name.
+///
+/// - Returns: The guarded document's file name, or `nil` if it is not an AutoCAD lock file.
+///
+func autoCADLockFileTargetName(_ lockFilename: String) -> String? {
+    guard isAutoCADLockFileName(lockFilename) else { return nil }
+    let baseName = (lockFilename as NSString).deletingPathExtension
+    return baseName.isEmpty ? nil : baseName + "." + autoCADDocumentExtension
+}
+
+///
 /// Resolve the document guarded by a lock file, regardless of the application that created it.
 ///
 /// Office and LibreOffice lock file names fully encode the document name, so it is decoded
 /// directly via ``originalFileName(fromLockFileName:dbManager:)``. Adobe lock file names only
 /// encode the base name, so the document is resolved by matching a sibling file via
-/// ``adobeLockFileTargetName(lockFilename:parentServerUrl:dbManager:)``.
+/// ``adobeLockFileTargetName(lockFilename:parentServerUrl:dbManager:)``. AutoCAD lock files
+/// share the document's base name, so the document is resolved by replacing the extension
+/// with `.dwg` via ``autoCADLockFileTargetName(_:)``.
 ///
 /// - Parameters:
 ///     - lockFilename: The lock file name.
@@ -218,6 +238,10 @@ func adobeLockFileTargetName(lockFilename: String, parentServerUrl: String, dbMa
 public func lockFileTargetName(forLockFileName lockFilename: String, parentServerUrl: String, dbManager: FilesDatabaseManager) -> String? {
     if isAdobeLockFileName(lockFilename) {
         return adobeLockFileTargetName(lockFilename: lockFilename, parentServerUrl: parentServerUrl, dbManager: dbManager)
+    }
+
+    if isAutoCADLockFileName(lockFilename) {
+        return autoCADLockFileTargetName(lockFilename)
     }
 
     return originalFileName(fromLockFileName: lockFilename, dbManager: dbManager)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -412,6 +412,99 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    func testDeleteAutoCADLockFileWithSiblingKeepsDocumentLocked() async {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let folderRemote = MockRemoteItem(
+            identifier: "folder-id",
+            versionIdentifier: "1",
+            name: "folder",
+            remotePath: Self.account.davFilesUrl + "/folder",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+
+        let targetFileName = "Drawing.dwg"
+        let targetRemote = MockRemoteItem(
+            identifier: "folder/\(targetFileName)",
+            versionIdentifier: "1",
+            name: targetFileName,
+            remotePath: folderRemote.remotePath + "/" + targetFileName,
+            data: Data("test data".utf8),
+            locked: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+
+        folderRemote.children = [targetRemote]
+        folderRemote.parent = rootItem
+        rootItem.children = [folderRemote]
+
+        var folderMetadata = SendableItemMetadata(
+            ocId: folderRemote.identifier, fileName: "folder", account: Self.account
+        )
+        folderMetadata.directory = true
+        Self.dbManager.addItemMetadata(folderMetadata)
+
+        var targetMetadata = SendableItemMetadata(
+            ocId: targetRemote.identifier, fileName: targetFileName, account: Self.account
+        )
+        targetMetadata.serverUrl += "/folder"
+        Self.dbManager.addItemMetadata(targetMetadata)
+
+        // Insert both .dwl and .dwl2 lock file metadata into the DB.
+        var dwlMetadata = SendableItemMetadata(
+            ocId: "dwl-id", fileName: "Drawing.dwl", account: Self.account
+        )
+        dwlMetadata.serverUrl += "/folder"
+        dwlMetadata.isLockFileOfLocalOrigin = true
+        Self.dbManager.addItemMetadata(dwlMetadata)
+
+        var dwl2Metadata = SendableItemMetadata(
+            ocId: "dwl2-id", fileName: "Drawing.dwl2", account: Self.account
+        )
+        dwl2Metadata.serverUrl += "/folder"
+        dwl2Metadata.isLockFileOfLocalOrigin = true
+        Self.dbManager.addItemMetadata(dwl2Metadata)
+
+        // Delete .dwl2 while .dwl still exists — document must stay locked.
+        let dwl2Item = Item(
+            metadata: dwl2Metadata,
+            parentItemIdentifier: .init(folderMetadata.ocId),
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await dwl2Item.delete(dbManager: Self.dbManager)
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: dwl2Metadata.ocId)?.deleted, true)
+        XCTAssertNil(error)
+        XCTAssertTrue(
+            targetRemote.locked, "Expected the document to stay locked while .dwl sibling exists"
+        )
+
+        // Now delete .dwl — with both gone, the document must unlock.
+        let dwlItem = Item(
+            metadata: dwlMetadata,
+            parentItemIdentifier: .init(folderMetadata.ocId),
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error2 = await dwlItem.delete(dbManager: Self.dbManager)
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: dwlMetadata.ocId)?.deleted, true)
+        XCTAssertNil(error2)
+        XCTAssertFalse(
+            targetRemote.locked, "Expected the document to be unlocked after both lock files are deleted"
+        )
+    }
+
     func testFailOnNonRecursiveNonEmptyDirDelete() async {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let remoteFolder = MockRemoteItem(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LocalFilesTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LocalFilesTests.swift
@@ -16,11 +16,16 @@ struct LocalFilesTests {
         #expect(isLockFileName("Test.IDLK")) // Case-insensitive extension.
         // Adobe Premiere Pro.
         #expect(isLockFileName("Test.prlock"))
+        // AutoCAD.
+        #expect(isLockFileName("Drawing.dwl"))
+        #expect(isLockFileName("Drawing.dwl2"))
+        #expect(isLockFileName("drawing.DWL")) // Case-insensitive extension.
 
         // Guarded documents themselves are not lock files.
         #expect(!isLockFileName("Test.indd"))
         #expect(!isLockFileName("Test.icml"))
         #expect(!isLockFileName("Test.prproj"))
+        #expect(!isLockFileName("Test.dwg"))
         #expect(!isLockFileName("Test.docx"))
         #expect(!isLockFileName("Test.odt"))
     }
@@ -34,6 +39,19 @@ struct LocalFilesTests {
         #expect(!isAdobeLockFileName(".~lock.Test.odt#")) // LibreOffice is not Adobe.
         #expect(!isAdobeLockFileName("Test.indd"))
         #expect(!isAdobeLockFileName("Test.prproj"))
+        #expect(!isAdobeLockFileName("Drawing.dwl")) // AutoCAD is not Adobe.
+    }
+
+    @Test func recognisesAutoCADLockFileNames() {
+        #expect(isAutoCADLockFileName("Drawing.dwl"))
+        #expect(isAutoCADLockFileName("Drawing.dwl2"))
+        #expect(isAutoCADLockFileName("drawing.DWL2")) // Case-insensitive extension.
+
+        #expect(!isAutoCADLockFileName("~$Test.docx")) // Microsoft Office is not AutoCAD.
+        #expect(!isAutoCADLockFileName(".~lock.Test.odt#")) // LibreOffice is not AutoCAD.
+        #expect(!isAutoCADLockFileName("Test.idlk")) // Adobe is not AutoCAD.
+        #expect(!isAutoCADLockFileName("Test.prlock"))
+        #expect(!isAutoCADLockFileName("Test.dwg")) // The document itself is not a lock file.
     }
 
     @Test func extractsAdobeDocumentBaseName() {
@@ -49,5 +67,19 @@ struct LocalFilesTests {
         // Non-Adobe extensions yield no base name.
         #expect(adobeLockFileDocumentBaseName("Test.docx") == nil)
         #expect(adobeLockFileDocumentBaseName("~$Test.docx") == nil)
+    }
+
+    @Test func resolvesAutoCADLockFileTargetName() {
+        // .dwl lock file resolves to .dwg document.
+        #expect(autoCADLockFileTargetName("Drawing.dwl") == "Drawing.dwg")
+        // .dwl2 lock file resolves to the same .dwg document.
+        #expect(autoCADLockFileTargetName("Drawing.dwl2") == "Drawing.dwg")
+        // Case-insensitive extension matching.
+        #expect(autoCADLockFileTargetName("drawing.DWL") == "drawing.dwg")
+
+        // Non-AutoCAD extensions yield no target name.
+        #expect(autoCADLockFileTargetName("Test.docx") == nil)
+        #expect(autoCADLockFileTargetName("Test.idlk") == nil)
+        #expect(autoCADLockFileTargetName("Test.dwg") == nil) // The document is not a lock file.
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
https://github.com/nextcloud/desktop/issues/10295

## Summary

Add handling of AutoCAD lock files (`.dwl` and `.dwl2`) within the FileProvider sync engine.

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.