### PR TITLE
Don't drop all remote changes when one folder read fails

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
@@ -42,6 +42,11 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     private var anchorKey: String?
     private var remainingUpdated: [SendableItemMetadata] = []
     private var remainingDeleted: [SendableItemMetadata] = []
+    /// Whether the derivation that primed this buffer was incomplete (at least one remote read failed
+    /// and was skipped). The caller uses this to avoid advancing the working-set sync point past changes
+    /// it could not discover this pass. Preserved across the whole `moreComing` drain sequence and cleared
+    /// alongside `anchorKey`.
+    private var primedIncomplete = false
 
     init(log: any FileProviderLogging) {
         logger = FileProviderLogger(category: "ChangeDeliveryBuffer", log: log)
@@ -59,20 +64,36 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     }
 
     ///
+    /// Whether the currently-primed derivation was incomplete (a remote read failed and was skipped).
+    /// Returns `false` once the buffer has fully drained. See ``prime(key:updated:deleted:incomplete:)``.
+    ///
+    func isPrimedIncomplete() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return anchorKey != nil && primedIncomplete
+    }
+
+    ///
     /// Store the full derived change set for a drain sequence, keyed by the originating sync anchor.
     ///
     /// `updated` must already be sorted parents-before-children (ascending remote-path length) so that
     /// draining the single combined list front-to-back never reports a child in an earlier batch than
     /// its parent.
     ///
-    func prime(key: String, updated: [SendableItemMetadata], deleted: [SendableItemMetadata]) {
+    func prime(
+        key: String,
+        updated: [SendableItemMetadata],
+        deleted: [SendableItemMetadata],
+        incomplete: Bool = false
+    ) {
         lock.lock()
         defer { lock.unlock() }
         anchorKey = key
         remainingUpdated = updated
         remainingDeleted = deleted
+        primedIncomplete = incomplete
         logger.debug(
-            "Primed change delivery buffer. anchor: \(key), updated: \(updated.count), deleted: \(deleted.count)"
+            "Primed change delivery buffer. anchor: \(key), updated: \(updated.count), deleted: \(deleted.count), incomplete: \(incomplete)."
         )
     }
 
@@ -105,6 +126,7 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
         let moreComing = !remainingUpdated.isEmpty || !remainingDeleted.isEmpty
         if !moreComing {
             anchorKey = nil
+            primedIncomplete = false
         }
 
         logger.debug(
@@ -128,6 +150,7 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
         anchorKey = nil
         remainingUpdated = []
         remainingDeleted = []
+        primedIncomplete = false
 
         // A non-empty discard means an in-progress drain was abandoned (a fresh enumeration arrived under
         // a different anchor). Log it loudly enough to spot potential change loss from a debug archive.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -53,15 +53,26 @@ extension Enumerator {
                 let sortedUpdated = changes.createdAndUpdated
                     .sorted { $0.remotePath().count < $1.remotePath().count }
 
-                changeBuffer.prime(key: anchorKey, updated: sortedUpdated, deleted: changes.deleted)
+                changeBuffer.prime(
+                    key: anchorKey,
+                    updated: sortedUpdated,
+                    deleted: changes.deleted,
+                    incomplete: serverChanges.hadFailure
+                )
             }
 
             // Intermediate batches keep the original anchor so an interrupted drain resumes behind all
-            // undelivered items; the final batch advances the working-set sync point to currentAnchor.
+            // undelivered items. The final batch normally advances the working-set sync point to
+            // currentAnchor — but when the scan was incomplete (a remote read failed and was skipped) we
+            // keep the incoming anchor instead, so we do not tell the framework we are synced up to "now"
+            // past changes we could not discover this pass. The next working-set signal re-derives and
+            // picks up the previously-unreadable folders once they succeed. (isPrimedIncomplete() is read
+            // before the final takeBatch clears the buffer, so it reflects this drain sequence.)
+            let finalAnchor = changeBuffer.isPrimedIncomplete() ? anchor : currentAnchor
             drainChangeBuffer(
                 for: observer,
                 startAnchor: anchor,
-                finalAnchor: currentAnchor,
+                finalAnchor: finalAnchor,
                 suggested: observer.suggestedBatchSize
             )
         }
