### PR TITLE
fix(file-provider): Remove the misleading size check for uploads again

### DIFF
--- a/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud Desktop Client.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c26c1a092746b0045e21925a0cab5d1826841e2d2331443fcb4eee281bc2ee1d",
+  "originHash" : "09a77c502e437790be000de1eb2b894b4b1d352b35dd71fb31e6522346845201",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nextcloud/NextcloudKit",
       "state" : {
-        "revision" : "7d2d18a15cea4fd510ff9a81c73f7f17a3f7ba8b",
-        "version" : "7.3.5"
+        "revision" : "71fe462e9bc4620325f4f12656f54849e2316e95",
+        "version" : "7.4.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
-        "version" : "0.61.1"
+        "revision" : "2226e9d89bf05a604cc985bab3dccb44ff7c8ee3",
+        "version" : "0.62.1"
       }
     },
     {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
@@ -65,10 +65,16 @@ extension NextcloudKit: RemoteInterface {
                 let ocId = self.nkCommonInstance.findHeader("oc-fileid", allHeaderFields: allHeaderFields)
                 let etag = self.nkCommonInstance.normalizedETag(self.nkCommonInstance.findHeader("oc-etag", allHeaderFields: allHeaderFields))
                 let date = self.nkCommonInstance.findHeader("date", allHeaderFields: allHeaderFields)?.parsedDate(using: "EEE, dd MMM y HH:mm:ss zzz")
+
+                // The size the server stored equals the bytes we sent, i.e. the local file's size.
+                // Do NOT read it from the response's `Content-Length`: a successful Nextcloud/SabreDAV
+                // PUT is `201 Created` with an empty body (`Content-Length: 0`), so that header is the
+                // response body length, never the stored-file size. This mirrors the chunked path,
+                // which likewise reports the local total on success.
                 var size: Int64 = 0
 
-                if let value = allHeaderFields?["Content-Length"] as? String {
-                    size = Int64(value) ?? 0
+                if nkError == .success {
+                    size = (try? FileManager.default.attributesOfItem(atPath: localPath)[.size] as? Int64) ?? 0
                 }
 
                 continuation.resume(returning: (

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -200,33 +200,6 @@ public extension Item {
             """
         )
 
-        // Integrity check: the size the server reports it stored must match the bytes we
-        // uploaded. On a mismatch the transfer was torn/truncated (a dropped connection, or an app
-        // such as Adobe InDesign/Illustrator still writing the file). Refuse to record a clean
-        // creation: delete the partial remote object (best effort) so a retry starts clean, then
-        // return a *transient* error so the File Provider system re-drives the create instead of
-        // surfacing a broken file as synced.
-        //
-        // The error must be transient to get an automatic retry: per NSFileProviderReplicatedExtension,
-        // resolvable NSFileProviderError codes such as `.cannotSynchronize` make the system back off
-        // until the provider signals resolution, whereas "any other error … in NSCocoaErrorDomain" is
-        // retried. NOTE: a create retry may arrive with `.mayAlreadyExist`, which `create()` currently
-        // short-circuits — tracked as a separate follow-up.
-        let localAttributes = try? FileManager.default.attributesOfItem(atPath: localPath)
-
-        if let localSize = localAttributes?[.size] as? Int64, let uploadedSize = size, uploadedSize != localSize {
-            logger.error("Upload integrity check failed for created item: server stored \(uploadedSize) bytes but the local file is \(localSize) bytes. Removing the partial remote object and returning a transient error so the system retries.", [.name: itemTemplate.filename])
-            let (_, _, deleteError) = await remoteInterface.delete(remotePath: remotePath, account: account, options: .init(), taskHandler: { _ in })
-
-            if deleteError != .success {
-                logger.error("Could not remove partial remote object after integrity failure.", [.name: itemTemplate.filename, .error: deleteError])
-            }
-
-            return (nil, NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError, userInfo: [
-                NSLocalizedDescriptionKey: "Upload integrity check failed: server stored \(uploadedSize) of \(localSize) bytes."
-            ]))
-        }
-
         let contentType: String = if itemTemplate.contentType == .aliasFile {
             UTType.aliasFile.identifier
         } else {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -306,27 +306,6 @@ public extension Item {
             """
         )
 
-        // Integrity check: the size the server reports it stored must match the bytes we handed it.
-        // A mismatch means a torn/truncated transfer (a dropped connection, or an app such as Adobe
-        // InDesign/Illustrator still writing the file). Do NOT record it as a clean upload — return a
-        // *transient* error so the File Provider system re-drives the modification instead of
-        // committing a broken file. See F1 in the Adobe compatibility diagnosis.
-        //
-        // The error must be transient to get an automatic retry: per NSFileProviderReplicatedExtension,
-        // the resolvable NSFileProviderError codes (`.cannotSynchronize`, `.notAuthenticated`,
-        // `.excludedFromSync`, …) make the system back off until the provider calls
-        // `signalErrorResolved(_:)`. "Any other error … in NSCocoaErrorDomain" is treated as transient
-        // and retried. We leave the row in its `.uploading` state so the retry settles it to `.normal`.
-        let contentAttributes = try? FileManager.default.attributesOfItem(atPath: newContents.path)
-
-        if let localSize = contentAttributes?[.size] as? Int64, let uploadedSize = size, uploadedSize != localSize {
-            logger.error("Upload integrity check failed for item: server stored \(uploadedSize) bytes but the local file is \(localSize) bytes. Returning a transient error so the system retries.", [.name: filename, .item: ocId])
-
-            return (nil, NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError, userInfo: [
-                NSLocalizedDescriptionKey: "Upload integrity check failed: server stored \(uploadedSize) of \(localSize) bytes."
-            ]))
-        }
-
         var newMetadata =
             dbManager.setStatusForItemMetadata(updatedMetadata, status: .normal) ?? SendableItemMetadata(value: updatedMetadata)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/LocalFiles.swift
@@ -246,7 +246,7 @@ func autoCADSiblingLockFileExists(lockFilename: String, parentServerUrl: String,
             .where({ $0.serverUrl.equals(parentServerUrl) })
             .where({ $0.fileName.equals(siblingName) })
             .first,
-           !sibling.deleted
+            !sibling.deleted
         {
             return true
         }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -591,14 +591,6 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// Use this to simulate server-side upload rejections (e.g. 404 path gone, 507 quota).
     public var uploadError: NKError?
 
-    /// When non-nil, the upload mock reports this as the stored size in its response, regardless
-    /// of the bytes actually written to the mock tree. Use this to simulate a torn/truncated
-    /// transfer (the server stores fewer/more bytes than the client sent) so the upload integrity
-    /// check in the production code can be exercised. The chunked upload path delegates to this
-    /// same `upload(...)`, so the override applies to both the single-shot and chunked paths.
-    /// `nil` echoes the real stored size.
-    public var uploadResponseSizeOverride: Int64?
-
     /// Records the `If-Match` header the most recent upload call carried (nil if none).
     /// Lets tests assert the optimistic-concurrency precondition was sent, and with
     /// which etag. Captured before any injected `uploadError` short-circuit.
@@ -851,7 +843,7 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
             item.identifier,
             item.versionIdentifier,
             responseDate,
-            uploadResponseSizeOverride ?? item.size,
+            item.size,
             nil,
             .success
         )

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -124,53 +124,6 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
         XCTAssertTrue(createdItem.isUploaded)
     }
 
-    /// Upload integrity guard (F1): when the server reports it stored a different number of bytes
-    /// than the local file contains, `create` must NOT record the item as a clean upload. It
-    /// returns a *transient* error (so the File Provider system automatically retries the create)
-    /// and best-effort removes the partial remote object, instead of surfacing a torn file as synced.
-    func testCreateFileFailsOnUploadSizeMismatch() async throws {
-        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
-        var fileItemMetadata = SendableItemMetadata(
-            ocId: "file-id", fileName: "file", account: Self.account
-        )
-        fileItemMetadata.classFile = NKTypeClassFile.document.rawValue
-
-        let tempUrl = FileManager.default.temporaryDirectory
-            .appendingPathComponent("integrity-mismatch-create")
-        try Data("Hello world".utf8).write(to: tempUrl)
-
-        // Simulate the server storing fewer bytes than we sent (a torn transfer).
-        remoteInterface.uploadResponseSizeOverride = 3
-
-        let fileItemTemplate = Item(
-            metadata: fileItemMetadata,
-            parentItemIdentifier: .rootContainer,
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            dbManager: Self.dbManager
-        )
-        let (createdItemMaybe, error) = await Item.create(
-            basedOn: fileItemTemplate,
-            contents: tempUrl,
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            progress: Progress(),
-            dbManager: Self.dbManager,
-            log: FileProviderLogMock()
-        )
-
-        XCTAssertNil(createdItemMaybe)
-
-        // The error must be *transient* (NSCocoaErrorDomain) so the system automatically retries
-        // the create rather than backing off until the provider signals resolution.
-        let nsError = try XCTUnwrap(error as NSError?)
-        XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
-        XCTAssertEqual(nsError.code, NSFileWriteUnknownError)
-
-        // Nothing must be recorded as a clean upload for this item.
-        XCTAssertNil(Self.dbManager.itemMetadata(ocId: "file-id"))
-    }
-
     func testCreateFile() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
         var fileItemMetadata = SendableItemMetadata(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -330,66 +330,6 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(remoteItem.data, originalRemoteData)
     }
 
-    /// Upload integrity guard (F1): when the server reports it stored a different number of bytes
-    /// than the local file contains, the modify must NOT record the item as a clean upload. It
-    /// returns a *transient* error (so the File Provider system automatically retries the modify)
-    /// and leaves the row un-uploaded, instead of committing a truncated/torn file.
-    func testModifyFileFailsOnUploadSizeMismatch() async throws {
-        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
-
-        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
-        itemMetadata.uploaded = true
-        itemMetadata.downloaded = true
-        Self.dbManager.addItemMetadata(itemMetadata)
-
-        let newContents = "Hello, New World!".data(using: .utf8)!
-        let newContentsUrl = FileManager.default.temporaryDirectory
-            .appendingPathComponent("integrity-mismatch-modify")
-        try newContents.write(to: newContentsUrl)
-
-        // Simulate the server storing fewer bytes than we sent (a torn transfer).
-        remoteInterface.uploadResponseSizeOverride = Int64(newContents.count - 1)
-
-        var targetItemMetadata = SendableItemMetadata(value: itemMetadata)
-        targetItemMetadata.size = Int64(newContents.count)
-
-        let item = Item(
-            metadata: itemMetadata,
-            parentItemIdentifier: .rootContainer,
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            dbManager: Self.dbManager
-        )
-        let targetItem = Item(
-            metadata: targetItemMetadata,
-            parentItemIdentifier: .rootContainer,
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            dbManager: Self.dbManager
-        )
-
-        let (modifiedItem, error) = await item.modify(
-            itemTarget: targetItem,
-            changedFields: [.contents],
-            contents: newContentsUrl,
-            dbManager: Self.dbManager
-        )
-
-        XCTAssertNil(modifiedItem)
-
-        // The error must be *transient* (NSCocoaErrorDomain, outside the resolvable
-        // NSFileProviderError set) so the system automatically retries the modify rather than
-        // backing off until the provider signals resolution.
-        let nsError = try XCTUnwrap(error as NSError?)
-        XCTAssertEqual(nsError.domain, NSCocoaErrorDomain)
-        XCTAssertEqual(nsError.code, NSFileWriteUnknownError)
-
-        // The item must not be recorded as a clean upload; it stays pending for the retry.
-        let dbItem = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: itemMetadata.ocId))
-        XCTAssertFalse(dbItem.uploaded)
-        XCTAssertNotEqual(dbItem.status, Status.normal.rawValue)
-    }
-
     /// When the server returns 404 during an upload (the parent folder was renamed
     /// on another client while the file was open), the extension must:
     ///   - clear the stale lock token so the next attempt goes without an If: header


### PR DESCRIPTION
I was mislead. We do not get the file size after upload to compare it with the local source size.

Also, this updates NextcloudKit which now ships improvements to chunked uploads.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
