### PR TITLE
fix(socketapi): defer move item dialog out of socket read loop.

### DIFF
--- a/src/gui/activity/activitylistmodel.cpp
+++ b/src/gui/activity/activitylistmodel.cpp
@@ -920,7 +920,13 @@ void ActivityListModel::slotTriggerDefaultAction(const int activityIndex)
 
     const auto activity = _finalList.at(activityIndex);
     if (activity._syncFileItemStatus == SyncFileItem::Conflict) {
-        displaySingleConflictDialog(activity);
+        if (_conflictsList.size() > 1) {
+            if (const auto systray = Systray::instance()) {
+                systray->createResolveConflictsDialog(allConflicts());
+            }
+        } else {
+            displaySingleConflictDialog(activity);
+        }
 
         return;
     } else if (activity._syncFileItemStatus == SyncFileItem::FileNameClash) {

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -491,6 +491,12 @@ Application::Application(int &argc, char **argv)
     connect(FolderMan::instance()->socketApi(), &SocketApi::fileActionsCommandReceived,
             _gui.data(), &ownCloudGui::slotShowFileActionsDialog);
 
+    connect(FolderMan::instance()->socketApi(), &SocketApi::resolveConflictCommandReceived,
+            _gui.data(), &ownCloudGui::slotResolveConflict);
+
+    connect(FolderMan::instance()->socketApi(), &SocketApi::moveItemCommandReceived,
+            _gui.data(), &ownCloudGui::slotMoveItem);
+
     // startup procedure.
     connect(&_checkConnectionTimer, &QTimer::timeout, this, &Application::slotCheckConnection);
     _checkConnectionTimer.setInterval(ConnectionValidator::DefaultCallingIntervalMsec); // check for connection every 32 seconds.

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -25,6 +25,8 @@
 #include "theme.h"
 #include "wheelhandler.h"
 #include "syncconflictsmodel.h"
+#include "conflictdialog.h"
+#include "conflictsolver.h"
 #include "syncengine.h"
 #include "wizard/accountwizardcontroller.h"
 #include "filedetails/datefieldbackend.h"
@@ -44,6 +46,7 @@
 #include "governance/getgovernancelabels.h"
 #include "governance/governancelabelslistmodel.h"
 #include "filesystem.h"
+#include "common/utility_mac_sandbox.h"
 
 #ifdef WITH_LIBCLOUDPROVIDERS
 #include "cloudproviders/cloudprovidermanager.h"
@@ -52,6 +55,7 @@
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QDir>
+#include <QFileDialog>
 #include <QGuiApplication>
 #include <QMessageBox>
 #include <QQmlApplicationEngine>
@@ -804,6 +808,52 @@ void ownCloudGui::slotShowFileActivityDialog(const QString &localPath) const
 void ownCloudGui::slotShowFileActionsDialog(const QString &localPath) const
 {
     _tray->showFileActionsDialog(localPath);
+}
+
+void ownCloudGui::slotResolveConflict(const QString &conflictedPath, const QString &basePath, const QString &baseName, const QString &folderAlias) const
+{
+    // Show with open(), never exec(): this runs inside SocketApi::slotReadSocket and a modal loop would crash on a nullptr socket.
+    auto dialog = new ConflictDialog;
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setBaseFilename(baseName);
+    dialog->setLocalVersionFilename(conflictedPath);
+    dialog->setRemoteVersionFilename(basePath);
+    connect(dialog, &ConflictDialog::accepted, dialog, [folderAlias] {
+        if (const auto folder = FolderMan::instance()->folder(folderAlias)) {
+            folder->scheduleThisFolderSoon();
+        }
+    });
+    dialog->open();
+    raiseDialog(dialog);
+}
+
+void ownCloudGui::slotMoveItem(const QString &localPath, const QString &defaultTarget) const
+{
+    // Show with open(), never exec(): this runs inside SocketApi::slotReadSocket and a modal loop would crash on a freed socket.
+    auto dialog = new QFileDialog(nullptr, tr("Select new location …"), QFileInfo(defaultTarget).absolutePath());
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setAcceptMode(QFileDialog::AcceptSave);
+    dialog->setOptions(QFileDialog::HideNameFilterDetails);
+    dialog->selectUrl(QUrl::fromLocalFile(defaultTarget));
+    connect(dialog, &QFileDialog::urlSelected, dialog, [localPath](const QUrl &targetUrl) {
+        if (targetUrl.isEmpty()) {
+            return;
+        }
+
+#ifdef Q_OS_MACOS
+        const auto scopedAccess = Utility::MacSandboxSecurityScopedAccess::create(targetUrl);
+        if (!scopedAccess->isValid()) {
+            qCWarning(lcOwnCloudGui) << "Could not access resource for conflict resolution:" << targetUrl;
+            return;
+        }
+#endif
+
+        ConflictSolver solver;
+        solver.setLocalVersionFilename(localPath);
+        solver.setRemoteVersionFilename(targetUrl.toLocalFile());
+    });
+    dialog->open();
+    raiseDialog(dialog);
 }
 
 #ifdef BUILD_FILE_PROVIDER_MODULE

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -102,6 +102,8 @@ public slots:
                                         const QString &fileId) const;
     void slotShowFileActivityDialog(const QString &localPath) const;
     void slotShowFileActionsDialog(const QString &localPath) const;
