### PR TITLE
feat(cli): support multiple folders to sync with `--include` file

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -10,6 +10,7 @@
 #include <QDir>
 #include <QStringList>
 #include <QTimer>
+#include <QMap>
 #include <QUrl>
 #include <QFile>
 #include <QFileInfo>
@@ -78,6 +79,7 @@ struct CmdOptions
     bool ignoreHiddenFiles = false;
     QString exclude;
     QString excludeAnchored;
+    QString include;
     QString unsyncedfolders;
     int restartTimes = 0;
     int downlimit = 0;
@@ -172,6 +174,7 @@ void help()
     std::cout << binaryName << " - command line " APPLICATION_NAME " client tool" << std::endl;
     std::cout << "" << std::endl;
     std::cout << "Usage: " << binaryName << " [OPTION] <source_dir> <server_url>" << std::endl;
+    std::cout << "       " << binaryName << " [OPTION] --include <include_file> <server_url>" << std::endl;
     std::cout << "       " << binaryName << " --userid <user> --serverurl <url> [--apppassword <pass>] [OPTION]" << std::endl;
     std::cout << "" << std::endl;
     std::cout << "A proxy can either be set manually using --httpproxy." << std::endl;
@@ -187,6 +190,7 @@ void help()
     std::cout << "                         sync root regardless of the file's own name" << std::endl;
     std::cout << "                         (use this if --exclude patterns aren't matching," << std::endl;
     std::cout << "                         see nextcloud/desktop#2916, #7682)" << std::endl;
+    std::cout << "  --include [file]       Include list file. If this option is set, <source_dir> can't be set" << std::endl;
     std::cout << "  --unsyncedfolders [file]    File containing the list of unsynced remote folders (selective sync)" << std::endl;
     std::cout << "  --user, -u [name]      Use [name] as the login name" << std::endl;
     std::cout << "  --password, -p [pass]  Use [pass] as password" << std::endl;
@@ -253,16 +257,20 @@ CommandMode parseOptions(const QStringList &app_args, CmdOptions *options)
 
         options->target_url = args.takeLast();
 
-        options->source_dir = args.takeLast();
-        if (!options->source_dir.endsWith('/')) {
-            options->source_dir.append('/');
+        if (!args.contains("--include")) {
+            options->source_dir = args.takeLast();
+            if (!options->source_dir.endsWith('/')) {
+                options->source_dir.append('/');
+            }
+
+            auto sourceDirFileInfo = QFileInfo{options->source_dir};
+            if (!sourceDirFileInfo.exists()) {
+                std::cerr << "Source dir '" << qPrintable(options->source_dir) << "' does not exist." << std::endl;
+                exit(1);
+            }
+
+            options->source_dir = sourceDirFileInfo.absoluteFilePath();
         }
-        auto sourceDirFileInfo = QFileInfo{options->source_dir};
-        if (!sourceDirFileInfo.exists()) {
-            std::cerr << "Source dir '" << qPrintable(options->source_dir) << "' does not exist." << std::endl;
-            exit(1);
-        }
-        options->source_dir = sourceDirFileInfo.absoluteFilePath();
     }
 
     auto it = QStringListIterator{args};
@@ -293,6 +301,9 @@ CommandMode parseOptions(const QStringList &app_args, CmdOptions *options)
             options->exclude = it.next();
         } else if (option == u"--exclude-anchored"_s && !it.peekNext().startsWith(u"-"_s)) {
             options->excludeAnchored = it.next();
+        } else if (option == u"--include"_s && it.hasNext() && !it.peekNext().startsWith("-")) {
+            auto includeFileInfo = QFileInfo(it.next());
+            options->include = includeFileInfo.absoluteFilePath();
         } else if (option == u"--unsyncedfolders"_s && it.hasNext() && !it.peekNext().startsWith(u"-"_s)) {
             options->unsyncedfolders = it.next();
         } else if (option == u"--max-sync-retries"_s && it.hasNext() && !it.peekNext().startsWith(u"-"_s)) {
@@ -318,7 +329,7 @@ CommandMode parseOptions(const QStringList &app_args, CmdOptions *options)
         }
     }
 
