### PR TITLE
fix(file-provider): Do not continue polling ETag from file provider when account is disabled

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1109,6 +1109,13 @@ bool FolderMan::isSwitchToVfsNeeded(const FolderDefinition &folderDefinition) co
     return result;
 }
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+bool FolderMan::canPollFileProviderEtag(const AccountState &accountState)
+{
+    return accountState.isConnected();
+}
+#endif
+
 void FolderMan::slotEtagPollTimerTimeout()
 {
     qCInfo(lcFolderMan) << "Etag poll timer timeout";
@@ -1139,7 +1146,7 @@ void FolderMan::slotEtagPollTimerTimeout()
     for (const auto &accountState : accounts) {
         const auto account = accountState->account();
 
-        if (!accountState->isConnected()) {
+        if (!canPollFileProviderEtag(*accountState)) {
             qCDebug(lcFolderMan) << "Account" << account->displayName() << "is not connected, skipping File Provider ETag check.";
             continue;
         }

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1139,6 +1139,11 @@ void FolderMan::slotEtagPollTimerTimeout()
     for (const auto &accountState : accounts) {
         const auto account = accountState->account();
 
+        if (!accountState->isConnected()) {
+            qCDebug(lcFolderMan) << "Account" << account->displayName() << "is not connected, skipping File Provider ETag check.";
+            continue;
+        }
+
         // Skip accounts that don't have a File Provider domain
         if (!Mac::FileProvider::instance()->domainManager()->domainForAccount(account.data())) {
             qCDebug(lcFolderMan) << "Account" << account->displayName() << "has no file provider domain, skipping.";

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -357,6 +357,11 @@ private:
     void runEtagJobsIfPossible(const QList<Folder *> &folderMap);
     void runEtagJobIfPossible(Folder *folder);
 
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    /** @brief Returns whether the account state permits File Provider ETag polling. */
+    [[nodiscard]] static bool canPollFileProviderEtag(const AccountState &accountState);
+#endif
+
     bool pushNotificationsFilesReady(const OCC::AccountPtr &account);
 
     [[nodiscard]] bool isSwitchToVfsNeeded(const FolderDefinition &folderDefinition) const;

--- a/test/testfolderman.cpp
+++ b/test/testfolderman.cpp
@@ -609,6 +609,30 @@ private slots:
     }
 
 #ifdef BUILD_FILE_PROVIDER_MODULE
+    void testFileProviderEtagPollingRequiresConnectedAccount()
+    {
+        const auto accountState = std::make_unique<FakeAccountState>(Account::create());
+        QVERIFY(FolderMan::canPollFileProviderEtag(*accountState));
+
+        const auto disconnectedStates = {
+            AccountState::SignedOut,
+            AccountState::Disconnected,
+            AccountState::ServiceUnavailable,
+            AccountState::RedirectDetected,
+            AccountState::MaintenanceMode,
+            AccountState::NetworkError,
+            AccountState::ConfigurationError,
+            AccountState::AskingCredentials,
+            AccountState::NeedToSignTermsOfService,
+        };
+
+        for (const auto state : disconnectedStates) {
+            accountState->setStateForTesting(state);
+            QVERIFY2(!FolderMan::canPollFileProviderEtag(*accountState),
+                qPrintable(AccountState::stateString(state)));
+        }
+    }
+
     void testAddFolderRefusedWhenFileProviderModeEnabled()
     {
         _fm.reset({});


### PR DESCRIPTION
the apple file provider extension is not respecting an 401 from the server (token revoked) and is still sending propfinds every 30 seconds. 
This change will align it to the classic sync

Assisted-by: GPT-5.6