@@ -81,7 +92,7 @@ extension Enumerator {
     ///   were marked deleted.
     ///
     func scanMaterialisedItemsForRemoteChanges() async -> (
-        updated: [SendableItemMetadata], deleted: [SendableItemMetadata]
+        updated: [SendableItemMetadata], deleted: [SendableItemMetadata], hadFailure: Bool
     ) {
         logger.debug("Checking materialised items for changes on the server...")
 
@@ -102,6 +113,11 @@ extension Enumerator {
         var accumulatedUpdates = [SendableItemMetadata]()
         var accumulatedDeletions = [SendableItemMetadata]()
         var scannedItemIds = Set<String>()
+        // Track read failures so one unreadable folder no longer aborts the whole scan (see the
+        // read-error branch below). `hadReadFailure` is returned to the caller so it can avoid
+        // advancing the working-set sync point past changes this pass could not discover.
+        var hadReadFailure = false
+        var failedItemIds = Set<String>()
 
         // Work queue seeded with the materialised items. A changed child directory discovered while
         // scanning is appended ONLY when its subtree actually contains a materialised item, so its
@@ -142,9 +158,21 @@ extension Enumerator {
                 // Children are not marked deleted here — they may have moved with their parent.
                 logger.debug("Parent returned 404; children will be checked individually.", [.url: itemRemoteUrl])
             } else if let readError = readResult.error, readError != .success {
-                logger.error("Finished remote change enumeration of materialised items with error.", [.error: readError])
-                // Report what was discovered before the error rather than discarding it.
-                break
+                // A single unreadable folder must NOT abort discovery for the rest of the working set.
+                // The queue is sorted parent-first, so the account root and top-level folders (e.g. a
+                // very large "Talk" whose depth-1 PROPFIND times out) are scanned first; a `break` here
+                // meant one early failure silently stalled ALL remote-change propagation for every other
+                // folder — the "files uploaded on the web never appear" bug. Skip only the failing item
+                // (it is retried on the next scan) and keep scanning the remainder.
+                // See nextcloud/desktop#10442.
+                logger.error(
+                    "Read of materialised item failed during working-set scan; skipping it and continuing with the rest of the working set.",
+                    [.error: readError, .url: itemRemoteUrl]
+                )
+                hadReadFailure = true
+                failedItemIds.insert(itemToScan.ocId)
+                scannedItemIds.insert(itemToScan.ocId)
+                continue
             } else {
                 accumulatedDeletions += changes.deleted
                 accumulatedUpdates += changes.updated
@@ -247,6 +275,13 @@ extension Enumerator {
             logger.info("No remote changes found in materialised items.")
         }
 
-        return (updated: discoveredUpdates, deleted: reportedDeletions)
+        if hadReadFailure {
+            logger.error(
+                "Working-set remote-change scan was incomplete: \(failedItemIds.count) item(s) could not be read and were skipped; their changes will be retried on the next scan. Not advancing the working-set sync point past the undiscovered changes.",
+                [.account: account]
+            )
+        }
+
+        return (updated: discoveredUpdates, deleted: reportedDeletions, hadFailure: hadReadFailure)
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -36,7 +36,7 @@ public extension Item {
             return nil
         }
 
-        let serverFileNameUrl = metadata.remotePath()
+        var serverFileNameUrl = metadata.remotePath()
 
         guard serverFileNameUrl != "" else {
             return NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemIdentifier)
@@ -44,6 +44,34 @@ public extension Item {
 
         guard metadata.classFile != "lock", !isLockFileName(metadata.fileName) else {
             return await deleteLockFile(domain: domain, dbManager: dbManager)
+        }
+
+        // Permanently deleting an item that already lives in the trash. The stored trashbin name can be
+        // the "rough" plain filename set optimistically when the item was moved to trash (see
+        // handleMetadataTrashModification below), rather than the server's real trashbin name — which
+        // carries a ".d<deletion-timestamp>" suffix whenever the name collided with an existing trash
+        // entry. DELETEing the plain path 404s forever, and macOS retries the purge with no backoff
+        // (observed: a handful of items failing thousands of times). Resolve the real trashbin name from
+        // a fresh trash listing; if the item is no longer in the trash, it has already been removed
+        // remotely, so report success and stop the retry loop. See nextcloud/desktop#10442.
+        let isTrashbinPurge = !trashing && metadata.serverUrl.hasPrefix(account.trashUrl)
+        if isTrashbinPurge {
+            switch await resolveTrashbinItemRemotePath(domain: domain) {
+                case let .resolved(resolvedUrl):
+                    serverFileNameUrl = resolvedUrl
+                case .alreadyGone:
+                    logger.info(
+                        "Trashbin item no longer present in a fresh trash listing; treating permanent delete as already complete.",
+                        [.item: ocId, .name: filename]
+                    )
+                    handleMetadataDeletion()
+                    return nil
+                case .unresolved:
+                    logger.info(
+                        "Could not resolve the trashbin item's server name from a fresh listing; falling back to the stored path.",
+                        [.item: ocId, .url: serverFileNameUrl]
+                    )
+            }
         }
 
         let (_, _, error) = await remoteInterface.delete(
@@ -62,6 +90,16 @@ public extension Item {
         )
 
         guard error == .success else {
+            // A purge that 404s means the item is already gone from the trash — the desired end state.
+            // Report success so macOS stops re-issuing the (now pointless) permanent delete.
+            if isTrashbinPurge, error.isNotFoundError {
+                logger.info(
+                    "Trashbin item returned 404 on permanent delete; it is already gone, treating as complete.",
+                    [.item: ocId, .url: serverFileNameUrl]
+                )
+                handleMetadataDeletion()
+                return nil
+            }
             logger.error("Could not delete item.", [.item: ocId, .url: serverFileNameUrl, .error: error])
             return error.fileProviderError(handlingNoSuchItemErrorUsingItemIdentifier: itemIdentifier)
         }
@@ -115,5 +153,54 @@ public extension Item {
         dbManager.addItemMetadata(metadata)
 
         return nil
+    }
+
+    /// Outcome of resolving the true server path for a trashbin item about to be permanently deleted.
+    enum TrashbinItemRemotePathResolution: Sendable {
+        /// The item was found in the remote trash; the associated URL is the correct DELETE target
+        /// (including any server-assigned ".d<deletion-timestamp>" suffix).
+        case resolved(String)
+        /// The item is no longer present in the remote trash — already permanently removed.
+        case alreadyGone
+        /// The trash listing itself failed (e.g. transient error); the caller should fall back.
+        case unresolved
+    }
+
+    /// Look up the item's current entry in the remote trash and return the correct DELETE URL.
+    ///
+    /// The database may hold a "rough" plain trashbin filename (see ``handleMetadataTrashModification()``),
+    /// but the server names collided trash entries `"<name>.d<deletion-timestamp>"`. Matching the fresh
+    /// listing by `ocId`/`fileId` (the server sometimes returns the `fileId` as the trash `ocId`, mirroring
+    /// ``Item/trash(_:account:dbManager:domain:log:)``) yields the real on-server name.
+    private func resolveTrashbinItemRemotePath(
+        domain: NSFileProviderDomain?
+    ) async -> TrashbinItemRemotePathResolution {
+        let (_, items, _, error) = await remoteInterface.listingTrashAsync(
+            filename: nil,
+            showHiddenFiles: true,
+            account: account.ncKitAccount,
+            options: .init(),
+            taskHandler: { task in
+                if let domain {
+                    NSFileProviderManager(for: domain)?.register(
+                        task,
+                        forItemWithIdentifier: self.itemIdentifier,
+                        completionHandler: { _ in }
+                    )
+                }
+            }
+        )
+
+        guard error == .success else {
+            return .unresolved
+        }
+
+        guard let match = items?.first(where: {
+            $0.ocId == metadata.ocId || $0.fileId == metadata.fileId
+        }) else {
+            return .alreadyGone
+        }
+
+        return .resolved(account.trashUrl + "/" + match.fileName)
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogDetail.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogDetail.swift
@@ -99,6 +99,16 @@ public enum FileProviderLogDetail: Encodable {
                 self = .string(url.absoluteString)
             } else if let account = someValue as? Account {
                 self = .string(account.ncKitAccount)
+            } else if let nkError = someValue as? NKError {
+                // NKError is a Swift struct (Error, no CustomNSError). Without this branch it would fall
+                // through to `as? NSError` below and bridge to domain "NextcloudKit.NKError" code 1,
+                // discarding the real HTTP/URL status. Log the struct's own fields so failures such as
+                // PROPFIND timeouts (-1001) or 5xx are actually visible in debug archives. See #10442.
+                self = .dictionary([
+                    "errorCode": .int(nkError.errorCode),
+                    "errorDescription": .string(nkError.errorDescription),
+                    "underlyingError": .string(nkError.error.localizedDescription)
+                ])
             } else if let error = someValue as? NSFileProviderError {
                 self = .string("NSFileProviderError.Code: \(error.code)")
             } else if let error = someValue as? NSError {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLogger.swift
@@ -133,6 +133,11 @@ public struct FileProviderLogger: Sendable {
                     account.ncKitAccount
                 case let date as Date:
                     date.ISO8601Format()
+                case let nkError as NKError:
+                    // Must precede the NSError case: NKError is a Swift struct with no CustomNSError, so
+                    // `as NSError` would bridge it to domain "NextcloudKit.NKError" code 1 and hide the
+                    // real status. Mirror the JSONL path in FileProviderLogDetail. See nextcloud/desktop#10442.
+                    "code: \(nkError.errorCode), description: \(nkError.errorDescription), underlying: \(nkError.error.localizedDescription)"
                 case let error as NSError:
                     error.debugDescription
                 case let lock as NKLock:

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -599,6 +599,11 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// Handler to track enumerate calls
     public var enumerateCallHandler: ((String, EnumerateDepth, Bool, [String], Data?, Account, NKRequestOptions, @escaping (URLSessionTask) -> Void) -> Void)?
 
+    /// Test hook: force `enumerate` to fail for remote paths ending with a given suffix, returning the
+    /// associated error instead of reading the mock tree. Lets tests reproduce a working-set scan in
+    /// which one folder's PROPFIND fails (e.g. a large container timing out) while the rest succeed.
+    public var enumerateErrorBySuffix: [String: NKError] = [:]
+
     public init(
         account: Account,
         rootItem: MockRemoteItem? = nil,
@@ -1114,6 +1119,11 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
 
         // Call the enumerate call handler if it exists
         enumerateCallHandler?(remotePath, depth, showHiddenFiles, includeHiddenFiles, requestBody, account, options, taskHandler)
+
+        // Test hook: inject a read failure for a targeted path (see `enumerateErrorBySuffix`).
+        if let injected = enumerateErrorBySuffix.first(where: { remotePath.hasSuffix($0.key) })?.value {
+            return (account.ncKitAccount, [], nil, injected)
+        }
 
         guard let item = item(remotePath: remotePath, account: account.ncKitAccount) else {
             print("Item at \(remotePath) not found.")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -451,6 +451,66 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    /// Headline regression for this fix (nextcloud/desktop#10442): a single unreadable folder must
+    /// NOT abort the whole working-set remote-change scan. Two visited folders each hold a changed
+    /// downloaded file; the FIRST-scanned folder's PROPFIND is forced to fail with a non-404 server
+    /// error (standing in for a large container timing out — the position the account root occupies in
+    /// production, since the scan queue is sorted parent-first). The change in the OTHER folder must
+    /// still be discovered and reported. Before the fix `scanMaterialisedItemsForRemoteChanges` `break`ed
+    /// on the first failure and silently dropped every later folder's changes (the "files uploaded on
+    /// the web never appear" bug). The incomplete scan must also NOT advance the working-set sync point,
+    /// so the next signal re-derives and can pick up the folder it could not read this pass.
+    func testWorkingSetScanContinuesPastAFailedFolderRead() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        // "a" sorts before "zzzzzzzzzz" by remote-path length, so the failing folder is scanned first.
+        let failingFolder = makeFolder(name: "a", parent: rootItem, etag: "a-v1")
+        let healthyFolder = makeFolder(name: "zzzzzzzzzz", parent: rootItem, etag: "z-v1")
+        let fileInFailing = makeFile(name: "itemA", parent: failingFolder, etag: "itemA-v1")
+        let fileInHealthy = makeFile(name: "itemZ", parent: healthyFolder, etag: "itemZ-v1")
+
+        seed(failingFolder, visitedDirectory: true)
+        seed(healthyFolder, visitedDirectory: true)
+        seed(fileInFailing, downloaded: true)
+        seed(fileInHealthy, downloaded: true)
+
+        // Both downloaded files changed on the server.
+        fileInFailing.versionIdentifier = "itemA-v2"; fileInFailing.modificationDate = Date()
+        fileInHealthy.versionIdentifier = "itemZ-v2"; fileInHealthy.modificationDate = Date()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        // Force the first-scanned folder's depth-1 read to fail with a non-404 error (not a deletion).
+        remoteInterface.enumerateErrorBySuffix = [
+            "/a": NKError(statusCode: 500, fallbackDescription: "Internal Server Error")
+        ]
+
+        let inputAnchor = Enumerator.syncAnchor(at: anchorDate)
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        try await observer.enumerateChanges(from: inputAnchor)
+
+        // The scan skips the failing folder and finishes normally (no error surfaced to the framework)…
+        XCTAssertNil(observer.error)
+        // …and the change in the folder scanned AFTER the failing one still surfaces — the core regression.
+        XCTAssertTrue(
+            reportedIds(observer).contains(fileInHealthy.identifier),
+            "A read failure on one folder must not prevent a later folder's change from being reported."
+        )
+        // The incomplete scan must keep the incoming sync anchor rather than advancing to a fresh "now",
+        // so the framework does not treat the domain as fully synced past the folder it could not read.
+        let finalAnchor = try XCTUnwrap(observer.finishes.last?.anchor)
+        XCTAssertEqual(
+            finalAnchor.rawValue, inputAnchor.rawValue,
+            "An incomplete working-set scan must not advance the working-set sync anchor."
+        )
+    }
+
     /// S3 (push gate): on notify_push servers `processFileIdsChanged` signals the working set when at
     /// least one received fileId is locally known (`containsAnyItemMetadata`). The server propagates
     /// a change's ETag up every ancestor to the user's root, so a `notify_file_id` for a newly-created


### PR DESCRIPTION
The working-set remote-change scan is the only path that pulls server-side changes into the macOS File Provider. It reads the materialised items parent-first and, on the first non-404 read error, did `break` — abandoning every remaining folder — then returned success and advanced the sync anchor. So one failing read (typically the account root or a large folder whose unpaginated depth-1 PROPFIND times out, and which is scanned first) silently stalled ALL inbound sync: web uploads and remote renames never appeared, no error was shown, and restarting did not help. On large/slow accounts nearly every pass failed at the same early folder, so it never caught up.

- Working-set scan: on a failed folder read, skip that item (`continue`) and keep scanning the rest of the working set instead of aborting the pass.
- When the scan was incomplete, keep the incoming sync anchor instead of advancing to a fresh "now", so the framework re-derives and converges on the next signal rather than being told (falsely) the domain is fully synced.
- Logging: log the real NKError.errorCode/description instead of the bridged "code 1 / NextcloudKit.NKError", which had masked the true failure for weeks.
- Trash: resolve the server's real ".d<timestamp>" trashbin filename from a fresh listing before a permanent delete, and treat an item already absent from the trash as deleted — stops an endless, back-off-free failing-purge retry loop caused by stale plain-name trash metadata.
- Tests: add a RemoteChangePropagationTests case that injects a non-404 error on the first-scanned folder and asserts a later folder's change still surfaces (fails before the fix, passes after).

Fixes #10442

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
