### PR TITLE
fix(discovery): move file lock state off the GUI thread.

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -353,7 +353,8 @@ bool ProcessDirectoryJob::handleExcluded(const QString &path, const Entries &ent
         }
     }
 
-    if (excluded == CSYNC_NOT_EXCLUDED && OCC::FileSystem::isFileLocked(_discoveryData->_localDir + path, OCC::FileSystem::LockMode::SharedRead) &&
+    // Lock state was accessed off the GUI thread during discovery, so this read cannot block
+    if (excluded == CSYNC_NOT_EXCLUDED && entries.localEntry.isLocked &&
         (!entries.dbEntry.isValid() || !entries.serverEntry.isValid() || entries.serverEntry.etag == entries.dbEntry._etag)) {
         qCInfo(lcDisco) << _discoveryData->_localDir + path << "is locked" << "exluding it from sync";
         excluded = CSYNC_FILE_LOCKED_SILENTLY_EXCLUDED;

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -339,14 +339,8 @@ DiscoverySingleLocalDirectoryJob::DiscoverySingleLocalDirectoryJob(const Account
     , _account{account}
     , _vfs{vfs}
     , _fileSystemReliablePermissions{fileSystemReliablePermissions}
-    , _isFileLockedOverride{}
 {
     qRegisterMetaType<QVector<OCC::LocalInfo> >("QVector<OCC::LocalInfo>");
-}
-
-void DiscoverySingleLocalDirectoryJob::setIsFileLockedOverride(std::function<bool(const QString &absoluteLocalPath)> isFileLockedOverride)
-{
-    _isFileLockedOverride  = std::move(isFileLockedOverride);
 }
 
 // Use as QRunnable
@@ -414,8 +408,7 @@ void DiscoverySingleLocalDirectoryJob::run() {
         // Access lock state on the worker thread so a blocking open cannot freeze the GUI #10464
         if (!i.isSymLink && !i.isVirtualFile && !i.isDirectory) {
             const auto absoluteLocalPath = localPath + QLatin1Char('/') + i.name;
-            i.isLocked = _isFileLockedOverride ? _isFileLockedOverride(absoluteLocalPath)
-                                                : FileSystem::isFileLocked(absoluteLocalPath, FileSystem::LockMode::SharedRead);
+            i.isLocked = FileSystem::isFileLocked(absoluteLocalPath, FileSystem::LockMode::SharedRead);
             qCDebug(lcDiscovery) << "File" << absoluteLocalPath << "isLocked" << i.isLocked;
         }
 

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -17,6 +17,7 @@
 
 #include "common/asserts.h"
 #include "common/checksums.h"
+#include "common/filesystembase.h"
 
 #include <csync_exclude.h>
 #include "vio/csync_vio_local.h"
@@ -338,8 +339,14 @@ DiscoverySingleLocalDirectoryJob::DiscoverySingleLocalDirectoryJob(const Account
     , _account{account}
     , _vfs{vfs}
     , _fileSystemReliablePermissions{fileSystemReliablePermissions}
+    , _isFileLockedOverride{}
 {
     qRegisterMetaType<QVector<OCC::LocalInfo> >("QVector<OCC::LocalInfo>");
+}
+
+void DiscoverySingleLocalDirectoryJob::setIsFileLockedOverride(std::function<bool(const QString &absoluteLocalPath)> isFileLockedOverride)
+{
+    _isFileLockedOverride  = std::move(isFileLockedOverride);
 }
 
 // Use as QRunnable
@@ -403,6 +410,15 @@ void DiscoverySingleLocalDirectoryJob::run() {
         i.isMetadataMissing = dirent->is_metadata_missing;
         i.isPermissionsInvalid = dirent->isPermissionsInvalid;
         i.type = dirent->type;
+
+        // Access lock state on the worker thread so a blocking open cannot freeze the GUI #10464
+        if (!i.isSymLink && !i.isVirtualFile && !i.isDirectory) {
+            const auto absoluteLocalPath = localPath + QLatin1Char('/') + i.name;
+            i.isLocked = _isFileLockedOverride ? _isFileLockedOverride(absoluteLocalPath)
+                                                : FileSystem::isFileLocked(absoluteLocalPath, FileSystem::LockMode::SharedRead);
+            qCDebug(lcDiscovery) << "File" << absoluteLocalPath << "isLocked" << i.isLocked;
+        }
+
         results.push_back(i);
     }
     if (errno != 0) {

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -23,6 +23,7 @@
 #include <QWaitCondition>
 #include <QRunnable>
 #include <deque>
+#include <functional>
 
 class ExcludedFiles;
 
@@ -64,6 +65,7 @@ struct LocalInfo
     bool isSymLink = false;
     bool isMetadataMissing = false;
     bool isPermissionsInvalid = false;
+    bool isLocked = false;
     [[nodiscard]] bool isValid() const { return !name.isNull(); }
 };
 
@@ -83,6 +85,9 @@ public:
                                               QObject *parent = nullptr);
 
     void run() override;
+
+    // Only used for testing the lock access; defaults to FileSystem::isFileLocked.
+    void setIsFileLockedOverride(std::function<bool(const QString &absoluteLocalPath)> isFileLockedOverride);
 signals:
     void finished(QVector<OCC::LocalInfo> result);
     void finishedFatalError(QString errorString);
@@ -96,6 +101,7 @@ private:
     AccountPtr _account;
     OCC::Vfs* _vfs;
     bool _fileSystemReliablePermissions = false;
+    std::function<bool(const QString &absoluteLocalPath)> _isFileLockedOverride;
 public:
 };
 

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -23,7 +23,6 @@
 #include <QWaitCondition>
 #include <QRunnable>
 #include <deque>
-#include <functional>
 
 class ExcludedFiles;
 
@@ -85,9 +84,6 @@ public:
                                               QObject *parent = nullptr);
 
     void run() override;
-
-    // Only used for testing the lock access; defaults to FileSystem::isFileLocked.
-    void setIsFileLockedOverride(std::function<bool(const QString &absoluteLocalPath)> isFileLockedOverride);
 signals:
     void finished(QVector<OCC::LocalInfo> result);
     void finishedFatalError(QString errorString);
@@ -101,7 +97,6 @@ private:
     AccountPtr _account;
     OCC::Vfs* _vfs;
     bool _fileSystemReliablePermissions = false;
-    std::function<bool(const QString &absoluteLocalPath)> _isFileLockedOverride;
 public:
 };
 

--- a/test/testlockedfiles.cpp
+++ b/test/testlockedfiles.cpp
@@ -16,7 +16,6 @@
 #include <localdiscoverytracker.h>
 #include "discoveryphase.h"
 #include <QThreadPool>
-#include <atomic>
 
 using namespace OCC;
 
@@ -132,9 +131,10 @@ private slots:
         QVERIFY(tmp.remove());
     }
 