-    if (!provisionMode && (options->target_url.isEmpty() || options->source_dir.isEmpty())) {
+    if (!provisionMode && (options->target_url.isEmpty() || (options->source_dir.isEmpty() && options->include.isEmpty()))) {
         result = CommandMode::HelpMode;
         help();
         return result;
@@ -347,6 +358,39 @@ void selectiveSyncFixup(OCC::SyncJournalDb *journal, const QStringList &newList)
 
         journal->setSelectiveSyncList(SyncJournalDb::SelectiveSyncBlackList, newList);
     }
+}
+
+QMap<QString, QString> parseIncludeFile(QFile *file)
+{
+    QMap<QString, QString> foldersToSync;
+    while (!file->atEnd()) {
+        auto line = file->readLine().trimmed();
+
+        if (line.isEmpty() || line.startsWith('#')) {
+            continue;
+        }
+
+        auto splitEntry = QString::fromUtf8(line).split(u' ');
+        if (splitEntry.count() != 2) {
+            std::cerr << "Entry '" << qPrintable(QString::fromUtf8(line)) << "' is not in format '<local path> <remote path>'" <<std::endl;
+            exit(1);
+        }
+
+        auto localPath = splitEntry.at(0);
+        if (localPath.endsWith('/')) {
+            localPath.append('/');
+        }
+
+        auto fi = QFileInfo(localPath);
+        if (!fi.exists()) {
+            std::cerr << "Included dir '" << qPrintable(localPath) << "' does not exist." << std::endl;
+            exit(1);
+        }
+
+        foldersToSync.insert(fi.absoluteFilePath(), splitEntry.at(1));
+    }
+
+    return foldersToSync;
 }
 
 [[nodiscard]] bool setupAccountsOnly()
@@ -528,14 +572,28 @@ int main(int argc, char **argv)
    
 
     // Find the folder and the original owncloud url
-
     hostUrl.setScheme(hostUrl.scheme().replace("owncloud", "http"));
 
     QUrl credentialFreeUrl = hostUrl;
     credentialFreeUrl.setUserName(QString());
     credentialFreeUrl.setPassword(QString());
 
-    const QString folder = options.remotePath;
+    QMap<QString, QString> foldersToSync;
+    if (!options.source_dir.isEmpty()) {
+        foldersToSync.insert(options.source_dir, options.remotePath);
+    } else {
+        auto file = QFile(options.include);
+        if (!file.exists()) {
+            std::cerr << "Include file '" << qPrintable(options.include) << "' does not exist." << std::endl;
+            exit(1);
+        }
+        if (!file.open(QIODevice::ReadOnly)) {
+            std::cerr << "Include file '" << qPrintable(file.fileName()) << "' could not be opened" << std::endl;
+            exit(1);
+        }
+
+        foldersToSync = parseIncludeFile(&file);
+    }
 
     if (!options.proxy.isNull()) {
         QString host;
@@ -656,31 +714,7 @@ restart_sync:
         }
     }
 
-    Cmd cmd;
-    QString dbPath = options.source_dir + SyncJournalDb::makeDbName(options.source_dir, credentialFreeUrl, folder, user);
-    SyncJournalDb db(dbPath);
-
-    if (!selectiveSyncList.empty()) {
-        selectiveSyncFixup(&db, selectiveSyncList);
-    }
-
-    SyncOptions syncOptions;
-    syncOptions.fillFromEnvironmentVariables();
-    syncOptions.verifyChunkSizes();
-    syncOptions.setIsCmd(true);
-    SyncEngine engine(account, options.source_dir, syncOptions, folder, &db);
-    engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
-    engine.setNetworkLimits(options.uplimit, options.downlimit);
-    QObject::connect(&engine, &SyncEngine::finished,
-        [&app](bool result) { app.exit(result ? EXIT_SUCCESS : EXIT_FAILURE); });
-    QObject::connect(&engine, &SyncEngine::transmissionProgress, &cmd, &Cmd::transmissionProgressSlot);
-    QObject::connect(&engine, &SyncEngine::syncError,
-        [](const QString &error) { qWarning() << "Sync error:" << error; });
-
-
     // Exclude lists
-
-    bool hasUserExcludeFile = !options.exclude.isEmpty() || !options.excludeAnchored.isEmpty();
     QString systemExcludeFile = ConfigFile::excludeFileFromSystem();
 
     // Always try to load the user-provided exclude list(s) if specified
