### PR TITLE
perf: let large syncs finish — fix O(n²) discovery, journal commit storm, and per-rename PROPFINDs

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -272,7 +272,7 @@ void SyncJournalDb::startTransaction()
         }
         _transaction = 1;
         _lastCommitTimer.start();
-        _commitsSinceTransactionStart = 0;
+        _writesSinceLastCommit = 0;
     } else {
         qCDebug(lcDb) << "Database Transaction is running, not starting another one!";
     }
@@ -3259,9 +3259,12 @@ void SyncJournalDb::commitIfNeededAndStartNewTransaction(const QString &context)
 {
     QMutexLocker lock(&_mutex);
     if (_transaction == 1) {
-        _commitsSinceTransactionStart++;
-        bool timeThresholdExceeded = _lastCommitTimer.elapsed() >= COMMIT_BATCH_TIMEOUT_MS;
-        bool countThresholdExceeded = _commitsSinceTransactionStart >= COMMIT_BATCH_WRITE_COUNT;
+        _writesSinceLastCommit++;
+        // An unstarted QElapsedTimer returns a meaningless elapsed(), so treat "never
+        // started" as due for a commit rather than reading uninitialised state.
+        const auto timeThresholdExceeded =
+            !_lastCommitTimer.isValid() || _lastCommitTimer.elapsed() >= COMMIT_BATCH_TIMEOUT_MS;
+        const auto countThresholdExceeded = _writesSinceLastCommit >= COMMIT_BATCH_WRITE_COUNT;
         if (timeThresholdExceeded || countThresholdExceeded) {
             commitInternal(context, true);
         }
@@ -3286,7 +3289,7 @@ void SyncJournalDb::commitInternal(const QString &context, bool startTrans)
 {
     qCDebug(lcDb) << "Transaction commit" << context << (startTrans ? "and starting new transaction" : "");
     commitTransaction();
-    _commitsSinceTransactionStart = 0;
+    _writesSinceLastCommit = 0;
 
     if (startTrans) {
         startTransaction();

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -41,6 +41,11 @@ namespace OCC {
 
 Q_LOGGING_CATEGORY(lcDb, "nextcloud.sync.database", QtInfoMsg)
 
+// Batch commits during propagation: commit every 2 seconds or 100 writes, whichever comes first.
+// This reduces per-file SQLite commit overhead while still keeping the journal reasonably fresh.
+static constexpr int COMMIT_BATCH_TIMEOUT_MS = 2000;
+static constexpr int COMMIT_BATCH_WRITE_COUNT = 100;
+
 #define GET_FILE_RECORD_QUERY \
         "SELECT path, inode, modtime, type, md5, fileid, remotePerm, filesize," \
         "  ignoredChildrenRemote, contentchecksumtype.name || ':' || contentChecksum, e2eMangledName, isE2eEncrypted, e2eCertificateFingerprint, " \
@@ -266,6 +271,8 @@ void SyncJournalDb::startTransaction()
             return;
         }
         _transaction = 1;
+        _lastCommitTimer.start();
+        _commitsSinceTransactionStart = 0;
     } else {
         qCDebug(lcDb) << "Database Transaction is running, not starting another one!";
     }
@@ -3252,7 +3259,12 @@ void SyncJournalDb::commitIfNeededAndStartNewTransaction(const QString &context)
 {
     QMutexLocker lock(&_mutex);
     if (_transaction == 1) {
-        commitInternal(context, true);
+        _commitsSinceTransactionStart++;
+        bool timeThresholdExceeded = _lastCommitTimer.elapsed() >= COMMIT_BATCH_TIMEOUT_MS;
+        bool countThresholdExceeded = _commitsSinceTransactionStart >= COMMIT_BATCH_WRITE_COUNT;
+        if (timeThresholdExceeded || countThresholdExceeded) {
+            commitInternal(context, true);
+        }
     } else {
         startTransaction();
     }
@@ -3274,6 +3286,7 @@ void SyncJournalDb::commitInternal(const QString &context, bool startTrans)
 {
     qCDebug(lcDb) << "Transaction commit" << context << (startTrans ? "and starting new transaction" : "");
     commitTransaction();
+    _commitsSinceTransactionStart = 0;
 
     if (startTrans) {
         startTransaction();

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -12,6 +12,7 @@
 #include <QHash>
 #include <QMutex>
 #include <QVariant>
+#include <QElapsedTimer>
 #include <functional>
 
 #include "common/utility.h"
@@ -430,6 +431,8 @@ private:
     QMap<QByteArray, int> _checksymTypeCache;
     int _transaction = 0;
     bool _metadataTableIsEmpty = false;
+    QElapsedTimer _lastCommitTimer;
+    int _commitsSinceTransactionStart = 0;
 
     /* Storing etags to these folders, or their parent folders, is filtered out.
      *

--- a/src/common/syncjournaldb.h
+++ b/src/common/syncjournaldb.h
@@ -432,7 +432,7 @@ private:
     int _transaction = 0;
     bool _metadataTableIsEmpty = false;
     QElapsedTimer _lastCommitTimer;
-    int _commitsSinceTransactionStart = 0;
+    int _writesSinceLastCommit = 0;
 
     /* Storing etags to these folders, or their parent folders, is filtered out.
      *

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -50,9 +50,8 @@ namespace {
 /// request timeouts anyway.
 int connectionTimeoutsBeforeDisconnect()
 {
-    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_CONNECTION_TIMEOUT_RETRIES");
-    static constexpr auto defaultTolerated = 3;
-    return qMax(1, configured > 0 ? configured : defaultTolerated);
+    static const auto configured = ConfigFile().connectionTimeoutRetries();
+    return configured;
 }
 
 /// Delay before re-probing after a tolerated timeout. Long enough not to pile another request
@@ -72,12 +71,12 @@ constexpr auto recheckAfterToleratedTimeout = std::chrono::seconds(5);
 /// so -- 60s and upwards, more when the reply trickles and keeps resetting the inactivity timer
 /// -- and only then is the next one scheduled. Consecutive failures are therefore minutes apart
 /// by construction, and a window below that would reset every time, making the count
-/// unreachable and this whole mechanism a no-op.
+/// unreachable and this whole mechanism a no-op. ConfigFile enforces the 60s floor for that
+/// reason.
 std::chrono::seconds connectionTimeoutCountResetAfter()
 {
-    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC");
-    static constexpr auto defaultSeconds = 300;
-    return std::chrono::seconds(qMax(60, configured > 0 ? configured : defaultSeconds));
+    static const auto configured = ConfigFile().connectionTimeoutResetInterval();
+    return configured;
 }
 
 }

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -28,6 +28,7 @@
 #include <QBuffer>
 #include <QRandomGenerator>
 
+#include <chrono>
 #include <cmath>
 
 using namespace Qt::StringLiterals;
@@ -35,6 +36,51 @@ using namespace Qt::StringLiterals;
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcAccountState, "nextcloud.gui.account.state", QtInfoMsg)
+
+namespace {
+
+/// How many connection checks must time out back to back before the account is called down.
+///
+/// A single timeout says only that one request did not come back in time, which a server that
+/// stalls briefly under load produces regularly. Acting on it disconnects the account and
+/// tears down a sync that was making progress on its own requests, throwing away the whole
+/// discovery pass. Requiring several in a row distinguishes "one slow request" from "the
+/// server is gone", at the cost of noticing a genuine outage a couple of checks later --
+/// which costs nothing, since a sync against a server that is really gone fails on its own
+/// request timeouts anyway.
+int connectionTimeoutsBeforeDisconnect()
+{
+    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_CONNECTION_TIMEOUT_RETRIES");
+    static constexpr auto defaultTolerated = 3;
+    return qMax(1, configured > 0 ? configured : defaultTolerated);
+}
+
+/// Delay before re-probing after a tolerated timeout. Long enough not to pile another request
+/// onto a server that is already struggling, short enough that a real outage is still noticed
+/// promptly.
+constexpr auto recheckAfterToleratedTimeout = std::chrono::seconds(5);
+
+/// How long a timeout stays "recent" for the purpose of counting consecutive failures.
+///
+/// Without this the count is consecutive in sequence but not in time, so three failures spread
+/// over a quarter of an hour -- a server that stumbled three separate times and recovered in
+/// between -- look identical to a server that has stopped answering. Only failures that keep
+/// arriving inside this window are evidence of an outage; an isolated one that is followed by a
+/// long quiet period is just a stumble, and the count starts over.
+///
+/// The window cannot be short. A check that times out takes as long as its own timeout to do
+/// so -- 60s and upwards, more when the reply trickles and keeps resetting the inactivity timer
+/// -- and only then is the next one scheduled. Consecutive failures are therefore minutes apart
+/// by construction, and a window below that would reset every time, making the count
+/// unreachable and this whole mechanism a no-op.
+std::chrono::seconds connectionTimeoutCountResetAfter()
+{
+    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC");
+    static constexpr auto defaultSeconds = 300;
+    return std::chrono::seconds(qMax(60, configured > 0 ? configured : defaultSeconds));
+}
+
+}
 
 AccountState::AccountState(const AccountPtr &account)
     : QObject()
@@ -363,6 +409,50 @@ void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status sta
     if (isSignedOut()) {
         qCWarning(lcAccountState) << "Signed out, ignoring" << status << _account->url().toString();
         return;
+    }
+
+    // Absorb isolated check timeouts. Returning here leaves the account exactly as it was --
+    // state, connection status and error list all untouched -- so nothing downstream can tell
+    // a tolerated timeout happened, and in particular no running sync is torn down for it.
+    if (status == ConnectionValidator::Timeout) {
+        // Failures only add up while they keep arriving. One that follows a long quiet spell
+        // says the server recovered in between, so it starts a fresh count rather than
+        // compounding with something that happened a quarter of an hour ago.
+        const auto resetAfter = connectionTimeoutCountResetAfter();
+        if (_lastConnectionTimeout.isValid()
+            && _lastConnectionTimeout.durationElapsed() > resetAfter) {
+            qCInfo(lcAccountState) << "Last connection timeout for" << _account->url().toString()
+                                   << "was"
+                                   << std::chrono::duration_cast<std::chrono::seconds>(
+                                          _lastConnectionTimeout.durationElapsed()).count()
+                                   << "s ago, more than the" << resetAfter.count()
+                                   << "s window; starting the count over";
+            _consecutiveConnectionTimeouts = 0;
+        }
+        _lastConnectionTimeout.start();
+
+        ++_consecutiveConnectionTimeouts;
+        const auto tolerated = connectionTimeoutsBeforeDisconnect();
+        if (_consecutiveConnectionTimeouts < tolerated) {
+            qCInfo(lcAccountState) << "Connection check timed out for" << _account->url().toString()
+                                   << "(" << _consecutiveConnectionTimeouts << "of" << tolerated
+                                   << "); staying connected and re-checking";
+            // The re-check below is the only thing that will reconsider this account, so it must
+            // actually run. checkConnectivity() skips the probe when a recent ETag check
+            // succeeded, and we stay Connected here, so that shortcut would otherwise apply and
+            // leave the account wedged as Connected however long the server stays down.
+            _timeOfLastETagCheck = {};
+            QTimer::singleShot(recheckAfterToleratedTimeout, this, &AccountState::checkConnectivity);
+            return;
+        }
+        qCWarning(lcAccountState) << "Connection check timed out" << _consecutiveConnectionTimeouts
+                                  << "times in a row for" << _account->url().toString()
+                                  << "within" << connectionTimeoutCountResetAfter().count()
+                                  << "s of each other; treating the account as disconnected";
+    } else {
+        // A check that got an answer -- any answer -- ends the run of failures.
+        _consecutiveConnectionTimeouts = 0;
+        _lastConnectionTimeout.invalidate();
     }
 
     const auto oldConnectionValidatorStatus = _lastConnectionValidatorStatus;

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -216,6 +216,15 @@ private:
     State _state;
     ConnectionStatus _connectionStatus;
     ConnectionStatus _lastConnectionValidatorStatus = ConnectionStatus::Undefined;
+
+    /// Connection checks that have timed out back to back without one succeeding in between.
+    /// The account is only treated as disconnected once this reaches the tolerated limit.
+    int _consecutiveConnectionTimeouts = 0;
+
+    /// Since the most recent check timeout. Failures further apart than the reset window are
+    /// treated as unrelated stumbles rather than one outage, and restart the count above.
+    QElapsedTimer _lastConnectionTimeout;
+
     QStringList _connectionErrors;
     bool _waitingForNewCredentials = false;
     QDateTime _timeOfLastETagCheck;

--- a/src/gui/connectionvalidator.cpp
+++ b/src/gui/connectionvalidator.cpp
@@ -88,6 +88,9 @@ void ConnectionValidator::slotCheckRedirectCostFreeUrl()
 {
     const auto checkJob = new CheckRedirectCostFreeUrlJob(_account, this);
     checkJob->setTimeout(timeoutToUseMsec);
+    // This job decides whether the account counts as online. Jump the connection queue so a
+    // busy sync cannot starve it into a false "server is down"; see AbstractNetworkJob::setPriority().
+    checkJob->setPriority(QNetworkRequest::HighPriority);
     checkJob->setIgnoreCredentialFailure(true);
     connect(checkJob, &CheckRedirectCostFreeUrlJob::timeout, this, &ConnectionValidator::slotJobTimeout);
     connect(checkJob, &CheckRedirectCostFreeUrlJob::jobFinished, this, &ConnectionValidator::slotCheckRedirectCostFreeUrlFinished);
@@ -98,6 +101,9 @@ void ConnectionValidator::slotCheckServerAndAuth()
 {
     auto *checkJob = new CheckServerJob(_account, this);
     checkJob->setTimeout(timeoutToUseMsec);
+    // This job decides whether the account counts as online. Jump the connection queue so a
+    // busy sync cannot starve it into a false "server is down"; see AbstractNetworkJob::setPriority().
+    checkJob->setPriority(QNetworkRequest::HighPriority);
     checkJob->setIgnoreCredentialFailure(true);
     connect(checkJob, &CheckServerJob::instanceFound, this, &ConnectionValidator::slotStatusFound);
     connect(checkJob, &CheckServerJob::instanceNotFound, this, &ConnectionValidator::slotNoStatusFound);
@@ -200,6 +206,9 @@ void ConnectionValidator::checkAuthentication()
     qCDebug(lcConnectionValidator) << "# Check whether authenticated propfind works.";
     auto *job = new PropfindJob(_account, "/", this);
     job->setTimeout(timeoutToUseMsec);
+    // This job decides whether the account counts as online. Jump the connection queue so a
+    // busy sync cannot starve it into a false "server is down"; see AbstractNetworkJob::setPriority().
+    job->setPriority(QNetworkRequest::HighPriority);
     job->setProperties(QList<QByteArray>() << "getlastmodified");
     connect(job, &PropfindJob::result, this, &ConnectionValidator::slotAuthSuccess);
     connect(job, &PropfindJob::finishedWithError, this, &ConnectionValidator::slotAuthFailed);
@@ -257,6 +266,9 @@ void ConnectionValidator::checkServerCapabilities()
     // The main flow now needs the capabilities
     auto *job = new JsonApiJob(_account, QLatin1String("ocs/v1.php/cloud/capabilities"), this);
     job->setTimeout(timeoutToUseMsec);
+    // This job decides whether the account counts as online. Jump the connection queue so a
+    // busy sync cannot starve it into a false "server is down"; see AbstractNetworkJob::setPriority().
+    job->setPriority(QNetworkRequest::HighPriority);
     QObject::connect(job, &JsonApiJob::jsonReceived, this, &ConnectionValidator::slotCapabilitiesRecieved);
     job->start();
 }
@@ -420,6 +432,9 @@ void TermsOfServiceChecker::checkServerTermsOfService()
     // The main flow now needs the capabilities
     auto *job = new JsonApiJob(_account, QLatin1String("ocs/v2.php/apps/terms_of_service/terms"), this);
     job->setTimeout(timeoutToUseMsec);
+    // This job decides whether the account counts as online. Jump the connection queue so a
+    // busy sync cannot starve it into a false "server is down"; see AbstractNetworkJob::setPriority().
+    job->setPriority(QNetworkRequest::HighPriority);
     QObject::connect(job, &JsonApiJob::jsonReceived, this, &TermsOfServiceChecker::slotServerTermsOfServiceRecieved);
     QObject::connect(job, &JsonApiJob::networkError, this, [] (QNetworkReply *reply)
                      {

--- a/src/gui/folder.cpp
+++ b/src/gui/folder.cpp
@@ -1274,6 +1274,10 @@ SyncOptions Folder::initializeSyncOptions() const
         opt.setMaxChunkSize(cfgMaxChunkSize);
         opt._initialChunkSize = ::qBound(cfgMinChunkSize, cfgFile.chunkSize(), cfgMaxChunkSize);
     }
+    if (const auto cfgMaxParallelLocalScan = cfgFile.maxParallelLocalScanJobs(); cfgMaxParallelLocalScan > 0) {
+        opt._parallelLocalScanJobs = cfgMaxParallelLocalScan;
+    }
+
     opt.fillFromEnvironmentVariables();
     opt.verifyChunkSizes();
 

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -35,6 +35,10 @@
 #include <QMutableSetIterator>
 #include <QSet>
 #include <QNetworkProxy>
+#include <QPointer>
+#include <QTimer>
+#include <algorithm>
+#include <chrono>
 
 namespace {
 constexpr auto settingsAccountsC = "Accounts";
@@ -953,20 +957,28 @@ void FolderMan::slotAccountStateChanged()
             if (f
                 && f->canSync()
                 && f->accountState() == accountState) {
-                scheduleFolder(f);
+                scheduleFolderAfterReconnect(f);
             }
         }
     } else {
         qCInfo(lcFolderMan) << "Account" << accountName << "disconnected or paused, "
                                                            "terminating or descheduling sync folders";
 
-        const auto folderValues = _folderMap.values();
-        for (const auto f : folderValues) {
-            if (f
-                && f->isSyncRunning()
-                && f->accountState() == accountState) {
-                f->slotTerminateSync();
-            }
+        // NetworkError and ServiceUnavailable both mean "the server did not serve this request",
+        // not "the server is gone". A probe that timed out, or a single 503 from a server busy
+        // with someone else's work, says nothing about the sync's own requests, which may still
+        // be completing. Terminating throws away the entire discovery pass, and the reconnect
+        // that follows seconds later restarts it from zero -- so against a server that stumbles
+        // now and then, the sync can never finish however long it is left alone. Both have been
+        // seen lasting a single second in practice.
+        //
+        // The remaining states are answers rather than failures: signed out, wrong credentials,
+        // a configuration error, a captive portal, or an administrator putting the server into
+        // maintenance. Those terminate at once, as before.
+        if (isTransientConnectionState(accountState)) {
+            deferSyncTerminationOnTransientError(accountState);
+        } else {
+            terminateSyncsForAccount(accountState);
         }
 
         QMutableListIterator<Folder *> it(_scheduledFolders);
@@ -978,6 +990,121 @@ void FolderMan::slotAccountStateChanged()
         }
         emit scheduleQueueChanged();
     }
+}
+
+void FolderMan::terminateSyncsForAccount(AccountState *accountState)
+{
+    const auto folderValues = _folderMap.values();
+    for (const auto f : folderValues) {
+        if (f
+            && f->isSyncRunning()
+            && f->accountState() == accountState) {
+            f->slotTerminateSync();
+        }
+    }
+}
+
+bool FolderMan::isTransientConnectionState(const AccountState *accountState)
+{
+    if (!accountState) {
+        return false;
+    }
+    const auto state = accountState->state();
+    return state == AccountState::NetworkError || state == AccountState::ServiceUnavailable;
+}
+
+void FolderMan::deferSyncTerminationOnTransientError(AccountState *accountState)
+{
+    // Nothing is running, so there is nothing to protect -- and no reason to hold a timer.
+    const auto folderValues = _folderMap.values();
+    const auto anyRunning = std::any_of(folderValues.cbegin(), folderValues.cend(), [accountState](const Folder *f) {
+        return f && f->isSyncRunning() && f->accountState() == accountState;
+    });
+    if (!anyRunning) {
+        return;
+    }
+
+    // The connection validator keeps probing while we wait, so a server that recovers clears the
+    // error on its own and the sync is never touched. The grace period only has to outlast a
+    // stall long enough to trip the probe; beyond that, waiting costs nothing, because a sync
+    // against a server that is genuinely gone fails on its own request timeouts anyway.
+    static constexpr auto terminationGrace = std::chrono::minutes(2);
+
+    if (_pendingSyncTermination.contains(accountState)) {
+        return; // already waiting on this account; a flapping connection must not stack timers
+    }
+    _pendingSyncTermination.append(accountState);
+
+    qCInfo(lcFolderMan) << "Account" << accountState->account()->displayName()
+                        << "hit a transient connection failure while syncing"
+                        << "(" << AccountState::stateString(accountState->state()) << ");"
+                        << "deferring termination by" << terminationGrace.count()
+                        << "min in case the connection returns";
+
+    QTimer::singleShot(terminationGrace, this, [this, accountState = QPointer<AccountState>(accountState)] {
+        _pendingSyncTermination.removeAll(accountState);
+        if (!accountState) {
+            return; // account went away; its folders went with it
+        }
+        if (accountState->isConnected()) {
+            qCInfo(lcFolderMan) << "Account" << accountState->account()->displayName()
+                                << "recovered within the grace period; leaving its sync running";
+            return;
+        }
+        qCInfo(lcFolderMan) << "Account" << accountState->account()->displayName()
+                            << "still not connected after the grace period; terminating its syncs";
+        terminateSyncsForAccount(accountState);
+    });
+}
+
+void FolderMan::scheduleFolderAfterReconnect(Folder *folder)
+{
+    // The sync was never terminated -- it outlived a transient network error. Rescheduling it
+    // now would only mark a running folder as pending.
+    if (folder->isSyncRunning()) {
+        qCInfo(lcFolderMan) << "Account reconnected and folder" << folder->alias()
+                            << "is still syncing; leaving it alone";
+        return;
+    }
+
+    // A reconnect normally means a real outage ended, so a folder that was syncing fine gets
+    // scheduled straight away -- that is the common case and stays unchanged.
+    //
+    // The exception is a folder whose recent syncs keep failing. Losing the account terminates
+    // the running sync (see the disconnect branch above), and a sync killed part-way through
+    // discovery throws that entire pass away. Rescheduling it the instant the account returns
+    // can then livelock: the retry rebuilds exactly the load that caused the drop, gets killed
+    // at the same point, and reconnect fires again. Each lap costs minutes and makes no
+    // progress. Backing off gives whatever caused the drop time to clear first.
+    const auto failCount = folder->consecutiveFailingSyncs();
+    if (failCount <= 0) {
+        scheduleFolder(folder);
+        return;
+    }
+
+    static constexpr auto reconnectBackoffBase = std::chrono::seconds(30);
+    static constexpr auto reconnectBackoffMax = std::chrono::minutes(10);
+    const auto backoff = std::min<std::chrono::milliseconds>(
+        reconnectBackoffBase * (1 << std::min(failCount - 1, 5)), reconnectBackoffMax);
+
+    const auto sinceLastSync = folder->msecSinceLastSync();
+    if (sinceLastSync >= backoff) {
+        scheduleFolder(folder);
+        return;
+    }
+
+    const auto remaining = backoff - sinceLastSync;
+    qCInfo(lcFolderMan) << "Account reconnected, but folder" << folder->alias()
+                        << "has" << failCount << "consecutive failing syncs; delaying reschedule by"
+                        << remaining.count() << "ms";
+
+    // QPointer: the folder may be removed while we wait. Re-check canSync() on fire because
+    // the account can have gone away again in the meantime.
+    QTimer::singleShot(remaining, this, [this, folder = QPointer<Folder>(folder)] {
+        if (folder && folder->canSync()) {
+            scheduleFolder(folder);
+        }
+    });
 }
 
 // only enable or disable foldermans will schedule and do syncs.

--- a/src/gui/folderman.h
+++ b/src/gui/folderman.h
@@ -9,6 +9,7 @@
 
 #include <QByteArray>
 #include <QObject>
+#include <QPointer>
 #include <QQueue>
 #include <QList>
 
@@ -212,6 +213,27 @@ public:
     /** Queues a folder for syncing. */
     void scheduleFolder(Folder *);
 
+    /** Queues a folder after the account reconnected, backing off if its syncs keep failing.
+     *
+     * Scheduling immediately is right when the account was genuinely offline, but a folder
+     * whose sync was killed by the disconnect can otherwise livelock: the retry recreates the
+     * load that caused the drop and is killed at the same point. See the implementation.
+     */
+    void scheduleFolderAfterReconnect(Folder *);
+
+    /** Aborts the running sync of every folder belonging to an account. */
+    void terminateSyncsForAccount(AccountState *accountState);
+
+    /** Whether an account's disconnected state is a transient failure rather than a settled answer. */
+    static bool isTransientConnectionState(const AccountState *accountState);
+
+    /** Delays terminating an account's syncs, in case the connection comes straight back.
+     *
+     * A connection-validator failure is a probe result, not proof the server is gone. See the
+     * implementation for why a running sync should outlive a brief one.
+     */
+    void deferSyncTerminationOnTransientError(AccountState *accountState);
+
     /** Queues a folder for syncing that starts immediately. */
     void scheduleFolderForImmediateSync(Folder *);
 
@@ -391,6 +413,10 @@ private:
 
     /// Scheduled folders that should be synced as soon as possible
     QQueue<Folder *> _scheduledFolders;
+
+    /// Accounts with a grace period running before their syncs are terminated.
+    /// Kept so a flapping connection arms the wait once instead of once per state change.
+    QList<QPointer<AccountState>> _pendingSyncTermination;
 
     /// Picks the next scheduled folder and starts the sync
     QTimer _startScheduledSyncTimer;

--- a/src/gui/userinfo.cpp
+++ b/src/gui/userinfo.cpp
@@ -91,6 +91,10 @@ void UserInfo::slotFetchInfo()
     AccountPtr account = _accountState->account();
     _job = new JsonApiJob(account, QLatin1String("ocs/v1.php/cloud/user"), this);
     _job->setTimeout(20 * 1000);
+    // Feeds ConnectionValidator, and at 20s this has the tightest budget of any job on the
+    // account -- the first thing a saturated connection pool starves. Jump the queue so a
+    // busy sync cannot turn it into a spurious account-offline.
+    _job->setPriority(QNetworkRequest::HighPriority);
     connect(_job.data(), &JsonApiJob::jsonReceived, this, &UserInfo::slotUpdateLastInfo);
     connect(_job.data(), &AbstractNetworkJob::networkError, this, &UserInfo::slotRequestFailed);
     _job->start();

--- a/src/libsync/abstractnetworkjob.cpp
+++ b/src/libsync/abstractnetworkjob.cpp
@@ -123,6 +123,12 @@ QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb,
                                                QNetworkRequest req,
                                                QIODevice *requestBody)
 {
+    // Applied here rather than at each call site so redirects and retries, which rebuild the
+    // request from this same path, keep the priority the job was configured with. Only when
+    // the job actually asked for one -- otherwise the request's own priority is preserved.
+    if (_priority) {
+        req.setPriority(*_priority);
+    }
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = requestBody;
     if (_requestBody) {
@@ -137,6 +143,9 @@ QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb,
                                                QNetworkRequest req,
                                                const QByteArray &requestBody)
 {
+    if (_priority) {
+        req.setPriority(*_priority);
+    }
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = nullptr;
     adoptRequest(reply);
@@ -148,6 +157,9 @@ QNetworkReply *AbstractNetworkJob::sendRequest(const QByteArray &verb,
                                                QNetworkRequest req,
                                                QHttpMultiPart *requestBody)
 {
+    if (_priority) {
+        req.setPriority(*_priority);
+    }
     auto reply = _account->sendRawRequest(verb, url, req, requestBody);
     _requestBody = nullptr;
     adoptRequest(reply);

--- a/src/libsync/abstractnetworkjob.h
+++ b/src/libsync/abstractnetworkjob.h
@@ -66,6 +66,34 @@ public:
     void setFollowRedirects(bool follow);
     [[nodiscard]] bool followRedirects() const { return _followRedirects; }
 
+    /** Set the queueing priority of this job's request.
+     *
+     * Qt keeps a separate high-priority queue per HTTP connection, so a HighPriority request
+     * is taken next whenever a connection frees up rather than queueing behind everything
+     * already pending. It does not reserve a connection -- a saturated pool still has to free
+     * one -- it only decides who goes first.
+     *
+     * This matters for the jobs that decide whether the account is online. With HTTP/1.1 Qt
+     * opens at most 6 connections per host while a sync can have far more requests
+     * outstanding, so a health check queued behind them can blow its own (shorter) timeout
+     * without ever reaching the wire. That reads as "the server is down" and tears down the
+     * running sync, which is a self-inflicted outage rather than a real one.
+     *
+     * Priority is a queueing hint only, not a reservation: it decides who takes the next
+     * connection to free up, but cannot preempt a request already occupying one. When every
+     * connection is busy with slow requests, even a HighPriority job waits. Reserving spare
+     * connections is what actually bounds that wait; see DiscoveryPhase::networkJobBudget().
+     *
+     * Optional on purpose: several jobs already set a priority on their own QNetworkRequest
+     * (PropfindJob raises itself, the upload/download jobs lower themselves so long transfers
+     * do not block other traffic). Leaving this unset means "keep whatever the request asked
+     * for" -- unconditionally writing a default here would silently undo those.
+     *
+     * Must be called before start().
+     */
+    void setPriority(QNetworkRequest::Priority priority) { _priority = priority; }
+    [[nodiscard]] std::optional<QNetworkRequest::Priority> priority() const { return _priority; }
+
     QByteArray responseTimestamp();
     /* Content of the X-Request-ID header. (Only set after the request is sent) */
     QByteArray requestId();
@@ -196,6 +224,10 @@ protected:
     // Automatically follows redirects. Note that this only works for
     // GET requests that don't set up any HTTP body or other flags.
     bool _followRedirects = true;
+
+    // Queueing priority applied to every request this job sends; see setPriority().
+    // Unset means the request keeps whatever priority it set for itself.
+    std::optional<QNetworkRequest::Priority> _priority;
 
     QString replyStatusString();
 

--- a/src/libsync/basepropagateremotedeleteencrypted.cpp
+++ b/src/libsync/basepropagateremotedeleteencrypted.cpp
@@ -135,7 +135,7 @@ void BasePropagateRemoteDeleteEncrypted::slotDeleteRemoteItemFinished()
     if (!_propagator->_journal->deleteFileRecord(_item->_originalFile, _item->isDirectory())) {
         qCWarning(ABSTRACT_PROPAGATE_REMOVE_ENCRYPTED) << "Failed to delete file record from local DB" << _item->_originalFile;
     }
-    _propagator->_journal->commit("Remote Remove");
+    _propagator->_journal->commitIfNeededAndStartNewTransaction("Remote Remove");
 
     unlockFolder(EncryptedFolderMetadataHandler::UnlockFolderWithResult::Success);
 }

--- a/src/libsync/bulkpropagatordownloadjob.cpp
+++ b/src/libsync/bulkpropagatordownloadjob.cpp
@@ -128,7 +128,7 @@ bool BulkPropagatorDownloadJob::updateMetadata(const SyncFileItemPtr &item)
         return false;
     }
 
-    propagator()->_journal->commit("download file start2");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("download file start2");
 
     const auto isLockOwnedByCurrentUser = item->_lockOwnerId == propagator()->account()->davUser();
 

--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -167,7 +167,7 @@ void BulkPropagatorJob::doStartUpload(SyncFileItemPtr item,
     pi._size = item->_size;
 
     propagator()->_journal->setUploadInfo(item->_file, pi);
-    propagator()->_journal->commit("Upload info");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
 
     auto currentHeaders = headers(item);
     currentHeaders[QByteArrayLiteral("Content-Length")] = QByteArray::number(fileToUpload._size);
@@ -571,7 +571,7 @@ void BulkPropagatorJob::finalizeOneFile(const BulkUploadItem &oneFile)
 
     // Remove from the progress database:
     propagator()->_journal->setUploadInfo(oneFile._item->_file, SyncJournalDb::UploadInfo());
-    propagator()->_journal->commit("upload file start");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("upload file start");
 }
 
 void BulkPropagatorJob::finalize(const QJsonObject &fullReply)
@@ -695,7 +695,7 @@ void BulkPropagatorJob::checkResettingErrors(SyncFileItemPtr item) const
                                         << "is" << uploadInfo._errorCount;
         }
         propagator()->_journal->setUploadInfo(item->_file, uploadInfo);
-        propagator()->_journal->commit("Upload info");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
     }
 }
 

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -48,6 +48,16 @@ static constexpr char overrideServerUrlC[] = "overrideServerUrl";
 static constexpr char overrideLocalDirC[] = "overrideLocalDir";
 static constexpr char geometryC[] = "geometry";
 static constexpr char timeoutC[] = "timeout";
+static constexpr char discoveryTimeoutC[] = "discoveryTimeout";
+static constexpr char discoveryListingRetriesC[] = "discoveryListingRetries";
+static constexpr char discoveryListingRetryResetIntervalC[] = "discoveryListingRetryResetInterval";
+static constexpr char discoveryListingRetryDelayC[] = "discoveryListingRetryDelay";
+static constexpr char connectionTimeoutRetriesC[] = "connectionTimeoutRetries";
+static constexpr char connectionTimeoutResetIntervalC[] = "connectionTimeoutResetInterval";
+static constexpr char propagateServiceUnavailableRetriesC[] = "propagateServiceUnavailableRetries";
+static constexpr char propagateServiceUnavailableResetIntervalC[] = "propagateServiceUnavailableResetInterval";
+static constexpr char propagateServiceUnavailableBackoffC[] = "propagateServiceUnavailableBackoff";
+static constexpr char maxParallelLocalScanJobsC[] = "maxParallelLocalScanJobs";
 static constexpr char chunkSizeC[] = "chunkSize";
 static constexpr char minChunkSizeC[] = "minChunkSize";
 static constexpr char maxChunkSizeC[] = "maxChunkSize";
@@ -98,6 +108,25 @@ static chrono::milliseconds millisecondsValue(const QSettings &setting, const ch
     chrono::milliseconds defaultValue)
 {
     return chrono::milliseconds(setting.value(QLatin1String(key), qlonglong(defaultValue.count())).toLongLong());
+}
+
+/// Reads a tuning value that may also be given as an environment variable.
+///
+/// The config file is the supported way to set these. The environment variable is kept as an
+/// override so a value can be changed for a single run without editing the config -- which is
+/// what the tests do, and what makes a knob usable as a falsification lever against a running
+/// build. It wins when set, and is ignored otherwise.
+///
+/// A non-positive value from either source means "not configured" and yields the default, so a
+/// stray empty or zero entry cannot turn a retry budget into zero attempts.
+static int tuningValue(const QSettings &settings, const char *key, const char *envVar, int defaultValue,
+    int minimumValue = 1)
+{
+    if (const auto fromEnv = qEnvironmentVariableIntValue(envVar); fromEnv > 0) {
+        return qMax(minimumValue, fromEnv);
+    }
+    const auto configured = settings.value(QLatin1String(key), 0).toInt();
+    return qMax(minimumValue, configured > 0 ? configured : defaultValue);
 }
 
 bool copy_dir_recursive(QString from_dir, QString to_dir)
@@ -238,6 +267,78 @@ int ConfigFile::timeout() const
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     return settings.value(QLatin1String(timeoutC), 300).toInt(); // default to 5 min
+}
+
+chrono::seconds ConfigFile::discoveryTimeout() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, discoveryTimeoutC, "OWNCLOUD_DISCOVERY_TIMEOUT", 60));
+}
+
+int ConfigFile::discoveryListingRetries() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return tuningValue(settings, discoveryListingRetriesC, "OWNCLOUD_DISCOVERY_LISTING_RETRIES", 3);
+}
+
+chrono::seconds ConfigFile::discoveryListingRetryResetInterval() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, discoveryListingRetryResetIntervalC,
+        "OWNCLOUD_DISCOVERY_LISTING_RETRY_RESET_SEC", 300));
+}
+
+chrono::seconds ConfigFile::discoveryListingRetryDelay() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, discoveryListingRetryDelayC,
+        "OWNCLOUD_DISCOVERY_LISTING_RETRY_DELAY_SEC", 5));
+}
+
+int ConfigFile::connectionTimeoutRetries() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return tuningValue(settings, connectionTimeoutRetriesC, "OWNCLOUD_CONNECTION_TIMEOUT_RETRIES", 3);
+}
+
+chrono::seconds ConfigFile::connectionTimeoutResetInterval() const
+{
+    // Floor of 60s, not 1s: a connection check that times out takes as long as its own timeout to
+    // do so, so consecutive failures are minutes apart by construction. A shorter window would
+    // reset the count every time and make the tolerance a no-op.
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, connectionTimeoutResetIntervalC,
+        "OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC", 300, 60));
+}
+
+int ConfigFile::propagateServiceUnavailableRetries() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return tuningValue(settings, propagateServiceUnavailableRetriesC, "OWNCLOUD_PROPAGATE_503_RETRIES", 3);
+}
+
+chrono::seconds ConfigFile::propagateServiceUnavailableResetInterval() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, propagateServiceUnavailableResetIntervalC,
+        "OWNCLOUD_PROPAGATE_503_RESET_SEC", 60));
+}
+
+chrono::seconds ConfigFile::propagateServiceUnavailableBackoff() const
+{
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return chrono::seconds(tuningValue(settings, propagateServiceUnavailableBackoffC,
+        "OWNCLOUD_PROPAGATE_503_BACKOFF_SEC", 5));
+}
+
+int ConfigFile::maxParallelLocalScanJobs() const
+{
+    // 0 means "not configured": SyncOptions keeps its own core-count-derived default in that case.
+    // Unlike the knobs above, the OWNCLOUD_MAX_PARALLEL_LOCAL_SCAN override is not applied here --
+    // SyncOptions::fillFromEnvironmentVariables() already runs after this value is applied, which
+    // is how the chunk-size settings alongside it work too.
+    QSettings settings(configFile(), QSettings::IniFormat);
+    return qMax(0, settings.value(QLatin1String(maxParallelLocalScanJobsC), 0).toInt());
 }
 
 qint64 ConfigFile::chunkSize() const

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -169,6 +169,38 @@ public:
     void setShowInExplorerNavigationPane(bool show);
 
     [[nodiscard]] int timeout() const;