-    void testLockRunsOffMainThread()
+#ifdef Q_OS_WIN
+    void testLockDetectionUsesRealFileSystemCheck()
     {
-        // Regression guard for #10464: the lock access must run on the worker thread, not the GUI thread
+        // Regression guard for #10464: exercise the real FileSystem::isFileLocked path
         QTemporaryDir tmp;
         QVERIFY(tmp.isValid());
         for (const auto &name : { QStringLiteral("locked.bin"), QStringLiteral("test.txt") }) {
@@ -144,31 +144,16 @@ private slots:
         }
         QVERIFY(QDir(tmp.path()).mkdir(QStringLiteral("subdir")));
 
-        const auto mainThread = QThread::currentThread();
-        std::atomic<QThread *> workerThread{nullptr};
-        std::atomic<bool> directoryProbed{false};
+        auto handle = makeHandle(tmp.filePath(QStringLiteral("locked.bin")), 0);
+        QVERIFY(handle != INVALID_HANDLE_VALUE);
 
         const auto job = new DiscoverySingleLocalDirectoryJob({}, tmp.path(), nullptr, false);
-        job->setIsFileLockedOverride([&workerThread, &directoryProbed](const QString &absoluteLocalPath) {
-            workerThread.store(QThread::currentThread());
-            if (absoluteLocalPath.endsWith(QStringLiteral("subdir"))) {
-                directoryProbed.store(true);
-            }
-            return absoluteLocalPath.endsWith(QStringLiteral("locked.bin"));
-        });
-
         QSignalSpy finishedSpy(job, &DiscoverySingleLocalDirectoryJob::finished);
         QThreadPool::globalInstance()->start(job);
         QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 5000);
 