@@ -694,45 +728,86 @@ restart_sync:
             qFatal("Exclude list file supplied via --exclude does not exist: %s", qUtf8Printable(options.exclude));
             return EXIT_FAILURE;
         }
-        // Keeps addExcludeFilePath()'s historic filename-based anchoring
-        // heuristic for --exclude, so existing setups that rely on it
-        // (however unintentionally) don't change behavior. Use
-        // --exclude-anchored instead if patterns aren't matching because
-        // the file isn't literally named "sync-exclude.lst".
-        engine.excludedFiles().addExcludeFilePath(options.exclude);
     }
     if (!options.excludeAnchored.isEmpty()) {
         if (!QFile::exists(options.excludeAnchored)) {
             qFatal("Exclude list file supplied via --exclude-anchored does not exist: %s", qUtf8Printable(options.excludeAnchored));
             return EXIT_FAILURE;
         }
-        // Always anchor patterns at the sync root regardless of the file's
-        // own name, see ExcludedFiles::addExcludeFilePath().
-        engine.excludedFiles().addExcludeFilePath(options.excludeAnchored, ExcludedFiles::ExcludeFileAnchor::SyncRoot);
-    }
-    // Load the system list if available, or if there's no user-provided list
-    if (!hasUserExcludeFile || QFile::exists(systemExcludeFile)) {
-        engine.excludedFiles().addExcludeFilePath(systemExcludeFile);
     }
 
-    if (!engine.excludedFiles().reloadExcludeFiles()) {
-        qFatal("Cannot load system exclude list or list supplied via --exclude/--exclude-anchored");
-        return EXIT_FAILURE;
-    }
+    Cmd cmd;
+    int resultCode;
+    bool hasUserExcludeFile = !options.exclude.isEmpty() || !options.excludeAnchored.isEmpty();
 
