### PR TITLE
fix(file-provider): Deletion of server-side item for items excluded from sync

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -31,7 +31,7 @@ public final class FilesDatabaseManager: Sendable {
         )
     }
 
-    private static let schemaVersion = SchemaVersion.addedNormalizedFileNameIndexToRealmItemMetadata
+    private static let schemaVersion = SchemaVersion.addedExcludedFromSyncItems
     let logger: FileProviderLogger
     let account: Account
 
@@ -100,7 +100,7 @@ public final class FilesDatabaseManager: Sendable {
                     }
                 }
             },
-            objectTypes: [RealmItemMetadata.self, RemoteFileChunk.self]
+            objectTypes: [RealmItemMetadata.self, RealmExcludedFromSyncItem.self, RemoteFileChunk.self]
         )
 
         Realm.Configuration.defaultConfiguration = configuration

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -536,6 +536,62 @@ public final class FilesDatabaseManager: Sendable {
         }
     }
 
+    /**
+     * @brief Records that the provider returned `.excludedFromSync` for an item.
+     *
+     * The marker is stored separately from item metadata so remote enumeration and
+     * materialization updates cannot overwrite it before the system calls `deleteItem`.
+     *
+     * @param ocId The file provider item identifier to mark.
+     * @return `true` when the marker was stored successfully.
+     */
+    @discardableResult
+    func markItemAsExcludedFromSync(ocId: String) -> Bool {
+        let database = ncDatabase()
+
+        do {
+            try database.write {
+                database.add(RealmExcludedFromSyncItem(ocId: ocId), update: .all)
+            }
+            return true
+        } catch {
+            logger.error("Could not mark item as excluded from sync.", [.item: ocId, .error: error])
+            return false
+        }
+    }
+
+    /**
+     * @brief Returns whether an item is awaiting the deletion callback caused by `.excludedFromSync`.
+     * @param ocId The file provider item identifier to look up.
+     */
+    func isItemExcludedFromSync(ocId: String) -> Bool {
+        ncDatabase().object(ofType: RealmExcludedFromSyncItem.self, forPrimaryKey: ocId) != nil
+    }
+
+    /**
+     * @brief Removes the durable exclusion marker after local metadata deletion succeeds.
+     * @param ocId The file provider item identifier whose marker should be removed.
+     * @return `true` when the marker was removed successfully or was already absent.
+     */
+    @discardableResult
+    func removeExcludedFromSyncMarker(ocId: String) -> Bool {
+        let database = ncDatabase()
+
+        guard let marker = database.object(ofType: RealmExcludedFromSyncItem.self, forPrimaryKey: ocId) else {
+            return true
+        }
+
+        do {
+            try database.write {
+                database.delete(marker)
+            }
+            return true
+        } catch {
+            logger.error("Could not remove excluded-from-sync marker.", [.item: ocId, .error: error])
+            return false
+        }
+    }
+
     ///
     /// Add or replace `metadata` while carrying over local-only fields the
     /// server payload cannot know about: ``keepDownloaded``, ``downloaded``,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmExcludedFromSyncItem.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmExcludedFromSyncItem.swift
