### PR TITLE
feat: Handle Affinity lock files in classic sync

### DIFF
--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -291,7 +291,7 @@ FileSystem::FileLockingInfo FileSystem::lockFileTargetFilePath(const QString &lo
         if (!documentName.isEmpty()) {
             result.path = lockFileInfo.dir().absoluteFilePath(documentName);
             if (QFile::exists(result.path)) {
-                result.type = QFile::exists(lockFilePath) ? FileLockingInfo::Type::Locked : FileLockingInfo::Type::Unlocked;
+                result.type = lockFileInfo.exists() ? FileLockingInfo::Type::Locked : FileLockingInfo::Type::Unlocked;
             } else {
                 result.path.clear();
             }

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -173,6 +173,8 @@ std::optional<QString> adobeLockFileTargetFilePath(const QString &lockFilePath)
     return std::nullopt;
 }
 
+
+constexpr std::array<std::string_view, 4> affinityDocumentExtensions = {"afphoto", "afdesign", "afpub", "af"};
 // iterates through the dirPath to find the matching fileName
 QString findMatchingUnlockedFileInDir(const QString &dirPath, const QString &lockFileName)
 {
@@ -252,6 +254,12 @@ bool FileSystem::isMatchingAdobeDocumentExtension(const QString &path)
     return std::ranges::any_of(adobeLockFileDocumentExtensions, [&extension](const auto &entry) {
         return std::ranges::any_of(entry.second, [&extension](const auto &documentExtension) { return documentExtension == extension; });
     });
+}
+
+bool FileSystem::isMatchingAffinityDocumentExtension(const QString &path)
+{
+    const auto extension = QFileInfo{path}.suffix().toLower().toStdString();
+    return std::ranges::any_of(affinityDocumentExtensions, [&extension](const auto &ext) { return ext == extension; });
 }
 
 FileSystem::FileLockingInfo FileSystem::lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern)

--- a/src/libsync/filesystem.cpp
+++ b/src/libsync/filesystem.cpp
@@ -173,8 +173,18 @@ std::optional<QString> adobeLockFileTargetFilePath(const QString &lockFilePath)
     return std::nullopt;
 }
 
+// Affinity by Canva creates `~lock~` suffix lock files (e.g., Screenshot.af~lock~)
+// when a document is opened. The guarded document name is recovered by stripping
+// the trailing `~lock~` suffix.
+constexpr std::string_view affinityLockFileSuffix = "~lock~";
 
 constexpr std::array<std::string_view, 4> affinityDocumentExtensions = {"afphoto", "afdesign", "afpub", "af"};
+
+bool isAffinityLockFile(const QString &path)
+{
+    return path.endsWith(QStringLiteral("~lock~"));
+}
+
 // iterates through the dirPath to find the matching fileName
 QString findMatchingUnlockedFileInDir(const QString &dirPath, const QString &lockFileName)
 {
@@ -215,6 +225,12 @@ QString FileSystem::filePathLockFilePatternMatch(const QString &path)
             qCDebug(OCC::lcFileSystem) << "Found a lock file with prefix:" << lockFilePattern << "in path:" << path;
             return lockFilePattern;
         }
+    }
+
+    // Affinity lock files are identified by the `~lock~` suffix.
+    if (isAffinityLockFile(pathSplit.last())) {
+        qCDebug(OCC::lcFileSystem) << "Found an Affinity lock file with suffix ~lock~ in path:" << path;
+        return QString::fromStdString(std::string(affinityLockFileSuffix));
     }
 
     // AutoCAD lock files (.dwl / .dwl2) are identified by extension, not prefix.
