### PR TITLE
Do not vend .allowsExcludingFromSync capability on items

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -63,7 +63,17 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             }
         }
 
-        capabilities.insert(.allowsExcludingFromSync)
+        // Intentionally NOT vending `.allowsExcludingFromSync`: Finder's "Do not
+        // synchronize" is delivered to the extension as an ordinary `deleteItem` call
+        // (the system force-downloads the item, then deletes it), and the framework gives
+        // no way to distinguish that from a genuine delete — `NSFileProviderDeleteItemOptions`
+        // has only `.recursive`, and `NSFileProviderRequest`'s actor flags are documented
+        // as invalid for the sync-up methods (createItem/modifyItem/deleteItem). As a
+        // result `Item.delete` would issue a real server-side DELETE and the file would
+        // disappear from the server and other devices. Do not re-add without a safe,
+        // provider-driven exclusion path (custom action → requestModificationOfFields →
+        // modifyItem returns `.excludedFromSync` → deleteItem recognizes the excluded item
+        // and skips the remote delete).
 
         return capabilities
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemPropertyTests.swift
@@ -1154,11 +1154,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
             .allowsReparenting
         ]
 
-        // Excluding from sync is macOS-specific and always added if available
-        var platformExpected = expected
-        platformExpected.insert(.allowsExcludingFromSync)
-
-        XCTAssertEqual(item.capabilities, platformExpected)
+        XCTAssertEqual(item.capabilities, expected)
     }
 
     func testCapabilitiesFullPermissionsFolder() {
@@ -1187,10 +1183,7 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
             .allowsAddingSubItems
         ]
 
-        var platformExpected = expected
-        platformExpected.insert(.allowsExcludingFromSync)
-
-        XCTAssertEqual(item.capabilities, platformExpected)
+        XCTAssertEqual(item.capabilities, expected)
     }
 
     func testCapabilitiesNoPermissions() {
@@ -1208,15 +1201,13 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
             log: FileProviderLogMock()
         )
 
-        // Trashing and Excluding from Sync might still be allowed as they don't depend on the
-        // permission string
-        var expected: NSFileProviderItemCapabilities = [.allowsTrashing]
-        expected.insert(.allowsExcludingFromSync)
+        // Trashing might still be allowed as it does not depend on the permission string
+        let expected: NSFileProviderItemCapabilities = [.allowsTrashing]
 
         XCTAssertEqual(item.capabilities, expected)
     }
 
-    func testCapabilitiesMacOSExclusion() {
+    func testDoesNotVendExcludingFromSync() {
         var metadata = SendableItemMetadata(
             ocId: "macos-exclusion", fileName: "file.txt", account: Self.account
         )
@@ -1232,9 +1223,13 @@ final class ItemPropertyTests: NextcloudFileProviderKitTestCase {
             log: FileProviderLogMock()
         )
 
-        XCTAssertTrue(
+        // We deliberately do NOT vend `.allowsExcludingFromSync`. Finder's "Do not
+        // synchronize" arrives as an ordinary `deleteItem` that cannot be distinguished
+        // from a genuine delete, so honouring it would delete the item on the server and
+        // lose data. This guard keeps the capability from being silently re-added.
+        XCTAssertFalse(
             item.capabilities.contains(.allowsExcludingFromSync),
-            "Should allow excluding from sync on supported macOS versions."
+            "Item must not vend .allowsExcludingFromSync; see Item.capabilities for the rationale."
         )
     }
 


### PR DESCRIPTION
We always vended the `.allowsExcludingFromSync` file provider item capability, all the time, for every item, statically. This can be considered and oversight which now surfaced in the changed first-party user interface of Finder. Finder now offers a context menu item to exclude items from synchronization. On code-level, the invocation results in a `deleteItem()` call which cannot be distinguished in its nature to be an actual deletion or just this kind of exception from synchronization.

This pull request changes the capabilities vended for file provider items to exclude this capability in general. In the future, such feature could be implemented at least with custom actions and manual metadata management. Right now, there is no possibility to implement a solution based on the new first-party behavior.

This is not ported back to previous release branches intentionally. They lack the required business logic to enforce cached metadata updates in the file provider framework which was only introduced during the development cycle of version 34. That code would be required though, to update existing client deployments and file provider domains. With the outlook of the soon release of 34 and it becoming the new enterprise release as well, a backport would require an unacceptable and disproportionate effort and will not be done.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
