### PR TITLE
(draft) fix: settings dialog is missing panel colors

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -59,7 +59,7 @@
 #include <QPushButton>
 #include <QStyle>
 #include <QFileDialog>
-#include <QFrame>
+#include <QGroupBox>
 
 using namespace Qt::StringLiterals;
 
@@ -180,10 +180,8 @@ AccountSettings::AccountSettings(AccountState *accountState, QWidget *parent)
 {
     _ui->setupUi(this);
 
-    _encryptionPanel = new QFrame(this);
+    _encryptionPanel = new QGroupBox(this);
     _encryptionPanel->setObjectName(QLatin1String("encryptionPanel"));
-    _encryptionPanel->setFrameShape(QFrame::NoFrame);
-    _encryptionPanel->setAttribute(Qt::WA_StyledBackground, true);
     auto *encryptionPanelLayout = new QVBoxLayout(_encryptionPanel);
     encryptionPanelLayout->setContentsMargins(0, 0, 0, 0);
     encryptionPanelLayout->setSpacing(0);

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -29,7 +29,7 @@ class QListWidgetItem;
 class QLabel;
 class QPushButton;
 class QIcon;
-class QFrame;
+class QGroupBox;
 
 namespace OCC {
 
@@ -168,7 +168,7 @@ private:
 
     bool _menuShown = false;
     bool _e2eEncryptionSetupDone = false;
-    QFrame *_encryptionPanel = nullptr;
+    QGroupBox *_encryptionPanel = nullptr;
 
     QHash<QString, QMetaObject::Connection> _folderConnections;
     QHash<QAction *, QPushButton *> _encryptionMessageButtons;

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -27,10 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="accountStatusPanel">
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
-     </property>
+    <widget class="QGroupBox" name="accountStatusPanel">
      <layout class="QVBoxLayout" name="accountStatusLayout">
       <property name="leftMargin">
        <number>0</number>
@@ -134,15 +131,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QFrame" name="syncFoldersPanel">
+    <widget class="QGroupBox" name="syncFoldersPanel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <layout class="QVBoxLayout" name="syncFoldersPanelLayout">
       <property name="sizeConstraint">
@@ -458,15 +452,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QFrame" name="accountActionsPanel">
+    <widget class="QGroupBox" name="accountActionsPanel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <layout class="QVBoxLayout" name="accountActionsPanelLayout">
       <item>

--- a/src/gui/generalsettings.cpp
+++ b/src/gui/generalsettings.cpp
@@ -313,12 +313,9 @@ void GeneralSettings::customizeStyle()
 {
     SettingsPanelStyle::apply(this);
 
-    // SettingsPanelStyle gives every row equal margins on all sides. For the File
-    // Provider description we only want a left indent that matches the switch label
-    // above it, and no padding on the other sides — so copy the row's left margin and
-    // zero the rest. Done after apply() so it is not overwritten.
-    const auto rowLeftMargin = _ui->fileProviderRow->contentsMargins().left();
-    _ui->fileProviderDescriptionRow->setContentsMargins(rowLeftMargin, 0, 0, 0);
+    // Keep the description close to the control row while matching the panel's outer inset.
+    const auto panelMargin = _ui->fileProviderRow->contentsMargins().left();
+    _ui->fileProviderDescriptionRow->setContentsMargins(panelMargin, 0, panelMargin, panelMargin);
 }
 
 } // namespace OCC

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -19,6 +19,7 @@
 #include "accountmanager.h"
 
 #include <QLabel>
+#include <QGroupBox>
 #include <QStandardItemModel>
 #include <QStackedWidget>
 #include <QPushButton>
@@ -54,14 +55,6 @@
 #endif
 
 using namespace Qt::StringLiterals;
-
-#ifdef Q_OS_WIN
-    // "light" looks too bright on dark mode on Windows only
-    #define BACKGROUND_PALETTE "alternate-base"
-#else
-    // ...and "alternate-base" looks too bright on macOS only.  On Linux/Plasma either one looked fine ...
-    #define BACKGROUND_PALETTE "light"
-#endif
 
 namespace {
 class CurrentPageSizeStackedWidget : public QStackedWidget
@@ -501,28 +494,13 @@ void SettingsDialog::customizeStyle()
         "#Settings { background: palette(window); border-radius: 0; }"
 
         /* Navigation */
-        "#settings_navigation_scroll { background: palette(" BACKGROUND_PALETTE "); border-radius: 12px; padding: 4px; }"
-        "#settings_navigation { background: transparent; border: none; padding: 0px; }"
+        "#settings_navigation_scroll, #settings_navigation { background: transparent; border: none; padding: 0px; }"
 
         /* Content area */
         "#settings_content, #settings_content_scroll { background: palette(window); border-radius: 12px; }"
 
         /* Panels */
-        "#generalGroupBox, #fileProviderGroupBox, #notificationsGroupBox, #advancedGroupBox, #syncBehaviorGroupBox,"
-        "#advancedActionsGroupBox, #aboutAndUpdatesGroupBox, #updatesGroupBox {"
-        " background: palette(" BACKGROUND_PALETTE ");"
-        " border: none;"
-        " border-radius: 12px;"
-        " margin: 0px;"
-        " padding: 0px;"
-        " }"
-        "#accountStatusPanel, #encryptionPanel, #syncFoldersPanel, #accountActionsPanel {"
-        " background: palette(" BACKGROUND_PALETTE ");"
-        " border: none;"
-        " border-radius: 12px;"
-        " margin: 0px;"
-        " padding: 6px;"
-        " }"
+        // Leave QGroupBox panels to the platform style, matching NetworkSettings.
         "#generalGroupBox QLabel, #fileProviderGroupBox QLabel, #notificationsGroupBox QLabel, #advancedGroupBox QLabel,"
         "#syncBehaviorGroupBox QLabel, #advancedActionsGroupBox QLabel,"
         "#aboutAndUpdatesGroupBox QLabel, #updatesGroupBox QLabel {"
@@ -684,7 +662,12 @@ void SettingsDialog::setupUi()
     contentScroll->viewport()->setAutoFillBackground(false);
     contentScroll->setWidget(_stack);
 
-    mainLayout->addWidget(navigationScroll);
+    auto *navigationPanel = new QGroupBox(this);
+    navigationPanel->setObjectName("settings_navigation_panel"_L1);
+    auto *navigationPanelLayout = new QVBoxLayout(navigationPanel);
+    navigationPanelLayout->setContentsMargins(0, 0, 0, 0);
+    navigationPanelLayout->addWidget(navigationScroll);
+    mainLayout->addWidget(navigationPanel);
     mainLayout->addWidget(contentScroll);
     mainLayout->setStretch(0, 0);
     mainLayout->setStretch(1, 1);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -173,6 +173,7 @@ if(NOT BUILD_FILE_PROVIDER_MODULE)
 endif()
 
 nextcloud_add_test(NetworkSettings)
+nextcloud_add_test(SettingsDialog)
 nextcloud_add_test(UpdateChannel)
 nextcloud_add_test(FileActionsModel)
 nextcloud_add_test(UriSchemeHandler)

--- a/test/testaccountsettings.cpp
+++ b/test/testaccountsettings.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <QtTest>
+#include <QGroupBox>
 
 #include "account.h"
 #include "testhelper.h"
@@ -52,6 +53,23 @@ private slots:
         auto accountState = new FakeAccountState(account);
         QCOMPARE_EQ(accountState->state(), OCC::AccountState::Connected);
         AccountSettings a(accountState);
+    }
+
+    void test_panelsUseGroupBoxes()
+    {
+        auto account = Account::create();
+        auto accountState = new FakeAccountState(account);
+        AccountSettings settings(accountState);
+
+        const auto panelNames = {
+            QStringLiteral("accountStatusPanel"),
+            QStringLiteral("encryptionPanel"),
+            QStringLiteral("syncFoldersPanel"),
+            QStringLiteral("accountActionsPanel"),
+        };
+        for (const auto &panelName : panelNames) {
+            QVERIFY(settings.findChild<QGroupBox *>(panelName));
+        }
     }
 };
 