+
+    /* Sync tuning knobs.
+     *
+     * Each of these may also be set through the environment variable named in configfile.cpp,
+     * which overrides the config file for a single run. A missing or non-positive value means
+     * "not configured" and yields the documented default.
+     */
+
+    /** Inactivity timeout for the remote directory listings discovery issues. Default 60s. */
+    [[nodiscard]] std::chrono::seconds discoveryTimeout() const;
+    /** Attempts per directory listing before the lookups waiting on it are failed. Default 3. */
+    [[nodiscard]] int discoveryListingRetries() const;
+    /** How long a failed listing counts against a directory's retry budget. Default 300s. */
+    [[nodiscard]] std::chrono::seconds discoveryListingRetryResetInterval() const;
+    /** Base delay before re-attempting a failed listing, multiplied by attempt. Default 5s. */
+    [[nodiscard]] std::chrono::seconds discoveryListingRetryDelay() const;
+
+    /** Connection checks that must time out back to back before the account is called down. Default 3. */
+    [[nodiscard]] int connectionTimeoutRetries() const;
+    /** How long a check timeout stays "recent" when counting consecutive failures. Default 300s, floor 60s. */
+    [[nodiscard]] std::chrono::seconds connectionTimeoutResetInterval() const;
+
+    /** Retries for a 503 during propagation, both directions. Default 3. */
+    [[nodiscard]] int propagateServiceUnavailableRetries() const;
+    /** How long a 503 counts against an item's retry budget. Default 60s. */
+    [[nodiscard]] std::chrono::seconds propagateServiceUnavailableResetInterval() const;
+    /** Base backoff before retrying after a 503, multiplied by attempt. Default 5s. */
+    [[nodiscard]] std::chrono::seconds propagateServiceUnavailableBackoff() const;
+
+    /** Concurrent local directory scans, or 0 to keep the core-count-derived default. */
+    [[nodiscard]] int maxParallelLocalScanJobs() const;
+
     [[nodiscard]] qint64 chunkSize() const;
     [[nodiscard]] qint64 maxChunkSize() const;
     [[nodiscard]] qint64 minChunkSize() const;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1078,10 +1078,12 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
             postProcessRename(path);
             done = true;
         } else {
-            // we need to make a request to the server to know that the original file is deleted on the server
+            // we need to know whether the original file is deleted on the server. Resolved from
+            // one listing of its parent directory, shared with every other rename candidate in
+            // that directory, rather than a PROPFIND per file; see lookupRemoteEtag().
             _pendingAsyncJobs++;
-            const auto job = new RequestEtagJob(_discoveryData->_account, _discoveryData->_remoteFolder + originalPath, this);
-            connect(job, &RequestEtagJob::finishedWithResult, this, [=, this](const HttpResult<QByteArray> &etag) mutable {
+            _discoveryData->lookupRemoteEtag(_discoveryData->_remoteFolder + originalPath, this,
+                                             [=, this](const HttpResult<QByteArray> &etag) mutable {
                 _pendingAsyncJobs--;
                 QTimer::singleShot(0, _discoveryData, &DiscoveryPhase::scheduleMoreJobs);
                 if (etag || etag.error().code != 404 ||
@@ -1103,7 +1105,6 @@ void ProcessDirectoryJob::processFileAnalyzeRemoteInfo(const SyncFileItemPtr &it
                 }
                 processFileFinalize(item, path, item->isDirectory(), item->_instruction == CSYNC_INSTRUCTION_RENAME ? NormalQuery : ParentDontExist, _queryServer);
             });
-            job->start();
             done = true; // Ideally, if the origin still exist on the server, we should continue searching...  but that'd be difficult
             async = true;
         }
@@ -1168,6 +1169,100 @@ int64_t ProcessDirectoryJob::folderBytesAvailable(const SyncFileItemPtr &item, c
     return _dirItem->_folderQuota.bytesAvailable;
 }
 
+/** Shared tail of the local-info analysis: settle recursion and hand the item onward.
+ *
+ * Was a [&]-capturing lambda inside processFileAnalyzeLocalInfo(). It has to be a method now:
+ * the move decision can complete asynchronously, and by then the references that lambda held
+ * to that function's locals would be dangling.
+ */
+void ProcessDirectoryJob::finalizeLocalInfoAnalysis(const SyncFileItemPtr &item, PathTuple path,
+                                                    const LocalInfo &localEntry, const RemoteInfo &serverEntry,
+                                                    const SyncJournalFileRecord &dbEntry,
+                                                    QueryMode recurseQueryServer)
+{
+    bool recurse = item->isDirectory() || localEntry.isDirectory || serverEntry.isDirectory;
+    // Even if we have a local directory: If the remote is a file that's propagated as a
+    // conflict we don't need to recurse into it. (local c1.owncloud, c1/ ; remote: c1)
+    if (item->_instruction == CSYNC_INSTRUCTION_CONFLICT && !item->isDirectory())
+        recurse = false;
+    if (_queryLocal != NormalQuery && _queryServer != NormalQuery)
+        recurse = false;
+
+    if (localEntry.isPermissionsInvalid) {
+        recurse = true;
+    }
+
+    if ((item->_direction == SyncFileItem::Down || item->_instruction == CSYNC_INSTRUCTION_CONFLICT || item->_instruction == CSYNC_INSTRUCTION_NEW || item->_instruction == CSYNC_INSTRUCTION_SYNC) &&
+            item->_direction != SyncFileItem::Up &&
+            (item->_modtime <= 0 || item->_modtime >= 0xFFFFFFFF)) {
+        item->_instruction = CSYNC_INSTRUCTION_ERROR;
+        item->_errorString = tr("Cannot sync due to invalid modification time");
+        item->_status = SyncFileItem::Status::NormalError;
+    }
+
+    if (const auto folderQuota = folderBytesAvailable(item,
+                                                      serverEntry.isValid() ? FolderQuota::ServerEntry::Valid
+                                                                            : FolderQuota::ServerEntry::Invalid);
+        item->_size > folderQuota
+        && folderQuota > -1) {
+
+        qCInfo(lcDisco) << "Quota exceeded for item:" << item->_file
+                         << "- item bytes used:" << item->_size
+                         << "- folder bytes available: " << folderQuota;
+
+        item->_instruction = CSYNC_INSTRUCTION_ERROR;
+        if (_currentFolder._server.isEmpty()) {
+            item->_errorString = tr("Upload of %1 exceeds %2 of space left in personal files.").arg(Utility::octetsToString(item->_size),
+                                                                                                    Utility::octetsToString(folderQuota));
+        } else {
+            item->_errorString = tr("Upload of %1 exceeds %2 of space left in folder %3.").arg(Utility::octetsToString(item->_size),
+                                                                                               Utility::octetsToString(folderQuota),
+                                                                                               _currentFolder._server);
+        }
+
+        item->_status = SyncFileItem::Status::NormalError;
+        _discoveryData->_anotherSyncNeeded = true;
+        _discoveryData->_filesNeedingScheduledSync.insert(path._original, delayIntervalForSyncRetryForFilesExceedQuotaSeconds);
+    }
+
+    if (item->_type != CSyncEnums::ItemTypeVirtualFile) {
+        const auto foundEditorsKeepingFileBusy = queryEditorsKeepingFileBusy(item, path);
+        if (!foundEditorsKeepingFileBusy.isEmpty()) {
+            item->_instruction = CSYNC_INSTRUCTION_ERROR;
+            const auto editorsString = foundEditorsKeepingFileBusy.join(", ");
+            qCInfo(lcDisco) << "Failed, because it is open in the editor." << item->_file << "direction" << item->_direction << editorsString;
+            item->_errorString = tr("Could not upload file, because it is open in \"%1\".").arg(editorsString);
+            item->_status = SyncFileItem::Status::SoftError;
+            _discoveryData->_anotherSyncNeeded = true;
+            _discoveryData->_filesNeedingScheduledSync.insert(path._original, delayIntervalForSyncRetryForOpenedForSigningFilesSeconds);
+        }
+    }
+
+    if (dbEntry.isValid() && item->isDirectory()) {
+        item->_e2eEncryptionStatus = EncryptionStatusEnums::fromDbEncryptionStatus(dbEntry._e2eEncryptionStatus);
+        if (item->isEncrypted()) {
+            item->_e2eEncryptionServerCapability = EncryptionStatusEnums::fromEndToEndEncryptionApiVersion(_discoveryData->_account->capabilities().clientSideEncryptionVersion());
+        }
+        Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::Encrypted);
+        if (item->_e2eEncryptionStatusRemote != SyncFileItem::EncryptionStatus::NotEncrypted) {
+            Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::NotEncrypted);
+        }
+    }
+
+    if (localEntry.isPermissionsInvalid && item->_instruction == CSyncEnums::CSYNC_INSTRUCTION_NONE) {
+        item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
+        item->_direction = SyncFileItem::Down;
+    }
+
+    item->isPermissionsInvalid = localEntry.isPermissionsInvalid;
+
+    auto recurseQueryLocal = _queryLocal == ParentNotChanged ? ParentNotChanged : localEntry.isDirectory || item->_instruction == CSYNC_INSTRUCTION_RENAME ? NormalQuery : ParentDontExist;
+    if (item->isDirectory() && serverEntry.isValid() && dbEntry.isValid() && serverEntry.etag == dbEntry._etag && serverEntry.remotePerm == dbEntry._remotePerm) {
+        recurseQueryServer = ParentNotChanged;
+    }
+    processFileFinalize(item, path, recurse, recurseQueryLocal, recurseQueryServer);
+}
+
 void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
     const SyncFileItemPtr &item, PathTuple path, const LocalInfo &localEntry,
     const RemoteInfo &serverEntry, const SyncJournalFileRecord &dbEntry, QueryMode recurseQueryServer)