+    QMapIterator<QString, QString> it(foldersToSync);
+    while (it.hasNext()) {
+        it.next();
+        QString dir = it.key();
+        QString folder = it.value();
 
-    // Have to be done async, else, an error before exec() does not terminate the event loop.
-    QMetaObject::invokeMethod(&engine, "startSync", Qt::QueuedConnection);
+        QString dbPath = dir + SyncJournalDb::makeDbName(dir, credentialFreeUrl, folder, user);
+        SyncJournalDb db(dbPath);
 
-    int resultCode = app.exec();
-
-    if (engine.isAnotherSyncNeeded() != NoFollowUpSync) {
-        if (restartCount < options.restartTimes) {
-            restartCount++;
-            qDebug() << "Restarting Sync, because another sync is needed" << restartCount;
-            goto restart_sync;
+        if (!selectiveSyncList.empty()) {
+            selectiveSyncFixup(&db, selectiveSyncList);
         }
-        qWarning() << "Another sync is needed, but not done because restart count is exceeded" << restartCount;
+
+        SyncOptions syncOptions;
+        syncOptions.fillFromEnvironmentVariables();
+        syncOptions.verifyChunkSizes();
+        syncOptions.setIsCmd(true);
+        SyncEngine engine(account, dir, syncOptions, folder, &db); //ERROR is still needed
+        engine.setIgnoreHiddenFiles(options.ignoreHiddenFiles);
+        engine.setNetworkLimits(options.uplimit, options.downlimit);
+        QObject::connect(&engine, &SyncEngine::finished,
+            [&app](bool result) { app.exit(result ? EXIT_SUCCESS : EXIT_FAILURE); });
+        QObject::connect(&engine, &SyncEngine::transmissionProgress, &cmd, &Cmd::transmissionProgressSlot);
+        QObject::connect(&engine, &SyncEngine::syncError,
+            [](const QString &error) { qWarning() << "Sync error:" << error; });
+
+        // Always try to load the user-provided exclude list(s) if specified
+        if (!options.exclude.isEmpty()) {
+            // Keeps addExcludeFilePath()'s historic filename-based anchoring
+            // heuristic for --exclude, so existing setups that rely on it
+            // (however unintentionally) don't change behavior. Use
+            // --exclude-anchored instead if patterns aren't matching because
+            // the file isn't literally named "sync-exclude.lst".
+            engine.excludedFiles().addExcludeFilePath(options.exclude);
+        }
+        if (!options.excludeAnchored.isEmpty()) {
+            // Always anchor patterns at the sync root regardless of the file's
+            // own name, see ExcludedFiles::addExcludeFilePath().
+            engine.excludedFiles().addExcludeFilePath(options.excludeAnchored, ExcludedFiles::ExcludeFileAnchor::SyncRoot);
+        }
+        
+        // Load the system list if available, or if there's no user-provided list
+        if (!hasUserExcludeFile || QFile::exists(systemExcludeFile)) {
+            engine.excludedFiles().addExcludeFilePath(systemExcludeFile);
+        }
+
+        if (!engine.excludedFiles().reloadExcludeFiles()) {
+            qFatal("Cannot load system exclude list or list supplied via --exclude/--exclude-anchored");
+            return EXIT_FAILURE;
+        }
+
+        // Have to be done async, else, an error before exec() does not terminate the event loop.
+        QMetaObject::invokeMethod(&engine, "startSync", Qt::QueuedConnection);
+
+        if (engine.isAnotherSyncNeeded() != NoFollowUpSync) {
+            if (restartCount < options.restartTimes) {
+                restartCount++;
+                qDebug() << "Restarting Sync, because another sync is needed" << restartCount;
+                goto restart_sync;
+            }
+
+            qWarning() << "Another sync is needed, but not done because restart count is exceeded" << restartCount;
+        }
+
+        resultCode = app.exec();
+        if (resultCode != 0) {
+            break;
+        }
     }
 
     return resultCode;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -131,6 +131,7 @@ nextcloud_add_test(FileSystem)
 nextcloud_add_test(FolderStatusModel)
 
 if(NOT BUILD_LIBRARIES_ONLY AND NOT APPLE)
+    nextcloud_add_test(NextcloudCmdInclude)
     nextcloud_add_test(NextcloudCmdProvisioning)
     add_dependencies(NextcloudCmdProvisioningTest nextcloudcmd)
 endif()

--- a/test/testnexctloudcmdinclude.cpp
+++ b/test/testnexctloudcmdinclude.cpp
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include <QtTest>
+#include <QProcess>
+#include <QString>
+#include <QByteArray>
+
+#include "config.h"
+
+// The binary is named APPLICATION_EXECUTABLEcmd and lives in OWNCLOUD_BIN_PATH.
+// Both macros are provided by the build system at compile time.
+static QString nextcloudCmdBinary()
+{
+    return QString::fromLatin1(OWNCLOUD_BIN_PATH "/" APPLICATION_EXECUTABLE "cmd");
+}
+
+class TestNextcloudCmdInclude : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Runs nextcloudcmd with the given arguments, waits up to timeoutMs for it
+    // to finish, and returns the combined stdout+stderr output together with the
+    // exit code via out-parameters.  stdin of the child process is closed
+    // immediately so that any accidental interactive read returns EOF rather
+    // than blocking the test suite.
+    static QByteArray runCmd(const QStringList &args, int *exitCodeOut, int timeoutMs = 12000)
+    {
+        QProcess proc;
+        proc.setProcessChannelMode(QProcess::MergedChannels);
+        proc.start(nextcloudCmdBinary(), args);
+        proc.closeWriteChannel(); // close stdin — no interactive reads
+        proc.waitForFinished(timeoutMs);
+        if (exitCodeOut) {
+            *exitCodeOut = proc.exitCode();
+        }
+        return proc.readAll();
+    }
+
+private slots:
+    // --userid without --serverurl must print a descriptive error and exit 1.
+    // It must NOT print the interactive "Please enter username:" prompt.
+    void testUserIdAlonePrintsServerUrlError()
+    {
+#if defined Q_OS_WINDOWS
+        constexpr auto expectedExitCode = -1;
+#else
+        constexpr auto expectedExitCode = 255;
+#endif
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--userid"), QStringLiteral("alice")}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("--serverurl"), output.constData());
+        QVERIFY2(!output.contains("Please enter username"), output.constData());
+    }
+
+    // --userid + --serverurl without --apppassword must enter provisioning mode
+    // (app password is optional, as in the nextcloud GUI executable).
+    // No credential prompt must appear.
+    void testUserIdAndServerUrlWithoutAppPasswordEntersProvisionMode()
+    {
+#if defined Q_OS_WINDOWS
+        constexpr auto expectedExitCode = -1;
+#else
+        constexpr auto expectedExitCode = 255;
+#endif
+
+        // 127.0.0.1:1 gives a fast "connection refused" without DNS latency.
+        int exitCode = 0;
+        const auto output = runCmd(
+            {QStringLiteral("--userid"), QStringLiteral("alice"),
+             QStringLiteral("--serverurl"), QStringLiteral("\"http://127.0.0.1:1\"")},
+            &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        // Must NOT fall through into interactive sync mode.
+        QVERIFY2(!output.contains("Please enter username"), output.constData());
+        QVERIFY2(!output.contains("Password for account with username"), output.constData());
+    }
+
+    // --userid + --serverurl (+ optional --apppassword) pointing at an unreachable
+    // server: the command must enter provisioning mode (no credential prompt)
+    // and fail with an error, not fall through into interactive sync mode.
+    void testProvisioningOptionsEnterProvisionModeNotSyncMode()
+    {
+#if defined Q_OS_WINDOWS
+        constexpr auto expectedExitCode = -1;
+#else
+        constexpr auto expectedExitCode = 255;
+#endif
+
+        // 127.0.0.1:1 gives a fast "connection refused" without DNS latency.
+        int exitCode = 0;
+        const auto output = runCmd(
+            {QStringLiteral("--userid"), QStringLiteral("alice"),
+             QStringLiteral("--apppassword"), QStringLiteral("secret"),
+             QStringLiteral("--serverurl"), QStringLiteral("\"http://127.0.0.1:1\"")},
+            &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        // Provisioning mode must NOT fall through into interactive sync mode.
+        QVERIFY2(!output.contains("Please enter username"), output.constData());
+        QVERIFY2(!output.contains("Password for account with username"), output.constData());
+    }
+
+    // No arguments: help text is printed, exit 0.  Guards against regressions
+    // in the normal (non-provisioning) sync-mode entry path.
+    void testNoArgsShowsHelp()
+    {
+#if defined Q_OS_MACOS
+        constexpr auto expectedExitCode = 255;
+#else
+        constexpr auto expectedExitCode = 0;
+#endif
+        int exitCode = -1;
+        const auto output = runCmd({}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("nextcloudcmd") || output.contains("nextclouddevcmd"),
+                 output.constData());
+        QVERIFY2(output.contains("--userid"), output.constData());
+    }
+
+    // --non-interactive combined with --userid (but missing the other two
+    // provisioning options) must still print a structured error, not a prompt.
+    void testNonInteractiveFlagDoesNotSuppressProvisioningError()
+    {
+#if defined Q_OS_WINDOWS
+        constexpr auto expectedExitCode = -1;
+#else
+        constexpr auto expectedExitCode = 255;
+#endif
+
+        int exitCode = 0;
+        const auto output = runCmd(
+            {QStringLiteral("--non-interactive"),
+             QStringLiteral("--userid"), QStringLiteral("alice")},
+            &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("--serverurl"), output.constData());
+        QVERIFY2(!output.contains("Please enter username"), output.constData());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestNextcloudCmdInclude)
+#include "testnextcloudcmdinclude.moc"

--- a/test/testnextcloudcmdinclude.cpp
+++ b/test/testnextcloudcmdinclude.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#include <QtTest>
+#include <QProcess>
+#include <QString>
+#include <QByteArray>
+
+#include "config.h"
+
+// The binary is named APPLICATION_EXECUTABLEcmd and lives in OWNCLOUD_BIN_PATH.
+// Both macros are provided by the build system at compile time.
+static QString nextcloudCmdBinary()
+{
+    return QString::fromLatin1(OWNCLOUD_BIN_PATH "/" APPLICATION_EXECUTABLE "cmd");
+}
+
+class TestNextcloudCmdInclude : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Runs nextcloudcmd with the given arguments, waits up to timeoutMs for it
+    // to finish, and returns the combined stdout+stderr output together with the
+    // exit code via out-parameters.  stdin of the child process is closed
+    // immediately so that any accidental interactive read returns EOF rather
+    // than blocking the test suite.
+    static QByteArray runCmd(const QStringList &args, int *exitCodeOut, int timeoutMs = 12000)
+    {
+        QProcess proc;
+        proc.setProcessChannelMode(QProcess::MergedChannels);
+        proc.start(nextcloudCmdBinary(), args);
+        proc.closeWriteChannel(); // close stdin — no interactive reads
+        proc.waitForFinished(timeoutMs);
+        if (exitCodeOut) {
+            *exitCodeOut = proc.exitCode();
+        }
+        return proc.readAll();
+    }
+
+private slots:
+    // --include  with not existent file must print a descriptive error and exit 1.
+    void testIncludeWithInvalidPathPrintsError()
+    {
+        auto expectedExitCode = 1;
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--non-interactive"), QStringLiteral("--include"), QStringLiteral("foo"), QStringLiteral("\"http://127.0.0.1:1\"")}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("does not exist"), output.constData());
+    }
+
+    // --include with existent, readeable file, but in the wrong format, must print a descriptive error and exit 1.
+    void testExistentAndReadableIncludeFileShouldNotParseIfFormatIsWrong()
+    {
+        auto expectedExitCode = 1;
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--non-interactive"), QStringLiteral("--include"), QStringLiteral("NextcloudCmdIncludeTest"), QStringLiteral("\"http://user:user@127.0.0.1:1\"")}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("is not in format"), output.constData());
+    }
+
+    // --include with existent and readeable file must not print an error.
+    void testExistentAndReadableIncludeFileShouldParseIfFormatIsCorrect()
+    {
+        auto expectedExitCode = 1;
+
+        auto testFile = QFile("foo");
+        if (testFile.open(QIODevice::ReadWrite)) {
+            auto stream = QTextStream(&testFile);
+            stream << ". /foo" << Qt::endl;
+        }
+
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--non-interactive"), QStringLiteral("--include"), QStringLiteral("foo"), QStringLiteral("\"http://user:user@127.0.0.1:1\"")}, &exitCode);
+
+        testFile.remove();
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(!output.contains("does not exist"), output.constData());
+        QVERIFY2(!output.contains("is not in format"), output.constData());
+        QVERIFY2(output.contains("server"), output.constData());
+    }
+
+    // --include with <source_dir> must print a descriptive error and exit 0.
+    void testValidIncludeFileWithSourceDir()
+    {
+        auto expectedExitCode = 0;
+
+        auto testFile = QFile("foo");
+        if (testFile.open(QIODevice::ReadWrite)) {
+            auto stream = QTextStream(&testFile);
+            stream << ". /foo" << Qt::endl;
+        }
+
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--non-interactive"), QStringLiteral("--include"), QStringLiteral("foo"), QStringLiteral("bar"),QStringLiteral("\"http://user:user@127.0.0.1:1\"")}, &exitCode);
+
+        testFile.remove();
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("--include"), output.constData());
+    }
+    
+    // <source_dir> without --include not print an error.
+    void testSourceDirWithoutInclude()
+    {
+        auto expectedExitCode = 1;
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--non-interactive"), QStringLiteral("."), QStringLiteral("\"http://user:user@127.0.0.1:1\"")}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(!output.contains("does not exist"), output.constData());
+        QVERIFY2(!output.contains("is not in format"), output.constData());
+        QVERIFY2(output.contains("server"), output.constData());
+    }
+
+    // No arguments: help text is printed, exit 0.  Guards against regressions.
+    void testNoArgsShowsHelp()
+    {
+#if defined Q_OS_MACOS
+        constexpr auto expectedExitCode = 255;
+#else
+        constexpr auto expectedExitCode = 0;
+#endif
+        int exitCode = -1;
+        const auto output = runCmd({}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("nextcloudcmd") || output.contains("nextclouddevcmd"),
+                 output.constData());
+        QVERIFY2(output.contains("--include"), output.constData());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestNextcloudCmdInclude)
+#include "testnextcloudcmdinclude.moc"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#4780 

## Summary
Added the new `--include` flag that reads a file with the format `<local path> <remote path>` and syncs these folders with nextcloud.
I'm not really confident or sure about the implementation. I don't know if it's a good idea to just recreate the SyncEngine and iterate over the list of directorys (maybe also replace `~` with the user home?). I think the best and cleanest solution would be to give SyncEngine not only a list of files to exclude, but also to include, that it doesn't need to be recreated every time. But I'm not really sure how big of a change that would be or if it is even worth it.
So this is the proposal for a solution to the issue :)

### TODO
- [ ] Add Documentation

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
