### PR TITLE
fix(macos): Get actual user home directory correctly

### DIFF
--- a/src/common/utility_mac_sandbox.h
+++ b/src/common/utility_mac_sandbox.h
@@ -29,13 +29,14 @@ namespace Utility {
 [[nodiscard]] QByteArray createSecurityScopedBookmarkData(const QString &localPath);
 
 /**
- * @brief Get the real user home directory path
+ * @brief Get the logged-in user's home directory path
  *
- * In sandboxed macOS apps, QStandardPaths::HomeLocation returns the sandbox
- * container directory, not the actual user home directory. This function uses
- * NSHomeDirectory() to retrieve the real home directory path.
+ * In sandboxed macOS apps, QStandardPaths::HomeLocation and NSHomeDirectory()
+ * return the app's sandbox container. This function resolves the logged-in
+ * user's home directory instead.
  *
- * @return The real user home directory path
+ * @return The logged-in user's home directory path, or an empty string if it
+ *         cannot be resolved
  */
 [[nodiscard]] QString getRealHomeDirectory();
 

--- a/src/common/utility_mac_sandbox.mm
+++ b/src/common/utility_mac_sandbox.mm
@@ -54,7 +54,11 @@ QByteArray createSecurityScopedBookmarkData(const QString &localPath)
 QString getRealHomeDirectory()
 {
     @autoreleasepool {
-        NSString *homeDir = NSHomeDirectory();
+        NSString * const homeDir = NSHomeDirectoryForUser(NSUserName());
+        if (!homeDir) {
+            qCWarning(lcMacSandboxUtility) << "Failed to resolve the logged-in user's home directory";
+            return {};
+        }
         return QString::fromNSString(homeDir);
     }
 }

--- a/src/gui/folderwizard.cpp
+++ b/src/gui/folderwizard.cpp
@@ -144,8 +144,6 @@ void FolderWizardLocalPath::slotChooseLocalFolder()
     QString sf;
 
     #ifdef Q_OS_MACOS
-        // On macOS with app sandbox, QStandardPaths returns the sandbox container directory,
-        // not the actual user home directory. Use NSHomeDirectory() to get the real path.
         sf = Utility::getRealHomeDirectory();
     #else
         sf = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);

--- a/test/macOS/CMakeLists.txt
+++ b/test/macOS/CMakeLists.txt
@@ -5,3 +5,4 @@
 # no GUI, so it runs in PR CI — unlike the signed-bundle checks, which need a signing identity
 # and a login session and therefore belong to the release pipeline.
 nextcloud_add_test(FinderSyncBrokerIdentity)
+nextcloud_add_test(MacSandboxUtility)

--- a/test/macOS/testmacsandboxutility.cpp
+++ b/test/macOS/testmacsandboxutility.cpp
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QtTest>
+#include <QDir>
+
+#include "common/utility_mac_sandbox.h"
+
+class TestMacSandboxUtility : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void userHomeDirectoryIsOutsideTheAppContainer()
+    {
+        const auto userHomeDirectory = OCC::Utility::getRealHomeDirectory();
+
+        QVERIFY(!userHomeDirectory.isEmpty());
+        QVERIFY(!userHomeDirectory.contains(QStringLiteral("/Library/Containers/")));
+        QVERIFY(QDir(userHomeDirectory).isAbsolute());
+    }
+};
+
+QTEST_APPLESS_MAIN(TestMacSandboxUtility)
+
+#include "testmacsandboxutility.moc"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

The sync folder location picker defaulting to the library/containers path

## Summary

This change ensures the current user's actual home folder is presented for syncing

https://developer.apple.com/documentation/foundation/nshomedirectory%28%29?language=objc
https://developer.apple.com/library/archive/documentation/General/Conceptual/MOSXAppProgrammingGuide/AppRuntime/AppRuntime.html

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
