### PR TITLE
Add a reset button in the app settings

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -261,6 +261,14 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
     connect(_ui->fileProviderConflictResolveButton, &QPushButton::clicked, this, [fpSettingsController] {
         fpSettingsController->performStartupReconciliation();
     });
+    connect(_ui->fileProviderResetButton, &QPushButton::clicked,
+            this, &AccountSettings::slotResetFileProviderDomain);
+    // Re-evaluate the maintenance row when this account's domain is (re)created/removed.
+    connect(fpSettingsController, &Mac::FileProviderSettingsController::vfsEnabledForAccountChanged,
+            this, &AccountSettings::updateSyncFoldersPanelVisibility);
+    // Block the reset while any File Provider operation (mode toggle, another reset) runs.
+    connect(fpSettingsController, &Mac::FileProviderSettingsController::operationInProgressChanged,
+            this, &AccountSettings::updateSyncFoldersPanelVisibility);
 #endif
     updateSyncFoldersPanelVisibility();
 
@@ -2014,6 +2022,16 @@ void AccountSettings::updateSyncFoldersPanelVisibility()
     _ui->syncFoldersPanel->setVisible(!fpModeOn || hasClassicFolders);
     _ui->fileProviderConflictBanner->setVisible(fpModeOn && hasClassicFolders);
 
+    // The maintenance row (Reset File Provider Domain) only makes sense once this account
+    // actually has a domain, i.e. File Provider mode is on and it is not stuck in the
+    // classic-folder conflict state above. Disable the button while any File Provider
+    // operation is running.
+    const auto userIdAtHost = _accountState->account()->userIdAtHostWithPort();
+    const auto fpController = Mac::FileProviderSettingsController::instance();
+    const auto domainReady = fpModeOn && fpController->vfsEnabledForAccount(userIdAtHost);
+    _ui->fileProviderMaintenancePanel->setVisible(domainReady);
+    _ui->fileProviderResetButton->setEnabled(domainReady && !fpController->isOperationInProgress());
+
     if (fpModeOn && hasClassicFolders && _ui->fileProviderConflictBannerIcon->pixmap().isNull()) {
         const auto iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, nullptr, this);
         const auto warningIcon = Theme::createColorAwareIcon(QStringLiteral(":/client/theme/black/warning.svg"));
@@ -2022,6 +2040,44 @@ void AccountSettings::updateSyncFoldersPanelVisibility()
 #else
     _ui->syncFoldersPanel->setVisible(true);
     _ui->fileProviderConflictBanner->setVisible(false);
+    _ui->fileProviderMaintenancePanel->setVisible(false);
+#endif
+}
+
+void AccountSettings::slotResetFileProviderDomain()
+{
+#if defined(BUILD_FILE_PROVIDER_MODULE)
+    const auto controller = Mac::FileProviderSettingsController::instance();
+    if (controller->isOperationInProgress()) {
+        return;
+    }
+
+    const auto prettyName = _accountState->account()->prettyName();
+
+    const auto text = tr("This resets the File Provider for %1 to its initial state. Use it "
+                         "when this account's files appear stuck, missing, or out of sync in Finder.")
+                          .arg(prettyName)
+        + QStringLiteral("\n\n")
+        + tr("The location will briefly disappear from and reappear in Finder. Any local "
+             "changes that have not been uploaded yet are preserved and revealed in a folder "
+             "in Finder.");
+
+    const auto messageBox = new QMessageBox(QMessageBox::Question,
+                                            tr("Reset File Provider Domain for this account?"),
+                                            text,
+                                            QMessageBox::NoButton,
+                                            this);
+    messageBox->setAttribute(Qt::WA_DeleteOnClose);
+    const auto resetButton = messageBox->addButton(tr("Reset File Provider Domain"), QMessageBox::AcceptRole);
+    const auto cancelButton = messageBox->addButton(tr("Cancel"), QMessageBox::RejectRole);
+    messageBox->setDefaultButton(cancelButton);
+    connect(messageBox, &QMessageBox::finished, this, [this, messageBox, resetButton] {
+        if (messageBox->clickedButton() == resetButton) {
+            Mac::FileProviderSettingsController::instance()->resetVfsForAccount(
+                _accountState->account()->userIdAtHostWithPort());
+        }
+    });
+    messageBox->open();
 #endif
 }
 

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -142,6 +142,7 @@ private slots:
     void removeActionFromEncryptionMessage(const QString &actionId);
     void setEncryptionPanelVisible(bool visible);
     void updateSyncFoldersPanelVisibility();
+    void slotResetFileProviderDomain();
 
 private:
     bool event(QEvent *) override;

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -470,6 +470,62 @@
      </property>
      <layout class="QVBoxLayout" name="accountActionsPanelLayout">
       <item>