--- a/test/testsettingsdialog.cpp
+++ b/test/testsettingsdialog.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * This software is in the public domain, furnished "as is", without technical
+ * support, and with no warranty, express or implied, as to its usefulness for
+ * any purpose.
+ */
+
+#include <QtTest>
+#include <QGroupBox>
+#include <QLayout>
+
+#include "settingsdialog.h"
+
+using namespace OCC;
+
+class TestSettingsDialog : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+    }
+
+    void settingsPanelsUseNativeStyle()
+    {
+        SettingsDialog dialog(nullptr);
+        const auto groupBoxPanelSelector = QStringLiteral("#generalGroupBox, #fileProviderGroupBox");
+        const auto accountPanelSelector = QStringLiteral("#accountStatusPanel, #encryptionPanel");
+
+        QVERIFY(!dialog.styleSheet().contains(groupBoxPanelSelector));
+        QVERIFY(!dialog.styleSheet().contains(accountPanelSelector));
+        QVERIFY(dialog.findChild<QGroupBox *>(QStringLiteral("settings_navigation_panel")));
+    }
+
+    void fileProviderDescriptionUsesPanelInset()
+    {
+        SettingsDialog dialog(nullptr);
+        const auto controlRow = dialog.findChild<QLayout *>(QStringLiteral("fileProviderRow"));
+        const auto descriptionRow = dialog.findChild<QLayout *>(QStringLiteral("fileProviderDescriptionRow"));
+        QVERIFY(controlRow);
+        QVERIFY(descriptionRow);
+
+        const auto panelMargin = controlRow->contentsMargins().left();
+        const auto descriptionMargins = descriptionRow->contentsMargins();
+        QCOMPARE(descriptionMargins.left(), panelMargin);
+        QCOMPARE(descriptionMargins.top(), 0);
+        QCOMPARE(descriptionMargins.right(), panelMargin);
+        QCOMPARE(descriptionMargins.bottom(), panelMargin);
+    }
+};
+
+QTEST_MAIN(TestSettingsDialog)
+#include "testsettingsdialog.moc"


### PR DESCRIPTION
Problem: the current settings dialog does not render the colours and is white on white
different rendering on different platforms.

Proposal:
- All settings panels now use platform-native QGroupBox rendering.
- Navigation always uses the same QGroupBox wrapper.
- Removed platform-specific panel colors and BACKGROUND_PALETTE.
- No hardcoded surface colors were introduced.

@kra-mo wdyt? the windows with the frames does not look perfect. but at least its not white/white. it does not use any hard coded colours but the "native" rendering fo the QGroupBox as a kind of compromise

Assisted-by: Codex:GPT-5

macOS:

<img width="962" height="550" alt="Bildschirmfoto 2026-08-01 um 10 49 38" src="https://github.com/user-attachments/assets/94fc247c-f074-41ca-b1d8-e541e300f557" />
<img width="965" height="549" alt="Bildschirmfoto 2026-08-01 um 10 49 06" src="https://github.com/user-attachments/assets/fe8456ba-3b2f-4fa6-9237-06bce7209e3b" />

Win:
<img width="970" height="546" alt="Bildschirmfoto 2026-08-02 um 11 14 52" src="https://github.com/user-attachments/assets/1c5eedac-0528-4742-bb49-9da0a7829ae4" />