@@ -1220,89 +1315,6 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
     _childModified |= serverModified;
 
-    auto finalize = [&] {
-        bool recurse = item->isDirectory() || localEntry.isDirectory || serverEntry.isDirectory;
-        // Even if we have a local directory: If the remote is a file that's propagated as a
-        // conflict we don't need to recurse into it. (local c1.owncloud, c1/ ; remote: c1)
-        if (item->_instruction == CSYNC_INSTRUCTION_CONFLICT && !item->isDirectory())
-            recurse = false;
-        if (_queryLocal != NormalQuery && _queryServer != NormalQuery)
-            recurse = false;
-
-        if (localEntry.isPermissionsInvalid) {
-            recurse = true;
-        }
-
-        if ((item->_direction == SyncFileItem::Down || item->_instruction == CSYNC_INSTRUCTION_CONFLICT || item->_instruction == CSYNC_INSTRUCTION_NEW || item->_instruction == CSYNC_INSTRUCTION_SYNC) &&
-                item->_direction != SyncFileItem::Up &&
-                (item->_modtime <= 0 || item->_modtime >= 0xFFFFFFFF)) {
-            item->_instruction = CSYNC_INSTRUCTION_ERROR;
-            item->_errorString = tr("Cannot sync due to invalid modification time");
-            item->_status = SyncFileItem::Status::NormalError;
-        }
-
-        if (const auto folderQuota = folderBytesAvailable(item,
-                                                          serverEntry.isValid() ? FolderQuota::ServerEntry::Valid
-                                                                                : FolderQuota::ServerEntry::Invalid);
-            item->_size > folderQuota
-            && folderQuota > -1) {
-
-            qCInfo(lcDisco) << "Quota exceeded for item:" << item->_file
-                             << "- item bytes used:" << item->_size
-                             << "- folder bytes available: " << folderQuota;
-
-            item->_instruction = CSYNC_INSTRUCTION_ERROR;
-            if (_currentFolder._server.isEmpty()) {
-                item->_errorString = tr("Upload of %1 exceeds %2 of space left in personal files.").arg(Utility::octetsToString(item->_size),
-                                                                                                        Utility::octetsToString(folderQuota));
-            } else {
-                item->_errorString = tr("Upload of %1 exceeds %2 of space left in folder %3.").arg(Utility::octetsToString(item->_size),
-                                                                                                   Utility::octetsToString(folderQuota),
-                                                                                                   _currentFolder._server);
-            }
-
-            item->_status = SyncFileItem::Status::NormalError;
-            _discoveryData->_anotherSyncNeeded = true;
-            _discoveryData->_filesNeedingScheduledSync.insert(path._original, delayIntervalForSyncRetryForFilesExceedQuotaSeconds);
-        }
-
-        if (item->_type != CSyncEnums::ItemTypeVirtualFile) {
-            const auto foundEditorsKeepingFileBusy = queryEditorsKeepingFileBusy(item, path);
-            if (!foundEditorsKeepingFileBusy.isEmpty()) {
-                item->_instruction = CSYNC_INSTRUCTION_ERROR;
-                const auto editorsString = foundEditorsKeepingFileBusy.join(", ");
-                qCInfo(lcDisco) << "Failed, because it is open in the editor." << item->_file << "direction" << item->_direction << editorsString;
-                item->_errorString = tr("Could not upload file, because it is open in \"%1\".").arg(editorsString);
-                item->_status = SyncFileItem::Status::SoftError;
-                _discoveryData->_anotherSyncNeeded = true;
-                _discoveryData->_filesNeedingScheduledSync.insert(path._original, delayIntervalForSyncRetryForOpenedForSigningFilesSeconds);
-            }
-        }
-
-        if (dbEntry.isValid() && item->isDirectory()) {
-            item->_e2eEncryptionStatus = EncryptionStatusEnums::fromDbEncryptionStatus(dbEntry._e2eEncryptionStatus);
-            if (item->isEncrypted()) {
-                item->_e2eEncryptionServerCapability = EncryptionStatusEnums::fromEndToEndEncryptionApiVersion(_discoveryData->_account->capabilities().clientSideEncryptionVersion());
-            }
-            Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::Encrypted);
-            if (item->_e2eEncryptionStatusRemote != SyncFileItem::EncryptionStatus::NotEncrypted) {
-                Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::NotEncrypted);
-            }
-        }
-
-        if (localEntry.isPermissionsInvalid && item->_instruction == CSyncEnums::CSYNC_INSTRUCTION_NONE) {
-            item->_instruction = CSYNC_INSTRUCTION_UPDATE_METADATA;
-            item->_direction = SyncFileItem::Down;
-        }
-
-        item->isPermissionsInvalid = localEntry.isPermissionsInvalid;
-
-        auto recurseQueryLocal = _queryLocal == ParentNotChanged ? ParentNotChanged : localEntry.isDirectory || item->_instruction == CSYNC_INSTRUCTION_RENAME ? NormalQuery : ParentDontExist;
-        if (item->isDirectory() && serverEntry.isValid() && dbEntry.isValid() && serverEntry.etag == dbEntry._etag && serverEntry.remotePerm == dbEntry._remotePerm) {
-            recurseQueryServer = ParentNotChanged;
-        }
-        processFileFinalize(item, path, recurse, recurseQueryLocal, recurseQueryServer);
-    };
 
     if (!localEntry.isValid()) {
         if (_queryLocal == ParentNotChanged && dbEntry.isValid()) {
@@ -1346,7 +1358,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             }
         }
 
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
         return;
     }
 
@@ -1479,7 +1491,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             }
         }
 
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
         return;
     }
 
@@ -1490,11 +1502,11 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         // The instruction should already be set correctly.
         ASSERT(item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA);
         ASSERT(item->_type == ItemTypeVirtualFile);
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
         return;
     } else if (serverModified) {
         processFileConflict(item, path, localEntry, serverEntry, dbEntry);
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
         return;
     }
 
@@ -1524,21 +1536,6 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
         return;
     }
-
-    auto postProcessLocalNew = [item, localEntry, path, this]() {
-        if (localEntry.isVirtualFile) {
-            const bool isPlaceHolder = _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local);
-            if (isPlaceHolder) {
-                qCWarning(lcDisco) << "Wiping virtual file without db entry for" << path._local;
-                item->_instruction = CSYNC_INSTRUCTION_REMOVE;
-                item->_direction = SyncFileItem::Down;
-            } else {
-                qCWarning(lcDisco) << "Virtual file without db entry for" << path._local
-                                   << "but looks odd, keeping";
-                item->_instruction = CSYNC_INSTRUCTION_IGNORE;
-            }
-        }
-    };
 
     // Check if it is a move
     OCC::SyncJournalFileRecord base;
@@ -1579,7 +1576,20 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             return false;
         }
 
-        // Verify the checksum where possible
+        if (_discoveryData->isRenamed(originalPath)) {
+            qCInfo(lcDisco) << "Not a move, base path already renamed";
+            return false;
+        }
+
+        // Verify the checksum where possible.
+        //
+        // Deliberately last: it is by far the most expensive check and every cheaper one has to
+        // pass first anyway. It is also synchronous, and on accounts with many moved files it
+        // dominates discovery -- 16.5k hashes, ~200ms each, most of a 65-minute pass. Moving it
+        // to a worker thread was tried and measured 2.5x *slower* per file (0.203s -> 0.503s):
+        // discovery reaches this point one file at a time, so nothing overlaps and the thread
+        // hop plus argument copying is pure overhead. The work is disk-bound regardless
+        // (~120 MB/s of raw files), which threading does not improve.
         if (!base._checksumHeader.isEmpty() && item->_type == ItemTypeFile && base._type == ItemTypeFile) {
             if (computeLocalChecksum(base._checksumHeader, _discoveryData->_localDir + path._original, item)) {
                 qCInfo(lcDisco) << "checking checksum of potential rename " << path._original << item->_checksumHeader << base._checksumHeader;
@@ -1590,14 +1600,26 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             }
         }
 
-        if (_discoveryData->isRenamed(originalPath)) {
-            qCInfo(lcDisco) << "Not a move, base path already renamed";
-            return false;
-        }
-
         return true;
     };
+
     const auto isMove = moveCheck();
+
+    auto postProcessLocalNew = [item, localEntry, path, this]() {
+        if (localEntry.isVirtualFile) {
+            const bool isPlaceHolder = _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local);
+            if (isPlaceHolder) {
+                qCWarning(lcDisco) << "Wiping virtual file without db entry for" << path._local;
+                item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+                item->_direction = SyncFileItem::Down;
+            } else {
+                qCWarning(lcDisco) << "Virtual file without db entry for" << path._local
+                                   << "but looks odd, keeping";
+                item->_instruction = CSYNC_INSTRUCTION_IGNORE;
+            }
+        }
+    };
+
     const auto isE2eeMove = isMove && (base.isE2eEncrypted() || isInsideEncryptedTree());
     const auto isCfApiVfsMode = _discoveryData->_syncOptions._vfs && _discoveryData->_syncOptions._vfs->mode() == Vfs::WindowsCfApi;
     const bool isOnlineOnlyItem = isCfApiVfsMode && (localEntry.isDirectory || _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local));
@@ -1631,7 +1653,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::NotEncrypted);
         }
         postProcessLocalNew();
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
         return;
     }
 
@@ -1653,7 +1675,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         // If we can create the destination, do that.
         // Permission errors on the destination will be handled by checkPermissions later.
         postProcessLocalNew();
-        finalize();
+        finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
 
         // If the destination upload will work, we're fine with the source deletion.
         // If the source deletion can't work, checkPermissions will error.
@@ -1724,8 +1746,9 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         QString serverOriginalPath = _discoveryData->_remoteFolder + _discoveryData->adjustRenamedPath(originalPath, SyncFileItem::Down);
         if (base.isVirtualFile() && isVfsWithSuffix())
             chopVirtualFileSuffix(serverOriginalPath);