+       <widget class="QWidget" name="fileProviderMaintenancePanel" native="true">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="fileProviderMaintenanceLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="fileProviderMaintenanceDescription">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>If this account's files appear stuck, missing, or out of sync in Finder, reset its File Provider storage. Unsynced local changes are preserved.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="fileProviderResetButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Reset File Provider Domain</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="accountActionsPanelContents" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/src/gui/macOS/fileprovidersettingscontroller.h
+++ b/src/gui/macOS/fileprovidersettingscontroller.h
@@ -67,6 +67,14 @@ public slots:
      */
     void setFileProviderModeEnabled(const bool enabled);
 
+    /**
+     * @brief Removes this account's File Provider domain (preserving unsynchronized
+     * local data, exactly like the disable path) and immediately re-creates a fresh
+     * domain with a clean state. Meant as a recovery action for a corrupted local
+     * state. No-op when the app-level File Provider mode is off.
+     */
+    void resetVfsForAccount(const QString &userIdAtHost);
+
 private:
     explicit FileProviderSettingsController(QObject *parent = nullptr);
 

--- a/src/gui/macOS/fileprovidersettingscontroller_mac.mm
+++ b/src/gui/macOS/fileprovidersettingscontroller_mac.mm
@@ -469,6 +469,69 @@ void FileProviderSettingsController::setVfsEnabledForAccount(const QString &user
     });
 }
 
+void FileProviderSettingsController::resetVfsForAccount(const QString &userIdAtHost)
+{
+    // Reset only makes sense while the app-level mode is on: with it off there is no
+    // domain to reset and recreating one would contradict the disabled state.
+    if (!fileProviderModeEnabled()) {
+        qCWarning(lcFileProviderSettingsController)
+            << "File provider mode is disabled, ignoring reset request for" << userIdAtHost;
+        return;
+    }
+
+    // Same single-flight guard the other mutating paths use.
+    if (_isOperationInProgress) {
+        qCWarning(lcFileProviderSettingsController)
+            << "Operation already in progress, ignoring reset request";
+        return;
+    }
+
+    setOperationInProgress(true, tr("Resetting…"));
+
+    // Capture necessary data for the background operation
+    // We need to copy the QString to ensure it's valid in the block
+    const QString capturedUserIdAtHost = userIdAtHost;
+    auto *controller = this;
+
+    // NOTE: the worker still reaches into AccountManager (accountFromUserId /
+    // setFileProviderDomainIdentifier) from this background queue — the same pre-existing
+    // cross-thread access the single-account and bulk paths use; a full fix would marshal
+    // all AccountManager access back to the main thread.
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        // Disable: removes the domain preserving dirty user data (may async an
+        // "Unsynchronized Content" box + Finder reveal onto the main queue) and clears
+        // the stored identifier. NoAction if the account currently has no domain.
+        const auto disableAction = controller->d->setVfsEnabledForAccount(capturedUserIdAtHost, false);
+
+        // Enable: the identifier was just cleared, so addFileProviderDomain mints a
+        // fresh UUID — a genuinely clean domain — and persists it.
+        const auto enableAction = controller->d->setVfsEnabledForAccount(capturedUserIdAtHost, true);
+
+        const auto reAddFailed = enableAction == MacImplementation::VfsAccountsAction::VfsAccountsFailed;
+
+        // Dispatch back to main queue for UI updates and signal emissions
+        dispatch_async(dispatch_get_main_queue(), ^{
+            controller->setOperationInProgress(false, QString());
+
+            if (disableAction != MacImplementation::VfsAccountsAction::VfsAccountsNoAction
+                || enableAction != MacImplementation::VfsAccountsAction::VfsAccountsNoAction) {
+                emit controller->vfsEnabledForAccountChanged(capturedUserIdAtHost);
+            }
+
+            if (reAddFailed) {
+                qCWarning(lcFileProviderSettingsController)
+                    << "Failed to re-create file provider domain after reset for" << capturedUserIdAtHost;
+                QMessageBox::warning(nullptr,
+                                     tr("File Provider reset failed"),
+                                     tr("The File Provider domain for this account could not be re-created. "
+                                        "File Provider is now turned off for this account; it will be set "
+                                        "up again the next time %1 starts.")
+                                         .arg(Theme::instance()->appNameGUI()));
+            }
+        });
+    });
+}
+
 bool FileProviderSettingsController::fileProviderModeEnabled() const
 {
     return ConfigFile().macFileProviderModeEnabled();


### PR DESCRIPTION
A reset button is a still missing piece in the reworked app settings.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).

<img width="1062" height="644" alt="Screenshot" src="https://github.com/user-attachments/assets/e69eb51f-8a53-447c-9714-c1cbbc1a2263" />