### PR TITLE
fix(file-provider): Clean up stale chunked upload chunks

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -198,6 +198,8 @@ public extension FilesDatabaseManager {
         // orphan after upload. Follow-up: defer parent deletion or re-parent after upload.
         for result in results {
             if result.status >= Status.inUpload.rawValue {
+                // Preserve the child metadata and its resumable chunks. Item deletion applies
+                // the same status boundary when deciding which descendant chunks to clean up.
                 logger.info("Skipping deletion of child with pending upload.", [.item: result.ocId])
                 continue
             }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -31,7 +31,7 @@ public final class FilesDatabaseManager: Sendable {
         )
     }
 
-    private static let schemaVersion = SchemaVersion.addedExcludedFromSyncItems
+    private static let schemaVersion = SchemaVersion.addedPendingChunkUploadCleanup
     let logger: FileProviderLogger
     let account: Account
 
@@ -100,7 +100,12 @@ public final class FilesDatabaseManager: Sendable {
                     }
                 }
             },
-            objectTypes: [RealmItemMetadata.self, RealmExcludedFromSyncItem.self, RemoteFileChunk.self]
+            objectTypes: [
+                RealmItemMetadata.self,
+                RealmExcludedFromSyncItem.self,
+                RemoteFileChunk.self,
+                RealmPendingChunkUploadCleanup.self
+            ]
         )
 
         Realm.Configuration.defaultConfiguration = configuration

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmPendingChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmPendingChunkUploadCleanup.swift
@@ -1,0 +1,16 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import RealmSwift
+
+/** @brief Durable record of a chunk upload whose local cleanup must be retried. */
+final class RealmPendingChunkUploadCleanup: Object {
+    /** @brief The chunk-upload identifier used to locate the local chunks. */
+    @Persisted(primaryKey: true) var uploadIdentifier = ""
+
+    /** @brief Creates a cleanup record for the provided chunk-upload identifier. */
+    convenience init(uploadIdentifier: String) {
+        self.init()
+        self.uploadIdentifier = uploadIdentifier
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
@@ -12,4 +12,5 @@ enum SchemaVersion: UInt64 {
     case addedCanonicalPathKeysToRealmItemMetadata = 203
     case addedNormalizedFileNameIndexToRealmItemMetadata = 204
     case addedExcludedFromSyncItems = 205
+    case addedPendingChunkUploadCleanup = 206
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ChunkedUploads.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ChunkedUploads.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Chunked upload lifecycle
+
+## Overview
+
+Chunk handling belongs to the shared upload layer. Item creation and content
+modification both provide a local file, an item identifier, and content dates
+to `upload()`. That function chooses a standard or chunked transfer and owns
+chunk identity, resume bookkeeping, and cleanup. `Item.modify()` handles File
+Provider modification concerns such as changed fields, conflict headers,
+progress, item status, and final metadata; it does not generate or delete
+individual chunks.
+
+Directories are never uploaded in chunks. Directory deletion participates in
+chunk cleanup only because deleting a directory can also delete descendant
+files with interrupted uploads.
+
+## Upload identity
+
+A chunked upload identifier is scoped to the item and the version of its
+contents. When a modification date is available, `chunkUploadIdentifier()`
+derives it from:
+
+- the File Provider item identifier;
+- the local file size; and
+- the modification date, rounded to seconds.
+
+The item identifier forms a prefix shared by all upload attempts for that
+item. Repeating an upload with the same size and modification date produces
+the same identifier and can resume the existing attempt. A changed size or
+modification date produces a different identifier, so chunks from an older
+version are not reused for new contents. The File Provider model is expected
+to provide a changed content modification date when contents change.
+
+If no modification date is available, the upload uses a unique identifier.
+That attempt cannot be resumed by deriving the same identifier later, but it
+also cannot accidentally reuse chunks from different contents.
+
+## Local and persisted state
+
+An interrupted chunked upload has three related forms of local state:
+
+| State | Owner | Purpose |
+| --- | --- | --- |
+| Chunk files | The `RemoteInterface` implementation | The concrete files generated for transfer. |
+| `RemoteFileChunk` rows | The upload layer | The chunks that have not completed, grouped by upload identifier. |
+| `RealmItemMetadata.chunkUploadId` | The item database | Associates an existing file item with its current resumable upload. |
+
+The protocol deliberately does not require callers to know where an adapter
+stores chunk files. The NextcloudKit adapter currently creates a directory
+named with the upload identifier under `FileManager.default.temporaryDirectory`.
+Other adapters can use a different layout.
+
+`RemoteInterface.chunkedUpload()` returns the concrete parent directory it
+used. The upload layer deletes that exact directory after the attempt when it
+is available. Cleanup performed later, when only the persisted identifier is
+known, calls `RemoteInterface.removeLocalChunks()` and lets the adapter resolve
+its own storage layout.
+
+## Transfer and resume
+
+Before a chunked transfer starts, `upload()` performs these steps:
+
+1. Derive the identifier for the current file version.
+2. Find uploads associated with the same item, including legacy bookkeeping
+   found through the per-item identifier prefix.
+3. Delete every matching upload except the current identifier. These are
+   stale attempts for older contents.
+4. Store the current identifier on existing item metadata.
+5. Load only `RemoteFileChunk` rows with the current identifier and pass them
+   to `RemoteInterface.chunkedUpload()` as the remaining chunks.
+
+The adapter reports the complete chunk list when a new transfer starts. The
+upload layer stores those chunks as `RemoteFileChunk` rows. Each completed
+chunk removes its corresponding row. If an attempt with the same identifier
+is retried, the remaining rows are supplied to the adapter so completed chunks
+are not sent again.
+
+For content modification, `modifyContents()` takes an item-metadata snapshot
+before calling `upload()`. A failed upload can update the persisted
+`chunkUploadId` while that call is running. Before the modification error path
+writes its snapshot back, it refreshes `chunkUploadId` from Realm so it does
+not overwrite the resumable identifier with the snapshot's older value.
+
+## Completion and failure
+
+After `RemoteInterface.chunkedUpload()` returns, the upload layer applies the
+following rules:
+
+| Result | Local directory | Chunk rows and metadata association |
+| --- | --- | --- |
+| Successful upload with a returned file | Removed | Removed or cleared. |
+| Failed upload with remaining chunk rows | Preserved for resume | Preserved for resume. |
+| Failed upload with no remaining chunk rows | Removed | Removed or cleared. |
+
+Cleanup uses `defer` in `upload()` so the decision is applied at every return
+from the chunked-transfer path. Bookkeeping is cleared only after local file
+removal succeeds. If directory removal fails, the rows and metadata association
+remain available for a later cleanup attempt.
+
+## Item deletion
+
+An item deletion records the affected file identifiers before deleting their
+metadata. After the remote deletion succeeds, it discards chunk uploads for
+those identifiers. A failed remote deletion preserves the chunks and their
+bookkeeping.
+
+For a file, only that file's identifier is considered. For a recursive
+directory deletion, the extension queries the directory's descendant files
+before their metadata is removed and cleans their uploads after the directory
+deletion succeeds. The directory itself cannot own a chunked upload.
+
+## Startup cleanup
+
+After account authentication and database creation, extension setup runs one
+cleanup pass. It collects upload identifiers from both `RemoteFileChunk` rows
+and item metadata. An upload is retained only when its owning metadata:
+
+- is not marked as deleted;
+- still points to that upload identifier; and
+- has status `inUpload`, `uploading`, or `uploadError`.
+
+The pass therefore removes uploads for deleted or settled items, metadata-less
+uploads, and superseded attempts that are no longer the current identifier.
+As with other cleanup paths, failed local directory removal leaves bookkeeping
+intact so cleanup can be retried.
+
+> Important: Initial item creation does not currently persist item metadata
+> until its upload succeeds. After an extension restart, an interrupted initial
+> create therefore has chunk rows but no metadata proving that it is resumable,
+> so startup cleanup removes it. Supporting resume for this case requires
+> persisting pending-create ownership, or another durable distinction between
+> pending initial creates and abandoned uploads.
+
+## Regression coverage
+
+The File Provider Kit tests cover:
+
+- successful chunk generation and cleanup;
+- retention and resumption after a partial failure;
+- removal of stale chunks when an item's contents produce a new identifier;
+- preservation of a failed modification's current metadata association;
+- cleanup after successful file and recursive directory deletion;
+- startup removal of deleted, settled, metadata-less, and superseded uploads;
+- preservation of resumable uploads during startup cleanup; and
+- retention of bookkeeping when local directory removal fails.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -50,4 +50,5 @@ It is designed specifically for the implementation of this file provider extensi
 ### Design notes
 
 - <doc:ExcludedFromSyncDeletion>
+- <doc:ChunkedUploads>
 - <doc:UnicodePathNormalization>

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -784,7 +784,21 @@ import OSLog
 
         await MainActor.run {
             ncAccount = account
-            dbManager = FilesDatabaseManager(account: account, fileProviderDomainIdentifier: domain.identifier, log: log)
+            let databaseManager = FilesDatabaseManager(
+                account: account,
+                fileProviderDomainIdentifier: domain.identifier,
+                log: log
+            )
+            // TODO: Initial file creation does not persist item metadata until the upload succeeds.
+            // Running cleanup during setup therefore removes its remaining chunks after an extension
+            // restart, before File Provider can resume the create. Persist pending-create metadata,
+            // or otherwise distinguish pending local creations from abandoned uploads, first.
+            cleanupAbandonedChunkUploads(
+                usingRemoteInterface: ncKit,
+                dbManager: databaseManager,
+                logger: logger
+            )
+            dbManager = databaseManager
 
             ncKit.setup(groupIdentifier: Bundle.main.bundleIdentifier!)
             completionHandler?(nil)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -790,9 +790,8 @@ import OSLog
                 log: log
             )
             // TODO: Initial file creation does not persist item metadata until the upload succeeds.
-            // Running cleanup during setup therefore removes its remaining chunks after an extension
-            // restart, before File Provider can resume the create. Persist pending-create metadata,
-            // or otherwise distinguish pending local creations from abandoned uploads, first.
+            // If the extension restarts while that upload is still in progress, startup cleanup
+            // cannot distinguish its chunks from an abandoned upload and may remove them.
             cleanupAbandonedChunkUploads(
                 usingRemoteInterface: ncKit,
                 dbManager: databaseManager,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
@@ -210,6 +210,17 @@ extension NextcloudKit: RemoteInterface {
         }
     }
 
+    public func removeLocalChunks(remoteChunkStoreFolderName: String) throws {
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(remoteChunkStoreFolderName, isDirectory: true)
+
+        do {
+            try FileManager.default.removeItem(at: chunksDirectory)
+        } catch CocoaError.fileNoSuchFile {
+            // Nothing remains to clean up.
+        }
+    }
+
     public func move(
         remotePathSource: String,
         remotePathDestination: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/NextcloudKit+RemoteInterface.swift
@@ -124,11 +124,11 @@ extension NextcloudKit: RemoteInterface {
         taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in },
         progressHandler: @escaping (Progress) -> Void = { _ in },
         chunkUploadCompleteHandler: @escaping (_ fileChunk: RemoteFileChunk) -> Void = { _ in }
-    ) async -> (account: String, file: NKFile?, nkError: NKError) {
+    ) async -> (account: String, file: NKFile?, chunksDirectory: URL?, nkError: NKError) {
         let logger = FileProviderLogger(category: "NextcloudKit+RemoteInterface", log: log)
 
         guard let remotePathComponents = chunkedUploadRemotePathComponents(from: remotePath) else {
-            return ("", nil, .urlError)
+            return ("", nil, nil, .urlError)
         }
         let localUrl = URL(fileURLWithPath: localPath)
 
@@ -143,7 +143,7 @@ extension NextcloudKit: RemoteInterface {
                 Could not create temporary directory for chunked files: \(error)
                 """
             )
-            return ("", nil, .urlError)
+            return ("", nil, nil, .urlError)
         }
 
         var directory = localUrl.deletingLastPathComponent().path
@@ -202,11 +202,11 @@ extension NextcloudKit: RemoteInterface {
                 }
             )
 
-            return (account, file, .success)
+            return (account, file, chunksOutputDirectoryUrl, .success)
         } catch let nkError as NKError {
-            return (account.ncKitAccount, nil, nkError)
+            return (account.ncKitAccount, nil, chunksOutputDirectoryUrl, nkError)
         } catch {
-            return (account.ncKitAccount, nil, NKError.urlError)
+            return (account.ncKitAccount, nil, chunksOutputDirectoryUrl, NKError.urlError)
         }
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -64,6 +64,7 @@ public protocol RemoteInterface: Sendable {
     ) async -> (
         account: String,
         file: NKFile?,
+        chunksDirectory: URL?,
         nkError: NKError
     )
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Interface/RemoteInterface.swift
@@ -68,6 +68,8 @@ public protocol RemoteInterface: Sendable {
         nkError: NKError
     )
 
+    func removeLocalChunks(remoteChunkStoreFolderName: String) throws
+
     func move(
         remotePathSource: String,
         remotePathDestination: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -23,6 +23,19 @@ public extension Item {
             return NSFileProviderError(.directoryNotEmpty)
         }
 
+        let chunkUploadOwnerIdentifiers = chunkUploadItemIdentifiers()
+        var deletionCompleted = false
+        defer {
+            if deletionCompleted {
+                discardChunkUploads(
+                    forItemIdentifiers: chunkUploadOwnerIdentifiers,
+                    usingRemoteInterface: remoteInterface,
+                    dbManager: dbManager,
+                    logger: logger
+                )
+            }
+        }
+
         let ocId = itemIdentifier.rawValue
         let relativePath = (metadata.remotePath()).replacingOccurrences(of: metadata.urlBase, with: "")
 
@@ -41,11 +54,13 @@ public extension Item {
                 return NSFileProviderError(.cannotSynchronize)
             }
 
+            deletionCompleted = true
             return nil
         }
 
         guard ignoredFiles == nil || ignoredFiles?.isExcluded(relativePath) == false else {
             logger.info("File is in the ignore list. Will delete from local database with no remote effect.", [.item: itemIdentifier, .name: filename])
+            deletionCompleted = true
             dbManager.deleteItemMetadata(ocId: ocId)
             return nil
         }
@@ -78,6 +93,7 @@ public extension Item {
                         "Trashbin item no longer present in a fresh trash listing; treating permanent delete as already complete.",
                         [.item: ocId, .name: filename]
                     )
+                    deletionCompleted = true
                     handleMetadataDeletion()
                     return nil
                 case .unresolved:
@@ -111,6 +127,7 @@ public extension Item {
                     "Trashbin item returned 404 on permanent delete; it is already gone, treating as complete.",
                     [.item: ocId, .url: serverFileNameUrl]
                 )
+                deletionCompleted = true
                 handleMetadataDeletion()
                 return nil
             }
@@ -119,6 +136,7 @@ public extension Item {
         }
 
         logger.info("Successfully deleted item.", [.item: ocId, .url: serverFileNameUrl])
+        deletionCompleted = true
 
         guard trashing else {
             handleMetadataDeletion()
@@ -126,6 +144,23 @@ public extension Item {
         }
 
         return handleMetadataTrashModification()
+    }
+
+    private func chunkUploadItemIdentifiers() -> [String] {
+        guard metadata.directory else {
+            return [metadata.ocId]
+        }
+
+        let directoryRemotePath = metadata.remotePath()
+        let itemAccount = metadata.account
+        return dbManager.itemMetadatas
+            .filter {
+                !$0.directory
+                    && $0.account == itemAccount
+                    && ($0.serverUrl == directoryRemotePath
+                        || $0.serverUrl.hasPrefix(directoryRemotePath + "/"))
+            }
+            .map(\.ocId)
     }
 
     @discardableResult

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -5,6 +5,7 @@
 import Foundation
 import NextcloudCapabilitiesKit
 import NextcloudKit
+import RealmSwift
 
 public extension Item {
     /// > Note: The trashing parameter does not affect whether the server will trash this or not.
@@ -154,11 +155,14 @@ public extension Item {
         let directoryRemotePath = metadata.remotePath()
         let itemAccount = metadata.account
         return dbManager.itemMetadatas
-            .filter {
-                !$0.directory
-                    && $0.account == itemAccount
-                    && ($0.serverUrl == directoryRemotePath
-                        || $0.serverUrl.hasPrefix(directoryRemotePath + "/"))
+            .where {
+                $0.directory == false &&
+                    $0.account == itemAccount &&
+                    RealmItemMetadata.hasServerUrl(
+                        $0,
+                        equalTo: directoryRemotePath,
+                        includingDescendants: true
+                    )
             }
             .map(\.ocId)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -24,12 +24,12 @@ public extension Item {
             return NSFileProviderError(.directoryNotEmpty)
         }
 
-        let chunkUploadOwnerIdentifiers = chunkUploadItemIdentifiers()
+        let chunkUploadOwnerIdentifiersToDiscard = chunkUploadItemIdentifiersToDiscard()
         var deletionCompleted = false
         defer {
             if deletionCompleted {
                 discardChunkUploads(
-                    forItemIdentifiers: chunkUploadOwnerIdentifiers,
+                    forItemIdentifiers: chunkUploadOwnerIdentifiersToDiscard,
                     usingRemoteInterface: remoteInterface,
                     dbManager: dbManager,
                     logger: logger
@@ -147,7 +147,7 @@ public extension Item {
         return handleMetadataTrashModification()
     }
 
-    private func chunkUploadItemIdentifiers() -> [String] {
+    private func chunkUploadItemIdentifiersToDiscard() -> [String] {
         guard metadata.directory else {
             return [metadata.ocId]
         }
@@ -158,6 +158,9 @@ public extension Item {
             .where {
                 $0.directory == false &&
                     $0.account == itemAccount &&
+                    // Keep chunks for in-progress or failed uploads that recursive metadata deletion
+                    // deliberately preserves.
+                    $0.status < Status.inUpload.rawValue &&
                     RealmItemMetadata.hasServerUrl(
                         $0,
                         equalTo: directoryRemotePath,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -202,6 +202,12 @@ public extension Item {
             progressHandler: { $0.copyCurrentStateToProgress(progress) }
         )
 
+        // `metadata` is a value snapshot captured before `upload()`. A partial chunked-upload
+        // failure leaves the current resumable upload identifier in Realm, but the error paths
+        // below write this snapshot back. Refresh the identifier so that write does not replace the
+        // current identifier with its pre-upload value. Successful and non-resumable uploads clear it.
+        metadata.chunkUploadId = dbManager.itemMetadata(ocId: ocId)?.chunkUploadId
+
         guard error == .success else {
             logger.error(
                 """
@@ -323,6 +329,7 @@ public extension Item {
         newMetadata.sessionTaskIdentifier = 0
         newMetadata.downloaded = true
         newMetadata.uploaded = true
+        newMetadata.chunkUploadId = nil
 
         dbManager.addItemMetadata(newMetadata)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Modify.swift
@@ -329,7 +329,7 @@ public extension Item {
         newMetadata.sessionTaskIdentifier = 0
         newMetadata.downloaded = true
         newMetadata.uploaded = true
-        newMetadata.chunkUploadId = nil
+        newMetadata.chunkUploadId = metadata.chunkUploadId
 
         dbManager.addItemMetadata(newMetadata)
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -42,9 +42,9 @@ func discardChunkUploads(
             uploadIdentifiers.insert(uploadIdentifier)
         }
 
-        let legacyPrefix = chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
+        let itemPrefix = chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
         let chunkIdentifiers = db.objects(RemoteFileChunk.self)
-            .where { $0.remoteChunkStoreFolderName.starts(with: legacyPrefix) }
+            .where { $0.remoteChunkStoreFolderName.starts(with: itemPrefix) }
             .map(\.remoteChunkStoreFolderName)
         uploadIdentifiers.formUnion(chunkIdentifiers)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -104,18 +104,23 @@ func cleanupAbandonedChunkUploads(
     let chunkIdentifiers = db.objects(RemoteFileChunk.self)
         .map(\.remoteChunkStoreFolderName)
     let metadata = db.objects(RealmItemMetadata.self)
-    let metadataUploadIdentifiers = metadata.compactMap { $0.chunkUploadId }
+    let metadataUploadIdentifiers = metadata
+        .where { $0.chunkUploadId != nil }
+        .compactMap(\.chunkUploadId)
     let knownIdentifiers = Set(chunkIdentifiers).union(
         metadataUploadIdentifiers
     )
-    let resumableStatuses = Set([
-        Status.inUpload.rawValue,
-        Status.uploading.rawValue,
-        Status.uploadError.rawValue
-    ])
-    let resumableIdentifiers = Set(metadata.compactMap {
-        !$0.deleted && resumableStatuses.contains($0.status) ? $0.chunkUploadId : nil
-    })
+    let resumableIdentifiers = Set(
+        metadata
+            .where {
+                $0.chunkUploadId != nil &&
+                    $0.deleted == false &&
+                    ($0.status == Status.inUpload.rawValue ||
+                        $0.status == Status.uploading.rawValue ||
+                        $0.status == Status.uploadError.rawValue)
+            }
+            .compactMap(\.chunkUploadId)
+    )
 
     discardChunkUploads(
         withIdentifiers: knownIdentifiers.subtracting(resumableIdentifiers),

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -69,6 +69,12 @@ func removeLocalChunkUpload(
     dbManager: FilesDatabaseManager,
     logger: FileProviderLogger
 ) {
+    recordPendingChunkUploadCleanup(
+        uploadIdentifier: uploadIdentifier,
+        dbManager: dbManager,
+        logger: logger
+    )
+
     do {
         if let chunksDirectory {
             do {
@@ -107,9 +113,11 @@ func cleanupAbandonedChunkUploads(
     let metadataUploadIdentifiers = metadata
         .where { $0.chunkUploadId != nil }
         .compactMap(\.chunkUploadId)
-    let knownIdentifiers = Set(chunkIdentifiers).union(
-        metadataUploadIdentifiers
-    )
+    let pendingCleanupIdentifiers = db.objects(RealmPendingChunkUploadCleanup.self)
+        .map(\.uploadIdentifier)
+    let knownIdentifiers = Set(chunkIdentifiers)
+        .union(metadataUploadIdentifiers)
+        .union(pendingCleanupIdentifiers)
     let resumableIdentifiers = Set(
         metadata
             .where {
@@ -167,13 +175,38 @@ private func removeChunkUploadBookkeeping(
             .where { $0.remoteChunkStoreFolderName == uploadIdentifier }
         let owners = db.objects(RealmItemMetadata.self)
             .where { $0.chunkUploadId == uploadIdentifier }
+        let pendingCleanup = db.objects(RealmPendingChunkUploadCleanup.self)
+            .where { $0.uploadIdentifier == uploadIdentifier }
         try db.write {
             db.delete(chunks)
+            db.delete(pendingCleanup)
             owners.forEach { $0.chunkUploadId = nil }
         }
     } catch {
         logger.error(
             "Could not clear chunk upload bookkeeping.",
+            [.error: error, .name: uploadIdentifier]
+        )
+    }
+}
+
+private func recordPendingChunkUploadCleanup(
+    uploadIdentifier: String,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    let db = dbManager.ncDatabase()
+
+    do {
+        try db.write {
+            db.add(
+                RealmPendingChunkUploadCleanup(uploadIdentifier: uploadIdentifier),
+                update: .modified
+            )
+        }
+    } catch {
+        logger.error(
+            "Could not record pending chunk upload cleanup.",
             [.error: error, .name: uploadIdentifier]
         )
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -4,6 +4,44 @@
 import Foundation
 import RealmSwift
 
+/// Removes tracked chunk uploads owned by the supplied items, optionally retaining one upload.
+func discardChunkUploads(
+    forItemIdentifiers itemIdentifiers: [String],
+    excluding retainedChunkUploadIdentifier: String? = nil,
+    usingRemoteInterface remoteInterface: RemoteInterface,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    let db = dbManager.ncDatabase()
+    var uploadIdentifiers = Set<String>()
+
+    for itemIdentifier in itemIdentifiers {
+        if let uploadIdentifier = db.object(
+            ofType: RealmItemMetadata.self,
+            forPrimaryKey: itemIdentifier
+        )?.chunkUploadId {
+            uploadIdentifiers.insert(uploadIdentifier)
+        }
+
+        let legacyPrefix = chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
+        let chunkIdentifiers = db.objects(RemoteFileChunk.self)
+            .where { $0.remoteChunkStoreFolderName.starts(with: legacyPrefix) }
+            .map(\.remoteChunkStoreFolderName)
+        uploadIdentifiers.formUnion(chunkIdentifiers)
+    }
+
+    if let retainedChunkUploadIdentifier {
+        uploadIdentifiers.remove(retainedChunkUploadIdentifier)
+    }
+
+    discardChunkUploads(
+        withIdentifiers: uploadIdentifiers,
+        usingRemoteInterface: remoteInterface,
+        dbManager: dbManager,
+        logger: logger
+    )
+}
+
 /// Removes one local chunk upload and its existing bookkeeping.
 func removeLocalChunkUpload(
     uploadIdentifier: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -37,6 +37,37 @@ func removeLocalChunkUpload(
     )
 }
 
+/// Removes tracked uploads that cannot be resumed after extension startup.
+func cleanupAbandonedChunkUploads(
+    usingRemoteInterface remoteInterface: RemoteInterface,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    let db = dbManager.ncDatabase()
+    let chunkIdentifiers = db.objects(RemoteFileChunk.self)
+        .map(\.remoteChunkStoreFolderName)
+    let metadata = db.objects(RealmItemMetadata.self)
+    let metadataUploadIdentifiers = metadata.compactMap { $0.chunkUploadId }
+    let knownIdentifiers = Set(chunkIdentifiers).union(
+        metadataUploadIdentifiers
+    )
+    let resumableStatuses = Set([
+        Status.inUpload.rawValue,
+        Status.uploading.rawValue,
+        Status.uploadError.rawValue
+    ])
+    let resumableIdentifiers = Set(metadata.compactMap {
+        !$0.deleted && resumableStatuses.contains($0.status) ? $0.chunkUploadId : nil
+    })
+
+    discardChunkUploads(
+        withIdentifiers: knownIdentifiers.subtracting(resumableIdentifiers),
+        usingRemoteInterface: remoteInterface,
+        dbManager: dbManager,
+        logger: logger
+    )
+}
+
 private func discardChunkUploads(
     withIdentifiers uploadIdentifiers: Set<String>,
     usingRemoteInterface remoteInterface: RemoteInterface,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -1,0 +1,87 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+import RealmSwift
+
+/// Removes one local chunk upload and its existing bookkeeping.
+func removeLocalChunkUpload(
+    uploadIdentifier: String,
+    chunksDirectory: URL?,
+    usingRemoteInterface remoteInterface: RemoteInterface,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    do {
+        if let chunksDirectory {
+            do {
+                try FileManager.default.removeItem(at: chunksDirectory)
+            } catch CocoaError.fileNoSuchFile {
+                // Nothing remains to clean up.
+            }
+        } else {
+            try remoteInterface.removeLocalChunks(remoteChunkStoreFolderName: uploadIdentifier)
+        }
+    } catch {
+        logger.error(
+            "Could not remove local upload chunks.",
+            [.error: error, .name: uploadIdentifier]
+        )
+        return
+    }
+
+    removeChunkUploadBookkeeping(
+        uploadIdentifier: uploadIdentifier,
+        dbManager: dbManager,
+        logger: logger
+    )
+}
+
+private func discardChunkUploads(
+    withIdentifiers uploadIdentifiers: Set<String>,
+    usingRemoteInterface remoteInterface: RemoteInterface,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    for uploadIdentifier in uploadIdentifiers {
+        do {
+            try remoteInterface.removeLocalChunks(remoteChunkStoreFolderName: uploadIdentifier)
+        } catch {
+            logger.error(
+                "Could not remove abandoned local chunks.",
+                [.error: error, .name: uploadIdentifier]
+            )
+            continue
+        }
+
+        removeChunkUploadBookkeeping(
+            uploadIdentifier: uploadIdentifier,
+            dbManager: dbManager,
+            logger: logger
+        )
+    }
+}
+
+private func removeChunkUploadBookkeeping(
+    uploadIdentifier: String,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    let db = dbManager.ncDatabase()
+
+    do {
+        let chunks = db.objects(RemoteFileChunk.self)
+            .where { $0.remoteChunkStoreFolderName == uploadIdentifier }
+        let owners = db.objects(RealmItemMetadata.self)
+            .where { $0.chunkUploadId == uploadIdentifier }
+        try db.write {
+            db.delete(chunks)
+            owners.forEach { $0.chunkUploadId = nil }
+        }
+    } catch {
+        logger.error(
+            "Could not clear chunk upload bookkeeping.",
+            [.error: error, .name: uploadIdentifier]
+        )
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/ChunkUploadCleanup.swift
@@ -4,6 +4,25 @@
 import Foundation
 import RealmSwift
 
+/// Associates an in-progress chunk upload with existing item metadata.
+func setChunkUploadIdentifier(
+    uploadIdentifier: String,
+    itemIdentifier: String,
+    dbManager: FilesDatabaseManager,
+    logger: FileProviderLogger
+) {
+    let db = dbManager.ncDatabase()
+    guard let metadata = db.object(ofType: RealmItemMetadata.self, forPrimaryKey: itemIdentifier) else {
+        return
+    }
+
+    do {
+        try db.write { metadata.chunkUploadId = uploadIdentifier }
+    } catch {
+        logger.error("Could not associate chunk upload with item metadata.", [.error: error, .item: itemIdentifier])
+    }
+}
+
 /// Removes tracked chunk uploads owned by the supplied items, optionally retaining one upload.
 func discardChunkUploads(
     forItemIdentifiers itemIdentifiers: [String],

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -234,7 +234,22 @@ func upload(
         }
     )
 
-    uploadLogger.info("\(localFilePath) successfully uploaded in chunks")
+    if nkError == .success, file != nil {
+        if let chunksDirectory {
+            do {
+                try FileManager.default.removeItem(at: chunksDirectory)
+            } catch CocoaError.fileNoSuchFile {
+                // The temporary directory may already have been removed by the system.
+            } catch {
+                uploadLogger.error(
+                    "Could not remove temporary chunk directory after completed upload.",
+                    [.error: error, .url: chunksDirectory.path]
+                )
+            }
+        }
+
+        uploadLogger.info("File successfully uploaded in chunks.", [.url: remotePath])
+    }
 
     return (file?.ocId, file?.etag, file?.date, file?.size, nkError)
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -176,7 +176,7 @@ func upload(
         .where { $0.remoteChunkStoreFolderName == chunkUploadId }
         .toUnmanagedResults()
 
-    let (_, file, nkError) = await remoteInterface.chunkedUpload(
+    let (_, file, chunksDirectory, nkError) = await remoteInterface.chunkedUpload(
         localPath: localFilePath,
         remotePath: remotePath,
         remoteChunkStoreFolderName: chunkUploadId,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -10,9 +10,12 @@ import RealmSwift
 let defaultFileChunkSize = 104_857_600 // 100 MiB
 
 /// The per-item prefix shared by every chunked-upload identifier for a given item, so stale chunk
-/// bookkeeping from earlier versions of the same item can be swept.
+/// bookkeeping from earlier versions of the same item can be swept without matching another item.
 func chunkUploadIdentifierPrefix(forItemWithIdentifier itemIdentifier: String) -> String {
-    itemIdentifier.replacingOccurrences(of: "/", with: "") + "_"
+    let encodedIdentifier = Data(itemIdentifier.utf8)
+        .map { String(format: "%02x", $0) }
+        .joined()
+    return encodedIdentifier + "_"
 }
 
 /// Derives a stable, *content-scoped* identifier for a chunked upload's server folder and its local
@@ -21,7 +24,9 @@ func chunkUploadIdentifierPrefix(forItemWithIdentifier itemIdentifier: String) -
 /// The identity is `(item, size, modificationDate)`: the same content re-uploads under the same id,
 /// so an interrupted transfer resumes and reuses the chunks already stored on the server. Any content
 /// change yields a different id, so chunks from a previous version are never spliced into a different
-/// one (see F3). The value is prefixed with the item id so stale sets can be swept by prefix.
+/// one (see F3). The value is prefixed with an unambiguous encoding of the item id so stale sets
+/// can be swept by prefix without collisions between identifiers such as `a` and `a_b`, or `a/b`
+/// and `ab`.
 ///
 /// When no modification date is available the content can't be bound to an id, so a per-attempt unique
 /// id is used: this forgoes resume for that upload but never risks a bad splice. In the File Provider

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Utilities/Upload.swift
@@ -150,25 +150,38 @@ func upload(
         """
     )
 
-    // Content-scoped resume (F3): drop any chunk bookkeeping left over from a *different* version of
-    // this same item — a prior interrupted upload whose content has since changed derives a different
-    // id. Keeping those rows would risk resuming against server-side chunks that belong to the old
-    // content and splicing them into the new file. Rows under the current id (a genuine resume of
-    // identical content) share the id and are preserved.
-    let staleChunkPrefix = chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
-    do {
-        let db = dbManager.ncDatabase()
-        let staleChunks = db.objects(RemoteFileChunk.self).where {
-            $0.remoteChunkStoreFolderName.starts(with: staleChunkPrefix)
-                && $0.remoteChunkStoreFolderName != chunkUploadId
+    var completedChunksDirectory: URL?
+    var shouldRemoveLocalChunkUpload = false
+    defer {
+        if shouldRemoveLocalChunkUpload {
+            removeLocalChunkUpload(
+                uploadIdentifier: chunkUploadId,
+                chunksDirectory: completedChunksDirectory,
+                usingRemoteInterface: remoteInterface,
+                dbManager: dbManager,
+                logger: uploadLogger
+            )
         }
-
-        if !staleChunks.isEmpty {
-            try db.write { db.delete(staleChunks) }
-        }
-    } catch {
-        uploadLogger.error("Could not clear stale chunk bookkeeping for item.", [.error: error])
     }
+
+    // A prior interrupted upload of different content has a different identifier. Remove its local
+    // chunks and bookkeeping, while preserving the current identifier for a genuine resume. If local
+    // removal fails, its rows remain so a later attempt can retry the cleanup; the exact-identifier
+    // query below prevents those stale rows from being used for this upload.
+    discardChunkUploads(
+        forItemIdentifiers: [itemIdentifier],
+        excluding: chunkUploadId,
+        usingRemoteInterface: remoteInterface,
+        dbManager: dbManager,
+        logger: uploadLogger
+    )
+
+    setChunkUploadIdentifier(
+        uploadIdentifier: chunkUploadId,
+        itemIdentifier: itemIdentifier,
+        dbManager: dbManager,
+        logger: uploadLogger
+    )
 
     let remainingChunks = dbManager
         .ncDatabase()
@@ -234,20 +247,16 @@ func upload(
         }
     )
 
-    if nkError == .success, file != nil {
-        if let chunksDirectory {
-            do {
-                try FileManager.default.removeItem(at: chunksDirectory)
-            } catch CocoaError.fileNoSuchFile {
-                // The temporary directory may already have been removed by the system.
-            } catch {
-                uploadLogger.error(
-                    "Could not remove temporary chunk directory after completed upload.",
-                    [.error: error, .url: chunksDirectory.path]
-                )
-            }
-        }
+    completedChunksDirectory = chunksDirectory
+    let chunkUploadCompleted = nkError == .success && file != nil
+    let hasRemainingChunks = !dbManager
+        .ncDatabase()
+        .objects(RemoteFileChunk.self)
+        .where { $0.remoteChunkStoreFolderName == chunkUploadId }
+        .isEmpty
+    shouldRemoveLocalChunkUpload = chunkUploadCompleted || !hasRemainingChunks
 
+    if nkError == .success, file != nil {
         uploadLogger.info("File successfully uploaded in chunks.", [.url: remotePath])
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
@@ -76,6 +76,8 @@ public struct TestableRemoteInterface: RemoteInterface, @unchecked Sendable {
         ("", nil, nil, .invalidResponseError)
     }
 
+    public func removeLocalChunks(remoteChunkStoreFolderName _: String) throws {}
+
     public func move(
         remotePathSource _: String,
         remotePathDestination _: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKitMocks/TestableRemoteInterface.swift
@@ -70,9 +70,10 @@ public struct TestableRemoteInterface: RemoteInterface, @unchecked Sendable {
     ) async -> (
         account: String,
         file: NKFile?,
+        chunksDirectory: URL?,
         nkError: NKError
     ) {
-        ("", nil, .invalidResponseError)
+        ("", nil, nil, .invalidResponseError)
     }
 
     public func move(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -568,6 +568,9 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     public var rootTrashItem: MockRemoteItem?
     public var currentChunks: [String: [RemoteFileChunk]] = [:]
     public var completedChunkTransferSize: [String: Int64] = [:]
+
+    /// Overrides the directory where chunked uploads create their local chunk files.
+    public var chunkUploadDirectory: URL?
     public var pagination: Bool
     public var expectedEnumerationPaginationTokens: [String: String] = [:]
     public var forceNextPageOnLastContentPage: Bool = false
@@ -883,13 +886,15 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
             return ("", nil, nil, .urlError)
         }
 
-        // Create temp directory for file and create chunks within it
+        // Create the local chunk directory used by the production adapter and populate it below.
         let fm = FileManager.default
-        let tempDirectoryUrl = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let tempDirectoryUrl = chunkUploadDirectory ?? fm.temporaryDirectory
+            .appendingPathComponent(remoteChunkStoreFolderName, isDirectory: true)
         try! fm.createDirectory(atPath: tempDirectoryUrl.path, withIntermediateDirectories: true)
 
         // Access local file and gather metadata
-        let fileSize = try! fm.attributesOfItem(atPath: localPath)[.size] as! Int
+        let localFileData = try! Data(contentsOf: URL(fileURLWithPath: localPath))
+        let fileSize = localFileData.count
 
         var remainingFileSize = fileSize
         let numChunks = Int(ceil(Double(fileSize) / Double(chunkSize)))
@@ -906,6 +911,18 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         let preexistingChunks = currentChunks[remoteChunkStoreFolderName] ?? []
         let totalChunks = preexistingChunks + newChunks
         currentChunks[remoteChunkStoreFolderName] = totalChunks
+
+        for chunk in newChunks {
+            guard let chunkNumber = Int(chunk.fileName), chunkNumber > 0 else { continue }
+
+            let startIndex = (chunkNumber - 1) * chunkSize
+            let endIndex = min(startIndex + Int(chunk.size), localFileData.count)
+            guard startIndex < endIndex else { continue }
+
+            let chunkData = localFileData.subdata(in: startIndex ..< endIndex)
+            try! chunkData.write(to: tempDirectoryUrl.appendingPathComponent(chunk.fileName))
+        }
+
         chunkUploadStartHandler(newChunks)
 
         let (_, ocId, etag, date, size, _, remoteError) = await upload(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -569,8 +569,17 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     public var currentChunks: [String: [RemoteFileChunk]] = [:]
     public var completedChunkTransferSize: [String: Int64] = [:]
 
+    /// Limits completion callbacks to simulate an interrupted chunk upload.
+    public var chunkUploadCompletedChunkCount: Int?
+
     /// Overrides the directory where chunked uploads create their local chunk files.
     public var chunkUploadDirectory: URL?
+
+    /// Maps chunk upload identifiers to the directories used for their local chunk files.
+    public var chunkUploadDirectories: [String: URL] = [:]
+
+    /// When set, local chunk removal fails with this error.
+    public var removeLocalChunksError: (any Error)?
     public var pagination: Bool
     public var expectedEnumerationPaginationTokens: [String: String] = [:]
     public var forceNextPageOnLastContentPage: Bool = false
@@ -890,6 +899,7 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         let fm = FileManager.default
         let tempDirectoryUrl = chunkUploadDirectory ?? fm.temporaryDirectory
             .appendingPathComponent(remoteChunkStoreFolderName, isDirectory: true)
+        chunkUploadDirectories[remoteChunkStoreFolderName] = tempDirectoryUrl
         try! fm.createDirectory(atPath: tempDirectoryUrl.path, withIntermediateDirectories: true)
 
         // Access local file and gather metadata
@@ -936,7 +946,10 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
             taskHandler: taskHandler,
             progressHandler: progressHandler
         )
-        newChunks.forEach { chunkUploadCompleteHandler($0) }
+        let completedChunks = chunkUploadCompletedChunkCount.map {
+            newChunks.prefix($0)
+        } ?? newChunks[...]
+        completedChunks.forEach { chunkUploadCompleteHandler($0) }
         print(remainingChunks)
         completedChunkTransferSize[remoteChunkStoreFolderName] =
             remainingChunks.reduce(0) { $0 + $1.size }
@@ -959,7 +972,13 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     }
 
     public func removeLocalChunks(remoteChunkStoreFolderName: String) throws {
-        let chunksDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+        if let removeLocalChunksError {
+            throw removeLocalChunksError
+        }
+
+        let chunksDirectory = chunkUploadDirectories.removeValue(
+            forKey: remoteChunkStoreFolderName
+        ) ?? FileManager.default.temporaryDirectory.appendingPathComponent(
             remoteChunkStoreFolderName,
             isDirectory: true
         )

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -578,6 +578,9 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// Maps chunk upload identifiers to the directories used for their local chunk files.
     public var chunkUploadDirectories: [String: URL] = [:]
 
+    /// When `false`, chunked uploads return no directory so cleanup uses `removeLocalChunks`.
+    public var returnsChunkUploadDirectory = true
+
     /// When set, local chunk removal fails with this error.
     public var removeLocalChunksError: (any Error)?
     public var pagination: Bool
@@ -968,7 +971,12 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         file.creationDate = creationDate ?? Date()
         file.date = date as? Date ?? Date()
 
-        return (account.ncKitAccount, file, tempDirectoryUrl, remoteError)
+        return (
+            account.ncKitAccount,
+            file,
+            returnsChunkUploadDirectory ? tempDirectoryUrl : nil,
+            remoteError
+        )
     }
 
     public func removeLocalChunks(remoteChunkStoreFolderName: String) throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -958,6 +958,19 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         return (account.ncKitAccount, file, tempDirectoryUrl, remoteError)
     }
 
+    public func removeLocalChunks(remoteChunkStoreFolderName: String) throws {
+        let chunksDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            remoteChunkStoreFolderName,
+            isDirectory: true
+        )
+
+        do {
+            try FileManager.default.removeItem(at: chunksDirectory)
+        } catch CocoaError.fileNoSuchFile {
+            // Nothing remains to clean up.
+        }
+    }
+
     public func move(
         remotePathSource: String,
         remotePathDestination: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -875,11 +875,12 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     ) async -> (
         account: String,
         file: NKFile?,
+        chunksDirectory: URL?,
         nkError: NKError
     ) {
         guard let remoteUrl = URL(string: remotePath) else {
             print("Invalid remote path!")
-            return ("", nil, .urlError)
+            return ("", nil, nil, .urlError)
         }
 
         // Create temp directory for file and create chunks within it
@@ -937,7 +938,7 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         file.creationDate = creationDate ?? Date()
         file.date = date as? Date ?? Date()
 
-        return (account.ncKitAccount, file, remoteError)
+        return (account.ncKitAccount, file, tempDirectoryUrl, remoteError)
     }
 
     public func move(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/InterfaceTests/MockRemoteInterfaceTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/InterfaceTests/MockRemoteInterfaceTests.swift
@@ -201,17 +201,23 @@ final class MockRemoteInterfaceTests: XCTestCase {
             FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let data = Data(repeating: 1, count: 8)
         try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
 
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: MockRemoteItem.rootItem(account: Self.account))
         debugPrint(remoteInterface)
 
         let remotePath = Self.account.davFilesUrl + "/file.txt"
         let chunkSize = 3
+        let uploadId = UUID().uuidString
+        let chunkDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(uploadId, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: chunkDirectory) }
+
         var uploadedChunks = [RemoteFileChunk]()
         let result = await remoteInterface.chunkedUpload(
             localPath: fileUrl.path,
             remotePath: remotePath,
-            remoteChunkStoreFolderName: UUID().uuidString,
+            remoteChunkStoreFolderName: uploadId,
             chunkSize: chunkSize,
             remainingChunks: [],
             creationDate: .init(),
@@ -227,6 +233,7 @@ final class MockRemoteInterfaceTests: XCTestCase {
         XCTAssertEqual(result.nkError, .success)
         XCTAssertNotNil(result.file)
         XCTAssertEqual(result.file?.size, Int64(data.count))
+        XCTAssertEqual(result.chunksDirectory, chunkDirectory)
 
         let firstUploadedChunk = try XCTUnwrap(uploadedChunks.first)
         let firstUploadedChunkNameInt = try XCTUnwrap(Int(firstUploadedChunk.fileName))
@@ -238,6 +245,14 @@ final class MockRemoteInterfaceTests: XCTestCase {
         XCTAssertEqual(
             Int(lastUploadedChunk.size), data.count - ((lastUploadedChunkNameInt - 1) * chunkSize)
         )
+
+        let storedChunkNames = try FileManager.default.contentsOfDirectory(atPath: chunkDirectory.path).sorted()
+        XCTAssertEqual(storedChunkNames, ["1", "2", "3"])
+        XCTAssertEqual(try Data(contentsOf: chunkDirectory.appendingPathComponent("1")).count, chunkSize)
+        XCTAssertEqual(
+            try Data(contentsOf: chunkDirectory.appendingPathComponent("3")).count,
+            data.count - (chunkSize * 2)
+        )
     }
 
     func testResumedChunkedUpload() async throws {
@@ -245,9 +260,14 @@ final class MockRemoteInterfaceTests: XCTestCase {
             FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let data = Data(repeating: 1, count: 8)
         try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
 
         let chunkSize = 3
         let uploadUuid = UUID().uuidString
+        let chunkDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(uploadUuid, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: chunkDirectory) }
+
         let previousUploadedChunkNum = 1
         let previousUploadedChunk = RemoteFileChunk(
             fileName: String(previousUploadedChunkNum),
@@ -292,6 +312,7 @@ final class MockRemoteInterfaceTests: XCTestCase {
         XCTAssertEqual(result.nkError, .success)
         XCTAssertNotNil(result.file)
         XCTAssertEqual(result.file?.size, Int64(data.count))
+        XCTAssertEqual(result.chunksDirectory, chunkDirectory)
 
         let firstUploadedChunk = try XCTUnwrap(uploadedChunks.first)
         let firstUploadedChunkNameInt = try XCTUnwrap(Int(firstUploadedChunk.fileName))
@@ -304,6 +325,9 @@ final class MockRemoteInterfaceTests: XCTestCase {
         XCTAssertEqual(
             Int(lastUploadedChunk.size), data.count - ((lastUploadedChunkNameInt - 1) * chunkSize)
         )
+
+        let storedChunkNames = try FileManager.default.contentsOfDirectory(atPath: chunkDirectory.path).sorted()
+        XCTAssertEqual(storedChunkNames, ["2", "3"])
     }
 
     func testMove() async {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
@@ -124,6 +124,27 @@ final class ChunkUploadCleanupTests: NextcloudFileProviderKitTestCase {
         assertUploadRemoved(seeded)
     }
 
+    func testStartupCleanupShouldPreserveInProgressInitialCreateWithoutMetadata() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "in-progress-initial-create",
+            metadataStatus: nil
+        )
+        XCTAssertNil(dbManager.itemMetadata(ocId: seeded.itemIdentifier))
+
+        // TODO: This expected failure tracks the startup-cleanup TODO in
+        // FileProviderExtension.swift: initial creates need durable state so their chunks can be
+        // distinguished from abandoned uploads after an extension restart.
+        XCTExpectFailure("Initial creates need durable metadata before startup cleanup can preserve them.") {
+            cleanupAbandonedChunkUploads(
+                usingRemoteInterface: remoteInterface,
+                dbManager: dbManager,
+                logger: makeLogger()
+            )
+
+            XCTAssertTrue(FileManager.default.fileExists(atPath: seeded.directory.path))
+        }
+    }
+
     func testStartupCleanupUsesMetadataIdentifierWhenNoChunkRowsRemain() throws {
         let seeded = try seedChunkUpload(
             itemIdentifier: "completed-chunks-item",

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
@@ -1,0 +1,254 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+import TestInterface
+import XCTest
+
+final class ChunkUploadCleanupTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser",
+        id: "testUserId",
+        serverUrl: "https://mock.nc.com",
+        password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+    private var remoteInterface: MockRemoteInterface!
+    private var temporaryChunkDirectories: [URL] = []
+
+    private func assertChunkCount(
+        for uploadIdentifier: String,
+        equals expectedCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let count = dbManager.ncDatabase().objects(RemoteFileChunk.self)
+            .where { $0.remoteChunkStoreFolderName == uploadIdentifier }
+            .count
+        XCTAssertEqual(count, expectedCount, file: file, line: line)
+    }
+
+    private func makeLogger() -> FileProviderLogger {
+        FileProviderLogger(category: "ChunkUploadCleanupTests", log: FileProviderLogMock())
+    }
+
+    override func setUp() {
+        super.setUp()
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier(name),
+            log: FileProviderLogMock()
+        )
+        remoteInterface = MockRemoteInterface(
+            account: Self.account,
+            rootItem: MockRemoteItem.rootItem(account: Self.account)
+        )
+    }
+
+    override func tearDown() {
+        for directory in temporaryChunkDirectories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryChunkDirectories.removeAll()
+        super.tearDown()
+    }
+
+    func testStartupCleanupRemovesDeletedItemUpload() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "deleted-item",
+            metadataStatus: .uploadError,
+            metadataDeleted: true
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        assertUploadRemoved(seeded)
+    }
+
+    func testStartupCleanupPreservesResumableUpload() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "uploading-item",
+            metadataStatus: .uploading
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: seeded.directory.path))
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: seeded.itemIdentifier)?.chunkUploadId,
+            seeded.uploadIdentifier
+        )
+        assertChunkCount(for: seeded.uploadIdentifier, equals: 1)
+    }
+
+    func testStartupCleanupRemovesUploadForItemInNormalState() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "completed-item",
+            metadataStatus: .normal
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        assertUploadRemoved(seeded)
+    }
+
+    func testStartupCleanupRemovesUploadWithoutMetadata() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "abandoned-new-item",
+            metadataStatus: nil
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        assertUploadRemoved(seeded)
+    }
+
+    func testStartupCleanupUsesMetadataIdentifierWhenNoChunkRowsRemain() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "completed-chunks-item",
+            metadataStatus: .normal,
+            includeChunkRow: false
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        assertUploadRemoved(seeded)
+    }
+
+    func testStartupCleanupRemovesSupersededUploadAndPreservesCurrentUpload() throws {
+        let stale = try seedChunkUpload(
+            uploadIdentifier: "superseded-upload",
+            itemIdentifier: "uploading-item",
+            metadataStatus: .uploading,
+            associateWithMetadata: false
+        )
+        let current = try seedChunkUpload(
+            uploadIdentifier: "current-upload",
+            itemIdentifier: "uploading-item",
+            metadataStatus: .uploading
+        )
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        assertUploadRemoved(stale)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: current.directory.path))
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: current.itemIdentifier)?.chunkUploadId,
+            current.uploadIdentifier
+        )
+        assertChunkCount(for: current.uploadIdentifier, equals: 1)
+    }
+
+    func testStartupCleanupRetainsBookkeepingWhenLocalRemovalFails() throws {
+        let seeded = try seedChunkUpload(
+            itemIdentifier: "deleted-item",
+            metadataStatus: .uploadError,
+            metadataDeleted: true
+        )
+        remoteInterface.removeLocalChunksError = CocoaError(.fileWriteNoPermission)
+
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: seeded.directory.path))
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: seeded.itemIdentifier)?.chunkUploadId,
+            seeded.uploadIdentifier
+        )
+        assertChunkCount(for: seeded.uploadIdentifier, equals: 1)
+    }
+
+    private func seedChunkUpload(
+        uploadIdentifier requestedUploadIdentifier: String? = nil,
+        itemIdentifier: String,
+        metadataStatus: Status?,
+        metadataDeleted: Bool = false,
+        associateWithMetadata: Bool = true,
+        includeChunkRow: Bool = true
+    ) throws -> (uploadIdentifier: String, itemIdentifier: String, directory: URL) {
+        let uploadIdentifier = requestedUploadIdentifier ?? "\(itemIdentifier)-upload"
+
+        if let metadataStatus {
+            var metadata = SendableItemMetadata(
+                ocId: itemIdentifier,
+                fileName: "file.txt",
+                account: Self.account
+            )
+            metadata.status = metadataStatus.rawValue
+            metadata.deleted = metadataDeleted
+            metadata.chunkUploadId = associateWithMetadata ? uploadIdentifier : nil
+            dbManager.addItemMetadata(metadata)
+        }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chunk-cleanup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        temporaryChunkDirectories.append(directory)
+        try Data([1]).write(to: directory.appendingPathComponent("1"))
+        remoteInterface.chunkUploadDirectories[uploadIdentifier] = directory
+
+        if includeChunkRow {
+            let db = dbManager.ncDatabase()
+            try db.write {
+                db.add(RemoteFileChunk(
+                    fileName: "1",
+                    size: 1,
+                    remoteChunkStoreFolderName: uploadIdentifier
+                ))
+            }
+        }
+
+        return (uploadIdentifier, itemIdentifier, directory)
+    }
+
+    private func assertUploadRemoved(
+        _ seeded: (uploadIdentifier: String, itemIdentifier: String, directory: URL),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: seeded.directory.path),
+            file: file,
+            line: line
+        )
+        XCTAssertNotEqual(
+            dbManager.itemMetadata(ocId: seeded.itemIdentifier)?.chunkUploadId,
+            seeded.uploadIdentifier,
+            file: file,
+            line: line
+        )
+        assertChunkCount(for: seeded.uploadIdentifier, equals: 0, file: file, line: line)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
@@ -190,6 +190,43 @@ final class ChunkUploadCleanupTests: NextcloudFileProviderKitTestCase {
         assertChunkCount(for: seeded.uploadIdentifier, equals: 1)
     }
 
+    func testDiscardChunkUploadsDoesNotMatchSimilarItemIdentifiers() throws {
+        for (itemIdentifier, similarItemIdentifier) in [("a", "a_b"), ("a/b", "ab")] {
+            let itemUploadIdentifier = chunkUploadIdentifier(
+                forItemWithIdentifier: itemIdentifier,
+                fileSize: 1,
+                modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+            let similarItemUploadIdentifier = chunkUploadIdentifier(
+                forItemWithIdentifier: similarItemIdentifier,
+                fileSize: 1,
+                modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+            let itemUpload = try seedChunkUpload(
+                uploadIdentifier: itemUploadIdentifier,
+                itemIdentifier: itemIdentifier,
+                metadataStatus: .normal
+            )
+            let similarItemUpload = try seedChunkUpload(
+                uploadIdentifier: similarItemUploadIdentifier,
+                itemIdentifier: similarItemIdentifier,
+                metadataStatus: .normal
+            )
+
+            discardChunkUploads(
+                forItemIdentifiers: [itemIdentifier],
+                usingRemoteInterface: remoteInterface,
+                dbManager: dbManager,
+                logger: makeLogger()
+            )
+
+            XCTAssertFalse(FileManager.default.fileExists(atPath: itemUpload.directory.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: similarItemUpload.directory.path))
+            assertChunkCount(for: itemUploadIdentifier, equals: 0)
+            assertChunkCount(for: similarItemUploadIdentifier, equals: 1)
+        }
+    }
+
     private func seedChunkUpload(
         uploadIdentifier requestedUploadIdentifier: String? = nil,
         itemIdentifier: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChunkUploadCleanupTests.swift
@@ -190,6 +190,48 @@ final class ChunkUploadCleanupTests: NextcloudFileProviderKitTestCase {
         assertChunkCount(for: seeded.uploadIdentifier, equals: 1)
     }
 
+    func testCompletedUploadCleanupIsRetriedFromDurableRecord() throws {
+        let uploadIdentifier = "completed-upload-with-failed-cleanup"
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pending-cleanup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        temporaryChunkDirectories.append(directory)
+        try Data([1]).write(to: directory.appendingPathComponent("1"))
+        remoteInterface.chunkUploadDirectories[uploadIdentifier] = directory
+        remoteInterface.removeLocalChunksError = CocoaError(.fileWriteNoPermission)
+
+        removeLocalChunkUpload(
+            uploadIdentifier: uploadIdentifier,
+            chunksDirectory: nil,
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertEqual(
+            dbManager.ncDatabase().objects(RealmPendingChunkUploadCleanup.self)
+                .where { $0.uploadIdentifier == uploadIdentifier }
+                .count,
+            1
+        )
+
+        remoteInterface.removeLocalChunksError = nil
+        cleanupAbandonedChunkUploads(
+            usingRemoteInterface: remoteInterface,
+            dbManager: dbManager,
+            logger: makeLogger()
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        XCTAssertEqual(
+            dbManager.ncDatabase().objects(RealmPendingChunkUploadCleanup.self)
+                .where { $0.uploadIdentifier == uploadIdentifier }
+                .count,
+            0
+        )
+    }
+
     func testDiscardChunkUploadsDoesNotMatchSimilarItemIdentifiers() throws {
         for (itemIdentifier, similarItemIdentifier) in [("a", "a_b"), ("a/b", "ab")] {
             let itemUploadIdentifier = chunkUploadIdentifier(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemCreateTests.swift
@@ -650,8 +650,8 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
 
     func testCreateFileChunkedResumed() async throws {
         let chunkSize = 2
-        let expectedChunkUploadIdBase = UUID().uuidString // Check that illegal characters are stripped.
-        let illegalChunkUploadId = expectedChunkUploadIdBase + "/" // Check that illegal characters are stripped.
+        let expectedChunkUploadIdBase = UUID().uuidString
+        let illegalChunkUploadId = expectedChunkUploadIdBase + "/" // Check that path separators are encoded safely.
 
         let tempUrl = FileManager.default.temporaryDirectory.appendingPathComponent("file")
         let tempData = Data(repeating: 1, count: chunkSize * 3)
@@ -667,7 +667,11 @@ final class ItemCreateTests: NextcloudFileProviderKitTestCase {
             fileSize: Int64(tempData.count),
             modificationDate: modificationDate
         )
-        XCTAssertTrue(chunkUploadId.hasPrefix(expectedChunkUploadIdBase + "_"))
+        XCTAssertTrue(
+            chunkUploadId.hasPrefix(
+                chunkUploadIdentifierPrefix(forItemWithIdentifier: illegalChunkUploadId)
+            )
+        )
         XCTAssertFalse(chunkUploadId.contains("/"))
 
         let previousUploadedChunkNum = 1

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -332,6 +332,94 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    func testDeleteFolderPreservesPendingDescendantChunkUpload() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
+        let remoteFolder = MockRemoteItem(
+            identifier: "folder-with-pending-upload",
+            name: "folder",
+            remotePath: Self.account.davFilesUrl + "/folder",
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        let itemIdentifier = "pending-descendant"
+        let remoteItem = MockRemoteItem(
+            identifier: itemIdentifier,
+            name: "pending.txt",
+            remotePath: Self.account.davFilesUrl + "/folder/pending.txt",
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        rootItem.children = [remoteFolder]
+        remoteFolder.parent = rootItem
+        remoteFolder.children = [remoteItem]
+        remoteItem.parent = remoteFolder
+
+        let folderMetadata = remoteFolder.toItemMetadata(account: Self.account)
+        var itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        itemMetadata.status = Status.uploading.rawValue
+        Self.dbManager.addItemMetadata(folderMetadata)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let chunkUploadId = chunkUploadIdentifier(
+            forItemWithIdentifier: remoteItem.identifier,
+            fileSize: 8,
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        setChunkUploadIdentifier(
+            uploadIdentifier: chunkUploadId,
+            itemIdentifier: remoteItem.identifier,
+            dbManager: Self.dbManager,
+            logger: FileProviderLogger(category: "ItemDeleteTests", log: FileProviderLogMock())
+        )
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.status, Status.uploading.rawValue)
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.chunkUploadId, chunkUploadId)
+
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preserved-descendant-chunks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
+        try Data([1]).write(to: chunksDirectory.appendingPathComponent("2"))
+        remoteInterface.chunkUploadDirectories[chunkUploadId] = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let db = Self.dbManager.ncDatabase()
+        try db.write {
+            db.add(RemoteFileChunk(
+                fileName: "2",
+                size: 3,
+                remoteChunkStoreFolderName: chunkUploadId
+            ))
+        }
+
+        let folder = Item(
+            metadata: folderMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await folder.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(error)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: chunksDirectory.path))
+        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.status, Status.uploading.rawValue)
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: itemIdentifier)?.chunkUploadId,
+            chunkUploadId
+        )
+        XCTAssertEqual(
+            db.objects(RemoteFileChunk.self)
+                .where { $0.remoteChunkStoreFolderName == chunkUploadId }
+                .count,
+            1
+        )
+    }
+
     func testDeleteWithTrashing() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let itemIdentifier = "file"

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -64,6 +64,69 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.deleted, true)
     }
 
+    func testDeleteFileDiscardsIncompleteChunkUpload() async throws {
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account,
+            rootItem: rootItem,
+            rootTrashItem: rootTrashItem
+        )
+        let itemIdentifier = "file-with-incomplete-upload"
+        let remoteItem = MockRemoteItem(
+            identifier: itemIdentifier,
+            name: "file.txt",
+            remotePath: Self.account.davFilesUrl + "/file.txt",
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        remoteItem.parent = rootItem
+        rootItem.children = [remoteItem]
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let chunkUploadId = chunkUploadIdentifier(
+            forItemWithIdentifier: itemIdentifier,
+            fileSize: 8,
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deleted-item-chunks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
+        try Data([1]).write(to: chunksDirectory.appendingPathComponent("2"))
+        remoteInterface.chunkUploadDirectories[chunkUploadId] = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let db = Self.dbManager.ncDatabase()
+        try db.write {
+            db.add(RemoteFileChunk(
+                fileName: "2",
+                size: 3,
+                remoteChunkStoreFolderName: chunkUploadId
+            ))
+        }
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await item.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(error)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: chunksDirectory.path))
+        XCTAssertEqual(
+            db.objects(RemoteFileChunk.self)
+                .where { $0.remoteChunkStoreFolderName == chunkUploadId }
+                .count,
+            0
+        )
+    }
+
     func testDeleteUnexcludedBundlePropagatesToServer() async {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let remoteBundle = MockRemoteItem(
@@ -134,7 +197,62 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         XCTAssertFalse(Self.dbManager.isItemExcludedFromSync(ocId: metadata.ocId))
     }
 
-    func testDeleteFolderAndContents() async {
+    func testFailedDeleteKeepsIncompleteChunkUpload() async throws {
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account,
+            rootItem: rootItem,
+            rootTrashItem: rootTrashItem
+        )
+        let itemIdentifier = "file-with-failed-delete"
+        let itemMetadata = SendableItemMetadata(
+            ocId: itemIdentifier,
+            fileName: "missing.txt",
+            account: Self.account
+        )
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let chunkUploadId = chunkUploadIdentifier(
+            forItemWithIdentifier: itemIdentifier,
+            fileSize: 8,
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failed-delete-chunks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
+        try Data([1]).write(to: chunksDirectory.appendingPathComponent("2"))
+        remoteInterface.chunkUploadDirectories[chunkUploadId] = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let db = Self.dbManager.ncDatabase()
+        try db.write {
+            db.add(RemoteFileChunk(
+                fileName: "2",
+                size: 3,
+                remoteChunkStoreFolderName: chunkUploadId
+            ))
+        }
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let error = await item.delete(dbManager: Self.dbManager)
+
+        XCTAssertNotNil(error)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: chunksDirectory.path))
+        XCTAssertEqual(
+            db.objects(RemoteFileChunk.self)
+                .where { $0.remoteChunkStoreFolderName == chunkUploadId }
+                .count,
+            1
+        )
+    }
+
+    func testDeleteFolderAndContents() async throws {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let remoteFolder = MockRemoteItem(
             identifier: "folder",
@@ -170,6 +288,27 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
         XCTAssertNotNil(Self.dbManager.itemMetadata(ocId: remoteItem.identifier))
 
+        let chunkUploadId = chunkUploadIdentifier(
+            forItemWithIdentifier: remoteItem.identifier,
+            fileSize: 8,
+            modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deleted-descendant-chunks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
+        try Data([1]).write(to: chunksDirectory.appendingPathComponent("2"))
+        remoteInterface.chunkUploadDirectories[chunkUploadId] = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let db = Self.dbManager.ncDatabase()
+        try db.write {
+            db.add(RemoteFileChunk(
+                fileName: "2",
+                size: 3,
+                remoteChunkStoreFolderName: chunkUploadId
+            ))
+        }
+
         let folder = Item(
             metadata: folderMetadata,
             parentItemIdentifier: .rootContainer,
@@ -184,6 +323,13 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
 
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: remoteFolder.identifier))
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: remoteItem.identifier))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: chunksDirectory.path))
+        XCTAssertEqual(
+            db.objects(RemoteFileChunk.self)
+                .where { $0.remoteChunkStoreFolderName == chunkUploadId }
+                .count,
+            0
+        )
     }
 
     func testDeleteWithTrashing() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -1424,6 +1424,66 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(modifiedItem.documentSize?.intValue, newContents.count)
 
         XCTAssertEqual(remoteItem.data, newContents)
+        XCTAssertNil(Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)?.chunkUploadId)
+    }
+
+    func testFailedChunkedModifyPreservesChunkUploadIdentifier() async throws {
+        let chunkSize = 2
+        let newContents = Data(repeating: 1, count: chunkSize * 3)
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failed-chunked-modify-\(UUID().uuidString)")
+        try newContents.write(to: newContentsUrl)
+        defer { try? FileManager.default.removeItem(at: newContentsUrl) }
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.uploadError = NKError(statusCode: 500, fallbackDescription: "Upload failed")
+        remoteInterface.chunkUploadCompletedChunkCount = 1
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failed-modify-chunks-\(UUID().uuidString)", isDirectory: true)
+        remoteInterface.chunkUploadDirectory = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let modificationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let uploadIdentifier = chunkUploadIdentifier(
+            forItemWithIdentifier: itemMetadata.ocId,
+            fileSize: Int64(newContents.count),
+            modificationDate: modificationDate
+        )
+        var targetItemMetadata = SendableItemMetadata(value: itemMetadata)
+        targetItemMetadata.date = modificationDate
+        targetItemMetadata.size = Int64(newContents.count)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: targetItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            forcedChunkSize: chunkSize,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(modifiedItem)
+        XCTAssertNotNil(error)
+        let storedMetadata = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: itemMetadata.ocId))
+        XCTAssertEqual(storedMetadata.status, Status.uploadError.rawValue)
+        XCTAssertEqual(storedMetadata.chunkUploadId, uploadIdentifier)
     }
 
     func testModifyFileContentsChunkedResumed() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemModifyTests.swift
@@ -1427,6 +1427,66 @@ final class ItemModifyTests: NextcloudFileProviderKitTestCase {
         XCTAssertNil(Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)?.chunkUploadId)
     }
 
+    func testSuccessfulChunkedModifyPreservesChunkUploadIdentifierWhenCleanupFails() async throws {
+        let chunkSize = 2
+        let newContents = Data(repeating: 1, count: chunkSize * 3)
+        let newContentsUrl = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failed-cleanup-chunked-modify-\(UUID().uuidString)")
+        try newContents.write(to: newContentsUrl)
+        defer { try? FileManager.default.removeItem(at: newContentsUrl) }
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.returnsChunkUploadDirectory = false
+        remoteInterface.removeLocalChunksError = CocoaError(.fileWriteNoPermission)
+
+        let chunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failed-cleanup-chunks-\(UUID().uuidString)", isDirectory: true)
+        remoteInterface.chunkUploadDirectory = chunksDirectory
+        defer { try? FileManager.default.removeItem(at: chunksDirectory) }
+
+        let itemMetadata = remoteItem.toItemMetadata(account: Self.account)
+        Self.dbManager.addItemMetadata(itemMetadata)
+
+        let modificationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        var targetItemMetadata = SendableItemMetadata(value: itemMetadata)
+        targetItemMetadata.date = modificationDate
+        targetItemMetadata.size = Int64(newContents.count)
+
+        let item = Item(
+            metadata: itemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        let targetItem = Item(
+            metadata: targetItemMetadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+
+        let (modifiedItem, error) = await item.modify(
+            itemTarget: targetItem,
+            changedFields: [.contents, .contentModificationDate],
+            contents: newContentsUrl,
+            forcedChunkSize: chunkSize,
+            dbManager: Self.dbManager
+        )
+
+        XCTAssertNil(error)
+        XCTAssertNotNil(modifiedItem)
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: itemMetadata.ocId)?.chunkUploadId,
+            chunkUploadIdentifier(
+                forItemWithIdentifier: itemMetadata.ocId,
+                fileSize: Int64(newContents.count),
+                modificationDate: modificationDate
+            )
+        )
+    }
+
     func testFailedChunkedModifyPreservesChunkUploadIdentifier() async throws {
         let chunkSize = 2
         let newContents = Data(repeating: 1, count: chunkSize * 3)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/UploadTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/UploadTests.swift
@@ -97,6 +97,16 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
         )
         XCTAssertTrue(chunkDirectoryExistedDuringUpload)
         XCTAssertFalse(FileManager.default.fileExists(atPath: chunkDirectory.path))
+        XCTAssertEqual(
+            Self.dbManager.ncDatabase().objects(RemoteFileChunk.self)
+                .where {
+                    $0.remoteChunkStoreFolderName.starts(
+                        with: chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
+                    )
+                }
+                .count,
+            0
+        )
     }
 
     func testFailedChunkedUploadKeepsTemporaryChunksForResume() async throws {
@@ -108,6 +118,7 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
         let remoteInterface =
             MockRemoteInterface(account: Self.account, rootItem: MockRemoteItem.rootItem(account: Self.account))
         remoteInterface.uploadError = NKError(statusCode: 500, fallbackDescription: "Upload failed")
+        remoteInterface.chunkUploadCompletedChunkCount = 1
 
         let chunkSize = 3
         let itemIdentifier = "failed-chunked-upload-\(UUID().uuidString)"
@@ -131,6 +142,59 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: chunkDirectory.path))
         let storedChunks = try FileManager.default.contentsOfDirectory(atPath: chunkDirectory.path)
         XCTAssertEqual(storedChunks.count, Int(ceil(Double(data.count) / Double(chunkSize))))
+        XCTAssertEqual(
+            Self.dbManager.ncDatabase().objects(RemoteFileChunk.self)
+                .where {
+                    $0.remoteChunkStoreFolderName.starts(
+                        with: chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
+                    )
+                }
+                .count,
+            2
+        )
+    }
+
+    func testFailedChunkedUploadWithoutRemainingChunksRemovesTemporaryDirectory() async throws {
+        let fileUrl = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let data = Data(repeating: 1, count: 8)
+        try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
+
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account,
+            rootItem: MockRemoteItem.rootItem(account: Self.account)
+        )
+        remoteInterface.uploadError = NKError(statusCode: 500, fallbackDescription: "Upload failed")
+
+        let itemIdentifier = "failed-complete-chunks-\(UUID().uuidString)"
+        let chunkDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mock-chunks-\(UUID().uuidString)", isDirectory: true)
+        remoteInterface.chunkUploadDirectory = chunkDirectory
+        defer { try? FileManager.default.removeItem(at: chunkDirectory) }
+
+        let result = await NextcloudFileProviderKit.upload(
+            fileLocatedAt: fileUrl.path,
+            toRemotePath: Self.account.davFilesUrl + "/file.txt",
+            usingRemoteInterface: remoteInterface,
+            withAccount: Self.account,
+            inChunksSized: 3,
+            forItemWithIdentifier: itemIdentifier,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertEqual(result.remoteError.errorCode, 500)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: chunkDirectory.path))
+        XCTAssertEqual(
+            Self.dbManager.ncDatabase().objects(RemoteFileChunk.self)
+                .where {
+                    $0.remoteChunkStoreFolderName.starts(
+                        with: chunkUploadIdentifierPrefix(forItemWithIdentifier: itemIdentifier)
+                    )
+                }
+                .count,
+            0
+        )
     }
 
     func testResumingInterruptedChunkedUpload() async throws {
@@ -383,26 +447,38 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
             FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let data = Data(repeating: 1, count: 8)
         try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
 
         let remoteInterface =
             MockRemoteInterface(account: Self.account, rootItem: MockRemoteItem.rootItem(account: Self.account))
         let chunkSize = 3
         let itemIdentifier = "content-change-item"
 
-        // Seed bookkeeping from a prior interrupted upload of an older version (older mtime).
+        // Seed an older attempt whose individual chunk rows have already been consumed.
         let staleModificationDate = Date(timeIntervalSince1970: 1_600_000_000)
         let staleUploadId = chunkUploadIdentifier(
             forItemWithIdentifier: itemIdentifier,
             fileSize: Int64(data.count),
             modificationDate: staleModificationDate
         )
-        let db = Self.dbManager.ncDatabase()
-        try db.write {
-            db.add([
-                RemoteFileChunk(fileName: "2", size: Int64(chunkSize), remoteChunkStoreFolderName: staleUploadId),
-                RemoteFileChunk(fileName: "3", size: 2, remoteChunkStoreFolderName: staleUploadId)
-            ])
-        }
+        let staleChunksDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stale-chunks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: staleChunksDirectory,
+            withIntermediateDirectories: true
+        )
+        try Data([1]).write(to: staleChunksDirectory.appendingPathComponent("2"))
+        remoteInterface.chunkUploadDirectories[staleUploadId] = staleChunksDirectory
+        defer { try? FileManager.default.removeItem(at: staleChunksDirectory) }
+
+        var metadata = SendableItemMetadata(
+            ocId: itemIdentifier,
+            fileName: "file.txt",
+            account: Self.account
+        )
+        metadata.status = Status.uploadError.rawValue
+        metadata.chunkUploadId = staleUploadId
+        Self.dbManager.addItemMetadata(metadata)
 
         // The newer version (different mtime) derives a different id.
         let newModificationDate = Date(timeIntervalSince1970: 1_700_000_000)
@@ -430,11 +506,9 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
 
         XCTAssertEqual(result.remoteError, .success)
 
-        // Stale rows for the previous version must have been swept.
-        let dbAfterUpload = Self.dbManager.ncDatabase()
-        let remainingStale = dbAfterUpload.objects(RemoteFileChunk.self)
-            .where { $0.remoteChunkStoreFolderName == staleUploadId }
-        XCTAssertEqual(remainingStale.count, 0)
+        // The old metadata pointer is consumed before it is replaced with the new attempt.
+        XCTAssertNil(Self.dbManager.itemMetadata(ocId: itemIdentifier)?.chunkUploadId)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staleChunksDirectory.path))
 
         // The upload started fresh (chunk 1 was re-sent, not resumed from chunk 2).
         let firstUploadedChunk = try XCTUnwrap(uploadedChunks.first)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/UploadTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/UploadTests.swift
@@ -4,6 +4,7 @@
 @preconcurrency import FileProvider
 @testable import NextcloudFileProviderKit
 import NextcloudFileProviderKitMocks
+import NextcloudKit
 import RealmSwift
 import TestInterface
 import XCTest
@@ -47,22 +48,35 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
             FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let data = Data(repeating: 1, count: 8)
         try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
 
         let remoteInterface =
             MockRemoteInterface(account: Self.account, rootItem: MockRemoteItem.rootItem(account: Self.account))
         let remotePath = Self.account.davFilesUrl + "/file.txt"
         let chunkSize = 3
+        let itemIdentifier = "chunked-upload-\(UUID().uuidString)"
+        let chunkDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mock-chunks-\(UUID().uuidString)", isDirectory: true)
+        remoteInterface.chunkUploadDirectory = chunkDirectory
+        defer { try? FileManager.default.removeItem(at: chunkDirectory) }
+
         var uploadedChunks = [RemoteFileChunk]()
+        var chunkDirectoryExistedDuringUpload = false
         let result = await NextcloudFileProviderKit.upload(
             fileLocatedAt: fileUrl.path,
             toRemotePath: remotePath,
             usingRemoteInterface: remoteInterface,
             withAccount: Self.account,
             inChunksSized: chunkSize,
-            forItemWithIdentifier: "chunked-upload-item",
+            forItemWithIdentifier: itemIdentifier,
             dbManager: Self.dbManager,
             log: FileProviderLogMock(),
-            chunkUploadCompleteHandler: { uploadedChunks.append($0) }
+            chunkUploadCompleteHandler: { chunk in
+                uploadedChunks.append(chunk)
+                chunkDirectoryExistedDuringUpload = FileManager.default.fileExists(
+                    atPath: chunkDirectory.appendingPathComponent(chunk.fileName).path
+                )
+            }
         )
         let expectedChunkCount = Int(ceil(Double(data.count) / Double(chunkSize)))
 
@@ -81,6 +95,42 @@ final class UploadTests: NextcloudFileProviderKitTestCase {
         XCTAssertEqual(
             Int(lastUploadedChunk.size), data.count - ((lastUploadedChunkNameInt - 1) * chunkSize)
         )
+        XCTAssertTrue(chunkDirectoryExistedDuringUpload)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: chunkDirectory.path))
+    }
+
+    func testFailedChunkedUploadKeepsTemporaryChunksForResume() async throws {
+        let fileUrl = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let data = Data(repeating: 1, count: 8)
+        try data.write(to: fileUrl)
+        defer { try? FileManager.default.removeItem(at: fileUrl) }
+
+        let remoteInterface =
+            MockRemoteInterface(account: Self.account, rootItem: MockRemoteItem.rootItem(account: Self.account))
+        remoteInterface.uploadError = NKError(statusCode: 500, fallbackDescription: "Upload failed")
+
+        let chunkSize = 3
+        let itemIdentifier = "failed-chunked-upload-\(UUID().uuidString)"
+        let chunkDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mock-chunks-\(UUID().uuidString)", isDirectory: true)
+        remoteInterface.chunkUploadDirectory = chunkDirectory
+        defer { try? FileManager.default.removeItem(at: chunkDirectory) }
+
+        let result = await NextcloudFileProviderKit.upload(
+            fileLocatedAt: fileUrl.path,
+            toRemotePath: Self.account.davFilesUrl + "/file.txt",
+            usingRemoteInterface: remoteInterface,
+            withAccount: Self.account,
+            inChunksSized: chunkSize,
+            forItemWithIdentifier: itemIdentifier,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+
+        XCTAssertEqual(result.remoteError.errorCode, 500)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: chunkDirectory.path))
+        let storedChunks = try FileManager.default.contentsOfDirectory(atPath: chunkDirectory.path)
+        XCTAssertEqual(storedChunks.count, Int(ceil(Double(data.count) / Double(chunkSize))))
     }
 
     func testResumingInterruptedChunkedUpload() async throws {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

Chunked upload chunks can stick around after upload attempts, filling up local storage. This PR adds various cleanup procedures to prevent this from happening


## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
