### PR TITLE
draft: feat(fileprovider): Handle Affinity lock files

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -18,10 +18,11 @@ NextcloudFileProviderKit is a Swift package designed to simplify the development
 
 ### Lock File Support
 
-Some applications like Microsoft Office, LibreOffice, Adobe and AutoCAD create hidden lock files in the same directory a file opened by them is located in.
+Some applications like Microsoft Office, LibreOffice, Adobe, AutoCAD and Affinity by Canva create hidden lock files in the same directory a file opened by them is located in.
 Office and LibreOffice lock files usually equal the name of the opened file with prefixes like `~$` or suffixes like `#`.
 Adobe applications (InDesign, InCopy, Premiere Pro) use dedicated lock file extensions (`.idlk`, `.prlock`) that carry only the document's base name — not its extension — so the guarded document is resolved by matching a sibling file.
 AutoCAD creates `.dwl` and `.dwl2` lock files that share the document's base name, so the guarded `.dwg` document is resolved by replacing the extension.
+Affinity apps (Photo, Designer, Publisher) create lock files with a `~lock~` suffix (e.g., `Screenshot.af~lock~`); the document is resolved by stripping the suffix.
 These are recognized by the file provider extension and not synchronized to the server.
 However, the capabilities of the `files_lock` server app are used to lock the file for editing remotely on the server.
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -40,6 +40,9 @@ let autoCADDocumentExtension = "dwg"
 /// recovered by stripping the trailing `~lock~` suffix.
 let affinityLockFileSuffix = "~lock~"
 
+/// Document extensions guarded by Affinity lock files.
+let affinityDocumentExtensions: Set<String> = ["afphoto", "afdesign", "afpub", "af"]
+
 ///
 /// Determine whether the given filename is a lock file as created by Adobe applications like InDesign or Premiere Pro.
 ///
@@ -278,6 +281,24 @@ func autoCADSiblingLockFileExists(lockFilename: String, parentServerUrl: String,
 }
 
 ///
+/// Resolve the document guarded by an Affinity lock file.
+///
+/// Affinity lock files use the pattern `<base>~lock~` (e.g., `Screenshot.af~lock~`).
+/// Strip the `~lock~` suffix to recover the guarded document name.
+///
+/// - Parameters:
+///     - lockFilename: The Affinity lock file name.
+///
+/// - Returns: The guarded document's file name, or `nil` if it is not an Affinity lock file.
+///
+func affinityLockFileTargetName(_ lockFilename: String) -> String? {
+    guard isAffinityLockFileName(lockFilename) else { return nil }
+    var documentName = lockFilename
+    documentName.removeLast(affinityLockFileSuffix.count)
+    return documentName.isEmpty ? nil : documentName
+}
+
+///
 /// Resolve the document guarded by a lock file, regardless of the application that created it.
 ///
 /// Office and LibreOffice lock file names fully encode the document name, so it is decoded
