### PR TITLE
fix(edit-locally): Correctly handle edit-locally request URLs with punycode hosts

### DIFF
--- a/doc/edit-locally.md
+++ b/doc/edit-locally.md
@@ -1,0 +1,132 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+# Edit locally
+
+Edit locally opens a file from the Nextcloud web interface with the locally
+synchronised copy. The operation is a client-server handshake followed by the
+normal desktop-client local-file workflow. It is not a download of the file
+from the web interface.
+
+## 1. The web interface starts an edit request
+
+The **Open locally** action is available for one synchronisable file that the
+current user can update. The web interface requests a short-lived token for
+the remote path and constructs the desktop URL after receiving it:
+
+```ts
+let url = `nc://open/${uid}@` + window.location.host + encodePath(path)
+url += '?token=' + result.data.ocs.data.token
+window.open(url, '_self')
+```
+
+The resulting URL has this shape:
+
+```text
+nc://open/<user>@<browser-serialized-host>[:<port>]/<remote-path>?token=<token>
+```
+
+The server creates and validates the token; the browser constructs the
+`nc://` URL.
+
+## 2. The desktop client receives the URI
+
+The URI scheme handler recognises `nc://open/...` as an
+`OpenLocalEdit` request and forwards the original URL to
+`EditLocallyManager`. The URI scheme handler does not perform account lookup
+or token validation.
+
+`EditLocallyManager::parseEditLocallyUrl()`:
+
+1. Splits the URL path on `/`.
+2. Takes the first component as `<user>@<host>[:<port>]`.
+3. Treats the remaining components as the remote file path.
+4. Reads the `token` query parameter.
+
+The path and token are passed to
+`AccountManager::accountFromUserId()`. If no configured account matches, the
+client stops before making the server validation request and displays an
+account-not-found error.
+
+### IDN host handling
+
+The browser supplies `window.location.host`. Browser URL serialization normally
+uses the ASCII-compatible encoding (ACE/Punycode) for internationalized
+domains, for example:
+
+```text
+Unicode:  cloud.münchen.example
+Punycode: cloud.xn--mnchen-3ya.example
+```
+
+Qt's `QUrl::host()` returns the configured account host in Unicode form.
+`accountFromUserId()` therefore converts the incoming host with
+`QUrl::fromAce()` before comparing it, while preserving the username and
+optional port. Both Unicode and Punycode links can consequently identify the
+same account.
+
+## 3. The desktop client validates the request
+
+Before accessing local files, `EditLocallyVerificationJob` rejects:
+
+- tokens that are not exactly 128 alphanumeric characters;
+- empty or non-canonical remote paths; and
+- requests for which account lookup returned no account.
+
+For a valid request, it sends a POST request to:
+
+```text
+/ocs/v2.php/apps/files/api/v1/openlocaleditor/<token>
+```
+
+with the remote path as the `path` query parameter. The server recomputes the
+path hash and verifies the authenticated user, path, token, and expiration.
+The token is deleted after validation. Only an HTTP 200 response allows the
+client to continue.
+
+## 4. The client prepares the local file
+
+After server validation, `EditLocallyManager` starts the platform-specific
+local-file job:
+
+- The standard job locates the configured sync folder for the account and
+  remote path.
+- It checks that the path is not excluded by selective sync.
+- For nested paths, it fetches the remote parent metadata when needed.
+- It determines whether the parent directory or file needs a targeted sync.
+- It waits for an active sync to finish before starting the targeted sync.
+- It synchronises the file when the local journal does not contain a current
+  copy.
+
+If the server supports file locking, the client attempts to acquire a lock
+before opening the file. An existing lock is reported to the user; a lock
+failure is reported, but the normal open attempt still proceeds.
+
+On macOS builds with the File Provider module, the client first obtains the
+file provider object identifier and attempts to open the file through the File
+Provider implementation. If that path is unavailable, it falls back to the
+standard local-file job.
+
+## 5. The file is opened
+
+The standard job calls `QDesktopServices::openUrl()` with the local file URL.
+The operating system then chooses the registered application, such as a
+spreadsheet editor. The loading dialog is removed and any deferred folder sync
+is restarted after the open attempt.
+
+Errors can occur at each stage and are surfaced through the tray notification
+and, where applicable, a message box. Common causes include an invalid URI,
+missing account, invalid or expired token, a path excluded by selective sync,
+remote metadata failure, sync failure, or failure to open the local file.
+
+## Tests
+
+The URI parsing behavior is covered by
+[`test/testurischemehandler.cpp`](../test/testurischemehandler.cpp).
+Account matching and the IDN/Punycode regression are covered by
+[`test/testaccountmanager.cpp`](../test/testaccountmanager.cpp), which
+generates Punycode from a Unicode hostname with `QUrl::toAce()` and verifies
+both representations, including a non-standard port, resolve to the same
+account.