+    void slotResolveConflict(const QString &conflictedPath, const QString &basePath, const QString &baseName, const QString &folderAlias) const;
+    void slotMoveItem(const QString &localPath, const QString &defaultTarget) const;
 #ifdef BUILD_FILE_PROVIDER_MODULE
     /**
      * @brief Open an item's web page in the user's browser on behalf of the macOS file provider extension.

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1132,30 +1132,34 @@ void SocketApi::command_MOVE_ITEM(const QString &localFile, SocketListener *)
     // Add back the folder path
     defaultDirAndName = QDir(fileData.folder->path()).filePath(defaultDirAndName);
 
-    // Use getSaveFileUrl for sandbox compatibility
-    const auto targetUrl = QFileDialog::getSaveFileUrl(
-        nullptr,
-        tr("Select new location …"),
-        QUrl::fromLocalFile(defaultDirAndName),
-        QString(), nullptr, QFileDialog::HideNameFilterDetails);
-    if (targetUrl.isEmpty())
-        return;
+    // Show the file dialog outside of the socket read loop. As in command_RESOLVE_CONFLICT,
+    // a nested modal loop from the Qt::DirectConnection dispatch can free the socket under us.
+    QTimer::singleShot(0, this, [localFile, defaultDirAndName] {
+        // Use getSaveFileUrl for sandbox compatibility
+        const auto targetUrl = QFileDialog::getSaveFileUrl(
+            nullptr,
+            SocketApi::tr("Select new location …"),
+            QUrl::fromLocalFile(defaultDirAndName),
+            QString(), nullptr, QFileDialog::HideNameFilterDetails);
+        if (targetUrl.isEmpty())
+            return;
 
 #ifdef Q_OS_MACOS
-    // On macOS with app sandbox, we need to explicitly access the security-scoped resource
-    auto scopedAccess = Utility::MacSandboxSecurityScopedAccess::create(targetUrl);
-    
-    if (!scopedAccess->isValid()) {
-        qCWarning(lcSocketApi) << "Could not access security-scoped resource for conflict resolution:" << targetUrl;
-        return;
-    }
+        // On macOS with app sandbox, we need to explicitly access the security-scoped resource
+        auto scopedAccess = Utility::MacSandboxSecurityScopedAccess::create(targetUrl);
+
+        if (!scopedAccess->isValid()) {
+            qCWarning(lcSocketApi) << "Could not access security-scoped resource for conflict resolution:" << targetUrl;
+            return;
+        }
 #endif
 
-    const auto target = targetUrl.toLocalFile();
+        const auto target = targetUrl.toLocalFile();
 
-    ConflictSolver solver;
-    solver.setLocalVersionFilename(localFile);
-    solver.setRemoteVersionFilename(target);
+        ConflictSolver solver;
+        solver.setLocalVersionFilename(localFile);
+        solver.setRemoteVersionFilename(target);
+    });
 }
 
 void SocketApi::command_LOCK_FILE(const QString &localFile, SocketListener *listener)

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -52,6 +52,7 @@
 #include <QMessageBox>
 #include <QInputDialog>
 #include <QFileDialog>
+#include <QTimer>
 
 
 #include <QAction>
@@ -1071,15 +1072,25 @@ void SocketApi::command_RESOLVE_CONFLICT(const QString &localFile, SocketListene
     const auto basePath = dir.filePath(baseRelativePath);
 
     const auto baseName = QFileInfo(basePath).fileName();
+    const auto folderAlias = fileData.folder->alias();
 
 #ifndef OWNCLOUD_TEST
-    ConflictDialog dialog;
-    dialog.setBaseFilename(baseName);
-    dialog.setLocalVersionFilename(conflictedPath);
-    dialog.setRemoteVersionFilename(basePath);
-    if (dialog.exec() == ConflictDialog::Accepted) {
-        fileData.folder->scheduleThisFolderSoon();
-    }
+    // Show the dialog outside of the socket read loop. This handler runs via a
+    // Qt::DirectConnection while SocketApi is still iterating the socket, so a nested
+    // modal loop here can let the socket or the Folder be destroyed underneath us.
+    // Defer to the next event loop iteration and look up the folder again by alias.
+    QTimer::singleShot(0, this, [conflictedPath, basePath, baseName, folderAlias] {
+        ConflictDialog dialog;
+        dialog.setBaseFilename(baseName);
+        dialog.setLocalVersionFilename(conflictedPath);
+        dialog.setRemoteVersionFilename(basePath);
+        if (dialog.exec() != ConflictDialog::Accepted) {
+            return;
+        }
+        if (const auto folder = FolderMan::instance()->folder(folderAlias)) {
+            folder->scheduleThisFolderSoon();
+        }
+    });
 #endif
 }
 

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -7,7 +7,6 @@
 #include "socketapi.h"
 #include "socketapi_p.h"
 
-#include "conflictdialog.h"
 #include "conflictsolver.h"
 
 #include "config.h"
@@ -51,8 +50,6 @@
 #include <QStringBuilder>
 #include <QMessageBox>
 #include <QInputDialog>
-#include <QFileDialog>
-#include <QTimer>
 
 
 #include <QAction>
@@ -1072,26 +1069,8 @@ void SocketApi::command_RESOLVE_CONFLICT(const QString &localFile, SocketListene
     const auto basePath = dir.filePath(baseRelativePath);
 
     const auto baseName = QFileInfo(basePath).fileName();
-    const auto folderAlias = fileData.folder->alias();
 
-#ifndef OWNCLOUD_TEST
-    // Show the dialog outside of the socket read loop. This handler runs via a
-    // Qt::DirectConnection while SocketApi is still iterating the socket, so a nested
-    // modal loop here can let the socket or the Folder be destroyed underneath us.
-    // Defer to the next event loop iteration and look up the folder again by alias.
-    QTimer::singleShot(0, this, [conflictedPath, basePath, baseName, folderAlias] {
-        ConflictDialog dialog;
-        dialog.setBaseFilename(baseName);
-        dialog.setLocalVersionFilename(conflictedPath);
-        dialog.setRemoteVersionFilename(basePath);
-        if (dialog.exec() != ConflictDialog::Accepted) {
-            return;
-        }
-        if (const auto folder = FolderMan::instance()->folder(folderAlias)) {
-            folder->scheduleThisFolderSoon();
-        }
-    });
-#endif
+    emit resolveConflictCommandReceived(conflictedPath, basePath, baseName, fileData.folder->alias());
 }
 
 void SocketApi::command_DELETE_ITEM(const QString &localFile, SocketListener *)
@@ -1132,34 +1111,7 @@ void SocketApi::command_MOVE_ITEM(const QString &localFile, SocketListener *)
     // Add back the folder path
     defaultDirAndName = QDir(fileData.folder->path()).filePath(defaultDirAndName);
 
-    // Show the file dialog outside of the socket read loop. As in command_RESOLVE_CONFLICT,
-    // a nested modal loop from the Qt::DirectConnection dispatch can free the socket under us.
-    QTimer::singleShot(0, this, [localFile, defaultDirAndName] {
-        // Use getSaveFileUrl for sandbox compatibility
-        const auto targetUrl = QFileDialog::getSaveFileUrl(
-            nullptr,
-            SocketApi::tr("Select new location …"),
-            QUrl::fromLocalFile(defaultDirAndName),
-            QString(), nullptr, QFileDialog::HideNameFilterDetails);
-        if (targetUrl.isEmpty())
-            return;
-
-#ifdef Q_OS_MACOS
-        // On macOS with app sandbox, we need to explicitly access the security-scoped resource
-        auto scopedAccess = Utility::MacSandboxSecurityScopedAccess::create(targetUrl);
-
-        if (!scopedAccess->isValid()) {
-            qCWarning(lcSocketApi) << "Could not access security-scoped resource for conflict resolution:" << targetUrl;
-            return;
-        }
-#endif
-
-        const auto target = targetUrl.toLocalFile();
-
-        ConflictSolver solver;
-        solver.setLocalVersionFilename(localFile);
-        solver.setRemoteVersionFilename(target);
-    });
+    emit moveItemCommandReceived(localFile, defaultDirAndName);
 }
 
 void SocketApi::command_LOCK_FILE(const QString &localFile, SocketListener *listener)

--- a/src/gui/socketapi/socketapi.h
+++ b/src/gui/socketapi/socketapi.h
@@ -74,6 +74,8 @@ signals:
     void fileActivityCommandReceived(const QString &localPath);
     void fileActionsCommandReceived(const QString &localPath);
     void governanceLabelsCommandReceived(OCC::AccountPtr account, const QString &filePath, const QString &fileId);
+    void resolveConflictCommandReceived(const QString &conflictedPath, const QString &basePath, const QString &baseName, const QString &folderAlias);
+    void moveItemCommandReceived(const QString &localPath, const QString &defaultTarget);
 
 private slots:
     void slotNewConnection();


### PR DESCRIPTION
## Resolves
#10519

## Summary
command_MOVE_ITEM showed QFileDialog::getSaveFileUrl as a nested modal loop
from the Qt::DirectConnection socket dispatch. Defer the dialog to the
next event loop iteration after computing the default path.

One extra change: now the notification for conflicts in the activity list opens the conflict dialog directly.

### TODO
- [x] test it => I have tested it with this build: https://cloud.nextcloud.com/s/k89S9zttsW2oKm9

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