@@ -265,6 +281,23 @@ bool FileSystem::isMatchingAffinityDocumentExtension(const QString &path)
 FileSystem::FileLockingInfo FileSystem::lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern)
 {
     FileLockingInfo result;
+
+    // Affinity lock files use a `~lock~` suffix (e.g., Screenshot.afphoto~lock~).
+    // Strip the suffix to recover the guarded document path.
+    if (isAffinityLockFile(lockFilePath)) {
+        const QFileInfo lockFileInfo{lockFilePath};
+        auto documentName = lockFileInfo.fileName();
+        documentName.chop(affinityLockFileSuffix.length());
+        if (!documentName.isEmpty()) {
+            result.path = lockFileInfo.dir().absoluteFilePath(documentName);
+            if (QFile::exists(result.path)) {
+                result.type = QFile::exists(lockFilePath) ? FileLockingInfo::Type::Locked : FileLockingInfo::Type::Unlocked;
+            } else {
+                result.path.clear();
+            }
+        }
+        return result;
+    }
 
     // AutoCAD lock files (.dwl / .dwl2) share the document's base name, so the
     // guarded document is resolved by replacing the extension with .dwg.

--- a/src/libsync/filesystem.h
+++ b/src/libsync/filesystem.h
@@ -60,6 +60,8 @@ namespace FileSystem {
     bool OWNCLOUDSYNC_EXPORT isMatchingAutoCADDocumentExtension(const QString &path);
     // check if it is an Adobe document guarded by an Adobe lock file (by extension), ONLY call it for files
     bool OWNCLOUDSYNC_EXPORT isMatchingAdobeDocumentExtension(const QString &path);
+    // check if it is an Affinity document (by extension), ONLY call it for files
+    bool OWNCLOUDSYNC_EXPORT isMatchingAffinityDocumentExtension(const QString &path);
     // finds and fetches FileLockingInfo for the corresponding file that we are locking/unlocking
     FileLockingInfo OWNCLOUDSYNC_EXPORT lockFileTargetFilePath(const QString &lockFilePath, const QString &lockFileNamePattern);
     // lists all files matching a lockfile pattern in dirPath

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -871,7 +871,7 @@ void SyncEngine::detectFileLock(const SyncFileItemPtr &item)
         item->_direction == SyncFileItem::Up && item->_status == SyncFileItem::Success;
 
     if (isNewlyUploadedFile && item->_locked != SyncFileItem::LockStatus::LockedItem && _account->capabilities().filesLockAvailable() &&
-        (FileSystem::isMatchingOfficeFileExtension(item->_file) || FileSystem::isMatchingAutoCADDocumentExtension(item->_file) || FileSystem::isMatchingAdobeDocumentExtension(item->_file))) {
+        (FileSystem::isMatchingOfficeFileExtension(item->_file) || FileSystem::isMatchingAutoCADDocumentExtension(item->_file) || FileSystem::isMatchingAdobeDocumentExtension(item->_file) || FileSystem::isMatchingAffinityDocumentExtension(item->_file))) {
         {
             SyncJournalFileRecord rec;
             if (!_journal->getFileRecord(item->_file, &rec) || !rec.isValid()) {

--- a/sync-exclude.lst
+++ b/sync-exclude.lst
@@ -17,6 +17,10 @@
 *.dwl
 *.dwl2
 
+# Affinity by Canva lock files (~lock~ suffix) created when opening a document.
+# e.g., Screenshot.afphoto~lock~ guards Screenshot.afphoto.
+*~lock~
+
 ]*.~*
 ]Icon\r*
 ].DS_Store

--- a/test/testlockfile.cpp
+++ b/test/testlockfile.cpp
@@ -1009,6 +1009,83 @@ private slots:
         QCOMPARE(unknownExt.type, OCC::FileSystem::FileLockingInfo::Type::Unset);
     }
 
+    void testLockFile_lockFile_detect_newly_uploaded_affinity_afphoto()
+    {
+        const auto testFileName = QStringLiteral("Screenshot.afphoto");
+        const auto testLockFileName = QStringLiteral("Screenshot.afphoto~lock~");
+
+        const auto testDocumentsDirName = QStringLiteral("documents");
+
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.localModifier().mkdir(testDocumentsDirName);
+        fakeFolder.syncEngine().excludedFiles().addManualExclude(QStringLiteral("*~lock~"));
+
+        fakeFolder.syncEngine().account()->setCapabilities({{"files", QVariantMap{{"locking", QByteArray{"1.0"}}}}});
+        QSignalSpy lockFileDetectedNewlyUploadedSpy(&fakeFolder.syncEngine(), &OCC::SyncEngine::lockFileDetected);
+
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testLockFileName);
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testFileName);
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(lockFileDetectedNewlyUploadedSpy.count(), 1);
+    }
+
+    void testLockFile_lockFile_detect_newly_uploaded_affinity_afdesign()
+    {
+        const auto testFileName = QStringLiteral("Icon.afdesign");
+        const auto testLockFileName = QStringLiteral("Icon.afdesign~lock~");
+
+        const auto testDocumentsDirName = QStringLiteral("documents");
+
+        FakeFolder fakeFolder{FileInfo{}};
+        fakeFolder.localModifier().mkdir(testDocumentsDirName);
+        fakeFolder.syncEngine().excludedFiles().addManualExclude(QStringLiteral("*~lock~"));
+
+        fakeFolder.syncEngine().account()->setCapabilities({{"files", QVariantMap{{"locking", QByteArray{"1.0"}}}}});
+        QSignalSpy lockFileDetectedNewlyUploadedSpy(&fakeFolder.syncEngine(), &OCC::SyncEngine::lockFileDetected);
+
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testLockFileName);
+        fakeFolder.localModifier().insert(testDocumentsDirName + QStringLiteral("/") + testFileName);
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(lockFileDetectedNewlyUploadedSpy.count(), 1);
+    }
+
+    void testLockFile_affinityLockFileTargetFilePath_resolution()
+    {
+        const auto dirPath = QStringLiteral("/tmp/affinityTestDir/");
+
+        QVERIFY(QDir{}.mkpath(dirPath));
+
+        // Create a document and an Affinity lock file for it.
+        const auto docPath = dirPath + QStringLiteral("Screenshot.afphoto");
+        const auto lockPath = dirPath + QStringLiteral("Screenshot.afphoto~lock~");
+        QVERIFY(QFile{docPath}.open(QIODevice::WriteOnly));
+        QVERIFY(QFile{lockPath}.open(QIODevice::WriteOnly));
+
+        const auto resolved = OCC::FileSystem::lockFileTargetFilePath(lockPath, QString{});
+        QCOMPARE(resolved.path, docPath);
+        QCOMPARE(resolved.type, OCC::FileSystem::FileLockingInfo::Type::Locked);
+
+        // Removing the lock file should resolve to Unlocked.
+        QFile::remove(lockPath);
+        const auto unlocked = OCC::FileSystem::lockFileTargetFilePath(lockPath, QString{});
+        QCOMPARE(unlocked.path, docPath);
+        QCOMPARE(unlocked.type, OCC::FileSystem::FileLockingInfo::Type::Unlocked);
+
+        // A non-Affinity file should not match.
+        const auto nonLock = OCC::FileSystem::lockFileTargetFilePath(dirPath + QStringLiteral("notes.txt"), QString{});
+        QVERIFY(nonLock.path.isEmpty());
+
+        // An Affinity lock file with no matching document resolves to nothing.
+        const auto orphanLockPath = dirPath + QStringLiteral("Orphan.afpub~lock~");
+        QVERIFY(QFile{orphanLockPath}.open(QIODevice::WriteOnly));
+        const auto orphan = OCC::FileSystem::lockFileTargetFilePath(orphanLockPath, QString{});
+        QVERIFY(orphan.path.isEmpty());
+    }
+
     void testLockFile_verifyE2eeFilesUseCorrectPath()
     {
         const auto e2eeRoot = QStringLiteral("encrypted");


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

https://github.com/nextcloud/desktop/issues/10392

## Summary

Handle automatic file locking for Affinity lock files in the standard sync engine

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