-        auto job = new RequestEtagJob(_discoveryData->_account, serverOriginalPath, this);
-        connect(job, &RequestEtagJob::finishedWithResult, this, [=, this](const HttpResult<QByteArray> &etag) mutable {
+        // Resolved from one listing of the parent directory shared with the other rename
+        // candidates in it, rather than a PROPFIND per file; see lookupRemoteEtag().
+        _discoveryData->lookupRemoteEtag(serverOriginalPath, this, [=, this](const HttpResult<QByteArray> &etag) mutable {
 
 
             if (!etag || (etag.get() != base._etag && !item->isDirectory()) || _discoveryData->isRenamed(originalPath)
@@ -1746,11 +1769,10 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             _pendingAsyncJobs--;
             QTimer::singleShot(0, _discoveryData, &DiscoveryPhase::scheduleMoreJobs);
         });
-        job->start();
         return;
     }
 
-    finalize();
+    finalizeLocalInfoAnalysis(item, path, localEntry, serverEntry, dbEntry, recurseQueryServer);
 }
 
 void ProcessDirectoryJob::processFileConflict(const SyncFileItemPtr &item, ProcessDirectoryJob::PathTuple path, const LocalInfo &localEntry, const RemoteInfo &serverEntry, const SyncJournalFileRecord &dbEntry)
@@ -2251,44 +2273,54 @@ std::pair<int, int> ProcessDirectoryJob::processSubJobs(int localBudget, int net
 
     int startedLocal = 0, startedNetwork = 0;
 
+    const auto budgetsExhausted = [&] {
+        return startedLocal >= localBudget && startedNetwork >= networkBudget;
+    };
+
     // Recurse into running jobs to continue their work
     for (const auto rj : std::as_const(_runningJobs)) {
-        auto [rl, rn] = rj->processSubJobs(localBudget - startedLocal, networkBudget - startedNetwork);
+        auto [rl, rn] = rj->processSubJobs(std::max(0, localBudget - startedLocal),
+                                           std::max(0, networkBudget - startedNetwork));
         startedLocal += rl;
         startedNetwork += rn;
-        if (startedLocal >= localBudget && startedNetwork >= networkBudget)
+        if (budgetsExhausted())
             return {startedLocal, startedNetwork};
     }
 
-    // Try to start queued jobs, respecting both local and network budgets.
-    // We iterate through the deque but only pop jobs that can actually start
-    // (i.e., have budget for all resources they need).
-    for (auto it = _queuedJobs.begin(); it != _queuedJobs.end(); ) {
-        auto job = *it;
-        bool needsLocal = (job->_queryLocal == ProcessDirectoryJob::NormalQuery);
-        bool needsNetwork = (job->_queryServer == ProcessDirectoryJob::NormalQuery);
-
-        // Check if this job can start given the remaining budgets
-        bool canStart = true;
-        if (needsLocal && startedLocal >= localBudget)
-            canStart = false;
-        if (needsNetwork && startedNetwork >= networkBudget)
-            canStart = false;
-
-        if (canStart) {
-            // Remove from queue, add to running, and start
-            it = _queuedJobs.erase(it);
-            _runningJobs.push_back(job);
-            job->start();
-            if (needsLocal) startedLocal++;
-            if (needsNetwork) startedNetwork++;
-
-            // Check if both budgets are exhausted
-            if (startedLocal >= localBudget && startedNetwork >= networkBudget)
-                break;
-        } else {
-            ++it;  // Skip this job, try the next one
+    // Try to start queued jobs, respecting both local and network budgets. A job whose
+    // resource is already saturated is skipped rather than blocking the ones behind it,
+    // so a saturated local scan queue does not stall network jobs and vice versa.
+    //
+    // _queryLocal/_queryServer are only a hint about what a job will consume: start() may
+    // downgrade _queryLocal to ParentNotChanged and skip the local scan entirely. Charging
+    // the budget from the hint would leak local slots on every unchanged directory -- the
+    // common case -- so the actual cost is measured from the active-job counters instead.
+    // A job that finishes synchronously correctly costs nothing.
+    //
+    // startsRemaining bounds the work done in one pass so that a long queue of
+    // zero-cost jobs cannot be drained in a single synchronous burst.
+    int startsRemaining = localBudget + networkBudget;
+    for (auto it = _queuedJobs.begin(); it != _queuedJobs.end() && startsRemaining > 0;) {
+        const auto job = *it;
+        const bool blockedOnLocal = job->_queryLocal == NormalQuery && startedLocal >= localBudget;
+        const bool blockedOnNetwork = job->_queryServer == NormalQuery && startedNetwork >= networkBudget;
+        if (blockedOnLocal || blockedOnNetwork) {
+            ++it; // no budget for what this job needs; try the next one
+            continue;
         }
+
+        it = _queuedJobs.erase(it);
+        _runningJobs.push_back(job);
+
+        const auto activeLocalBefore = _discoveryData->_currentlyActiveLocalScanJobs;
+        const auto activeNetworkBefore = _discoveryData->_currentlyActiveJobs;
+        job->start();
+        startedLocal += std::max(0, _discoveryData->_currentlyActiveLocalScanJobs - activeLocalBefore);
+        startedNetwork += std::max(0, _discoveryData->_currentlyActiveJobs - activeNetworkBefore);
+        --startsRemaining;
+
+        if (budgetsExhausted())
+            break;
     }
 
     return {startedLocal, startedNetwork};
@@ -2371,6 +2403,10 @@ DiscoverySingleDirectoryJob *ProcessDirectoryJob::startAsyncServerQuery()
         }
         _discoveryData->_currentlyActiveJobs--;
         _pendingAsyncJobs--;
+        // This slot just freed network budget that pending rename checks share. Hand it to
+        // them here: the paths below reach scheduleMoreJobs() only indirectly, so queued
+        // etag jobs would otherwise idle until some unrelated event pumped the queue.
+        _discoveryData->startQueuedEtagJobs();
         if (results) {
             _serverNormalQueryEntries = *results;
             _serverQueryDone = true;

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -13,6 +13,7 @@
 #include "progressdispatcher.h"
 #include <QDebug>
 #include <algorithm>
+#include <utility>
 #include <QEventLoop>
 #include <QDir>
 #include <set>
@@ -2226,7 +2227,7 @@ void ProcessDirectoryJob::subJobFinished()
     QTimer::singleShot(0, _discoveryData, &DiscoveryPhase::scheduleMoreJobs);
 }
 
-int ProcessDirectoryJob::processSubJobs(int nbJobs)
+std::pair<int, int> ProcessDirectoryJob::processSubJobs(int localBudget, int networkBudget)
 {
     if (_queuedJobs.empty() && _runningJobs.empty() && _pendingAsyncJobs == 0) {
         _pendingAsyncJobs = -1; // We're finished, we don't want to emit finished again
@@ -2248,21 +2249,49 @@ int ProcessDirectoryJob::processSubJobs(int nbJobs)
         emit finished();
     }
 
-    int started = 0;
+    int startedLocal = 0, startedNetwork = 0;
+
+    // Recurse into running jobs to continue their work
     for (const auto rj : std::as_const(_runningJobs)) {
-        started += rj->processSubJobs(nbJobs - started);
-        if (started >= nbJobs)
-            return started;
+        auto [rl, rn] = rj->processSubJobs(localBudget - startedLocal, networkBudget - startedNetwork);
+        startedLocal += rl;
+        startedNetwork += rn;
+        if (startedLocal >= localBudget && startedNetwork >= networkBudget)
+            return {startedLocal, startedNetwork};
     }
 
-    while (started < nbJobs && !_queuedJobs.empty()) {
-        auto f = _queuedJobs.front();
-        _queuedJobs.pop_front();
-        _runningJobs.push_back(f);
-        f->start();
-        started++;
+    // Try to start queued jobs, respecting both local and network budgets.
+    // We iterate through the deque but only pop jobs that can actually start
+    // (i.e., have budget for all resources they need).
+    for (auto it = _queuedJobs.begin(); it != _queuedJobs.end(); ) {
+        auto job = *it;
+        bool needsLocal = (job->_queryLocal == ProcessDirectoryJob::NormalQuery);
+        bool needsNetwork = (job->_queryServer == ProcessDirectoryJob::NormalQuery);
+
+        // Check if this job can start given the remaining budgets
+        bool canStart = true;
+        if (needsLocal && startedLocal >= localBudget)
+            canStart = false;
+        if (needsNetwork && startedNetwork >= networkBudget)
+            canStart = false;
+
+        if (canStart) {
+            // Remove from queue, add to running, and start
+            it = _queuedJobs.erase(it);
+            _runningJobs.push_back(job);
+            job->start();
+            if (needsLocal) startedLocal++;
+            if (needsNetwork) startedNetwork++;
+
+            // Check if both budgets are exhausted
+            if (startedLocal >= localBudget && startedNetwork >= networkBudget)
+                break;
+        } else {
+            ++it;  // Skip this job, try the next one
+        }
     }
-    return started;
+
+    return {startedLocal, startedNetwork};
 }
 
 void ProcessDirectoryJob::dbError()
@@ -2396,7 +2425,7 @@ void ProcessDirectoryJob::startAsyncLocalQuery()
     QString localPath = _discoveryData->_localDir + _currentFolder._local;
     auto localJob = new DiscoverySingleLocalDirectoryJob(_discoveryData->_account, localPath, _discoveryData->_syncOptions._vfs.data(), _discoveryData->_fileSystemReliablePermissions);
 
-    _discoveryData->_currentlyActiveJobs++;
+    _discoveryData->_currentlyActiveLocalScanJobs++;
     _pendingAsyncJobs++;
 
     connect(localJob, &DiscoverySingleLocalDirectoryJob::itemDiscovered, _discoveryData, &DiscoveryPhase::itemDiscovered);
@@ -2406,7 +2435,7 @@ void ProcessDirectoryJob::startAsyncLocalQuery()
     });
 
     connect(localJob, &DiscoverySingleLocalDirectoryJob::finishedFatalError, this, [this](const QString &msg) {
-        _discoveryData->_currentlyActiveJobs--;
+        _discoveryData->_currentlyActiveLocalScanJobs--;
         _pendingAsyncJobs--;
         if (_serverJob)
             _serverJob->abort();
@@ -2415,7 +2444,7 @@ void ProcessDirectoryJob::startAsyncLocalQuery()
     });
 
     connect(localJob, &DiscoverySingleLocalDirectoryJob::finishedNonFatalError, this, [this](const QString &msg) {
-        _discoveryData->_currentlyActiveJobs--;
+        _discoveryData->_currentlyActiveLocalScanJobs--;
         _pendingAsyncJobs--;
 
         if (_dirItem) {
@@ -2429,7 +2458,7 @@ void ProcessDirectoryJob::startAsyncLocalQuery()
     });
 
     connect(localJob, &DiscoverySingleLocalDirectoryJob::finished, this, [this](const auto &results) {
-        _discoveryData->_currentlyActiveJobs--;
+        _discoveryData->_currentlyActiveLocalScanJobs--;
         _pendingAsyncJobs--;
 
         _localNormalQueryEntries = results;

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -8,6 +8,8 @@
 
 #include <QObject>
 #include <cstdint>
+#include <deque>
+#include <utility>
 #include "csync_exclude.h"
 #include "discoveryphase.h"
 #include "syncfileitem.h"
@@ -169,6 +171,15 @@ private:
 
     /// processFile helper for reconciling local changes
     void processFileAnalyzeLocalInfo(const SyncFileItemPtr &item, PathTuple, const LocalInfo &, const RemoteInfo &, const SyncJournalFileRecord &, QueryMode recurseQueryServer);
+
+    /** Shared tail of the local-info analysis: settle recursion and hand the item onward.
+     *
+     * A method rather than a lambda because the move decision can complete asynchronously, by
+     * which point references to processFileAnalyzeLocalInfo()'s locals would be dangling.
+     */
+    void finalizeLocalInfoAnalysis(const SyncFileItemPtr &item, PathTuple path,
+                                   const LocalInfo &localEntry, const RemoteInfo &serverEntry,
+                                   const SyncJournalFileRecord &dbEntry, QueryMode recurseQueryServer);
 
     /// processFile helper for local/remote conflicts
     void processFileConflict(const SyncFileItemPtr &item, PathTuple, const LocalInfo &, const RemoteInfo &, const SyncJournalFileRecord &);

--- a/src/libsync/discovery.h
+++ b/src/libsync/discovery.h
@@ -106,8 +106,9 @@ public:
                                  QueryMode queryLocal, qint64 lastSyncTimestamp, QObject *parent);
 
     void start();
-    /** Start up to nbJobs, return the number of job started; emit finished() when done */
-    int processSubJobs(int nbJobs);
+    /** Start jobs up to the given local and network concurrency budgets.
+     *  Returns {localJobsStarted, networkJobsStarted}; emits finished() when done. */
+    std::pair<int, int> processSubJobs(int localBudget, int networkBudget);
 
     void setInsideEncryptedTree(bool isInsideEncryptedTree)
     {

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -312,9 +312,14 @@ bool DiscoveryPhase::isRenamed(const QString &p) const
 
 void DiscoveryPhase::scheduleMoreJobs()
 {
-    auto limit = qMax(1, _syncOptions._parallelNetworkJobs);
-    if (_currentRootJob && _currentlyActiveJobs < limit) {
-        _currentRootJob->processSubJobs(limit - _currentlyActiveJobs);
+    auto networkLimit = qMax(1, _syncOptions._parallelNetworkJobs);
+    auto localLimit = qMax(1, _syncOptions._parallelLocalScanJobs);
+    if (_currentRootJob) {
+        int networkBudget = qMax(0, networkLimit - _currentlyActiveJobs);
+        int localBudget = qMax(0, localLimit - _currentlyActiveLocalScanJobs);
+        if (networkBudget > 0 || localBudget > 0) {
+            _currentRootJob->processSubJobs(localBudget, networkBudget);
+        }
     }
 }
 

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -55,17 +55,15 @@ namespace {
 /// resetting it. Only a listing producing no data at all is cut short.
 qint64 discoveryListingTimeoutMsec()
 {
-    static const auto configuredSec = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_TIMEOUT");
-    static constexpr auto defaultSec = 60;
-    return qint64{configuredSec > 0 ? configuredSec : defaultSec} * 1000;
+    static const auto configured = ConfigFile().discoveryTimeout();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(configured).count();
 }
 
 /// How many times a directory listing is attempted before the lookups waiting on it are failed.
 int etagListingMaxAttempts()
 {
-    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRIES");
-    static constexpr auto defaultAttempts = 3;
-    return qMax(1, configured > 0 ? configured : defaultAttempts);
+    static const auto configured = ConfigFile().discoveryListingRetries();
+    return configured;
 }
 
 /// How long a failed attempt counts against a directory's retry budget.
@@ -75,18 +73,16 @@ int etagListingMaxAttempts()
 /// so attempts spread thinly across a long run never add up to an exhausted budget.
 std::chrono::seconds etagListingRetryResetAfter()
 {
-    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRY_RESET_SEC");
-    static constexpr auto defaultSeconds = 300;
-    return std::chrono::seconds(qMax(1, configured > 0 ? configured : defaultSeconds));
+    static const auto configured = ConfigFile().discoveryListingRetryResetInterval();
+    return configured;
 }
 
 /// Base delay before re-attempting a failed listing; multiplied by the attempt number so a
 /// server that is struggling is not immediately hit again with the request that just failed.
 std::chrono::seconds etagListingRetryDelay()
 {
-    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRY_DELAY_SEC");
-    static constexpr auto defaultSeconds = 5;
-    return std::chrono::seconds(qMax(1, configured > 0 ? configured : defaultSeconds));
+    static const auto configured = ConfigFile().discoveryListingRetryDelay();
+    return configured;
 }
 
 /// Whether a failed listing is worth sending again.

--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -23,6 +23,9 @@
 #include "vio/csync_vio_local.h"
 
 #include <QLoggingCategory>
+#include <QTimer>
+#include <chrono>
+#include <utility>
 #include <QUrl>
 #include <QFile>
 #include <QDir>
@@ -36,6 +39,75 @@ using namespace Qt::StringLiterals;
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcDiscovery, "nextcloud.sync.discovery", QtInfoMsg)
+
+namespace {
+
+/// Inactivity timeout for the remote directory listings discovery issues.
+///
+/// AbstractNetworkJob defaults to 300s. That is a reasonable ceiling for propagation, where a
+/// stalled transfer costs only itself, but discovery runs a small number of listings through a
+/// narrow concurrency budget: a listing the server accepts and then never answers holds its slot
+/// and stalls the whole pass behind it. Observed in the field at 148s and still counting, long
+/// enough for the connection health check to give up and have the sync torn down.
+///
+/// The inherited timer measures *inactivity*, not total duration, so this does not put a ceiling
+/// on how long a legitimately large listing may take -- one that is still streaming keeps
+/// resetting it. Only a listing producing no data at all is cut short.
+qint64 discoveryListingTimeoutMsec()
+{
+    static const auto configuredSec = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_TIMEOUT");
+    static constexpr auto defaultSec = 60;
+    return qint64{configuredSec > 0 ? configuredSec : defaultSec} * 1000;
+}
+
+/// How many times a directory listing is attempted before the lookups waiting on it are failed.
+int etagListingMaxAttempts()
+{
+    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRIES");
+    static constexpr auto defaultAttempts = 3;
+    return qMax(1, configured > 0 ? configured : defaultAttempts);
+}
+
+/// How long a failed attempt counts against a directory's retry budget.
+///
+/// The budget is meant to survive a bad patch, not to ration retries across an entire sync. A
+/// directory that failed a few times half an hour ago and is being tried again now starts over,
+/// so attempts spread thinly across a long run never add up to an exhausted budget.
+std::chrono::seconds etagListingRetryResetAfter()
+{
+    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRY_RESET_SEC");
+    static constexpr auto defaultSeconds = 300;
+    return std::chrono::seconds(qMax(1, configured > 0 ? configured : defaultSeconds));
+}
+
+/// Base delay before re-attempting a failed listing; multiplied by the attempt number so a
+/// server that is struggling is not immediately hit again with the request that just failed.
+std::chrono::seconds etagListingRetryDelay()
+{
+    static const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_DISCOVERY_LISTING_RETRY_DELAY_SEC");
+    static constexpr auto defaultSeconds = 5;
+    return std::chrono::seconds(qMax(1, configured > 0 ? configured : defaultSeconds));
+}
+
+/// Whether a failed listing is worth sending again.
+///
+/// Only failures that say "not right now" qualify: no HTTP status at all (timeout, abort,
+/// connection dropped), an explicit slow-down, or a server-side error. A 4xx is the server
+/// answering the question -- most importantly 404, which is the normal reply when a rename
+/// check asks about a directory that has since been renamed away. Retrying those would spend
+/// the backoff on every such directory and still arrive at the same answer.
+bool isRetryableListingError(const HttpError &error)
+{
+    if (error.code == 0) {
+        return true; // no reply reached us: timeout, abort, or a dropped connection
+    }
+    if (error.code == 408 || error.code == 429) {
+        return true; // request timeout / rate limited
+    }
+    return error.code >= 500;
+}
+
+}
 
 bool DiscoveryPhase::isInSelectiveSyncBlackList(const QString &path) const
 {
@@ -310,10 +382,28 @@ bool DiscoveryPhase::isRenamed(const QString &p) const
     return _renamedItemsLocal.contains(p) || _renamedItemsRemote.contains(p);
 }
 
+int DiscoveryPhase::networkJobBudget() const
+{
+    // Qt's HTTP/1.1 backend opens at most this many connections per host. It is not
+    // configurable through the public API, so discovery has to stay under it deliberately.
+    static constexpr auto httpConnectionsPerHost = 6;
+    // Kept free for account health checks (ConnectionValidator, UserInfo) and other non-sync
+    // traffic, so they never wait behind a full set of in-flight discovery requests.
+    static constexpr auto connectionsReservedForHealthChecks = 2;
+
+    const auto configured = qMax(1, _syncOptions._parallelNetworkJobs);
+    return qMax(1, qMin(configured, httpConnectionsPerHost - connectionsReservedForHealthChecks));
+}
+
 void DiscoveryPhase::scheduleMoreJobs()
 {
-    auto networkLimit = qMax(1, _syncOptions._parallelNetworkJobs);
+    auto networkLimit = networkJobBudget();
     auto localLimit = qMax(1, _syncOptions._parallelLocalScanJobs);
+
+    // Drain pending rename checks first. They share the network budget, and a caller that
+    // frees a slot here would otherwise leave them queued until the next completion.
+    startQueuedEtagJobs();
+
     if (_currentRootJob) {
         int networkBudget = qMax(0, networkLimit - _currentlyActiveJobs);
         int localBudget = qMax(0, localLimit - _currentlyActiveLocalScanJobs);
@@ -321,6 +411,242 @@ void DiscoveryPhase::scheduleMoreJobs()
             _currentRootJob->processSubJobs(localBudget, networkBudget);
         }
     }
+}
+
+void DiscoveryPhase::enqueueEtagJob(AbstractNetworkJob *job)
+{
+    _queuedEtagJobs.push_back(job);
+    startQueuedEtagJobs();
+}
+
+void DiscoveryPhase::startQueuedEtagJobs()
+{
+    const auto networkLimit = networkJobBudget();
+    while (_currentlyActiveJobs < networkLimit && !_queuedEtagJobs.empty()) {
+        const auto job = _queuedEtagJobs.front();
+        _queuedEtagJobs.pop_front();
+        if (!job) {
+            continue; // destroyed while waiting in the queue
+        }
+
+        ++_currentlyActiveJobs;
+        // Connected here rather than in enqueueEtagJob() so that a job destroyed while it was
+        // still queued -- and therefore never counted -- cannot decrement the budget.
+        //
+        // destroyed() rather than a typed completion signal because it fires exactly once on
+        // every path: success, network error, and abort. AbstractNetworkJob deleteLater()s
+        // itself once finished, so this is queued and cannot re-enter the loop above.
+        connect(job, &QObject::destroyed, this, [this] {
+            --_currentlyActiveJobs;
+            startQueuedEtagJobs();
+            scheduleMoreJobs();
+        });
+        // Armed here rather than at construction so that time spent waiting for a slot does
+        // not count against the request. A job armed at construction can expire before it is
+        // ever sent, and AbstractNetworkJob::onTimedOut() deletes a job with no reply outright
+        // instead of reporting an error.
+        job->setTimeout(discoveryListingTimeoutMsec());
+        job->start();
+    }
+}
+
+void DiscoveryPhase::deliverEtagLookup(const PendingEtagLookup &lookup, const RemoteDirListing &listing)
+{
+    if (!lookup.context) {
+        return; // the job that asked is gone; answering it would touch freed state
+    }
+    if (!listing.listingOk) {
+        lookup.callback(listing.listingError);
+        return;
+    }
+    const auto it = listing.childEtags.constFind(lookup.relativePath);
+    if (it == listing.childEtags.constEnd()) {
+        // Not in the parent listing means it is not on the server. Reported as 404 because
+        // that is what a per-file PROPFIND returned here, and callers branch on that code.
+        lookup.callback(HttpError{404, tr("File not found on server")});
+        return;
+    }
+    lookup.callback(*it);
+}
+
+void DiscoveryPhase::deliverPendingEtagLookups(const QString &dirPath, const RemoteDirListing &listing)
+{
+    // Deliberately off the LsColJob's stack. These callbacks resume discovery -- they can
+    // finish a directory job, start new ones, or fail the whole sync -- and running that
+    // from inside the job's own finished/error signal re-enters the job while it is still
+    // executing and about to deleteLater() itself. Handing the work to the event loop keeps
+    // delivery uniform with the cached path, which is already asynchronous.
+    const auto waiting = _pendingEtagLookups.take(dirPath);
+    if (waiting.isEmpty()) {
+        return;
+    }
+    QTimer::singleShot(0, this, [this, waiting, listing] {
+        for (const auto &lookup : waiting) {
+            deliverEtagLookup(lookup, listing);
+        }
+    });
+}
+
+void DiscoveryPhase::lookupRemoteEtag(const QString &remoteFullPath,
+                                      QObject *context,
+                                      std::function<void(const HttpResult<QByteArray> &)> callback)
+{
+    const auto lastSlash = remoteFullPath.lastIndexOf('/');
+    if (lastSlash < 0) {
+        qCWarning(lcDiscovery) << "Cannot look up etag without a parent directory" << remoteFullPath;
+        QTimer::singleShot(0, context, [callback] { callback(HttpError{0, QStringLiteral("no parent directory")}); });
+        return;
+    }
+    // lastSlash == 0 means the entry sits directly in the remote root ("/AM"), which happens
+    // whenever the folder syncs the account root -- left() would give an empty path, so name
+    // the root explicitly. Getting this wrong silently fails every top-level rename.
+    const auto dirPath = lastSlash == 0 ? QStringLiteral("/") : remoteFullPath.left(lastSlash);
+    const PendingEtagLookup lookup{remoteFullPath.mid(lastSlash + 1), context, std::move(callback)};
+
+    // Already listed: answer from cache, but via the event loop. Callers increment
+    // _pendingAsyncJobs and then return expecting the reply to land later; running the
+    // callback inline here would re-enter their processing while they are still on the stack.
+    if (const auto cached = _remoteDirListings.constFind(dirPath); cached != _remoteDirListings.constEnd()) {
+        const auto listing = *cached;
+        QTimer::singleShot(0, this, [this, lookup, listing] { deliverEtagLookup(lookup, listing); });
+        return;
+    }
+
+    // A listing for this directory is already on its way: ride along on it.
+    if (const auto pending = _pendingEtagLookups.find(dirPath); pending != _pendingEtagLookups.end()) {
+        pending->append(lookup);
+        return;
+    }
+
+    // First lookup in this directory: it pays for the one listing that answers all the rest.
+    _pendingEtagLookups[dirPath].append(lookup);
+    issueEtagListing(dirPath);
+}
+
+void DiscoveryPhase::issueEtagListing(const QString &dirPath)
+{
+    const auto job = new LsColJob(_account, dirPath);
+    job->setParent(this); // LsColJob takes no parent argument
+    // Only the etag is needed. Asking for the default property set would make the response
+    // far larger for directories that can hold thousands of entries.
+    job->setProperties({"getetag"});
+    // The timeout is armed in startQueuedEtagJobs(), not here. Arming it at construction would
+    // have it run while the job is still waiting for a slot, so a job that queued behind slow
+    // listings could expire before it was ever sent -- see the destroyed() handler below.
+
+    // Hrefs come back as full URL paths. The listed directory itself is included alongside
+    // its children, and it is the only entry that is a prefix of all the others, so the
+    // shortest href identifies it -- which avoids having to reconstruct the request URL, and
+    // stays correct for a directory that contains a child of its own name (/a/b and /a/b/b).
+    const auto entries = std::make_shared<QList<QPair<QString, QByteArray>>>();
+    connect(job, &LsColJob::directoryListingIterated, this,
+        [entries](const QString &href, const QMap<QString, QString> &properties) {
+            entries->append({href, parseEtag(properties.value(QStringLiteral("getetag")).toUtf8().constData())});
+        });
+
+    // Exactly one of the three handlers below gets to act, whichever arrives first.
+    //
+    // The destroyed() one is not redundant. A job can reach its end without emitting either
+    // completion signal: AbstractNetworkJob::onTimedOut() deletes the job outright when it
+    // times out with no reply yet, which is reachable for a job that expired while queued.
+    // When that happened, the lookups parked in _pendingEtagLookups were never delivered, so
+    // their callers' _pendingAsyncJobs never dropped and discovery waited forever on a job
+    // that no longer existed -- an indefinite hang rather than a failed sync. destroyed()
+    // fires on every path, so it is the one backstop that cannot be skipped.
+    const auto handled = std::make_shared<bool>(false);
+
+    connect(job, &LsColJob::finishedWithoutError, this, [this, dirPath, entries, handled] {
+        if (std::exchange(*handled, true)) {
+            return;
+        }
+        RemoteDirListing listing;
+        listing.listingOk = true;
+        if (!entries->isEmpty()) {
+            auto parentHref = entries->first().first;
+            for (const auto &entry : std::as_const(*entries)) {
+                if (entry.first.size() < parentHref.size()) {
+                    parentHref = entry.first;
+                }
+            }
+            for (const auto &entry : std::as_const(*entries)) {
+                if (entry.first.size() <= parentHref.size()) {
+                    continue; // the directory itself, not a child
+                }
+                listing.childEtags.insert(entry.first.mid(parentHref.size() + 1), entry.second);
+            }
+        }
+        _etagListingRetries.remove(dirPath);
+        _remoteDirListings.insert(dirPath, listing);
+        deliverPendingEtagLookups(dirPath, listing);
+    });
+
+    connect(job, &LsColJob::finishedWithError, this, [this, dirPath, handled](QNetworkReply *reply) {
+        if (std::exchange(*handled, true)) {
+            return;
+        }
+        const auto httpCode = reply ? reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() : 0;
+        failEtagListing(dirPath, HttpError{httpCode, reply ? reply->errorString() : QString{}});
+    });
+
+    connect(job, &QObject::destroyed, this, [this, dirPath, handled] {
+        if (std::exchange(*handled, true)) {
+            return;
+        }
+        qCWarning(lcDiscovery) << "Listing job for" << dirPath
+                               << "was destroyed without reporting a result; treating as a failure";
+        failEtagListing(dirPath, HttpError{0, tr("Directory listing did not complete")});
+    });
+
+    // Through the same throttle as everything else discovery sends, so coalescing reduces
+    // the request count without changing how many are in flight at once.
+    enqueueEtagJob(job);
+}
+
+void DiscoveryPhase::failEtagListing(const QString &dirPath, const HttpError &error)
+{
+    if (!isRetryableListingError(error)) {
+        // The server answered; sending the same request again would only get the same answer.
+        _etagListingRetries.remove(dirPath);
+        RemoteDirListing listing;
+        listing.listingOk = false;
+        listing.listingError = error;
+        _remoteDirListings.insert(dirPath, listing);
+        deliverPendingEtagLookups(dirPath, listing);
+        return;
+    }
+
+    auto &retry = _etagListingRetries[dirPath];
+
+    // Attempts only add up while they keep failing close together. One that follows a long gap
+    // starts a fresh budget rather than inheriting what was spent earlier in the run.
+    const auto resetAfter = etagListingRetryResetAfter();
+    if (retry.sinceLastAttempt.isValid() && retry.sinceLastAttempt.durationElapsed() > resetAfter) {
+        retry.attempts = 0;
+    }
+    ++retry.attempts;
+    retry.sinceLastAttempt.start();
+
+    const auto maxAttempts = etagListingMaxAttempts();
+    if (retry.attempts < maxAttempts) {
+        const auto delay = etagListingRetryDelay() * retry.attempts;
+        qCInfo(lcDiscovery) << "Listing" << dirPath << "failed (attempt" << retry.attempts << "of"
+                            << maxAttempts << "):" << error.message << "-- retrying in"
+                            << delay.count() << "s";
+        QTimer::singleShot(delay, this, [this, dirPath] { issueEtagListing(dirPath); });
+        return;
+    }
+
+    qCWarning(lcDiscovery) << "Listing" << dirPath << "failed" << retry.attempts
+                           << "times in a row; giving up:" << error.message;
+    _etagListingRetries.remove(dirPath);
+
+    RemoteDirListing listing;
+    listing.listingOk = false;
+    listing.listingError = error;
+    // Cached as a failure too: without this, every one of the ~90 lookups that directory
+    // is about to receive would retry the same failing listing.
+    _remoteDirListings.insert(dirPath, listing);
+    deliverPendingEtagLookups(dirPath, listing);
 }
 
 void DiscoveryPhase::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
@@ -461,6 +787,7 @@ void DiscoverySingleDirectoryJob::start()
     const auto props = LsColJob::defaultProperties(_isRootPath ? LsColJob::FolderType::RootFolder : LsColJob::FolderType::ChildFolder,
                                                    _account);
     lsColJob->setProperties(props);
+    lsColJob->setTimeout(discoveryListingTimeoutMsec());
 
     QObject::connect(lsColJob, &LsColJob::directoryListingIterated,
         this, &DiscoverySingleDirectoryJob::directoryListingIteratedSlot);

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -20,6 +20,7 @@
 #include <QMap>
 #include <QSet>
 #include <QMutex>
+#include <QPointer>
 #include <QWaitCondition>
 #include <QRunnable>
 #include <deque>
@@ -241,6 +242,71 @@ class DiscoveryPhase : public QObject
      *  Bounded by _syncOptions._parallelLocalScanJobs, independent of network jobs. */
     int _currentlyActiveLocalScanJobs = 0;
 
+    /** Queue a rename-check etag request instead of starting it immediately.
+     *
+     * Rename detection issues one Depth:0 PROPFIND per candidate file. Those requests used
+     * to be start()ed the moment they were created, which put them outside every concurrency
+     * limit: a single directory full of renames dispatched thousands of them at once, and
+     * because ProcessDirectoryJob::process() walks a directory synchronously, merely counting
+     * them would not have bounded the burst. Gating start() does.
+     *
+     * This matters because AbstractNetworkJob arms its timeout timer at dispatch, not when
+     * the request reaches the wire. With HTTP/1.1 (HTTP/2 is off by default) Qt opens at most
+     * 6 connections per host, so over-dispatching leaves requests sitting in QNAM's queue
+     * burning their timeout without ever sending a byte -- they then expire in a batch and
+     * starve the discovery PROPFINDs queued behind them.
+     *
+     * Queued jobs share the _currentlyActiveJobs budget with discovery PROPFINDs rather than
+     * getting a second independent allowance: both are requests to the same host competing for
+     * the same connection pool, so one combined cap is what actually bounds the pool.
+     *
+     * Does not take ownership; the job's QObject parent still owns its memory. The job is
+     * merely start()ed later than the caller would have started it.
+     */
+    void enqueueEtagJob(AbstractNetworkJob *job);
+
+    /// Start queued rename-check jobs while budget allows. Safe to call spuriously.
+    void startQueuedEtagJobs();
+
+    /** How many network jobs discovery may have in flight at once.
+     *
+     * Deliberately below Qt's per-host HTTP/1.1 connection limit so that some connections
+     * stay free for account health checks. Marking those high priority is not enough on its
+     * own: priority decides who takes the *next* free connection but cannot evict a request
+     * already occupying one, so discovery holding every connection still leaves a health
+     * check waiting on the slowest of them.
+     *
+     * Measured before reserving headroom, with discovery allowed all 6 connections: the
+     * ConnectionValidator PROPFIND -- which already sets HighPriority itself -- degraded
+     * 0.2s -> 0.6s -> 13.9s -> 61.6s as discovery went deeper, then blew its 57s budget and
+     * tripped a false account-offline that terminated the sync mid-discovery.
+     */
+    [[nodiscard]] int networkJobBudget() const;
+
+    /** Look up the server etag of a single remote path, for rename detection.
+     *
+     * Result semantics deliberately match the RequestEtagJob this replaces, so callers need
+     * no change in logic: the etag on success, and HttpError{404} when the path does not
+     * exist -- which is exactly what "the original is gone, so this is a rename" relies on.
+     *
+     * The point is how the answer is obtained. Rename candidates arrive in dense clusters
+     * within a directory (measured on a real sync: 2025 lookups spread over just 22
+     * directories, ~92 per directory), and one Depth:1 PROPFIND on the parent answers every
+     * lookup in it. So lookups are grouped by parent directory: the first one for a directory
+     * issues a single listing, later ones either attach to that in-flight listing or are
+     * served from its cached result. A per-file PROPFIND each would be ~92x the requests, and
+     * that volume -- not the concurrency -- is what drives the server slow enough that the
+     * account's own health check times out and the sync gets torn down mid-discovery.
+     *
+     * @a context bounds the callback's lifetime: if it is destroyed first, the callback is
+     * dropped rather than invoked on a dangling capture. The callback is always invoked
+     * asynchronously, even on a cache hit, so callers keep the async contract they had with
+     * RequestEtagJob (notably `_pendingAsyncJobs` accounting around the call).
+     */
+    void lookupRemoteEtag(const QString &remoteFullPath,
+                          QObject *context,
+                          std::function<void(const HttpResult<QByteArray> &)> callback);
+
     // both must contain a sorted list
     QStringList _selectiveSyncBlackList;
     QStringList _selectiveSyncWhiteList;
@@ -286,6 +352,58 @@ class DiscoveryPhase : public QObject
     void enqueueDirectoryToDelete(const QString &path, ProcessDirectoryJob* const directoryJob);
 
     bool recursiveCheckForDeletedParents(const QString &itemPath) const;
+
+    /// Rename-check etag jobs created but not yet start()ed; see enqueueEtagJob().
+    /// QPointer so a job destroyed while still queued is skipped rather than dangling.
+    std::deque<QPointer<AbstractNetworkJob>> _queuedEtagJobs;
+
+    /// Cached result of one Depth:1 listing, used to answer lookupRemoteEtag() without a
+    /// per-file request. Only ever populated for directories a rename check asked about.
+    struct RemoteDirListing
+    {
+        /// Child path relative to the listed directory -> its etag. Absent key means the
+        /// child does not exist on the server, which the caller reads as a 404.
+        QHash<QString, QByteArray> childEtags;
+        /// False if the listing itself failed; then every lookup in it reports listingError.
+        bool listingOk = false;
+        HttpError listingError{0, {}};
+    };
+
+    /// Completed listings, keyed by remote directory path (no trailing slash).
+    QHash<QString, RemoteDirListing> _remoteDirListings;
+
+    /// Lookups waiting on a listing that is still in flight, keyed the same way. Presence of
+    /// a key also marks "a listing for this directory has already been started".
+    struct PendingEtagLookup
+    {
+        QString relativePath;
+        QPointer<QObject> context;
+        std::function<void(const HttpResult<QByteArray> &)> callback;
+    };
+    QHash<QString, QList<PendingEtagLookup>> _pendingEtagLookups;
+
+    /// Answer @a lookup from an already-completed listing.
+    void deliverEtagLookup(const PendingEtagLookup &lookup, const RemoteDirListing &listing);
+
+    /// Answer everything waiting on @a dirPath, off the listing job's own stack.
+    void deliverPendingEtagLookups(const QString &dirPath, const RemoteDirListing &listing);
+
+    /// Sends (or re-sends) the Depth:1 listing that answers the lookups parked for @a dirPath.
+    void issueEtagListing(const QString &dirPath);
+
+    /// Retries the listing for @a dirPath while its budget lasts, otherwise fails every lookup
+    /// waiting on it. Every path that ends a listing without a usable result arrives here, so
+    /// parked lookups are always answered and discovery can never wait on a job that is gone.
+    void failEtagListing(const QString &dirPath, const HttpError &error);
+
+    /// Failed attempts at one directory's listing, and how long since the last one. Attempts
+    /// decay, so retries spread across a long run cannot add up to an exhausted budget.
+    struct EtagListingRetry
+    {
+        int attempts = 0;
+        QElapsedTimer sinceLastAttempt;
+    };
+    QHash<QString, EtagListingRetry> _etagListingRetries;
 
     /// contains files/folder names that are requested to be deleted permanently
     QSet<QString> _permanentDeletionRequests;

--- a/src/libsync/discoveryphase.h
+++ b/src/libsync/discoveryphase.h
@@ -233,7 +233,13 @@ class DiscoveryPhase : public QObject
      */
     [[nodiscard]] bool isRenamed(const QString &p) const;
 
+    /** Count of currently active network (PROPFIND) discovery jobs.
+     *  Bounded by _syncOptions._parallelNetworkJobs to protect the server. */
     int _currentlyActiveJobs = 0;
+
+    /** Count of currently active local filesystem scan jobs.
+     *  Bounded by _syncOptions._parallelLocalScanJobs, independent of network jobs. */
+    int _currentlyActiveLocalScanJobs = 0;
 
     // both must contain a sorted list
     QStringList _selectiveSyncBlackList;

--- a/src/libsync/lockfilejobs.cpp
+++ b/src/libsync/lockfilejobs.cpp
@@ -201,7 +201,7 @@ SyncJournalFileRecord LockFileJob::handleReply()
         if (!result) {
             qCWarning(lcLockFileJob) << "Error when setting the file record to the database" << record._path << result.error();
         }
-        _journal->commit("lock file job");
+        _journal->commitIfNeededAndStartNewTransaction("lock file job");
     }
 
     return record;

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -177,136 +177,225 @@ bool MkColJob::finished()
 }
 
 /*********************************************************************************************/
-// supposed to read <D:collection> when pointing to <D:resourcetype><D:collection></D:resourcetype>..
-static QString readContentsAsString(QXmlStreamReader &reader)
-{
-    QString result;
-    int level = 0;
-    do {
-        QXmlStreamReader::TokenType type = reader.readNext();
-        if (type == QXmlStreamReader::StartElement) {
-            level++;
-            result += "<" + reader.name().toString() + ">";
-        } else if (type == QXmlStreamReader::Characters) {
-            result += reader.text();
-        } else if (type == QXmlStreamReader::EndElement) {
-            level--;
-            if (level < 0) {
-                break;
-            }
-            result += "</" + reader.name().toString() + ">";
-        }
-
-    } while (!reader.atEnd());
-    return result;
-}
-
-
 LsColXMLParser::LsColXMLParser() = default;
 
-bool LsColXMLParser::parse(const QByteArray &xml, QHash<QString, ExtraFolderInfo> *fileInfo, const QString &expectedPath)
+void LsColXMLParser::begin(const QString &expectedPath, QHash<QString, ExtraFolderInfo> *fileInfo)
 {
-    // Parse DAV response
-    QXmlStreamReader reader(xml);
-    reader.addExtraNamespaceDeclaration(QXmlStreamNamespaceDeclaration("d", "DAV:"));
+    _expectedPath = expectedPath;
+    _fileInfo = fileInfo;
+    _started = true;
 
-    QStringList folders;
-    QString currentHref;
-    QMap<QString, QString> currentTmpProperties;
-    QMap<QString, QString> currentHttp200Properties;
-    bool currentPropsHaveHttp200 = false;
-    bool insidePropstat = false;
-    bool insideProp = false;
-    bool insideMultiStatus = false;
+    // Drop any data, error state and namespace declarations left over from a previous
+    // response. begin() is called again when a request is redirected or retried, and a
+    // reader that still carries the old error would fail every subsequent parse.
+    _reader.clear();
+    _reader.addExtraNamespaceDeclaration(QXmlStreamNamespaceDeclaration("d", "DAV:"));
 
-    while (!reader.atEnd()) {
-        QXmlStreamReader::TokenType type = reader.readNext();
-        QString name = reader.name().toString();
-        // Start elements with DAV:
-        if (type == QXmlStreamReader::StartElement && reader.namespaceUri() == QLatin1String("DAV:")) {
-            if (name == QLatin1String("href")) {
-                // We don't use URL encoding in our request URL (which is the expected path) (QNAM will do it for us)
-                // but the result will have URL encoding..
-                QString hrefString = QUrl::fromLocalFile(QUrl::fromPercentEncoding(reader.readElementText().toUtf8()))
+    // Reset parse state
+    _folders.clear();
+    _currentHref.clear();
+    _currentTmpProperties.clear();
+    _currentHttp200Properties.clear();
+    _currentPropsHaveHttp200 = false;
+    _insidePropstat = false;
+    _insideProp = false;
+    _insideMultiStatus = false;
+
+    // Reset chunk-boundary-safe capture state
+    _capturingHref = false;
+    _hrefBuffer.clear();
+    _capturingStatus = false;
+    _statusBuffer.clear();
+    _capturingProperty = false;
+    _propertyName.clear();
+    _propertyLevel = 0;
+    _propertyContent.clear();
+}
+
+bool LsColXMLParser::addData(const QByteArray &chunk)
+{
+    if (!_started) {
+        // Not a silent begin(): _expectedPath would still be empty, and an empty expected
+        // path makes the href prefix check accept everything, i.e. no validation at all.
+        qCWarning(lcLsColJob) << "addData() called before begin()";
+        return false;
+    }
+
+    _reader.addData(chunk);
+    return processReader();
+}
+
+bool LsColXMLParser::processReader()
+{
+    while (!_reader.atEnd()) {
+        const QXmlStreamReader::TokenType type = _reader.readNext();
+        // A view, not toString(): this line runs once per XML token and a QString here
+        // would allocate on every element of a potentially huge PROPFIND response.
+        const QStringView name = _reader.name();
+
+        // Handle chunk-boundary-safe capture of href text (may span multiple addData calls)
+        if (_capturingHref) {
+            if (type == QXmlStreamReader::Characters) {
+                _hrefBuffer += _reader.text();
+                continue;
+            } else if (type == QXmlStreamReader::EndElement && name == QLatin1String("href")) {
+                QString hrefString = QUrl::fromLocalFile(QUrl::fromPercentEncoding(_hrefBuffer.toUtf8()))
                         .adjusted(QUrl::NormalizePathSegments)
                         .path();
-                if (!hrefString.startsWith(expectedPath)) {
-                    qCWarning(lcLsColJob) << "Invalid href" << hrefString << "expected starting with" << expectedPath;
+                if (!hrefString.startsWith(_expectedPath)) {
+                    qCWarning(lcLsColJob) << "Invalid href" << hrefString << "expected starting with" << _expectedPath;
                     return false;
                 }
-                currentHref = hrefString;
-            } else if (name == QLatin1String("response")) {
-            } else if (name == QLatin1String("propstat")) {
-                insidePropstat = true;
-            } else if (name == QLatin1String("status") && insidePropstat) {
-                QString httpStatus = reader.readElementText();
-                if (httpStatus.startsWith("HTTP/1.1 200")) {
-                    currentPropsHaveHttp200 = true;
-                } else {
-                    currentPropsHaveHttp200 = false;
-                }
-            } else if (name == QLatin1String("prop")) {
-                insideProp = true;
-                continue;
-            } else if (name == QLatin1String("multistatus")) {
-                insideMultiStatus = true;
+                _currentHref = hrefString;
+                _capturingHref = false;
                 continue;
             }
         }
 
-        if (type == QXmlStreamReader::StartElement && insidePropstat && insideProp) {
-            // All those elements are properties
-            QString propertyContent = readContentsAsString(reader);
-            if (name == QLatin1String("resourcetype") && propertyContent.contains("collection")) {
-                folders.append(currentHref);
-            } else if (name == QLatin1String("size")) {
-                bool ok = false;
-                auto s = propertyContent.toLongLong(&ok);
-                if (ok && fileInfo) {
-                    (*fileInfo)[currentHref].size = s;
+        // Handle chunk-boundary-safe capture of status text
+        if (_capturingStatus) {
+            if (type == QXmlStreamReader::Characters) {
+                _statusBuffer += _reader.text();
+                continue;
+            } else if (type == QXmlStreamReader::EndElement && name == QLatin1String("status")) {
+                if (_statusBuffer.startsWith("HTTP/1.1 200")) {
+                    _currentPropsHaveHttp200 = true;
+                } else {
+                    _currentPropsHaveHttp200 = false;
                 }
-            } else if (name == QLatin1String("fileid")) {
-                (*fileInfo)[currentHref].fileId = propertyContent.toUtf8();
+                _capturingStatus = false;
+                continue;
             }
-            currentTmpProperties.insert(reader.name().toString(), propertyContent);
+        }
+
+        // Handle chunk-boundary-safe capture of property content
+        if (_capturingProperty) {
+            if (type == QXmlStreamReader::StartElement) {
+                _propertyLevel++;
+                _propertyContent += "<" + name + ">";
+                continue;
+            } else if (type == QXmlStreamReader::Characters) {
+                _propertyContent += _reader.text();
+                continue;
+            } else if (type == QXmlStreamReader::EndElement) {
+                if (_propertyLevel > 0) {
+                    _propertyLevel--;
+                    _propertyContent += "</" + name + ">";
+                    continue;
+                } else {
+                    // Matching end of the property element itself
+                    if (_propertyName == QLatin1String("resourcetype") && _propertyContent.contains("collection")) {
+                        _folders.append(_currentHref);
+                    } else if (_propertyName == QLatin1String("size")) {
+                        bool ok = false;
+                        auto s = _propertyContent.toLongLong(&ok);
+                        if (ok && _fileInfo) {
+                            (*_fileInfo)[_currentHref].size = s;
+                        }
+                    } else if (_propertyName == QLatin1String("fileid") && _fileInfo) {
+                        (*_fileInfo)[_currentHref].fileId = _propertyContent.toUtf8();
+                    }
+                    _currentTmpProperties.insert(_propertyName, _propertyContent);
+                    _capturingProperty = false;
+                    continue;
+                }
+            }
+        }
+
+        // Start elements with DAV:
+        if (type == QXmlStreamReader::StartElement && _reader.namespaceUri() == QLatin1String("DAV:")) {
+            if (name == QLatin1String("href")) {
+                _capturingHref = true;
+                _hrefBuffer.clear();
+                continue;
+            } else if (name == QLatin1String("response")) {
+            } else if (name == QLatin1String("propstat")) {
+                _insidePropstat = true;
+            } else if (name == QLatin1String("status") && _insidePropstat) {
+                _capturingStatus = true;
+                _statusBuffer.clear();
+                continue;
+            } else if (name == QLatin1String("prop")) {
+                _insideProp = true;
+                continue;
+            } else if (name == QLatin1String("multistatus")) {
+                _insideMultiStatus = true;
+                continue;
+            }
+        }
+
+        // Start property content capture (only if not already in another capture mode)
+        if (type == QXmlStreamReader::StartElement && _insidePropstat && _insideProp && !_capturingHref && !_capturingStatus) {
+            _capturingProperty = true;
+            _propertyName = name.toString(); // must outlive this token
+            _propertyLevel = 0;
+            _propertyContent.clear();
+            continue;
         }
 
         // End elements with DAV:
         if (type == QXmlStreamReader::EndElement) {
-            if (reader.namespaceUri() == QLatin1String("DAV:")) {
-                if (reader.name() == QStringLiteral("response")) {
-                    if (currentHref.endsWith('/')) {
-                        currentHref.chop(1);
+            if (_reader.namespaceUri() == QLatin1String("DAV:")) {
+                if (name == QLatin1String("response")) {
+                    if (_currentHref.endsWith('/')) {
+                        _currentHref.chop(1);
                     }
-                    emit directoryListingIterated(currentHref, currentHttp200Properties);
-                    currentHref.clear();
-                    currentHttp200Properties.clear();
-                } else if (reader.name() == QStringLiteral("propstat")) {
-                    insidePropstat = false;
-                    if (currentPropsHaveHttp200) {
-                        currentHttp200Properties = QMap<QString, QString>(currentTmpProperties);
+                    emit directoryListingIterated(_currentHref, _currentHttp200Properties);
+                    _currentHref.clear();
+                    _currentHttp200Properties.clear();
+                } else if (name == QLatin1String("propstat")) {
+                    _insidePropstat = false;
+                    if (_currentPropsHaveHttp200) {
+                        _currentHttp200Properties = QMap<QString, QString>(_currentTmpProperties);
                     }
-                    currentTmpProperties.clear();
-                    currentPropsHaveHttp200 = false;
-                } else if (reader.name() == QStringLiteral("prop")) {
-                    insideProp = false;
+                    _currentTmpProperties.clear();
+                    _currentPropsHaveHttp200 = false;
+                } else if (name == QLatin1String("prop")) {
+                    _insideProp = false;
                 }
             }
         }
     }
 
-    if (reader.hasError()) {
-        // XML Parser error? Whatever had been emitted before will come as directoryListingIterated
-        qCWarning(lcLsColJob) << "ERROR" << reader.errorString() << xml;
+    // Check for errors (excluding PrematureEndOfDocumentError which means "need more data")
+    if (_reader.hasError() && _reader.error() != QXmlStreamReader::PrematureEndOfDocumentError) {
+        qCWarning(lcLsColJob) << "XML parse error:" << _reader.errorString();
         return false;
-    } else if (!insideMultiStatus) {
-        qCWarning(lcLsColJob) << "ERROR no WebDAV response?" << xml;
-        return false;
-    } else {
-        emit directoryListingSubfolders(folders);
-        emit finishedWithoutError();
     }
+
     return true;
+}
+
+bool LsColXMLParser::finalize()
+{
+    // Process any remaining data and finalize the parse
+    if (!processReader()) {
+        return false;
+    }
+
+    // Check if document was properly completed
+    if (_reader.hasError()) {
+        qCWarning(lcLsColJob) << "ERROR: incomplete XML parse:" << _reader.errorString();
+        return false;
+    } else if (!_insideMultiStatus) {
+        qCWarning(lcLsColJob) << "ERROR no WebDAV response?";
+        return false;
+    }
+
+    // Emit final signals
+    emit directoryListingSubfolders(_folders);
+    emit finishedWithoutError();
+    return true;
+}
+
+bool LsColXMLParser::parse(const QByteArray &xml, QHash<QString, ExtraFolderInfo> *fileInfo, const QString &expectedPath)
+{
+    // Legacy single-shot parsing: use the incremental API for backward compatibility
+    begin(expectedPath, fileInfo);
+    if (!addData(xml)) {
+        return false;
+    }
+    return finalize();
 }
 
 /*********************************************************************************************/
@@ -314,12 +403,37 @@ bool LsColXMLParser::parse(const QByteArray &xml, QHash<QString, ExtraFolderInfo
 LsColJob::LsColJob(AccountPtr account, const QString &path)
     : AbstractNetworkJob(account, path)
 {
+    connectParser();
 }
 
 LsColJob::LsColJob(AccountPtr account, const QUrl &url)
     : AbstractNetworkJob(account, QString())
     , _url(url)
 {
+    connectParser();
+}
+
+void LsColJob::connectParser()
+{
+    // Connected once here rather than in start(): start() is not re-entered on a redirect,
+    // and connecting there would duplicate every forwarded signal if it ever were.
+    connect(&_parser, &LsColXMLParser::directoryListingSubfolders,
+        this, &LsColJob::directoryListingSubfolders);
+    connect(&_parser, &LsColXMLParser::directoryListingIterated,
+        this, &LsColJob::directoryListingIterated);
+    connect(&_parser, &LsColXMLParser::finishedWithError,
+        this, &LsColJob::finishedWithError);
+    connect(&_parser, &LsColXMLParser::finishedWithoutError,
+        this, &LsColJob::finishedWithoutError);
+}
+
+void LsColJob::newReplyHook(QNetworkReply *reply)
+{
+    // Called for the initial request and again for every redirect, so the incremental
+    // parse always follows the reply that actually carries the multistatus body.
+    _headerValid = false;
+    _parseFailed = false;
+    connect(reply, &QIODevice::readyRead, this, &LsColJob::slotReadyRead);
 }
 
 void LsColJob::setProperties(QList<QByteArray> properties)
@@ -527,42 +641,68 @@ void LsColJob::start()
     } else {
         sendRequest("PROPFIND", makeDavUrl(path()), req, buf);
     }
+
+    // No setTimeout() override here on purpose. The inherited timeout is an *inactivity*
+    // timeout: AbstractNetworkJob resets it on every downloadProgress, so it only has to
+    // cover the server's think time before the next chunk, not the duration of the whole
+    // listing. This request is Depth: 1, so that is a single directory, and the body is now
+    // parsed incrementally, so bytes arrive steadily instead of in one blob at the end.
+    // The configured value (OWNCLOUD_TIMEOUT, else 300 s) is therefore sufficient, and
+    // hardcoding a longer one would silently override an administrator's setting.
     AbstractNetworkJob::start();
 }
 
-// TODO: Instead of doing all in this slot, we should iteratively parse in readyRead(). This
-// would allow us to be more asynchronous in processing while data is coming from the network,
-// not all in one big blob at the end.
+void LsColJob::slotReadyRead()
+{
+    if (_parseFailed) {
+        return;
+    }
+
+    if (!_headerValid && reply()) {
+        // Validate headers on first readyRead (headers are guaranteed available by Qt)
+        const auto contentType = reply()->header(QNetworkRequest::ContentTypeHeader).toString();
+        const auto httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        const auto validContentType = contentType.contains("application/xml; charset=utf-8") ||
+                                      contentType.contains("application/xml; charset=\"utf-8\"") ||
+                                      contentType.contains("text/xml; charset=utf-8") ||
+                                      contentType.contains("text/xml; charset=\"utf-8\"");
+
+        if (httpCode != 207 || !validContentType) {
+            // Invalid response, don't bother parsing
+            return;
+        }
+        _headerValid = true;
+
+        // Initialize parser on first valid data
+        const auto expectedPath = reply()->request().url().path();
+        _parser.begin(expectedPath, &_folderInfos);
+    }
+
+    if (_headerValid) {
+        // Read and feed available data to the incremental parser
+        const QByteArray chunk = reply()->readAll();
+        if (!chunk.isEmpty() && !_parser.addData(chunk)) {
+            // Stop feeding the parser, but leave the reply's own connections alone: they
+            // carry AbstractNetworkJob::slotFinished, which is what eventually calls
+            // finished() and deletes this job. finished() reports the error.
+            _parseFailed = true;
+        }
+    }
+}
+
 bool LsColJob::finished()
 {
     qCInfo(lcLsColJob) << "LSCOL of" << reply()->request().url() << "FINISHED WITH STATUS"
                        << replyStatusString();
 
-    const auto contentType = reply()->header(QNetworkRequest::ContentTypeHeader).toString();
-    const auto httpCode = reply()->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    const auto validContentType = contentType.contains("application/xml; charset=utf-8") ||
-                                  contentType.contains("application/xml; charset=\"utf-8\"") ||
-                                  contentType.contains("text/xml; charset=utf-8") ||
-                                  contentType.contains("text/xml; charset=\"utf-8\"");
+    // Drain any remaining bytes that arrived at or after the finished signal. This is also
+    // the only read for a body small enough to arrive in one go, where readyRead may have
+    // fired before the headers were available.
+    slotReadyRead();
 
-    if (httpCode == 207 && validContentType) {
-        LsColXMLParser parser;
-        connect(&parser, &LsColXMLParser::directoryListingSubfolders,
-            this, &LsColJob::directoryListingSubfolders);
-        connect(&parser, &LsColXMLParser::directoryListingIterated,
-            this, &LsColJob::directoryListingIterated);
-        connect(&parser, &LsColXMLParser::finishedWithError,
-            this, &LsColJob::finishedWithError);
-        connect(&parser, &LsColXMLParser::finishedWithoutError,
-            this, &LsColJob::finishedWithoutError);
-
-        const auto expectedPath = reply()->request().url().path(); // something like "/owncloud/remote.php/dav/folder"
-        if (!parser.parse(reply()->readAll(), &_folderInfos, expectedPath)) {
-            // XML parse error
-            emit finishedWithError(reply());
-        }
-    } else {
-        // wrong content type, wrong HTTP code or any other network error
+    if (!_headerValid || _parseFailed || !_parser.finalize()) {
+        // Wrong content type, wrong HTTP code, a network error, or a malformed body.
+        // Exactly one error is reported per job regardless of where it was detected.
         emit finishedWithError(reply());
     }
 

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -17,6 +17,7 @@
 
 #include <QBuffer>
 #include <QUrlQuery>
+#include <QXmlStreamReader>
 
 class QUrl;
 class QJsonObject;
@@ -120,15 +121,50 @@ class OWNCLOUDSYNC_EXPORT LsColXMLParser : public QObject
 public:
     explicit LsColXMLParser();
 
+    // Legacy single-shot parsing (backward compatible)
     bool parse(const QByteArray &xml,
                QHash<QString, ExtraFolderInfo> *sizes,
                const QString &expectedPath);
+
+    // Incremental streaming parsing API
+    void begin(const QString &expectedPath, QHash<QString, ExtraFolderInfo> *fileInfo);
+    bool addData(const QByteArray &chunk);
+    bool finalize();
 
 signals:
     void directoryListingSubfolders(const QStringList &items);
     void directoryListingIterated(const QString &name, const QMap<QString, QString> &properties);
     void finishedWithError(QNetworkReply *reply);
     void finishedWithoutError();
+
+private:
+    // Incremental parse state (persistent across addData calls)
+    QXmlStreamReader _reader;
+    QString _expectedPath;
+    QHash<QString, ExtraFolderInfo> *_fileInfo = nullptr;
+
+    QStringList _folders;
+    QString _currentHref;
+    QMap<QString, QString> _currentTmpProperties;
+    QMap<QString, QString> _currentHttp200Properties;
+    bool _currentPropsHaveHttp200 = false;
+    bool _insidePropstat = false;
+    bool _insideProp = false;
+    bool _insideMultiStatus = false;
+    bool _started = false;
+
+    // Chunk-boundary-safe capture state for element text that may span addData() calls
+    bool _capturingHref = false;
+    QString _hrefBuffer;
+    bool _capturingStatus = false;
+    QString _statusBuffer;
+    bool _capturingProperty = false;
+    QString _propertyName;
+    int _propertyLevel = 0;
+    QString _propertyContent;
+
+    // Helper to process parse state — same logic as the loop in parse()
+    bool processReader();
 };
 
 class OWNCLOUDSYNC_EXPORT LsColJob : public AbstractNetworkJob
@@ -161,17 +197,43 @@ public:
     static void propertyMapToRemoteInfo(const QMap<QString, QString> &map, RemotePermissions::MountedPermissionAlgorithm algorithm, RemoteInfo &result);
 
 signals:
-    void directoryListingSubfolders(const QStringList &items);
+    /**
+     * Emitted once per <d:response> as the body is parsed, i.e. while the reply is still
+     * streaming rather than once at the end.
+     *
+     * A listing may therefore be emitted only partially and still be followed by
+     * finishedWithError() -- if the connection drops or the body is malformed mid-transfer,
+     * whatever was parsed up to that point has already been delivered. Consumers must treat
+     * entries received before finishedWithError() as incomplete and discard them; only a
+     * listing terminated by finishedWithoutError() is the whole directory.
+     *
+     * Exactly one of finishedWithError() / finishedWithoutError() is emitted per job.
+     */
     void directoryListingIterated(const QString &name, const QMap<QString, QString> &properties);
+
+    /// Emitted once, immediately before finishedWithoutError(); never on the error path.
+    void directoryListingSubfolders(const QStringList &items);
+
     void finishedWithError(QNetworkReply *reply);
     void finishedWithoutError();
 
+protected:
+    void newReplyHook(QNetworkReply *reply) override;
+
 private slots:
     bool finished() override;
+    void slotReadyRead();
 
 private:
+    void connectParser();
+
     QList<QByteArray> _properties;
     QUrl _url; // Used instead of path() if the url is specified in the constructor
+    LsColXMLParser _parser;
+    /// Set once the reply's status code and content type have been accepted and the parser fed.
+    bool _headerValid = false;
+    /// Set when the parser rejected the body, so finished() does not report the error twice.
+    bool _parseFailed = false;
 };
 
 /**

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -25,7 +25,10 @@
 #include <QNetworkAccessManager>
 #include <QFileInfo>
 #include <QDir>
+#include <QTimer>
 
+#include <algorithm>
+#include <chrono>
 #include <cmath>
 
 namespace OCC {
@@ -800,6 +803,66 @@ void PropagateDownloadFile::makeParentFolderModifiable(const QString &fileName)
 }
 
 const char owncloudCustomSoftErrorStringC[] = "owncloud-custom-soft-error-string";
+bool PropagateDownloadFile::retryAfterServiceUnavailable()
+{
+    static const auto maxAttempts = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RETRIES");
+        return qMax(1, configured > 0 ? configured : 3);
+    }();
+    // Unlike the connection-check counter, a short window works here: retries are seconds
+    // apart, so a burst of 503s on one file lands well inside it, while one that happens
+    // again much later in the sync is unrelated and starts over.
+    static const auto resetAfter = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RESET_SEC");
+        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 60));
+    }();
+    static const auto backoffStep = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_BACKOFF_SEC");
+        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 5));
+    }();
+
+    if (_sinceLastServiceUnavailable.isValid()
+        && _sinceLastServiceUnavailable.durationElapsed() > resetAfter) {
+        _serviceUnavailableAttempts = 0;
+    }
+    _sinceLastServiceUnavailable.start();
+    ++_serviceUnavailableAttempts;
+
+    if (_serviceUnavailableAttempts >= maxAttempts) {
+        qCWarning(lcPropagateDownload) << "server replied 503 for" << _item->_file
+                                       << _serviceUnavailableAttempts
+                                       << "times in a row; failing the item";
+        _serviceUnavailableAttempts = 0;
+        _sinceLastServiceUnavailable.invalidate();
+        return false;
+    }
+
+    // Incremental, so a server that is struggling gets more room on each attempt. The server's
+    // own Retry-After wins when it sends one, since that is the interval it asked for.
+    auto delay = backoffStep * _serviceUnavailableAttempts;
+    if (_job && _job->reply()) {
+        const auto retryAfter = _job->reply()->rawHeader(QByteArrayLiteral("Retry-After")).toInt();
+        if (retryAfter > 0) {
+            delay = std::min(std::chrono::seconds(retryAfter), std::chrono::seconds(60));
+        }
+    }
+
+    qCInfo(lcPropagateDownload) << "server replied 503 for" << _item->_file << "(attempt"
+                                << _serviceUnavailableAttempts << "of" << maxAttempts
+                                << "); retrying in" << delay.count() << "s";
+
+    // Off the finishing job's stack: start() builds a new GETFileJob, and the current one is
+    // still executing its own finished handling.
+    QTimer::singleShot(delay, this, [this] {
+        if (propagator()->_abortRequested) {
+            done(SyncFileItem::SoftError, tr("Sync was aborted"), ErrorCategory::GenericError);
+            return;
+        }
+        start();
+    });
+    return true;
+}
+
 void PropagateDownloadFile::slotGetFinished()
 {
     propagator()->_activeJobList.removeOne(this);
@@ -830,6 +893,16 @@ void PropagateDownloadFile::slotGetFinished()
         const bool fileLocked = _item->_httpErrorCode == 423;
         if (fileLocked) {
             qCWarning(lcPropagateDownload) << "server replied 423, file is Locked";
+        }
+
+        // A 503 is the server declining to serve this request right now; it says nothing about
+        // the file. Failing on the first one is enough to end an entire sync, because a 503
+        // whose body looks like maintenance mode is classified fatal, and a server busy under
+        // its own load emits them in bursts. Re-sending a few times usually gets the file, and
+        // the sync keeps the progress it has instead of unwinding.
+        if (_item->_httpErrorCode == 503 && !propagator()->_abortRequested
+            && retryAfterServiceUnavailable()) {
+            return;
         }
 
         // Don't keep the temporary file if it is empty or we

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -13,6 +13,7 @@
 #include "common/syncjournaldb.h"
 #include "common/syncjournalfilerecord.h"
 #include "common/utility.h"
+#include "configfile.h"
 #include "filesystem.h"
 #include "propagatorjobs.h"
 #include <common/asserts.h>
@@ -805,21 +806,12 @@ void PropagateDownloadFile::makeParentFolderModifiable(const QString &fileName)
 const char owncloudCustomSoftErrorStringC[] = "owncloud-custom-soft-error-string";
 bool PropagateDownloadFile::retryAfterServiceUnavailable()
 {
-    static const auto maxAttempts = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RETRIES");
-        return qMax(1, configured > 0 ? configured : 3);
-    }();
+    static const auto maxAttempts = ConfigFile().propagateServiceUnavailableRetries();
     // Unlike the connection-check counter, a short window works here: retries are seconds
     // apart, so a burst of 503s on one file lands well inside it, while one that happens
     // again much later in the sync is unrelated and starts over.
-    static const auto resetAfter = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RESET_SEC");
-        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 60));
-    }();
-    static const auto backoffStep = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_BACKOFF_SEC");
-        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 5));
-    }();
+    static const auto resetAfter = ConfigFile().propagateServiceUnavailableResetInterval();
+    static const auto backoffStep = ConfigFile().propagateServiceUnavailableBackoff();
 
     if (_sinceLastServiceUnavailable.isValid()
         && _sinceLastServiceUnavailable.durationElapsed() > resetAfter) {

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -716,7 +716,7 @@ void PropagateDownloadFile::startDownload()
         pi._tmpfile = tmpFileName;
         pi._valid = true;
         propagator()->_journal->setDownloadInfo(_item->_file, pi);
-        propagator()->_journal->commit("download file start");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("download file start");
     }
 
     QMap<QByteArray, QByteArray> headers;

--- a/src/libsync/propagatedownload.h
+++ b/src/libsync/propagatedownload.h
@@ -249,6 +249,11 @@ private slots:
 private:
     void startAfterIsEncryptedIsChecked();
     void deleteExistingFolder();
+
+    /// Re-sends the download after a 503 while this file's retry budget lasts.
+    /// @return true if a retry was scheduled and the caller should stop handling the failure.
+    bool retryAfterServiceUnavailable();
+
     [[nodiscard]] bool isEncrypted() const { return _isEncrypted; }
 
     qint64 _resumeStart = 0;
@@ -261,6 +266,13 @@ private:
     ConflictRecord _conflictRecord;
 
     QElapsedTimer _stopwatch;
+
+    /// Attempts spent on 503 replies for this file, and how long since the last one. A 503 is
+    /// the server declining to serve the request right now, not a verdict about the file, so
+    /// the download is re-sent a few times before the item is failed. Attempts decay, so a file
+    /// that hit one earlier in a long sync starts over instead of inheriting a spent budget.
+    int _serviceUnavailableAttempts = 0;
+    QElapsedTimer _sinceLastServiceUnavailable;
 
     PropagateDownloadEncrypted *_downloadEncryptedHelper = nullptr;
 

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -125,7 +125,7 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
         return;
     }
 
-    propagator()->_journal->commit("Remote Remove");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("Remote Remove");
 
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }

--- a/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
+++ b/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
@@ -123,7 +123,7 @@ void PropagateRemoteDeleteEncryptedRootFolder::slotDeleteNestedRemoteItemFinishe
             if (!_propagator->_journal->deleteFileRecord(nestedItem._path, nestedItem._type == ItemTypeDirectory)) {
                 qCWarning(PROPAGATE_REMOVE_ENCRYPTED_ROOTFOLDER) << "Failed to delete file record from local DB" << nestedItem._path;
             }
-            _propagator->_journal->commit("Remote Remove");
+            _propagator->_journal->commitIfNeededAndStartNewTransaction("Remote Remove");
         }
     }
 

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -309,7 +309,7 @@ void PropagateRemoteMove::finalize()
         }
     }
 
-    propagator()->_journal->commit("Remote Rename");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("Remote Rename");
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }
 

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -30,7 +30,10 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QFileInfo>
+#include <QTimer>
 
+#include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 
@@ -700,11 +703,87 @@ void PropagateUploadFileCommon::checkResettingErrors()
     }
 }
 
+bool PropagateUploadFileCommon::retryAfterServiceUnavailable(AbstractNetworkJob *job)
+{
+    // A chunked upload can have sibling chunk jobs still in flight. Restarting the item from
+    // underneath them would leave those writing into an upload this job has already walked
+    // away from, so only the last job standing retries; otherwise the item fails as before.
+    if (_jobs.count() > 1) {
+        qCInfo(lcPropagateUpload) << "server replied 503 for" << _item->_file << "but"
+                                  << _jobs.count() - 1
+                                  << "sibling jobs are still running; not retrying";
+        return false;
+    }
+
+    // Same policy and the same env knobs as the download side, deliberately: a server that is
+    // refusing work refuses it in both directions, and one set of numbers is easier to tune.
+    static const auto maxAttempts = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RETRIES");
+        return qMax(1, configured > 0 ? configured : 3);
+    }();
+    static const auto resetAfter = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RESET_SEC");
+        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 60));
+    }();
+    static const auto backoffStep = [] {
+        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_BACKOFF_SEC");
+        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 5));
+    }();
+
+    if (_sinceLastServiceUnavailable.isValid()
+        && _sinceLastServiceUnavailable.durationElapsed() > resetAfter) {
+        _serviceUnavailableAttempts = 0;
+    }
+    _sinceLastServiceUnavailable.start();
+    ++_serviceUnavailableAttempts;
+
+    if (_serviceUnavailableAttempts >= maxAttempts) {
+        qCWarning(lcPropagateUpload) << "server replied 503 for" << _item->_file
+                                     << _serviceUnavailableAttempts
+                                     << "times in a row; failing the item";
+        _serviceUnavailableAttempts = 0;
+        _sinceLastServiceUnavailable.invalidate();
+        return false;
+    }
+
+    auto delay = backoffStep * _serviceUnavailableAttempts;
+    if (job && job->reply()) {
+        const auto retryAfter = job->reply()->rawHeader(QByteArrayLiteral("Retry-After")).toInt();
+        if (retryAfter > 0) {
+            delay = std::min(std::chrono::seconds(retryAfter), std::chrono::seconds(60));
+        }
+    }
+
+    qCInfo(lcPropagateUpload) << "server replied 503 for" << _item->_file << "(attempt"
+                              << _serviceUnavailableAttempts << "of" << maxAttempts
+                              << "); retrying in" << delay.count() << "s";
+
+    // Deliberately no abort() here. abort() latches _aborting, which never clears, so the
+    // restarted upload would be a no-op. The sub-job that failed has already finished and
+    // takes itself out of _jobs when it is destroyed.
+    QTimer::singleShot(delay, this, [this] {
+        if (propagator()->_abortRequested) {
+            done(SyncFileItem::SoftError, tr("Sync was aborted"), ErrorCategory::GenericError);
+            return;
+        }
+        start();
+    });
+    return true;
+}
+
 void PropagateUploadFileCommon::commonErrorHandling(AbstractNetworkJob *job)
 {
     QByteArray replyContent;
     QString errorString = job->errorStringParsingBody(&replyContent);
     qCWarning(lcPropagateUpload) << replyContent; // display the XML error in the debug
+
+    // A 503 is the server declining to take this upload right now, not a verdict about the
+    // file. Checked before checkResettingErrors() below, so a retried attempt does not spend
+    // the chunked-upload reset budget.
+    if (_item->_httpErrorCode == 503 && !propagator()->_abortRequested
+        && retryAfterServiceUnavailable(job)) {
+        return;
+    }
 
     if (_item->_httpErrorCode == LockFileJob::PRECONDITION_FAILED_ERROR_CODE
         || _item->_httpErrorCode == LockFileJob::LOCKED_HTTP_ERROR_CODE) {

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -126,7 +126,7 @@ bool PollJob::finished()
                 info._file = _item->_file;
                 // no info._url removes it from the database
                 _journal->setPollInfo(info);
-                _journal->commit("remove poll info");
+                _journal->commitIfNeededAndStartNewTransaction("remove poll info");
             }
             emit finishedSignal();
             return true;
@@ -175,7 +175,7 @@ bool PollJob::finished()
     info._file = _item->_file;
     // no info._url removes it from the database
     _journal->setPollInfo(info);
-    _journal->commit("remove poll info");
+    _journal->commitIfNeededAndStartNewTransaction("remove poll info");
 
     emit finishedSignal();
     return true;
@@ -654,7 +654,7 @@ void PropagateUploadFileCommon::startPollJob(const QString &path)
     }
     info._fileSize = _item->_size;
     propagator()->_journal->setPollInfo(info);
-    propagator()->_journal->commit("add poll info");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("add poll info");
     propagator()->_activeJobList.append(this);
     job->start();
 }
@@ -696,7 +696,7 @@ void PropagateUploadFileCommon::checkResettingErrors()
                                       << "is" << uploadInfo._errorCount;
         }
         propagator()->_journal->setUploadInfo(_item->_file, uploadInfo);
-        propagator()->_journal->commit("Upload info");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
     }
 }
 
@@ -866,7 +866,7 @@ void PropagateUploadFileCommon::finalize()
 
     // Remove from the progress database:
     propagator()->_journal->setUploadInfo(_item->_file, SyncJournalDb::UploadInfo());
-    propagator()->_journal->commit("upload file start");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("upload file start");
 
     if (_uploadingEncrypted) {
         Q_ASSERT(_item->isEncrypted());

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -13,6 +13,7 @@
 #include "common/syncjournaldb.h"
 #include "common/syncjournalfilerecord.h"
 #include "common/utility.h"
+#include "configfile.h"
 #include "filesystem.h"
 #include "propagatorjobs.h"
 #include "lockfilejobs.h"
@@ -715,20 +716,11 @@ bool PropagateUploadFileCommon::retryAfterServiceUnavailable(AbstractNetworkJob 
         return false;
     }
 
-    // Same policy and the same env knobs as the download side, deliberately: a server that is
+    // Same policy and the same settings as the download side, deliberately: a server that is
     // refusing work refuses it in both directions, and one set of numbers is easier to tune.
-    static const auto maxAttempts = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RETRIES");
-        return qMax(1, configured > 0 ? configured : 3);
-    }();
-    static const auto resetAfter = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_RESET_SEC");
-        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 60));
-    }();
-    static const auto backoffStep = [] {
-        const auto configured = qEnvironmentVariableIntValue("OWNCLOUD_PROPAGATE_503_BACKOFF_SEC");
-        return std::chrono::seconds(qMax(1, configured > 0 ? configured : 5));
-    }();
+    static const auto maxAttempts = ConfigFile().propagateServiceUnavailableRetries();
+    static const auto resetAfter = ConfigFile().propagateServiceUnavailableResetInterval();
+    static const auto backoffStep = ConfigFile().propagateServiceUnavailableBackoff();
 
     if (_sinceLastServiceUnavailable.isValid()
         && _sinceLastServiceUnavailable.durationElapsed() > resetAfter) {

--- a/src/libsync/propagateupload.h
+++ b/src/libsync/propagateupload.h
@@ -214,6 +214,16 @@ protected:
      */
     bool _aborting BITFIELD(1);
 
+    /// Attempts spent on 503 replies for this upload, and how long since the last one. Same
+    /// policy and env knobs as the download side; see
+    /// PropagateDownloadFile::retryAfterServiceUnavailable().
+    int _serviceUnavailableAttempts = 0;
+    QElapsedTimer _sinceLastServiceUnavailable;
+
+    /// Re-sends the upload after a 503 while this file's retry budget lasts.
+    /// @return true if a retry was scheduled and the caller should stop handling the failure.
+    bool retryAfterServiceUnavailable(AbstractNetworkJob *job);
+
     /* This is a minified version of the SyncFileItem,
      * that holds only the specifics about the file that's
      * being uploaded.

--- a/src/libsync/propagateuploadng.cpp
+++ b/src/libsync/propagateuploadng.cpp
@@ -265,7 +265,7 @@ void PropagateUploadFileNG::startNewUpload()
     pi._contentChecksum = _item->_checksumHeader;
     pi._size = _item->_size;
     propagator()->_journal->setUploadInfo(_item->_file, pi);
-    propagator()->_journal->commit("Upload info");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
     QMap<QByteArray, QByteArray> headers;
 
     // But we should send the temporary (or something) one.
@@ -487,7 +487,7 @@ void PropagateUploadFileNG::slotPutFinished()
         auto uploadInfo = propagator()->_journal->getUploadInfo(_item->_file);
         uploadInfo._errorCount = 0;
         propagator()->_journal->setUploadInfo(_item->_file, uploadInfo);
-        propagator()->_journal->commit("Upload info");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
     }
     startNextChunk();
 }

--- a/src/libsync/propagateuploadv1.cpp
+++ b/src/libsync/propagateuploadv1.cpp
@@ -65,7 +65,7 @@ void PropagateUploadFileV1::doStartUpload()
         pi._contentChecksum = _item->_checksumHeader;
         pi._size = _item->_size;
         propagator()->_journal->setUploadInfo(_item->_file, pi);
-        propagator()->_journal->commit("Upload info");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
     }
 
     _currentChunk = 0;
@@ -314,7 +314,7 @@ void PropagateUploadFileV1::slotPutFinished()
         pi._contentChecksum = _item->_checksumHeader;
         pi._size = _item->_size;
         propagator()->_journal->setUploadInfo(_item->_file, pi);
-        propagator()->_journal->commit("Upload info");
+        propagator()->_journal->commitIfNeededAndStartNewTransaction("Upload info");
         startNextChunk();
         return;
     }

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -185,7 +185,7 @@ void PropagateLocalRemove::start()
         done(SyncFileItem::NormalError, tr("Could not delete file record %1 from local DB").arg(_item->_originalFile), ErrorCategory::GenericError);
         return;
     }
-    propagator()->_journal->commit("Local remove");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("Local remove");
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }
 
@@ -324,7 +324,7 @@ void PropagateLocalMkdir::startLocalMkdir()
         done(SyncFileItem::SoftError, tr("The file %1 is currently in use").arg(newItem._file), ErrorCategory::GenericError);
         return;
     }
-    propagator()->_journal->commit("localMkdir");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("localMkdir");
 
     auto resultStatus = _item->_instruction == CSYNC_INSTRUCTION_CONFLICT
         ? SyncFileItem::Conflict
@@ -569,7 +569,7 @@ void PropagateLocalRename::start()
         return;
     }
 
-    propagator()->_journal->commit("localRename");
+    propagator()->_journal->commitIfNeededAndStartNewTransaction("localRename");
 
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -1072,8 +1072,10 @@ void SyncEngine::finishSync()
         _anotherSyncNeeded = ImmediateFollowUp;
     }
 
-    std::sort(_syncItems.begin(), _syncItems.end());
-    Q_ASSERT(std::is_sorted(_syncItems.begin(), _syncItems.end()));
+    // stable_sort, not sort: operator< orders by destination() only, so two distinct items
+    // sharing a destination compare equivalent. Stability keeps them in discovery order
+    // instead of an arbitrary one, so propagation stays reproducible across runs.
+    std::stable_sort(_syncItems.begin(), _syncItems.end());
 
     qCInfo(lcEngine) << "#### Reconcile (aboutToPropagate) #################################################### " << _stopWatch.addLapTime(QStringLiteral("Reconcile (aboutToPropagate)")) << "ms";
 

--- a/src/libsync/syncengine.cpp
+++ b/src/libsync/syncengine.cpp
@@ -33,6 +33,7 @@
 #include <climits>
 #include <cassert>
 #include <chrono>
+#include <algorithm>
 
 #include <QCoreApplication>
 #include <QSslSocket>
@@ -473,9 +474,8 @@ void OCC::SyncEngine::slotItemDiscovered(const OCC::SyncFileItemPtr &item)
     checkErrorBlacklisting(*item);
     _needsUpdate = true;
 
-    // Insert sorted
-    auto it = std::lower_bound( _syncItems.begin(), _syncItems.end(), item ); // the _syncItems is sorted
-    _syncItems.insert( it, item );
+    // Append unsorted; sorting happens once in finishSync() before propagation.
+    _syncItems.append(item);
 
     slotNewItem(item);
 
@@ -1072,6 +1072,7 @@ void SyncEngine::finishSync()
         _anotherSyncNeeded = ImmediateFollowUp;
     }
 
+    std::sort(_syncItems.begin(), _syncItems.end());
     Q_ASSERT(std::is_sorted(_syncItems.begin(), _syncItems.end()));
 
     qCInfo(lcEngine) << "#### Reconcile (aboutToPropagate) #################################################### " << _stopWatch.addLapTime(QStringLiteral("Reconcile (aboutToPropagate)")) << "ms";

--- a/src/libsync/syncoptions.cpp
+++ b/src/libsync/syncoptions.cpp
@@ -60,6 +60,10 @@ void SyncOptions::fillFromEnvironmentVariables()
     int maxParallel = qgetenv("OWNCLOUD_MAX_PARALLEL").toInt();
     if (maxParallel > 0)
         _parallelNetworkJobs = maxParallel;
+
+    int maxParallelLocalScan = qgetenv("OWNCLOUD_MAX_PARALLEL_LOCAL_SCAN").toInt();
+    if (maxParallelLocalScan > 0)
+        _parallelLocalScanJobs = maxParallelLocalScan;
 }
 
 void SyncOptions::verifyChunkSizes()

--- a/src/libsync/syncoptions.h
+++ b/src/libsync/syncoptions.h
@@ -12,6 +12,7 @@
 #include <QRegularExpression>
 #include <QSharedPointer>
 #include <QString>
+#include <QThread>
 
 #include <chrono>
 
@@ -55,8 +56,15 @@ public:
      */
     std::chrono::milliseconds _targetChunkUploadDuration = std::chrono::minutes(1);
 
-    /** The maximum number of active jobs in parallel  */
+    /** The maximum number of active network (PROPFIND) jobs in parallel.
+     *  This limit protects the server from being overwhelmed. */
     int _parallelNetworkJobs = 6;
+
+    /** The maximum number of concurrent local filesystem directory scans.
+     *  Independent of _parallelNetworkJobs since local I/O and network I/O
+     *  don't contend for the same resource. Defaults to CPU core count bounded
+     *  between 4 and 16 to avoid excessive parallelism on network-backed storage. */
+    int _parallelLocalScanJobs = qBound(4, QThread::idealThreadCount(), 16);
 
     static constexpr auto chunkV2MinChunkSize = 5LL * 1000LL * 1000LL; // 5 MB
     static constexpr auto chunkV2MaxChunkSize = 5LL * 1000LL * 1000LL * 1000LL; // 5 GB

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,6 +95,7 @@ if (NOT WIN32)
     nextcloud_add_test(FolderWatcher)
 endif()
 
+nextcloud_add_test(ConfigFile)
 nextcloud_add_test(Capabilities)
 nextcloud_add_test(PushNotifications)
 nextcloud_add_test(Theme)

--- a/test/testconfigfile.cpp
+++ b/test/testconfigfile.cpp
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * This software is in the public domain, furnished "as is", without technical
+ * support, and with no warranty, express or implied, as to its usefulness for
+ * any purpose.
+ */
+
+#include <QtTest>
+#include <QTemporaryDir>
+
+#include "configfile.h"
+#include "theme.h"
+
+using namespace OCC;
+
+namespace {
+
+/// Writes the given key/value pairs into the config file ConfigFile will read.
+void writeConfig(const QString &confDir, const QVariantMap &values)
+{
+    QSettings settings(confDir + QLatin1Char('/') + Theme::instance()->configFileName(), QSettings::IniFormat);
+    for (auto it = values.cbegin(); it != values.cend(); ++it) {
+        settings.setValue(it.key(), it.value());
+    }
+    settings.sync();
+}
+
+}
+
+/// Covers the resolution of the sync tuning knobs: config file first, environment variable as an
+/// override, documented default when neither says anything usable.
+///
+/// Each accessor reads the config file on every call rather than caching, so a single test process
+/// can rewrite the config between checks. The call sites cache in a function-local static, which is
+/// why the values are read here through ConfigFile directly.
+class TestConfigFile : public QObject
+{
+    Q_OBJECT
+
+    QTemporaryDir _confDir;
+
+private slots:
+    void init()
+    {
+        QVERIFY(_confDir.isValid());
+        ConfigFile::setConfDir(_confDir.path());
+        // Start every case from an empty config file.
+        QFile::remove(_confDir.path() + QLatin1Char('/') + Theme::instance()->configFileName());
+    }
+
+    void cleanup()
+    {
+        qunsetenv("OWNCLOUD_DISCOVERY_TIMEOUT");
+        qunsetenv("OWNCLOUD_DISCOVERY_LISTING_RETRIES");
+        qunsetenv("OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC");
+        qunsetenv("OWNCLOUD_PROPAGATE_503_RETRIES");
+    }
+
+    /// Nothing configured anywhere: every knob reports its documented default.
+    void testDefaults()
+    {
+        ConfigFile cfg;
+        QCOMPARE(cfg.discoveryTimeout(), std::chrono::seconds(60));
+        QCOMPARE(cfg.discoveryListingRetries(), 3);
+        QCOMPARE(cfg.discoveryListingRetryResetInterval(), std::chrono::seconds(300));
+        QCOMPARE(cfg.discoveryListingRetryDelay(), std::chrono::seconds(5));
+        QCOMPARE(cfg.connectionTimeoutRetries(), 3);
+        QCOMPARE(cfg.connectionTimeoutResetInterval(), std::chrono::seconds(300));
+        QCOMPARE(cfg.propagateServiceUnavailableRetries(), 3);
+        QCOMPARE(cfg.propagateServiceUnavailableResetInterval(), std::chrono::seconds(60));
+        QCOMPARE(cfg.propagateServiceUnavailableBackoff(), std::chrono::seconds(5));
+        QCOMPARE(cfg.maxParallelLocalScanJobs(), 0);
+    }
+
+    /// The whole point of the change: a value in the config file is what takes effect.
+    void testReadFromConfigFile()
+    {
+        writeConfig(_confDir.path(),
+            {{QStringLiteral("discoveryTimeout"), 150},
+                {QStringLiteral("discoveryListingRetries"), 5},
+                {QStringLiteral("discoveryListingRetryResetInterval"), 600},
+                {QStringLiteral("discoveryListingRetryDelay"), 7},
+                {QStringLiteral("connectionTimeoutRetries"), 4},
+                {QStringLiteral("connectionTimeoutResetInterval"), 900},
+                {QStringLiteral("propagateServiceUnavailableRetries"), 6},
+                {QStringLiteral("propagateServiceUnavailableResetInterval"), 90},
+                {QStringLiteral("propagateServiceUnavailableBackoff"), 2},
+                {QStringLiteral("maxParallelLocalScanJobs"), 8}});
+
+        ConfigFile cfg;
+        QCOMPARE(cfg.discoveryTimeout(), std::chrono::seconds(150));
+        QCOMPARE(cfg.discoveryListingRetries(), 5);
+        QCOMPARE(cfg.discoveryListingRetryResetInterval(), std::chrono::seconds(600));
+        QCOMPARE(cfg.discoveryListingRetryDelay(), std::chrono::seconds(7));
+        QCOMPARE(cfg.connectionTimeoutRetries(), 4);
+        QCOMPARE(cfg.connectionTimeoutResetInterval(), std::chrono::seconds(900));
+        QCOMPARE(cfg.propagateServiceUnavailableRetries(), 6);
+        QCOMPARE(cfg.propagateServiceUnavailableResetInterval(), std::chrono::seconds(90));
+        QCOMPARE(cfg.propagateServiceUnavailableBackoff(), std::chrono::seconds(2));
+        QCOMPARE(cfg.maxParallelLocalScanJobs(), 8);
+    }
+
+    /// The environment variable still wins, so a single run can be retuned without touching the
+    /// config -- which is what the sync tests rely on to neuter a retry budget.
+    void testEnvironmentOverridesConfigFile()
+    {
+        writeConfig(_confDir.path(),
+            {{QStringLiteral("discoveryTimeout"), 150},
+                {QStringLiteral("propagateServiceUnavailableRetries"), 6}});
+
+        qputenv("OWNCLOUD_DISCOVERY_TIMEOUT", "42");
+        qputenv("OWNCLOUD_PROPAGATE_503_RETRIES", "1");
+
+        ConfigFile cfg;
+        QCOMPARE(cfg.discoveryTimeout(), std::chrono::seconds(42));
+        QCOMPARE(cfg.propagateServiceUnavailableRetries(), 1);
+        // Untouched by the environment, so still the config file's value.
+        QCOMPARE(cfg.discoveryListingRetries(), 3);
+    }
+
+    /// A zero or negative entry means "not configured" rather than "no attempts": a stray 0 in the
+    /// config must not turn a retry budget into an immediate failure.
+    void testNonPositiveValuesFallBackToDefault()
+    {
+        writeConfig(_confDir.path(),
+            {{QStringLiteral("discoveryListingRetries"), 0},
+                {QStringLiteral("propagateServiceUnavailableRetries"), -1},
+                {QStringLiteral("discoveryTimeout"), QStringLiteral("not a number")}});
+
+        ConfigFile cfg;
+        QCOMPARE(cfg.discoveryListingRetries(), 3);
+        QCOMPARE(cfg.propagateServiceUnavailableRetries(), 3);
+        QCOMPARE(cfg.discoveryTimeout(), std::chrono::seconds(60));
+    }
+
+    /// The connection-timeout window has a 60s floor. A check that times out takes as long as its
+    /// own timeout to do so, so consecutive failures are minutes apart by construction and a
+    /// shorter window would reset the count every time, making the tolerance a no-op.
+    void testConnectionTimeoutResetHasFloor()
+    {
+        writeConfig(_confDir.path(), {{QStringLiteral("connectionTimeoutResetInterval"), 5}});
+        QCOMPARE(ConfigFile().connectionTimeoutResetInterval(), std::chrono::seconds(60));
+
+        qputenv("OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC", "5");
+        QCOMPARE(ConfigFile().connectionTimeoutResetInterval(), std::chrono::seconds(60));
+    }
+};
+
+QTEST_APPLESS_MAIN(TestConfigFile)
+#include "testconfigfile.moc"

--- a/test/testsyncengine.cpp
+++ b/test/testsyncengine.cpp
@@ -2564,6 +2564,47 @@ private slots:
         QVERIFY(!fakeFolder.syncEngine().isAnotherSyncNeeded());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    /** A 503 on an upload must be re-sent, not failed.
+     *
+     * The server saying "not right now" says nothing about the file. Failing on the first one
+     * loses the item, and when the 503 body looks like maintenance mode it is classified fatal
+     * and takes the whole sync down with it -- which is how one refused request ended a
+     * two-hour sync in the field.
+     *
+     * The fake server rejects the first PUT and accepts the second, so the file only reaches
+     * the remote if the upload was genuinely retried.
+     */
+    void testUploadRetriesTransientServiceUnavailable()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+
+        // The default is five seconds per attempt; the test needn't sit through that.
+        qputenv("OWNCLOUD_PROPAGATE_503_BACKOFF_SEC", "1");
+
+        auto putAttempts = 0;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op,
+                                          const QNetworkRequest &request,
+                                          QIODevice *) -> QNetworkReply * {
+            if (op == QNetworkAccessManager::PutOperation
+                && request.url().path().endsWith(QLatin1String("/A/transient"))
+                && ++putAttempts == 1) {
+                return new FakeErrorReply(op, request, this, 503,
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    "<d:error xmlns:d=\"DAV:\" xmlns:s=\"http://sabredav.org/ns\">\n"
+                    "<s:exception>Sabre\\DAV\\Exception\\ServiceUnavailable</s:exception>\n"
+                    "<s:message>Storage is temporarily not available</s:message>\n"
+                    "</d:error>");
+            }
+            return nullptr;
+        });
+
+        fakeFolder.localModifier().insert("A/transient");
+
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(putAttempts, 2); // refused once, then accepted
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSyncEngine)

--- a/test/testsyncmove.cpp
+++ b/test/testsyncmove.cpp
@@ -240,6 +240,69 @@ private slots:
         }
     }
 
+    /** The checksum guard on rename detection, both ways round.
+     *
+     * Rename detection matches on inode, and only reaches the checksum once type, size and
+     * mtime already agree and the old path is gone. The checksum is the last thing standing
+     * between "the same file moved" and "a different file that happens to reuse an inode" --
+     * and getting that wrong means MOVEing the wrong file on the server.
+     *
+     * Pinned separately from testLocalMoveDetection() because the computation is a candidate
+     * for being made asynchronous: if the move decision were ever taken before the checksum
+     * came back, the second half of this test is what would catch it.
+     */
+    void testRenameChecksumGuard()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+
+        auto nPUT = 0;
+        auto nDELETE = 0;
+        auto nMOVE = 0;
+        fakeFolder.setServerOverride([&](QNetworkAccessManager::Operation op,
+                                          const QNetworkRequest &request,
+                                          QIODevice *) -> QNetworkReply * {
+            if (op == QNetworkAccessManager::PutOperation) {
+                ++nPUT;
+            }
+            if (op == QNetworkAccessManager::DeleteOperation) {
+                ++nDELETE;
+            }
+            if (request.attribute(QNetworkRequest::CustomVerbAttribute).toString() == QLatin1String("MOVE")) {
+                ++nMOVE;
+            }
+            return nullptr;
+        });
+
+        // Give the file a checksum in the database, so the guard actually runs.
+        fakeFolder.localModifier().insert("A/checked");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nPUT, 1);
+        nPUT = nDELETE = nMOVE = 0;
+
+        // Contents untouched, so the checksum matches: this is a move, and must go over the
+        // wire as a MOVE rather than a re-upload.
+        fakeFolder.localModifier().rename("A/checked", "A/checked_moved");
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nMOVE, 1);
+        QCOMPARE(nPUT, 0);
+        QCOMPARE(nDELETE, 0);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+        nPUT = nDELETE = nMOVE = 0;
+
+        // Now the dangerous one. Rename *and* rewrite the contents, keeping size and mtime
+        // identical so every cheaper guard still says "move". Only the checksum can tell these
+        // apart, so this must come out as upload + delete, never as a MOVE.
+        const auto mtime = fakeFolder.remoteModifier().find("A/checked_moved")->lastModified;
+        fakeFolder.localModifier().rename("A/checked_moved", "A/checked_changed");
+        fakeFolder.localModifier().setContents("A/checked_changed", 'Z');
+        fakeFolder.localModifier().setModTime("A/checked_changed", mtime);
+        QVERIFY(fakeFolder.syncOnce());
+        QCOMPARE(nMOVE, 0);
+        QCOMPARE(nPUT, 1);
+        QCOMPARE(nDELETE, 1);
+        QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
+
     void testLocalMoveDetection()
     {
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };


### PR DESCRIPTION
## Resolves

- Fixes [#6792](https://github.com/nextcloud/desktop/issues/6792) — client hangs on a large
  folder, sync never ends, logs show repeated rapid PROPFIND requests.
- Fixes [#9279](https://github.com/nextcloud/desktop/issues/9279) — client never finishes
  syncing large folders and generates massive logs in a discovery loop.
- Partially addresses [#9275](https://github.com/nextcloud/desktop/issues/9275) — initial-sync
  performance. The algorithmic and request-volume halves are fixed; UI responsiveness during
  discovery is **not** (see "What this does not fix").

## Summary

Two commits, both aimed at accounts large enough that sync never finishes at all.

Found on a ~16k-file photo library with a large number of moved files: discovery ran 30–65
minutes and was then torn down, discarding the whole pass and restarting from zero, so the client
made no lasting progress across an entire day.

---

### Commit 1 — `perf: reduce O(n²) discovery and per-file journal commits`

**O(n²) insert while building `_syncItems`.** Discovery inserted each item into a sorted
`QVector` (O(n) per item). Changed to `append()` (O(1)) with a single sort before propagation.
Nothing mid-discovery depends on the ordering.

**100k–200k SQLite commits per sync.** Every propagated item called `_journal->commit()`, each a
WAL flush. Added time/count batching (2s or 100 writes) and switched ~20 per-item call sites to
`commitIfNeededAndStartNewTransaction()`. Boundary commits at sync start and end remain full
commits.

### Commit 2 — `perf: let large syncs survive a slow or stalling server`

**Rename detection issued one PROPFIND per candidate.** Each candidate created its own
`RequestEtagJob`. Those increment only `_pendingAsyncJobs`, which is a completion test and **not**
a throttle, so 645–6085 requests were in flight against Qt's limit of 6 connections per host. The
account's own health checks (`ConnectionValidator`, `UserInfo`) starved behind that queue and
timed out, `FolderMan` terminated the running sync, and the reconnect immediately rescheduled it —
a livelock that burned minutes per lap and never progressed.

`DiscoveryPhase::lookupRemoteEtag()` now answers every rename check in a directory from a single
`Depth: 1` listing, cached and shared between the candidates waiting on it. Discovery also
reserves 2 of the 6 connections for health checks.

| | Before | After |
|---|---|---|
| Per-file PROPFINDs per pass | 8,870 | **0** |
| Total network jobs, 5.5-min discovery | thousands | **132** |
| Peak concurrent PROPFINDs | 645–6,085 | **4** |

**A single transient failure destroyed the whole pass.**

- `AccountState` tolerates 3 consecutive connection-check timeouts before declaring the account
  down, and the count decays — failures more than 5 minutes apart are unrelated stumbles and
  start over. The window cannot be short: a check that times out takes 60–170s to do so, so
  consecutive failures are minutes apart by construction and a small window would make the count
  unreachable.
- `FolderMan` waits 2 minutes before terminating a sync on a transient connection failure, and
  treats `ServiceUnavailable` as transient alongside `NetworkError`. A one-second 503 was killing
  four-minute discovery passes.
- Directory listings retry 3 times with backoff, but only for errors worth retrying (no HTTP
  status, 408, 429, 5xx). A 404 is the server answering — it is the normal reply when a rename
  check asks about a directory that has since been renamed away.
- Downloads and uploads retry a 503 rather than failing the item, honouring `Retry-After`.

Measured over one night: **32 health-check timeouts absorbed, 16 decay resets, 15,102 items
synced** where previous runs managed none. A pass finally completed discovery (64m51s) and
propagated files; the following pass then pruned 41–47% of directories via unchanged etags,
against 20–26% before — progress compounds instead of being discarded.

## Tests

Both new tests were verified to **fail** when the behaviour they cover is disabled, so they can
actually catch a regression rather than merely passing:

- `TestSyncMove::testRenameChecksumGuard` — pins both branches of the rename checksum guard:
  matching contents produce a MOVE; contents changed at identical size and mtime must not.
  Verified red when the comparison is sabotaged.
- `TestSyncEngine::testUploadRetriesTransientServiceUnavailable` — the server refuses the first
  PUT with 503 and accepts the second. Verified red with `OWNCLOUD_PROPAGATE_503_RETRIES=1`.

Run against this branch rebased on current master: `SyncMoveTest` 36/36, `SyncEngineTest` 62/62
(6 skipped), `ChunkingNgTest` 20/20, `DownloadTest` 6/6 (1 skipped), `FolderManTest` 9/9,
`AllFilesDeletedTest` 12/12, `BlacklistTest` 4/4, `UploadResetTest` 3/3,
`NextcloudPropagatorTest` 6/6, `ConnectionValidatorTest` 3/3, `AccountTest` 22/22.

## Tuning knobs (optional; defaults preserve current behaviour where it was sane)

`OWNCLOUD_DISCOVERY_TIMEOUT` (60s), `OWNCLOUD_DISCOVERY_LISTING_RETRIES` (3),
`OWNCLOUD_DISCOVERY_LISTING_RETRY_RESET_SEC` (300),
`OWNCLOUD_DISCOVERY_LISTING_RETRY_DELAY_SEC` (5), `OWNCLOUD_CONNECTION_TIMEOUT_RETRIES` (3),
`OWNCLOUD_CONNECTION_TIMEOUT_RESET_SEC` (300, floor 60), `OWNCLOUD_PROPAGATE_503_RETRIES` (3),
`OWNCLOUD_PROPAGATE_503_RESET_SEC` (60), `OWNCLOUD_PROPAGATE_503_BACKOFF_SEC` (5).

Happy to convert any of these to hardcoded constants if maintainers prefer fewer env vars.

## What this does not fix

- **UI responsiveness during discovery** (the second half of #9275). Rename detection still
  computes full-file checksums synchronously on the discovery thread — on the affected account,
  16,537 hashes at ~200ms each, most of a 65-minute pass. Moving that to a worker thread was
  implemented and measured **2.5× slower per file** (0.203s → 0.503s) and abandoned: discovery
  reaches the move decision one file at a time so nothing overlaps, and the work is disk-bound
  (~400 GB at ~120 MB/s) regardless. Reducing it needs fewer or cheaper hashes, not a different
  thread.
- **Multi-chunk uploads** do not get the 503 retry — restarting one while sibling chunk jobs are
  in flight would leave them writing into an abandoned upload.
- **A 503 whose body matches Sabre's `ServiceUnavailable`** is still treated as maintenance mode
  and ends the sync. That heuristic matches a translated string and is unreliable (there is
  already a `BUG:` comment on it), but removing it without a `status.php`-based replacement would
  have the client hammer a server that is deliberately down. Retries now sit in front of it.
- **Server-side stalls.** The server this was found against periodically stops answering all
  requests for a user for minutes at a time. Nothing here makes that syncable; it stops the
  client throwing away its work when it happens.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
- [x] Uploaded screenshots from before and after for UI changes. *(n/a — no UI changes)*
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required. *(not required)*
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.
- [x] Confirm maintainers are happy with env-var knobs vs. hardcoded constants. No env variables, config file prefered
## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
- [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
- [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
