### PR TITLE
fix(folderwatcher): ignore events for stale inotify watch descriptors

### DIFF
--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -168,7 +168,13 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
             || fileName.startsWith(".sync_")) {
             continue;
         }
-        const QString p = _watchToPath[event->wd] + '/' + fileName;
+        const auto watchPathIt = _watchToPath.constFind(event->wd);
+        if (watchPathIt == _watchToPath.cend()) {
+            qCDebug(lcFolderWatcher) << "Ignoring event for unknown watch descriptor" << event->wd << fileName;
+            continue;
+        }
+
+        const QString p = *watchPathIt + '/' + fileName;
         _parent->changeDetected(p);
 
         if ((event->mask & (IN_MOVED_TO | IN_CREATE))

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -41,6 +41,12 @@ protected slots:
     void slotAddFolderRecursive(const QString &path);
 
 protected:
+    /**
+     * @brief Checks whether an inotify watch descriptor is registered.
+     * @param watchDescriptor The inotify watch descriptor to check.
+     */
+    [[nodiscard]] bool testWatchContains(int watchDescriptor) const { return _watchToPath.contains(watchDescriptor); }
+
     bool findFoldersBelow(const QDir &dir, QStringList &fullList);
     void inotifyRegisterPath(const QString &path);
     void removeFoldersBelow(const QString &path);

--- a/test/testinotifywatcher.cpp
+++ b/test/testinotifywatcher.cpp
@@ -10,6 +10,11 @@
 
 #include <QtTest>
 
+#include <array>
+#include <climits>
+#include <sys/inotify.h>
+#include <unistd.h>
+
 #include "folderwatcher_linux.h"
 #include "common/utility.h"
 
@@ -62,6 +67,30 @@ private slots:
         QVERIFY2(dirs.count() == 11, "Directory count wrong.");
 
         QVERIFY2(ok, "findFoldersBelow failed.");
+    }
+
+    void testStaleWatchDescriptorIsIgnored()
+    {
+        QVERIFY(!testWatchContains(INT_MAX));
+
+        std::array<int, 2> pipeFds {};
+        QVERIFY(::pipe(pipeFds.data()) == 0);
+
+        QByteArray payload(sizeof(inotify_event) + sizeof("lib"), '\0');
+        const auto event = reinterpret_cast<inotify_event *>(payload.data());
+        event->wd = INT_MAX;
+        event->mask = IN_CREATE;
+        event->cookie = 0;
+        event->len = sizeof("lib");
+        memcpy(event->name, "lib", sizeof("lib"));
+
+        QCOMPARE(::write(pipeFds[1], payload.constData(), payload.size()), payload.size());
+        slotReceivedNotification(pipeFds[0]);
+
+        ::close(pipeFds[0]);
+        ::close(pipeFds[1]);
+
+        QVERIFY(!testWatchContains(INT_MAX));
     }
 
     void cleanupTestCase() {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->


## Summary

The desktop client (linux) may escape the watched folders and starts iterating on the root partition. This happens almost certainly, when for example working with codex-cli: codex writes and deletes files relatively fast, so an added watcher resolves into "/" and nextcloud starts iterating from there. 

A bit more precise:

- A missing descriptor previously inserted an empty QString into _watchToPath.
- Combining that empty value for example with "lib" produced /lib, which could then be traversed and recursively watched.

What this PR implements:

- Unknown descriptors are now ignored before constructing a path.
- A test. It feeds slotReceivedNotification() a synthetic IN_CREATE event with an unknown descriptor and verifies that the descriptor is not inserted into _watchToPath.


### TODO
- [ ] Run CI test suite.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] ~~Uploaded screenshots from before and after for UI changes.~~
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] ~~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).~~
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
