### PR TITLE
feat: Handle AutoCAD lock files in classic sync

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -18,6 +18,7 @@
 #include <QCoreApplication>
 
 #include <array>
+#include <ranges>
 #include <string_view>
 
 #ifdef Q_OS_WIN
@@ -30,6 +31,14 @@ namespace
 {
 constexpr std::array<const char *, 2> lockFilePatterns = {{".~lock.", "~$"}};
 constexpr std::array<std::string_view, 8> officeFileExtensions = {"doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "odp"};
+
+// AutoCAD creates .dwl (plain text) and .dwl2 (XML) lock files when a .dwg drawing
+// is opened. Both share the document's base name — only the extension differs — so
+// the guarded document is resolved by replacing the lock extension with .dwg.
+// Both lock files are deleted when the drawing is closed.
+constexpr std::array<const char *, 2> autoCADLockFileExtensions = {"dwl", "dwl2"};
+constexpr std::string_view autoCADDocumentExtension = "dwg";
+
 // iterates through the dirPath to find the matching fileName
 QString findMatchingUnlockedFileInDir(const QString &dirPath, const QString &lockFileName)
 {
@@ -83,6 +92,11 @@ bool FileSystem::isMatchingOfficeFileExtension(const QString &path)
     const auto pathSplit = path.split(QLatin1Char('.'));
     const auto extension = pathSplit.size() > 1 ? pathSplit.last().toStdString() : std::string{};
     return std::find(std::cbegin(officeFileExtensions), std::cend(officeFileExtensions), extension) != std::cend(officeFileExtensions);
+}
+
+bool FileSystem::isMatchingAutoCADDocumentExtension(const QString &path)
+{
+    return QFileInfo{path}.suffix().toLower().toStdString() == autoCADDocumentExtension;
 }
 
 FileSystem::FileLockingInfo FileSystem::lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern)

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -18,6 +18,7 @@
 #include <QCoreApplication>
 
 #include <array>
+#include <optional>
 #include <ranges>
 #include <string_view>
 
@@ -38,6 +39,46 @@ constexpr std::array<std::string_view, 8> officeFileExtensions = {"doc", "docx",
 // Both lock files are deleted when the drawing is closed.
 constexpr std::array<const char *, 2> autoCADLockFileExtensions = {"dwl", "dwl2"};
 constexpr std::string_view autoCADDocumentExtension = "dwg";
+
+// Returns true if the path's suffix is an AutoCAD lock file extension (.dwl/.dwl2).
+bool isAutoCADLockFileExtension(const QString &path)
+{
+    const auto suffix = QFileInfo{path}.suffix().toLower().toStdString();
+    return std::ranges::any_of(autoCADLockFileExtensions, [&suffix](const auto ext) { return ext == suffix; });
+}
+
+// Resolve the document guarded by an AutoCAD lock file. The lock file shares the
+// document's base name, so the document path is derived by replacing the extension
+// with .dwg. Returns std::nullopt if the lock file is not an AutoCAD lock file
+// or the guarded document does not exist.
+std::optional<QString> autoCADLockFileTargetFilePath(const QString &lockFilePath)
+{
+    const QFileInfo lockFileInfo{lockFilePath};
+    const auto baseName = lockFileInfo.completeBaseName();
+    if (baseName.isEmpty()) {
+        return std::nullopt;
+    }
+    const auto dir = lockFileInfo.dir();
+    const auto candidatePath = dir.absoluteFilePath(baseName + QLatin1Char('.') + QString::fromStdString(std::string(autoCADDocumentExtension)));
+    return QFileInfo::exists(candidatePath) ? std::make_optional(candidatePath) : std::nullopt;
+}
+
+// Returns true if a sibling AutoCAD lock file for the same base name still exists
+// on disk. AutoCAD creates .dwl and .dwl2 as a pair; the document must only be
+// unlocked when both are gone.
+bool autoCADSiblingLockFileExists(const QString &lockFilePath)
+{
+    const QFileInfo lockFileInfo{lockFilePath};
+    const auto baseName = lockFileInfo.completeBaseName();
+    if (baseName.isEmpty()) {
+        return false;
+    }
+    const auto deletedExt = lockFileInfo.suffix().toLower().toStdString();
+    const auto dir = lockFileInfo.dir();
+    return std::ranges::any_of(autoCADLockFileExtensions, [&](const auto ext) {
+        return ext != deletedExt && QFileInfo::exists(dir.absoluteFilePath(baseName + QLatin1Char('.') + QString::fromStdString(ext)));
+    });
+}
 
 // iterates through the dirPath to find the matching fileName
 QString findMatchingUnlockedFileInDir(const QString &dirPath, const QString &lockFileName)
@@ -72,19 +113,23 @@ QString FileSystem::filePathLockFilePatternMatch(const QString &path)
     if (pathSplit.isEmpty()) {
         return {};
     }
-    QString lockFilePatternFound;
+
+    // Office / LibreOffice lock files are identified by a filename prefix.
     for (const auto &lockFilePattern : lockFilePatterns) {
         if (pathSplit.last().startsWith(lockFilePattern)) {
-            lockFilePatternFound = lockFilePattern;
-            break;
+            qCDebug(OCC::lcFileSystem) << "Found a lock file with prefix:" << lockFilePattern << "in path:" << path;
+            return lockFilePattern;
         }
     }
 
-    if (!lockFilePatternFound.isEmpty()) {
-        qCDebug(OCC::lcFileSystem) << "Found a lock file with prefix:" << lockFilePatternFound << "in path:" << path;
+    // AutoCAD lock files (.dwl / .dwl2) are identified by extension, not prefix.
+    if (isAutoCADLockFileExtension(pathSplit.last())) {
+        const auto suffix = QFileInfo{pathSplit.last()}.suffix().toLower();
+        qCDebug(OCC::lcFileSystem) << "Found an AutoCAD lock file with extension:" << suffix << "in path:" << path;
+        return QStringLiteral(".") + suffix;
     }
 
-    return lockFilePatternFound;
+    return {};
 }
 
 bool FileSystem::isMatchingOfficeFileExtension(const QString &path)
@@ -102,6 +147,24 @@ bool FileSystem::isMatchingAutoCADDocumentExtension(const QString &path)
 FileSystem::FileLockingInfo FileSystem::lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern)
 {
     FileLockingInfo result;
+
+    // AutoCAD lock files (.dwl / .dwl2) share the document's base name, so the
+    // guarded document is resolved by replacing the extension with .dwg.
+    // AutoCAD creates .dwl and .dwl2 as a pair — only report Unlocked when both
+    // are gone; if a sibling lock file still exists, leave the type as Unset so
+    // the watcher does not prematurely unlock the document.
+    if (isAutoCADLockFileExtension(lockFilePath)) {
+        const auto targetPath = autoCADLockFileTargetFilePath(lockFilePath);
+        if (targetPath) {
+            result.path = *targetPath;
+            if (QFile::exists(lockFilePath)) {
+                result.type = FileLockingInfo::Type::Locked;
+            } else if (!autoCADSiblingLockFileExists(lockFilePath)) {
+                result.type = FileLockingInfo::Type::Unlocked;
+            }
+        }
+        return result;
+    }
 
     if (lockFileNamePattern.isEmpty()) {
         return result;

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -56,6 +56,8 @@ namespace FileSystem {
     QString OWNCLOUDSYNC_EXPORT filePathLockFilePatternMatch(const QString &path);
     // check if it is an office file (by extension), ONLY call it for files
     bool OWNCLOUDSYNC_EXPORT isMatchingOfficeFileExtension(const QString &path);
+    // check if it is an AutoCAD document (by .dwg extension), ONLY call it for files
+    bool OWNCLOUDSYNC_EXPORT isMatchingAutoCADDocumentExtension(const QString &path);
     // finds and fetches FileLockingInfo for the corresponding file that we are locking/unlocking
     FileLockingInfo OWNCLOUDSYNC_EXPORT lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern);
     // lists all files matching a lockfile pattern in dirPath

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -871,7 +871,7 @@ void SyncEngine::detectFileLock(const SyncFileItemPtr &item)
         item->_direction == SyncFileItem::Up && item->_status == SyncFileItem::Success;
 
     if (isNewlyUploadedFile && item->_locked != SyncFileItem::LockStatus::LockedItem && _account->capabilities().filesLockAvailable() &&
-        FileSystem::isMatchingOfficeFileExtension(item->_file)) {
+        (FileSystem::isMatchingOfficeFileExtension(item->_file) || FileSystem::isMatchingAutoCADDocumentExtension(item->_file))) {
         {
             SyncJournalFileRecord rec;
             if (!_journal->getFileRecord(item->_file, &rec) || !rec.isValid()) {

--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -4,6 +4,12 @@
 ~$*
 .~lock.*
 ~*.tmp
+
+# AutoCAD lock files (.dwl / .dwl2) created when opening a .dwg drawing.
+# Both share the document's base name and are deleted when it is closed.
+*.dwl
+*.dwl2
+
 ]*.~*
 ]Icon\r*
 ].DS_Store

--- a/test/testlockfile.cpp
+++ b/test/testlockfile.cpp
@@ -14,6 +14,9 @@
 
 #include <QTest>
 #include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QIODevice>
 
 using namespace Qt::StringLiterals;
 
@@ -795,6 +798,89 @@ private slots:
         QVERIFY(fakeFolder.syncOnce());
 
         QCOMPARE(lockFileDetectedNewlyUploadedSpy.count(), 1);
+    }
+
+    void testLockFile_lockFile_detect_newly_uploaded_autocad()
+    {
+        // AutoCAD: opening a .dwg creates both .dwl and .dwl2 lock files.
+        // Both share the document's base name — the guarded document is
+        // resolved by replacing the extension with .dwg.
+        const auto testFileName = QStringLiteral("floorplan.dwg");
+        const auto testLockFileName = QStringLiteral("floorplan.dwl");
+
+        const auto testDocumentsDirName = "documents";
+
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.localModifier().mkdir(testDocumentsDirName);
+        // AutoCAD lock files are excluded from sync by the default exclude list;
+        // the FakeFolder does not load it, so replicate the exclusion here.
+        fakeFolder.syncEngine().excludedFiles().addManualExclude(QStringLiteral("*.dwl"));
+        fakeFolder.syncEngine().excludedFiles().addManualExclude(QStringLiteral("*.dwl2"));
+
+        fakeFolder.syncEngine().account()->setCapabilities({{"files", QVariantMap{{"locking", QByteArray{"1.0"}}}}});
+        QSignalSpy lockFileDetectedNewlyUploadedSpy(&fakeFolder.syncEngine(), &OCC::SyncEngine::lockFileDetected);
+
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testLockFileName);
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testFileName);
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(lockFileDetectedNewlyUploadedSpy.count(), 1);
+    }
+
+    void testLockFile_autoCADLockFileTargetFilePath_resolution()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const auto dirPath = dir.path() + QLatin1Char('/');
+
+        // .dwl lock file guards the .dwg document with the same base name.
+        const auto dwgPath = dirPath + QStringLiteral("Drawing.dwg");
+        const auto dwlPath = dirPath + QStringLiteral("Drawing.dwl");
+        QVERIFY(QFile{dwgPath}.open(QIODevice::WriteOnly));
+        QVERIFY(QFile{dwlPath}.open(QIODevice::WriteOnly));
+
+        const auto dwlResolved = OCC::FileSystem::lockFileTargetFilePath(dwlPath, QString{});
+        QCOMPARE(dwlResolved.path, dwgPath);
+        QCOMPARE(dwlResolved.type, OCC::FileSystem::FileLockingInfo::Type::Locked);
+
+        // .dwl2 lock file also guards the same .dwg document.
+        const auto dwl2Path = dirPath + QStringLiteral("Drawing.dwl2");
+        QVERIFY(QFile{dwl2Path}.open(QIODevice::WriteOnly));
+        const auto dwl2Resolved = OCC::FileSystem::lockFileTargetFilePath(dwl2Path, QString{});
+        QCOMPARE(dwl2Resolved.path, dwgPath);
+        QCOMPARE(dwl2Resolved.type, OCC::FileSystem::FileLockingInfo::Type::Locked);
+
+        // Deleting only .dwl2 while .dwl still exists must NOT unlock the document.
+        QVERIFY(QFile::remove(dwl2Path));
+        const auto dwl2Deleted = OCC::FileSystem::lockFileTargetFilePath(dwl2Path, QString{});
+        QCOMPARE(dwl2Deleted.path, dwgPath);
+        QCOMPARE(dwl2Deleted.type, OCC::FileSystem::FileLockingInfo::Type::Unset);
+
+        // Recreate .dwl2, then delete only .dwl while .dwl2 still exists.
+        // This must also NOT unlock the document.
+        QVERIFY(QFile{dwl2Path}.open(QIODevice::WriteOnly));
+        QVERIFY(QFile::remove(dwlPath));
+        const auto dwlDeleted = OCC::FileSystem::lockFileTargetFilePath(dwlPath, QString{});
+        QCOMPARE(dwlDeleted.path, dwgPath);
+        QCOMPARE(dwlDeleted.type, OCC::FileSystem::FileLockingInfo::Type::Unset);
+
+        // Removing the remaining .dwl2 now unlocks the document (both are gone).
+        QVERIFY(QFile::remove(dwl2Path));
+        const auto dwlUnlocked = OCC::FileSystem::lockFileTargetFilePath(dwl2Path, QString{});
+        QCOMPARE(dwlUnlocked.path, dwgPath);
+        QCOMPARE(dwlUnlocked.type, OCC::FileSystem::FileLockingInfo::Type::Unlocked);
+
+        // A non-lock file resolves to nothing.
+        const auto nonLock = OCC::FileSystem::lockFileTargetFilePath(dirPath + QStringLiteral("notes.txt"), QString{});
+        QVERIFY(nonLock.path.isEmpty());
+        QCOMPARE(nonLock.type, OCC::FileSystem::FileLockingInfo::Type::Unset);
+
+        // An AutoCAD lock file with no matching .dwg sibling resolves to nothing.
+        const auto orphanDwlPath = dirPath + QStringLiteral("orphan.dwl");
+        QVERIFY(QFile{orphanDwlPath}.open(QIODevice::WriteOnly));
+        const auto orphan = OCC::FileSystem::lockFileTargetFilePath(orphanDwlPath, QString{});
+        QVERIFY(orphan.path.isEmpty());
     }
 
     void testLockFile_verifyE2eeFilesUseCorrectPath()


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

https://github.com/nextcloud/desktop/issues/10295

## Summary

Add handling of AutoCAD lock files (.dwl and .dwl2) within the FileProvider sync engine.

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.