### PR TITLE
Detect upload conflicts with an If-Match precondition

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -99,6 +99,8 @@ public extension Item {
         remotePath: String,
         newCreationDate: Date?,
         newContentModificationDate: Date?,
+        baseVersion: NSFileProviderItemVersion,
+        options: NSFileProviderModifyItemOptions,
         forcedChunkSize: Int?,
         domain: NSFileProviderDomain?,
         progress: Progress,
@@ -131,7 +133,49 @@ public extension Item {
             headers["If"] = "<\(remotePath)> (<opaquelocktoken:\(token)>)"
         }
 
-        let options = NKRequestOptions(customHeader: headers, queue: .global(qos: .utility))
+        // Optimistic-concurrency guard. Without a precondition the PUT is
+        // unconditional and silently overwrites a server copy that changed since
+        // we last synced (another client, or Adobe's rapid multi-step re-saves) —
+        // last-writer-wins. Send `If-Match: <baseEtag>` so the server rejects a
+        // conflicting write with 412 instead of clobbering. `baseVersion` carries
+        // the version the local edit was based on (its `contentVersion` is the
+        // etag bytes — see Item.swift); fall back to our stored etag.
+        let baseEtag: String? = {
+            if let s = String(data: baseVersion.contentVersion, encoding: .utf8), !s.isEmpty {
+                return s
+            }
+            return metadata.etag.isEmpty ? nil : metadata.etag
+        }()
+
+        // macOS 26+ has a real conflict-resolution contract: when the system asks
+        // for it via `.failOnConflict`, we fail the upload with
+        // `.localVersionConflictingWithServer` and the system creates a conflict
+        // copy so both versions survive. That option/error is macOS 26.0+ only,
+        // but the extension deploys back to macOS 13, so on older systems we apply
+        // a best-effort heuristic: always send `If-Match` and, on 412, fail
+        // transiently + re-enumerate to stop the silent overwrite.
+        var shouldSendIfMatch = false
+        var nativeFailOnConflict = false
+        if #available(macOS 26.0, *) {
+            if options.contains(.failOnConflict) {
+                shouldSendIfMatch = true
+                nativeFailOnConflict = true
+            }
+        } else {
+            shouldSendIfMatch = true
+        }
+
+        // We can only guard the write if we know the version to match against. When we
+        // do, a subsequent 412 is a real content conflict (below); when we don't, the
+        // upload stays unconditional and 412 keeps its previous stale-lock meaning.
+        let sentIfMatch = shouldSendIfMatch && baseEtag != nil
+        if sentIfMatch, let baseEtag {
+            // Our stored etag is normalized (unquoted); Sabre/DAV compares If-Match
+            // against the quoted resource ETag, so re-add the quotes.
+            headers["If-Match"] = "\"\(baseEtag)\""
+        }
+
+        let uploadOptions = NKRequestOptions(customHeader: headers, queue: .global(qos: .utility))
 
         let (_, etag, date, size, error) = await upload(
             fileLocatedAt: newContents.path,
@@ -143,7 +187,7 @@ public extension Item {
             dbManager: dbManager,
             creationDate: newCreationDate,
             modificationDate: newContentModificationDate,
-            options: options,
+            options: uploadOptions,
             log: logger.log,
             requestHandler: { progress.setHandlersFromAfRequest($0) },
             taskHandler: { task in
@@ -167,6 +211,39 @@ public extension Item {
                 \(error.errorDescription)
                 """
             )
+
+            // We sent `If-Match`, so a 412 here means the server copy diverged
+            // from the version this edit was based on — a genuine content conflict,
+            // not merely a stale lock. Do NOT commit the rejected upload. Clear any
+            // lock token, drop the row into an error state, and re-enumerate so the
+            // server's newer version is fetched.
+            if sentIfMatch, error.isPreconditionFailedError {
+                logger.error("Upload rejected: server version changed since last sync (If-Match precondition failed).", [.item: itemIdentifier, .name: filename])
+                metadata.lockToken = nil
+                metadata.status = Status.uploadError.rawValue
+                metadata.sessionError = error.errorDescription
+                dbManager.addItemMetadata(metadata)
+                if let domain, let manager = NSFileProviderManager(for: domain) {
+                    Task {
+                        try? await manager.signalEnumerator(for: .workingSet)
+                    }
+                }
+
+                // macOS 26+: hand the system the dedicated conflict error so it
+                // creates a conflict copy and both versions survive.
+                if nativeFailOnConflict, #available(macOS 26.0, *) {
+                    return (nil, NSFileProviderError(.localVersionConflictingWithServer))
+                }
+
+                // Older systems have no conflict-copy contract. Return a transient
+                // error (NSCocoaErrorDomain, outside the resolvable NSFileProviderError
+                // set) so the system re-drives the modification after the
+                // re-enumeration above has refreshed our base etag — turning a silent
+                // overwrite into a visible sync round-trip.
+                return (nil, NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError, userInfo: [
+                    NSLocalizedDescriptionKey: "Upload rejected: the file changed on the server since it was last synced."
+                ]))
+            }
 
             if error.isPreconditionFailedError || error.isLockedError {
                 logger.info("Clearing stale lock token after lock/precondition error.", [.item: itemIdentifier])
@@ -538,6 +615,8 @@ public extension Item {
                 remotePath: newServerUrlFileName,
                 newCreationDate: newCreationDate,
                 newContentModificationDate: newContentModificationDate,
+                baseVersion: baseVersion,
+                options: options,
                 forcedChunkSize: forcedChunkSize,
                 domain: domain,
                 progress: progress,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -599,6 +599,11 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// `nil` echoes the real stored size.
     public var uploadResponseSizeOverride: Int64?
 
+    /// Records the `If-Match` header the most recent upload call carried (nil if none).
+    /// Lets tests assert the optimistic-concurrency precondition was sent, and with
+    /// which etag. Captured before any injected `uploadError` short-circuit.
+    public var lastUploadIfMatchHeader: String?
+
     /// Handler to track enumerate calls
     public var enumerateCallHandler: ((String, EnumerateDepth, Bool, [String], Data?, Account, NKRequestOptions, @escaping (URLSessionTask) -> Void) -> Void)?
 
@@ -667,7 +672,9 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         }
 
         var pathComponents = sanitisedPath?.components(separatedBy: "/")
-        if pathComponents?.first?.isEmpty == true { pathComponents?.removeFirst() }
+        if pathComponents?.first?.isEmpty == true {
+            pathComponents?.removeFirst()
+        }
         var currentNode = remotePath.hasPrefix(account.trashUrl) ? rootTrashItem : rootItem
 
         while pathComponents?.isEmpty == false {
@@ -690,7 +697,9 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     func parentPath(path: String, account: Account) -> String {
         let sanitisedPath = sanitisedPath(path, account: account)
         var pathComponents = sanitisedPath?.components(separatedBy: "/")
-        if pathComponents?.first?.isEmpty == true { pathComponents?.removeFirst() }
+        if pathComponents?.first?.isEmpty == true {
+            pathComponents?.removeFirst()
+        }
         guard pathComponents?.isEmpty == false else { return "/" }
         pathComponents?.removeLast()
         let rootPath = path.hasPrefix(account.trashUrl) ? account.trashUrl : account.davFilesUrl
@@ -759,7 +768,7 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         creationDate: Date? = .init(),
         modificationDate: Date? = .init(),
         account: Account,
-        options _: NKRequestOptions = .init(),
+        options: NKRequestOptions = .init(),
         requestHandler _: @escaping (Alamofire.UploadRequest) -> Void = { _ in },
         taskHandler _: @escaping (URLSessionTask) -> Void = { _ in },
         progressHandler _: @escaping (Progress) -> Void = { _ in }
@@ -772,6 +781,8 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         response: HTTPURLResponse?,
         remoteError: NKError
     ) {
+        lastUploadIfMatchHeader = options.customHeader?["If-Match"]
+
         if let uploadError {
             return (account.ncKitAccount, nil, nil, nil, 0, nil, uploadError)
         }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -481,9 +481,182 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         )
 
         XCTAssertNil(modifiedItem)
-        XCTAssertEqual((error as? NSFileProviderError)?.code, .cannotSynchronize)
+        // On macOS < 26 the heuristic sends `If-Match` on every content upload
+        // (the item has a base etag), so a 412 is now read as a version conflict and
+        // returns a transient NSCocoaError. On macOS 26+ no `.failOnConflict` was
+        // requested, so no `If-Match` is sent and 412 keeps its stale-lock meaning.
+        if #available(macOS 26.0, *) {
+            XCTAssertEqual((error as? NSFileProviderError)?.code, .cannotSynchronize)
+        } else {
+            let nsError = error as NSError?
+            XCTAssertEqual(nsError?.domain, NSCocoaErrorDomain)
+            XCTAssertEqual(nsError?.code, NSFileWriteUnknownError)
+        }
         let updatedMetadata = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
         XCTAssertNil(updatedMetadata?.lockToken, "Stale lock token must be cleared on 412.")
+    }
+
+    /// With conflict detection active, the content upload must carry an
+    /// `If-Match` precondition set to the (quoted) base etag so the server can
+    /// reject a write that would clobber a newer version. On macOS 26+ this is
+    /// requested by the system via `.failOnConflict`; on older systems the
+    /// heuristic sends it unconditionally.
+    func testModifyPassesIfMatchWhenConflictDetectionActive() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-ifmatch-sent")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let options: NSFileProviderModifyItemOptions = if #available(macOS 26.0, *) {
+            .failOnConflict
+        } else {
+            []
+        }
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            options: options,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(error)
+        XCTAssertNotNil(modifiedItem)
+        XCTAssertEqual(
+            remoteInterface.lastUploadIfMatchHeader, "\"0\"",
+            "Content upload must carry If-Match set to the quoted base etag."
+        )
+    }
+
+    /// macOS 26+: a 412 from the server while `If-Match` was sent means the
+    /// server copy changed under us. With `.failOnConflict` the extension must
+    /// return `.localVersionConflictingWithServer` so the system creates a conflict
+    /// copy — and must not commit the rejected upload.
+    func testModifyNativeConflictReturnsLocalVersionConflict() async throws {
+        guard #available(macOS 26.0, *) else {
+            throw XCTSkip("Native fail-on-conflict requires macOS 26+")
+        }
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 412, fallbackDescription: "Precondition Failed")
+
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.lockToken = "opaquelocktoken:token"
+        itemMetadata.uploaded = true
+        itemMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-native-conflict")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            options: .failOnConflict,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertEqual((error as? NSFileProviderError)?.code, .localVersionConflictingWithServer)
+        XCTAssertEqual(remoteInterface.lastUploadIfMatchHeader, "\"0\"")
+
+        let updated = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
+        XCTAssertNil(updated?.lockToken, "Lock token must be cleared on conflict.")
+        XCTAssertNotEqual(
+            updated?.status, Status.normal.rawValue,
+            "A rejected upload must not be committed as a normal, synced item."
+        )
+    }
+
+    /// macOS < 26: no conflict-copy contract exists, so a detected conflict
+    /// (412 while `If-Match` was sent) must fail transiently — an NSCocoaError
+    /// outside the resolvable NSFileProviderError set — so the system re-drives the
+    /// edit after re-enumeration instead of silently overwriting the server copy.
+    func testModifyHeuristicConflictReturnsTransientError() async throws {
+        guard #unavailable(macOS 26.0) else {
+            throw XCTSkip("Below-26 heuristic path; macOS 26+ uses the native mechanism.")
+        }
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 412, fallbackDescription: "Precondition Failed")
+
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.lockToken = "opaquelocktoken:token"
+        itemMetadata.uploaded = true
+        itemMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("modify-heuristic-conflict")
+        try "Updated content".write(to: newContentsUrl, atomically: true, encoding: .utf8)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        let nsError = error as NSError?
+        XCTAssertEqual(nsError?.domain, NSCocoaErrorDomain)
+        XCTAssertEqual(nsError?.code, NSFileWriteUnknownError)
+        XCTAssertEqual(remoteInterface.lastUploadIfMatchHeader, "\"0\"")
+
+        let updated = Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)
+        XCTAssertNil(updated?.lockToken, "Lock token must be cleared on conflict.")
     }
 
     func testModifyWith423ClearsLockToken() async throws {

--- a/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
+++ b/shell_integration/MacOSX/NextcloudIntegration/FileProviderExt/Info.plist
@@ -102,6 +102,8 @@
 		<string>$(DEVELOPMENT_TEAM).$(OC_APPLICATION_REV_DOMAIN)</string>
 		<key>NSExtensionFileProviderSupportsEnumeration</key>
 		<true/>
+		<key>NSExtensionFileProviderSupportsFailingUploadOnConflict</key>
+		<true/>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.fileprovider-nonui</string>
 		<key>NSExtensionPrincipalClass</key>


### PR DESCRIPTION
Modify-path content uploads were unconditional PUTs — the extension never told the server "only accept this if your copy is still the version I edited." So when the server copy changed since our last sync (another device/user, or an app like Adobe InDesign/Illustrator doing rapid multi-step re-saves), the client **silently overwrote it**: last-writer-wins, data loss.

This PR sends the base version's etag as an **`If-Match`** precondition so the server rejects a conflicting write with **412 Precondition Failed** instead of clobbering, and handles that 412 as a conflict.

## Behaviour (tiered by OS)

Apple's real conflict resolution — fail the upload, system makes a **conflict copy** so both versions survive — is `NSFileProviderModifyItemFailOnConflict` + `.localVersionConflictingWithServer`, both **macOS 26.0+ only**. The extension deploys back to **macOS 13**, so:

| OS | `If-Match` sent | On 412 |
|----|-----------------|--------|
| **macOS 26+**, system set `.failOnConflict` | yes | return `.localVersionConflictingWithServer` → system creates a conflict copy (data-safe) |
| **macOS 26+**, no `.failOnConflict` | no | unchanged |
| **macOS 13–25** (heuristic) | always (when a base etag exists) | clear lock, re-enumerate, return a transient `NSError` so the server version is fetched before the edit is re-applied |

The pre-26 heuristic's guarantee is bounded and honest: it **stops the silent overwrite** and forces a sync round-trip; it does not itself create a conflict copy (that's the 26+ native win).

## Changes

- **`FileProviderExt/Info.plist`** — advertise `NSExtensionFileProviderSupportsFailingUploadOnConflict` (ignored by macOS < 26).
- **`Item/Item+Modify.swift`** — thread `baseVersion` + `options` into `modifyContents`; derive the base etag (`baseVersion.contentVersion`, falling back to `metadata.etag`); send `If-Match` via the existing `NKRequestOptions.customHeader`; branch a 412 into native/heuristic conflict handling. A `sentIfMatch` guard keeps a lock-only 412 in its prior stale-lock meaning.
- **Tests** — three new `ItemModifyTests` (OS-gated), an updated `testModifyWith412ClearsLockToken`, and a `lastUploadIfMatchHeader` capture knob on the mock.

## Testing

- Build clean; full suite **318 XCTest (1 skipped) + 50 Swift Testing, 0 failures** on macOS 26.5.2.
- The macOS < 26 heuristic test skips on macOS 26 (it can only execute on < 26); its path is compile-checked here and should be exercised on an older-macOS CI runner.

## Reviewer notes / follow-ups

- ⚠️ **Etag quoting** needs one live-server confirmation before merge. Sabre/DAV compares `If-Match` against the *quoted* ETag; our stored etag is normalized/unquoted, so we re-add quotes (`"<etag>"`). If the accepted form differs, non-conflicting uploads would 412 — worth one manual round-trip against a real Nextcloud.
- **Deferred (separate NextcloudKit PR):** chunked/large-file conflict detection needs an upstream `ifMatch:` parameter applied *only* to the assembly MOVE — a naive shared-header `If-Match` would wrongly ride the chunk PUTs.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md)