-        // it ran off the GUI thread
-        QVERIFY(workerThread.load() != nullptr);
-        QVERIFY(workerThread.load() != mainThread);
+        CloseHandle(handle);
 
-        // Directories are skipped entirely, not just precomputed as unlocked
-        QVERIFY(!directoryProbed.load());
-
-        // The precomputed flag reflects the access result per entry
         const auto results = finishedSpy.takeFirst().at(0).value<QVector<OCC::LocalInfo>>();
         QCOMPARE(results.size(), 3);
         for (const auto &info : results) {
@@ -184,7 +169,6 @@ private slots:
         }
     }
 
-#ifdef Q_OS_WIN
     void testDirectoryLockChecks()
     {
         QTemporaryDir tmp;

--- a/test/testlockedfiles.cpp
+++ b/test/testlockedfiles.cpp
@@ -14,6 +14,9 @@
 #include "lockwatcher.h"
 #include <syncengine.h>
 #include <localdiscoverytracker.h>
+#include "discoveryphase.h"
+#include <QThreadPool>
+#include <atomic>
 
 using namespace OCC;
 
@@ -127,6 +130,58 @@ private slots:
         QVERIFY(!watcher.contains(tmpFile));
 #endif
         QVERIFY(tmp.remove());
+    }
+
+    void testLockRunsOffMainThread()
+    {
+        // Regression guard for #10464: the lock access must run on the worker thread, not the GUI thread
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        for (const auto &name : { QStringLiteral("locked.bin"), QStringLiteral("test.txt") }) {
+            QFile tmpFile(tmp.filePath(name));
+            QVERIFY(tmpFile.open(QIODevice::WriteOnly));
+            tmpFile.write("x");
+        }
+        QVERIFY(QDir(tmp.path()).mkdir(QStringLiteral("subdir")));
+
+        const auto mainThread = QThread::currentThread();
+        std::atomic<QThread *> workerThread{nullptr};
+        std::atomic<bool> directoryProbed{false};
+
+        const auto job = new DiscoverySingleLocalDirectoryJob({}, tmp.path(), nullptr, false);
+        job->setIsFileLockedOverride([&workerThread, &directoryProbed](const QString &absoluteLocalPath) {
+            workerThread.store(QThread::currentThread());
+            if (absoluteLocalPath.endsWith(QStringLiteral("subdir"))) {
+                directoryProbed.store(true);
+            }
+            return absoluteLocalPath.endsWith(QStringLiteral("locked.bin"));
+        });
+
+        QSignalSpy finishedSpy(job, &DiscoverySingleLocalDirectoryJob::finished);
+        QThreadPool::globalInstance()->start(job);
+        QTRY_COMPARE_WITH_TIMEOUT(finishedSpy.count(), 1, 5000);
+
+        // it ran off the GUI thread
+        QVERIFY(workerThread.load() != nullptr);
+        QVERIFY(workerThread.load() != mainThread);
+
+        // Directories are skipped entirely, not just precomputed as unlocked
+        QVERIFY(!directoryProbed.load());
+
+        // The precomputed flag reflects the access result per entry
+        const auto results = finishedSpy.takeFirst().at(0).value<QVector<OCC::LocalInfo>>();
+        QCOMPARE(results.size(), 3);
+        for (const auto &info : results) {
+            if (info.name == QStringLiteral("locked.bin")) {
+                QVERIFY(info.isLocked);
+                continue;
+            }
+
+            QVERIFY(!info.isLocked);
+            if (info.name == QStringLiteral("subdir")) {
+                QVERIFY(info.isDirectory);
+            }
+        }
     }
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
## Resolves
#10464

## Summary
isFileLocked opened files synchronously on the GUI thread during discovery. A blocking open froze the UI and, through the shell extension, Explorer too. Compute the lock state on the local listing worker and carry it in LocalInfo, so handleExcluded reads a precomputed flag. Skip symlinks, virtual placeholders and directories.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