@@ -285,7 +306,8 @@ func autoCADSiblingLockFileExists(lockFilename: String, parentServerUrl: String,
 /// encode the base name, so the document is resolved by matching a sibling file via
 /// ``adobeLockFileTargetName(lockFilename:parentServerUrl:dbManager:)``. AutoCAD lock files
 /// share the document's base name, so the document is resolved by replacing the extension
-/// with `.dwg` via ``autoCADLockFileTargetName(_:)``.
+/// with `.dwg` via ``autoCADLockFileTargetName(_:)``. Affinity lock files use a `~lock~`
+/// suffix, so the document is resolved by stripping it via ``affinityLockFileTargetName(_:)``.
 ///
 /// - Parameters:
 ///     - lockFilename: The lock file name.
@@ -301,6 +323,10 @@ public func lockFileTargetName(forLockFileName lockFilename: String, parentServe
 
     if isAutoCADLockFileName(lockFilename) {
         return autoCADLockFileTargetName(lockFilename)
+    }
+
+    if isAffinityLockFileName(lockFilename) {
+        return affinityLockFileTargetName(lockFilename)
     }
 
     return originalFileName(fromLockFileName: lockFilename, dbManager: dbManager)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -293,9 +293,8 @@ func autoCADSiblingLockFileExists(lockFilename: String, parentServerUrl: String,
 ///
 func affinityLockFileTargetName(_ lockFilename: String) -> String? {
     guard isAffinityLockFileName(lockFilename) else { return nil }
-    var documentName = lockFilename
-    documentName.removeLast(affinityLockFileSuffix.count)
-    return documentName.isEmpty ? nil : documentName
+    let base = String(lockFilename.dropLast(affinityLockFileSuffix.count))
+    return base.isEmpty ? nil : base
 }
 
 ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -33,6 +33,13 @@ let autoCADLockFileExtensions: Set<String> = ["dwl", "dwl2"]
 /// The document extension guarded by AutoCAD lock files.
 let autoCADDocumentExtension = "dwg"
 
+/// The suffix used by Affinity by Canva lock files.
+///
+/// Affinity apps (Photo, Designer, Publisher) create lock files with the pattern `<base>~lock~`
+/// (e.g., `Screenshot.af~lock~`) when a document is opened. The guarded document name is
+/// recovered by stripping the trailing `~lock~` suffix.
+let affinityLockFileSuffix = "~lock~"
+
 ///
 /// Determine whether the given filename is a lock file as created by Adobe applications like InDesign or Premiere Pro.
 ///
@@ -58,7 +65,21 @@ public func isAutoCADLockFileName(_ filename: String) -> Bool {
 }
 
 ///
-/// Determine whether the given filename is a lock file as created by certain applications like Microsoft Office, LibreOffice, Adobe or AutoCAD.
+/// Determine whether the given filename is a lock file as created by Affinity by Canva.
+///
+/// Affinity lock files use a `~lock~` suffix (e.g., `Screenshot.af~lock~`).
+///
+/// - Parameters:
+///     - filename: The filename to check.
+///
+/// - Returns: `true` if the filename is an Affinity lock file, `false` otherwise.
+///
+public func isAffinityLockFileName(_ filename: String) -> Bool {
+    filename.hasSuffix(affinityLockFileSuffix)
+}
+
+///
+/// Determine whether the given filename is a lock file as created by certain applications like Microsoft Office, LibreOffice, Adobe, AutoCAD, or Affinity.
 ///
 /// - Parameters:
 ///     - filename: The filename to check.
@@ -73,7 +94,9 @@ public func isLockFileName(_ filename: String) -> Bool {
         // Adobe lock files
         isAdobeLockFileName(filename) ||
         // AutoCAD lock files
-        isAutoCADLockFileName(filename)
+        isAutoCADLockFileName(filename) ||
+        // Affinity lock files
+        isAffinityLockFileName(filename)
 }
 
 ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LocalFilesTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/LocalFilesTests.swift
@@ -82,4 +82,32 @@ struct LocalFilesTests {
         #expect(autoCADLockFileTargetName("Test.idlk") == nil)
         #expect(autoCADLockFileTargetName("Test.dwg") == nil) // The document is not a lock file.
     }
+
+    @Test func recognisesAffinityLockFileNames() {
+        #expect(isAffinityLockFileName("Screenshot.afphoto~lock~"))
+        #expect(isAffinityLockFileName("Icon.afdesign~lock~"))
+        #expect(isAffinityLockFileName("Layout.afpub~lock~"))
+        #expect(isAffinityLockFileName("Screenshot.af~lock~"))
+        #expect(isAffinityLockFileName("MY DOCUMENT.afdesign~lock~")) // Case-insensitive.
+
+        #expect(!isAffinityLockFileName("~$Test.docx")) // Microsoft Office is not Affinity.
+        #expect(!isAffinityLockFileName(".~lock.Test.odt#")) // LibreOffice is not Affinity.
+        #expect(!isAffinityLockFileName("Test.idlk")) // Adobe is not Affinity.
+        #expect(!isAffinityLockFileName("Test.prlock")) // Adobe is not Affinity.
+        #expect(!isAffinityLockFileName("Drawing.dwl")) // AutoCAD is not Affinity.
+        #expect(!isAffinityLockFileName("Screenshot.afphoto")) // The document itself is not a lock file.
+    }
+
+    @Test func resolvesAffinityLockFileTargetName() {
+        #expect(affinityLockFileTargetName("Screenshot.afphoto~lock~") == "Screenshot.afphoto")
+        #expect(affinityLockFileTargetName("Icon.afdesign~lock~") == "Icon.afdesign")
+        #expect(affinityLockFileTargetName("Layout.afpub~lock~") == "Layout.afpub")
+        #expect(affinityLockFileTargetName("Screenshot.af~lock~") == "Screenshot.af")
+
+        // Non-Affinity names yield no target name.
+        #expect(affinityLockFileTargetName("Test.docx") == nil)
+        #expect(affinityLockFileTargetName("Test.idlk") == nil)
+        #expect(affinityLockFileTargetName("Screenshot.afphoto") == nil) // No ~lock~ suffix.
+        #expect(affinityLockFileTargetName("~lock~") == nil) // Bare suffix with no base name.
+    }
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
https://github.com/nextcloud/desktop/issues/10392

## Summary
Handle automatic file locking for Affinity lock files in FileProvider sync engine

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