--- a/src/gui/accountmanager.cpp
+++ b/src/gui/accountmanager.cpp
@@ -731,8 +731,28 @@ AccountStatePtr AccountManager::account(const QString &name)
     return it != _accounts.cend() ? *it : AccountStatePtr();
 }
 
+// Decodes the host portion of a "user@host" or "user@host:port" userId string
+// from ACE to Unicode via QUrl::fromAce so that it can be compared against the
+// Unicode host returned by QUrl::host().
+static QString normalizeUserIdHost(const QString &id)
+{
+    const auto atIdx = id.lastIndexOf(QLatin1Char('@'));
+    if (atIdx < 0) {
+        return id;
+    }
+    const auto userPart = id.left(atIdx);
+    const auto hostWithPort = id.mid(atIdx + 1);
+    const auto colonIdx = hostWithPort.lastIndexOf(QLatin1Char(':'));
+    const auto hostPart = (colonIdx >= 0) ? hostWithPort.left(colonIdx) : hostWithPort;
+    const auto portPart = (colonIdx >= 0) ? hostWithPort.mid(colonIdx) : QString{};
+    const auto unicodeHost = QUrl::fromAce(hostPart.toLatin1());
+    return unicodeHost.isEmpty() ? id : (userPart + QLatin1Char('@') + unicodeHost + portPart);
+}
+
 AccountStatePtr AccountManager::accountFromUserId(const QString &id) const
 {
+    const auto normalizedId = normalizeUserIdHost(id);
+
     const auto accountsList = accounts();
     for (const auto &account : accountsList) {
         const auto isUserIdWithPort = id.split(QLatin1Char(':')).size() > 1;
@@ -740,7 +760,7 @@ AccountStatePtr AccountManager::accountFromUserId(const QString &id) const
         const auto portString = (port > 0 && port != 80 && port != 443) ? QStringLiteral(":%1").arg(port) : QStringLiteral("");
         const QString davUserId = QStringLiteral("%1@%2").arg(account->account()->davUser(), account->account()->url().host()) + portString;
 
-        if (davUserId == id) {
+        if (davUserId == normalizedId) {
             return account;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,7 @@ nextcloud_add_test(LongPath)
 nextcloud_add_benchmark(LargeSync)
 
 nextcloud_add_test(Account)
+nextcloud_add_test(AccountManager)
 nextcloud_add_test(AccountWizardController)
 nextcloud_add_test(Folder)
 nextcloud_add_test(FolderMan)

--- a/test/testaccountmanager.cpp
+++ b/test/testaccountmanager.cpp
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * This software is in the public domain, furnished "as is", without technical
+ * support, and with no warranty, express or implied, as to its usefulness for
+ * any purpose.
+ */
+
+#include <QtTest>
+
+#include <QStandardPaths>
+#include <QUrl>
+
+#include "account.h"
+#include "accountmanager.h"
+#include "accountstate.h"
+#include "logger.h"
+#include "syncenginetestutils.h"
+
+using namespace OCC;
+using namespace Qt::StringLiterals;
+
+class TestAccountManager : public QObject
+{
+    Q_OBJECT
+
+private:
+    //! @brief The account state registered with AccountManager for the current
+    //! test. Set by addTestAccount() and cleared by the cleanup() slot.
+    AccountState *_accountState = nullptr;
+
+    //! @brief Creates an account with the given server URL and DAV user, registers
+    //! it with AccountManager, and stores the resulting AccountState in
+    //! _accountState so that cleanup() can remove it.
+    AccountState *addTestAccount(const QString &serverUrl, const QString &davUser)
+    {
+        auto account = Account::create();
+        account->setUrl(QUrl(serverUrl));
+        account->setDavUser(davUser);
+        account->setCredentials(new FakeCredentials{new FakeQNAM({})});
+        _accountState = AccountManager::instance()->addAccount(account);
+        return _accountState;
+    }
+
+private slots:
+    void initTestCase()
+    {
+        OCC::Logger::instance()->setLogFlush(true);
+        OCC::Logger::instance()->setLogDebug(true);
+
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    //! @brief Removes the test account from AccountManager after each test
+    //! function, including every data-driven row.
+    void cleanup()
+    {
+        if (_accountState) {
+            AccountManager::instance()->removeAccountState(_accountState);
+            _accountState = nullptr;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // accountFromUserId – plain ASCII domain
+    // ---------------------------------------------------------------------------
+
+    //! @brief Verifies that accountFromUserId finds an account whose server URL
+    //! uses a plain ASCII domain when queried with the matching userId string.
+    void testAccountFromUserId_asciiDomain_matchesByExactId()
+    {
+        QVERIFY(addTestAccount(u"https://cloud.example.com"_s, u"alice"_s));
+
+        const auto found = AccountManager::instance()->accountFromUserId(u"alice@cloud.example.com"_s);
+        QVERIFY(found);
+        QCOMPARE(found->account()->davUser(), u"alice"_s);
+    }
+
+    //! @brief Verifies that accountFromUserId returns a null pointer for an
+    //! entirely unknown userId so that a mismatch is detectable.
+    void testAccountFromUserId_unknownId_returnsNull()
+    {
+        QVERIFY(addTestAccount(u"https://cloud.example.com"_s, u"alice"_s));
+
+        const auto notFound = AccountManager::instance()->accountFromUserId(u"bob@other.example.com"_s);
+        QVERIFY(!notFound);
+    }
+
+    // ---------------------------------------------------------------------------
+    // accountFromUserId – IDN / Punycode domain normalisation
+    // ---------------------------------------------------------------------------
+
+    void testAccountFromUserId_idnDomain_data()
+    {
+        QTest::addColumn<QString>("serverUrl");
+        QTest::addColumn<QString>("davUser");
+        QTest::addColumn<QString>("incomingUserId");
+        QTest::addColumn<bool>("shouldMatch");
+
+        const auto unicodeHost = u"cloud.münchen.example"_s;
+        const auto punycodeHost = QString::fromLatin1(QUrl::toAce(unicodeHost.toUtf8()));
+        const auto mismatchedPunycodeHost = QString::fromLatin1(QUrl::toAce(u"cloud.zürich.example"_s.toUtf8()));
+        QVERIFY2(!punycodeHost.isEmpty(), "The Unicode test host must convert to Punycode");
+        QVERIFY2(!mismatchedPunycodeHost.isEmpty(), "The mismatched Unicode test host must convert to Punycode");
+
+        // Account configured with the Unicode form of an IDN hostname.
+        // The nc://open/ link may arrive with the corresponding ACE/Punycode form.
+        QTest::newRow("unicode server url, unicode userid")
+            << u"https://cloud.münchen.example"_s
+            << u"testuser"_s
+            << u"testuser@cloud.münchen.example"_s
+            << true;
+
+        QTest::newRow("unicode server url, punycode userid")
+            << u"https://cloud.münchen.example"_s
+            << u"testuser"_s
+            << u"testuser@"_s + punycodeHost
+            << true;
+
+        // Account configured with the ACE/Punycode form (as reported in the bug):
+        // QUrl::host() decodes it to Unicode internally, so the stored host is
+        // Unicode regardless. Both userId forms must still match.
+        QTest::newRow("punycode server url, punycode userid")
+            << u"https://"_s + punycodeHost
+            << u"testuser"_s
+            << u"testuser@"_s + punycodeHost
+            << true;
+
+        QTest::newRow("punycode server url, unicode userid")
+            << u"https://"_s + punycodeHost
+            << u"testuser"_s
+            << u"testuser@cloud.münchen.example"_s
+            << true;
+
+        // A Punycode userid for a completely different domain must not match.
+        QTest::newRow("punycode server url, mismatched punycode userid")
+            << u"https://"_s + punycodeHost
+            << u"testuser"_s
+            << u"testuser@"_s + mismatchedPunycodeHost
+            << false;
+
+        // Non-IDN ASCII domain must still work normally.
+        QTest::newRow("ascii server url, ascii userid")
+            << u"https://nextcloud.example.com"_s
+            << u"testuser"_s
+            << u"testuser@nextcloud.example.com"_s
+            << true;
+    }
+
+    //! @brief Verifies that accountFromUserId correctly matches (or rejects)
+    //! accounts when the incoming userId contains either the Unicode or the
+    //! ACE/Punycode form of an internationalised domain name. This guards against
+    //! the regression where nc://open/ links with a Punycode host failed to find
+    //! an account whose stored URL was canonicalised to Unicode by QUrl.
+    void testAccountFromUserId_idnDomain()
+    {
+        QFETCH(QString, serverUrl);
+        QFETCH(QString, davUser);
+        QFETCH(QString, incomingUserId);
+        QFETCH(bool, shouldMatch);
+
+        QVERIFY(addTestAccount(serverUrl, davUser));
+
+        const auto found = AccountManager::instance()->accountFromUserId(incomingUserId);
+        if (shouldMatch) {
+            QVERIFY2(found, qPrintable(u"Expected to find account for userId '%1' but got null"_s.arg(incomingUserId)));
+            QCOMPARE(found->account()->davUser(), davUser);
+        } else {
+            QVERIFY2(!found, qPrintable(u"Expected no account for userId '%1' but found one"_s.arg(incomingUserId)));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // accountFromUserId – IDN domain with non-standard port
+    // ---------------------------------------------------------------------------
+
+    //! @brief Verifies that accountFromUserId handles IDN hostnames correctly
+    //! when the server URL also specifies a non-standard port.
+    void testAccountFromUserId_idnDomainWithPort_data()
+    {
+        QTest::addColumn<QString>("serverUrl");
+        QTest::addColumn<QString>("davUser");
+        QTest::addColumn<QString>("incomingUserId");
+        QTest::addColumn<bool>("shouldMatch");
+
+        const auto unicodeHost = u"cloud.münchen.example"_s;
+        const auto punycodeHost = QString::fromLatin1(QUrl::toAce(unicodeHost.toUtf8()));
+        QVERIFY2(!punycodeHost.isEmpty(), "The Unicode test host must convert to Punycode");
+
+        QTest::newRow("unicode server url with port, punycode userid with port")
+            << u"https://"_s + unicodeHost + u":8443"_s
+            << u"testuser"_s
+            << u"testuser@"_s + punycodeHost + u":8443"_s
+            << true;
+
+        QTest::newRow("punycode server url with port, unicode userid with port")
+            << u"https://"_s + punycodeHost + u":8443"_s
+            << u"testuser"_s
+            << u"testuser@"_s + unicodeHost + u":8443"_s
+            << true;
+    }
+
+    //! @brief Companion to testAccountFromUserId_idnDomain covering the port
+    //! component of the userId so that port-qualified IDN accounts can be located.
+    void testAccountFromUserId_idnDomainWithPort()
+    {
+        QFETCH(QString, serverUrl);
+        QFETCH(QString, davUser);
+        QFETCH(QString, incomingUserId);
+        QFETCH(bool, shouldMatch);
+
+        QVERIFY(addTestAccount(serverUrl, davUser));
+
+        const auto found = AccountManager::instance()->accountFromUserId(incomingUserId);
+        if (shouldMatch) {
+            QVERIFY2(found, qPrintable(u"Expected to find account for userId '%1' but got null"_s.arg(incomingUserId)));
+            QCOMPARE(found->account()->davUser(), davUser);
+        } else {
+            QVERIFY2(!found, qPrintable(u"Expected no account for userId '%1' but found one"_s.arg(incomingUserId)));
+        }
+    }
+};
+
+QTEST_GUILESS_MAIN(TestAccountManager)
+#include "testaccountmanager.moc"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

https://github.com/nextcloud/desktop/issues/10420

## Summary

Edit-locally can fail due to Unicode/Punycode host mismatches. This PR updates the account matching code to normalize incoming Punycode hosts.

Also added some documentation for the complete edit-locally flow.

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