@@ -1,0 +1,16 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import RealmSwift
+
+/** @brief Durable record of an item awaiting the deletion callback triggered by `.excludedFromSync`. */
+final class RealmExcludedFromSyncItem: Object {
+    /** @brief The file provider item identifier associated with the exclusion. */
+    @Persisted(primaryKey: true) var ocId = ""
+
+    /** @brief Creates an exclusion record for the provided item identifier. */
+    convenience init(ocId: String) {
+        self.init()
+        self.ocId = ocId
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
@@ -11,4 +11,5 @@ enum SchemaVersion: UInt64 {
     case addedIsLockFileOfLocalOriginToRealmItemMetadata = 202
     case addedCanonicalPathKeysToRealmItemMetadata = 203
     case addedNormalizedFileNameIndexToRealmItemMetadata = 204
+    case addedExcludedFromSyncItems = 205
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -49,4 +49,5 @@ It is designed specifically for the implementation of this file provider extensi
 
 ### Design notes
 
+- <doc:ExcludedFromSyncDeletion>
 - <doc:UnicodePathNormalization>

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ExcludedFromSyncDeletion.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ExcludedFromSyncDeletion.md
@@ -1,0 +1,117 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Safe deletion after excluding an item from sync
+
+## Overview
+
+Returning `NSFileProviderError(.excludedFromSync)` from an item creation or
+modification callback starts a system-managed removal sequence. It does not
+only report that the operation was rejected.
+
+For a materialized item, macOS can perform the following callbacks:
+
+1. The extension enumerates an item that already exists on the server.
+2. The user changes the item locally and macOS calls `modifyItem`.
+3. The extension returns `.excludedFromSync` because it cannot synchronize the
+   changed item.
+4. macOS fetches the item and its descendants so the package is locally
+   available.
+5. macOS calls `deleteItem` for the same item identifier to remove it from the
+   File Provider domain.
+
+The final callback looks like an ordinary user-requested deletion. If it is
+handled by the normal deletion path, the extension sends a WebDAV deletion to
+the server. The item is then removed for every client, even though the
+extension intended only to exclude the unsupported local item. This behavior
+caused [desktop issue #10521](https://github.com/nextcloud/desktop/issues/10521).
+
+## Provider-owned exclusion intent
+
+The extension must establish the reason for the future deletion before it
+returns `.excludedFromSync`.
+
+When a bundle or package modification is rejected, `Item.modify` stores a
+`RealmExcludedFromSyncItem` record keyed by the item's `ocId`. Only after that
+write succeeds does it return `.excludedFromSync`. If the record cannot be
+written, the modification fails with `.cannotSynchronize` instead of starting
+a deletion sequence that cannot be recognized safely.
+
+The exclusion record is stored separately from `RealmItemMetadata`. Fetching,
+materializing, and enumerating an item can replace its item metadata with a
+fresh server-derived value before the deletion callback arrives. A field on
+that replaceable value could therefore be lost at exactly the point where it
+is needed. The separate Realm object survives those writes and extension
+process restarts. It was introduced with Realm schema version 205.
+
+When `Item.delete` receives the subsequent callback, it checks for this record
+before invoking the remote interface:
+
+- If the record exists, only the local item metadata and descendants are
+  marked as deleted. No WebDAV deletion is sent. The exclusion record is
+  removed after local cleanup succeeds.
+- If the record does not exist, deletion follows the ordinary path and is
+  propagated to the server. This includes an explicit user deletion of a
+  bundle or package.
+
+Failures during local cleanup or removal of the exclusion record return
+`.cannotSynchronize`. The record remains available for a retry, preventing a
+retry from falling through to remote deletion.
+
+## Why item type is not sufficient
+
+The deletion path must not skip every bundle or package. A user can explicitly
+delete a package and reasonably expect that deletion to synchronize. The item
+type describes what is being deleted, but not why macOS requested deletion.
+
+The durable exclusion record supplies that missing intent. It is created only
+by a provider-controlled operation that will return `.excludedFromSync` and
+is consumed only by the resulting deletion callback.
+
+For the same reason, the extension does not vend
+`NSFileProviderItemCapabilities.allowsExcludingFromSync`. Finder can represent
+“Do not synchronize” as an ordinary deletion callback without first passing
+through the provider-controlled modification path. There would be no durable
+intent record with which to distinguish it from a real deletion.
+
+Ignored files are handled independently. Their deletion path re-evaluates the
+ignore matcher and performs local-only cleanup without using an exclusion
+record.
+
+## Diagnosing this sequence
+
+Use the File Provider extension's JSONL log, not only the main desktop-client
+log. A failing sequence can be identified by the same item identifier appearing
+in this order:
+
+1. A request to modify a bundle or package.
+2. Completion of the modification with error code `-2010`
+   (`NSFileProviderError.excludedFromSync`).
+3. A request to fetch the item's contents, followed by successful
+   materialization.
+4. A request to delete the same item.
+5. A successful remote deletion for its WebDAV path.
+
+After this safeguard, the fourth event is followed by local metadata cleanup
+and no remote deletion request.
+
+## Rules for future changes
+
+Any new path that returns `.excludedFromSync` for an item that may already
+exist on the server must follow the same contract:
+
+1. Persist provider-owned exclusion intent before returning the error.
+2. Do not store that intent only in metadata that remote synchronization can
+   replace.
+3. Do not issue a remote deletion when consuming the intent.
+4. Remove the intent only after local cleanup succeeds.
+5. Preserve ordinary remote deletion for items without exclusion intent.
+
+Regression coverage is provided by
+`ItemModifyTests.testModifyRemoteBundleExclusionDoesNotDeleteRemoteBundle`,
+which exercises the complete modification, metadata replacement, and deletion
+sequence. `ItemDeleteTests.testDeleteExcludedBundleDoesNotPropagateToServer`
+and `testDeleteUnexcludedBundlePropagatesToServer` directly cover both branches
+of the deletion contract.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -114,14 +114,15 @@ public extension Item {
         return handleMetadataTrashModification()
     }
 
-    private func handleMetadataDeletion() {
+    @discardableResult
+    private func handleMetadataDeletion() -> Bool {
         let ocId = metadata.ocId
 
         if metadata.directory {
-            _ = dbManager.deleteDirectoryAndSubdirectoriesMetadata(ocId: ocId)
-        } else {
-            dbManager.deleteItemMetadata(ocId: ocId)
+            return dbManager.deleteDirectoryAndSubdirectoriesMetadata(ocId: ocId) != nil
         }
+
+        return dbManager.deleteItemMetadata(ocId: ocId)
     }
 
     /// NOTE: the trashing metadata modification procedure here is rough. You SHOULD run a rescan of

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -30,6 +30,20 @@ public extension Item {
             return await deleteLockFile(domain: domain, dbManager: dbManager)
         }
 
+        if dbManager.isItemExcludedFromSync(ocId: ocId) {
+            logger.info("Item deletion follows an exclusion from sync. Will delete from local database with no remote effect.", [.item: itemIdentifier, .name: filename])
+
+            guard handleMetadataDeletion() else {
+                return NSFileProviderError(.cannotSynchronize)
+            }
+
+            guard dbManager.removeExcludedFromSyncMarker(ocId: ocId) else {
+                return NSFileProviderError(.cannotSynchronize)
+            }
+
+            return nil
+        }
+
         guard ignoredFiles == nil || ignoredFiles?.isExcluded(relativePath) == false else {
             logger.info("File is in the ignore list. Will delete from local database with no remote effect.", [.item: itemIdentifier, .name: filename])
             dbManager.deleteItemMetadata(ocId: ocId)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -380,6 +380,11 @@ public extension Item {
                 return (nil, NSFileProviderError(.cannotSynchronize))
             }
 
+            guard dbManager.markItemAsExcludedFromSync(ocId: metadata.ocId) else {
+                logger.error("Unable to persist bundle exclusion state.", [.item: itemIdentifier, .name: filename])
+                return (nil, NSFileProviderError(.cannotSynchronize))
+            }
+
             return (modifiedIgnored, NSFileProviderError(.excludedFromSync))
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -98,6 +98,42 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(Self.dbManager.itemMetadata(ocId: metadata.ocId)?.deleted, true)
     }
 
+    func testDeleteExcludedBundleDoesNotPropagateToServer() async {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
+        let remoteBundle = MockRemoteItem(
+            identifier: "excluded-bundle-id",
+            name: "Excluded.key",
+            remotePath: Self.account.davFilesUrl + "/Excluded.key",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        remoteBundle.parent = rootItem
+        rootItem.children = [remoteBundle]
+
+        var metadata = remoteBundle.toItemMetadata(account: Self.account)
+        metadata.contentType = UTType.bundle.identifier
+        Self.dbManager.addItemMetadata(metadata)
+        XCTAssertTrue(Self.dbManager.markItemAsExcludedFromSync(ocId: metadata.ocId))
+
+        let item = Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await item.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(error)
+        XCTAssertTrue(rootItem.children.contains { $0.identifier == remoteBundle.identifier })
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: metadata.ocId)?.deleted, true)
+        XCTAssertFalse(Self.dbManager.isItemExcludedFromSync(ocId: metadata.ocId))
+    }
+
     func testDeleteFolderAndContents() async {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let remoteFolder = MockRemoteItem(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -7,6 +7,7 @@ import NextcloudFileProviderKitMocks
 import NextcloudKit
 import RealmSwift
 import TestInterface
+import UniformTypeIdentifiers
 import XCTest
 
 final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
@@ -61,6 +62,40 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         XCTAssertTrue(rootItem.children.isEmpty)
 
         XCTAssertEqual(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.deleted, true)
+    }
+
+    func testDeleteUnexcludedBundlePropagatesToServer() async {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
+        let remoteBundle = MockRemoteItem(
+            identifier: "bundle-id",
+            name: "ExplicitlyDeleted.key",
+            remotePath: Self.account.davFilesUrl + "/ExplicitlyDeleted.key",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        remoteBundle.parent = rootItem
+        rootItem.children = [remoteBundle]
+
+        var metadata = remoteBundle.toItemMetadata(account: Self.account)
+        metadata.contentType = UTType.bundle.identifier
+        Self.dbManager.addItemMetadata(metadata)
+
+        let item = Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await item.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(error)
+        XCTAssertTrue(rootItem.children.isEmpty)
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: metadata.ocId)?.deleted, true)
     }
 
     func testDeleteFolderAndContents() async {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -724,28 +724,28 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         // We do not yet support modification of folder contents
     }
 
-    /// Verify that a modify operation on a bundle is refused at the file provider boundary
-    /// with `.excludedFromSync` and that the (mock) server is left untouched. Replaces the
-    /// previous `testModifyBundleContents` test, which validated the now-removed recursive-
-    /// mirror code path. See https://github.com/nextcloud/desktop/issues/9827.
-    func testModifyBundleIsExcluded() async {
+    /// Verify the framework callback sequence caused by excluding a remotely synced bundle.
+    func testModifyRemoteBundleExclusionDoesNotDeleteRemoteBundle() async throws {
         let db = Self.dbManager.ncDatabase()
         debugPrint(db)
 
         let bundleFilename = "test.key"
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
-
-        // Pre-seed: the bundle exists locally + in the DB but never reached the server. This
-        // mirrors what would happen after the create-time exclusion path ran on a fresh drag.
-        var bundleMetadata = SendableItemMetadata(
-            ocId: "test-bundle-id", fileName: bundleFilename, account: Self.account
+        let remoteBundle = MockRemoteItem(
+            identifier: "test-bundle-id",
+            name: bundleFilename,
+            remotePath: Self.account.davFilesUrl + "/" + bundleFilename,
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
         )
-        bundleMetadata.directory = true
-        bundleMetadata.serverUrl = Self.account.davFilesUrl
-        bundleMetadata.classFile = NKTypeClassFile.directory.rawValue
+        remoteBundle.parent = rootItem
+        rootItem.children.append(remoteBundle)
+
+        var bundleMetadata = remoteBundle.toItemMetadata(account: Self.account)
         bundleMetadata.contentType = UTType.bundle.identifier
-        bundleMetadata.uploaded = false
-        bundleMetadata.downloaded = true
         Self.dbManager.addItemMetadata(bundleMetadata)
 
         let bundleItem = Item(
@@ -765,8 +765,31 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
 
         XCTAssertNotNil(modifiedItem)
         XCTAssertEqual((error as? NSFileProviderError)?.code, .excludedFromSync)
-        // Mock server stays untouched.
-        XCTAssertNil(rootItem.children.first { $0.name == bundleFilename })
+        XCTAssertTrue(Self.dbManager.isItemExcludedFromSync(ocId: bundleMetadata.ocId))
+
+        // Returning `.excludedFromSync` makes macOS fetch the package, then call deleteItem.
+        // Replacing the metadata here models writes made while that fetch/materialization runs.
+        var materializedMetadata = remoteBundle.toItemMetadata(account: Self.account)
+        materializedMetadata.contentType = UTType.bundle.identifier
+        materializedMetadata.downloaded = true
+        Self.dbManager.addItemMetadata(materializedMetadata)
+        XCTAssertTrue(Self.dbManager.isItemExcludedFromSync(ocId: bundleMetadata.ocId))
+
+        let storedMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: bundleMetadata.ocId))
+        let storedBundle = Item(
+            metadata: storedMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let deleteError = await storedBundle.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(deleteError)
+        XCTAssertTrue(rootItem.children.contains { $0.identifier == remoteBundle.identifier })
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: bundleMetadata.ocId)?.deleted, true)
+        XCTAssertFalse(Self.dbManager.isItemExcludedFromSync(ocId: bundleMetadata.ocId))
     }
 
     func testMoveFileToTrash() async throws {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

https://github.com/nextcloud/desktop/issues/10521#issuecomment-5185173809

## Summary

Returning `NSFileProviderError(.excludedFromSync)` from an item creation or modification callback starts a system-managed removal sequence. It does not only report that the operation was rejected. This currently causes an item's standard deletion pipeline to be called, which culminates in a server deletion.

This PR adds a marker for items excluded from sync to prevent this from happening.

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.
