### PR TITLE
feat(governance): update governance API for latest changes

### DIFF
--- a/src/gui/governance/governancelabelslistmodel.cpp
+++ b/src/gui/governance/governancelabelslistmodel.cpp
@@ -289,55 +289,33 @@ void GovernanceLabelsListModel::refreshModel()
                           oneLabelObject.value(u"color"_s).toString()
                           );
 
+        auto labelKeyName = QString{};
         switch (_labelType)
         {
         case Governance::LabelType::Sensitivity:
-        {
-            qCDebug(lcGovernanceLabelsListModel()) << "checking existing sensitivity labels";
-            if (!existingLabelsObject.contains(u"sensitivity"_s)) {
-                qCWarning(lcGovernanceLabelsListModel()) << "missing sensitivity data in OCS reply";
-                break;
-            }
-
-            const auto &sensitivityLabel = existingLabelsObject[u"sensitivity"_s].toObject();
-
-            parseExistingSingleLabel(rowIndex, sensitivityLabel);
+            labelKeyName = u"sensitivity"_s;
             break;
-        }
         case Governance::LabelType::Retention:
-        {
-            qCDebug(lcGovernanceLabelsListModel()) << "checking existing retention labels";
-            if (!existingLabelsObject.contains(u"retention"_s)) {
-                qCWarning(lcGovernanceLabelsListModel()) << "missing retention data in OCS reply";
-                break;
-            }
-
-            const auto retentionLabels = existingLabelsObject[u"retention"_s].toArray();
-
-            for (const auto &oneLabel : retentionLabels) {
-                const auto &oneLabelObject = oneLabel.toObject();
-                parseExistingSingleLabel(rowIndex, oneLabelObject);
-            }
+            labelKeyName = u"retention"_s;
             break;
-        }
         case Governance::LabelType::LegalHold:
-        {
-            qCDebug(lcGovernanceLabelsListModel()) << "checking existing legal hold labels";
-            if (!existingLabelsObject.contains(u"hold"_s)) {
-                qCWarning(lcGovernanceLabelsListModel()) << "missing legal hold data in OCS reply";
-                break;
-            }
-
-            const auto legalHoldLabels = existingLabelsObject[u"hold"_s].toArray();
-
-            for (const auto &oneLabel : legalHoldLabels) {
-                const auto &oneLabelObject = oneLabel.toObject();
-                parseExistingSingleLabel(rowIndex, oneLabelObject);
-            }
+            labelKeyName = u"hold"_s;
             break;
-        }
         case Governance::LabelType::InvalidLabelType:
             break;
+        }
+
+        qCDebug(lcGovernanceLabelsListModel()) << "checking existing" << labelKeyName << "labels";
+        if (!existingLabelsObject.contains(labelKeyName)) {
+            qCWarning(lcGovernanceLabelsListModel()) << "missing" << labelKeyName << "data in OCS reply";
+            break;
+        }
+
+        const auto &sensitivityLabels = existingLabelsObject[labelKeyName].toArray();
+
+        for (const auto &oneLabel : sensitivityLabels) {
+            const auto &oneLabelObject = oneLabel.toObject();
+            parseExistingSingleLabel(rowIndex, oneLabelObject);
         }
     }
     endResetModel();

--- a/test/testgovernance.cpp
+++ b/test/testgovernance.cpp
@@ -581,16 +581,18 @@ private slots:
     },
     "data": {
       "retention": [],
-      "sensitivity": {
-        "id": "91785883351310337",
-        "name": "Test Sensitivity",
-        "priority": 0,
-        "description": "This is a long description",
-        "color": "bf4040",
-        "canAssign": "no",
-        "canRemove": "no",
-        "isAssigned": true
-      }
+      "sensitivity": [
+        {
+          "id": "91785883351310337",
+          "name": "Test Sensitivity",
+          "priority": 0,
+          "description": "This is a long description",
+          "color": "bf4040",
+          "canAssign": "no",
+          "canRemove": "no",
+          "isAssigned": true
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
related to https://github.com/nextcloud-gmbh/governance/pull/140

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
