### PR TITLE
fix(windows): Prevent reupload of placeholder dirs deleted remotely

### DIFF
--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1484,7 +1484,17 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
     Q_ASSERT(!dbEntry.isValid());
 
-    if (localEntry.isVirtualFile && !noServerEntry) {
+    if (localEntry.type == ItemTypeVirtualDirectory && noServerEntry) {
+        // A virtual directory without a database record is a stale placeholder.
+        // A newly created local directory is not a virtual directory, so it can
+        // still follow the normal local-new path below.
+        qCWarning(lcDisco) << "Wiping virtual directory without db entry for" << path._local;
+        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+        item->_direction = SyncFileItem::Down;
+        item->_type = ItemTypeVirtualDirectory;
+        finalize();
+        return;
+    } else if (localEntry.isVirtualFile && !noServerEntry) {
         // Somehow there is a missing DB entry while the virtual file already exists.
         // The instruction should already be set correctly.
         ASSERT(item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA);

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -1484,17 +1484,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
 
     Q_ASSERT(!dbEntry.isValid());
 
-    if (localEntry.type == ItemTypeVirtualDirectory && noServerEntry) {
-        // A virtual directory without a database record is a stale placeholder.
-        // A newly created local directory is not a virtual directory, so it can
-        // still follow the normal local-new path below.
-        qCWarning(lcDisco) << "Wiping virtual directory without db entry for" << path._local;
-        item->_instruction = CSYNC_INSTRUCTION_REMOVE;
-        item->_direction = SyncFileItem::Down;
-        item->_type = ItemTypeVirtualDirectory;
-        finalize();
-        return;
-    } else if (localEntry.isVirtualFile && !noServerEntry) {
+    if (localEntry.isVirtualFile && !noServerEntry) {
         // Somehow there is a missing DB entry while the virtual file already exists.
         // The instruction should already be set correctly.
         ASSERT(item->_instruction == CSYNC_INSTRUCTION_UPDATE_METADATA);
@@ -1607,6 +1597,7 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
         return true;
     };
     const auto isMove = moveCheck();
+    const auto isStaleVirtualDirectory = localEntry.type == ItemTypeVirtualDirectory && noServerEntry;
     const auto isE2eeMove = isMove && (base.isE2eEncrypted() || isInsideEncryptedTree());
     const auto isCfApiVfsMode = _discoveryData->_syncOptions._vfs && _discoveryData->_syncOptions._vfs->mode() == Vfs::WindowsCfApi;
     const bool isOnlineOnlyItem = isCfApiVfsMode && (localEntry.isDirectory || _discoveryData->_syncOptions._vfs->isDehydratedPlaceholder(_discoveryData->_localDir + path._local));
@@ -1639,7 +1630,17 @@ void ProcessDirectoryJob::processFileAnalyzeLocalInfo(
             }
             Q_ASSERT(item->_e2eEncryptionStatus != SyncFileItem::EncryptionStatus::NotEncrypted);
         }
-        postProcessLocalNew();
+        if (isStaleVirtualDirectory && !isMove) {
+            // A virtual directory without a database record is a stale placeholder.
+            // A newly created local directory is not a virtual directory, so it can
+            // still follow the normal local-new path below.
+            qCWarning(lcDisco) << "Wiping virtual directory without db entry for" << path._local;
+            item->_instruction = CSYNC_INSTRUCTION_REMOVE;
+            item->_direction = SyncFileItem::Down;
+            item->_type = ItemTypeVirtualDirectory;
+        } else {
+            postProcessLocalNew();
+        }
         finalize();
         return;
     }

--- a/src/libsync/vfs/cfapi/cfapiwrapper.h
+++ b/src/libsync/vfs/cfapi/cfapiwrapper.h
@@ -82,7 +82,7 @@ NEXTCLOUD_CFAPI_EXPORT bool isSparseFile(const QString &path);
 
 NEXTCLOUD_CFAPI_EXPORT FileHandle handleForPath(const QString &path);
 
-PlaceHolderInfo findPlaceholderInfo(const QString &path);
+NEXTCLOUD_CFAPI_EXPORT PlaceHolderInfo findPlaceholderInfo(const QString &path);
 
 enum SetPinRecurseMode {
     NoRecurse = 0,

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -416,7 +416,6 @@ private slots:
         fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::FilesystemOnly);
         completeSpy.clear();
 
-        QVERIFY(!fakeFolder.syncOnce());
         QVERIFY(fakeFolder.syncOnce());
 
         QCOMPARE(fakeFolder.remoteModifier().find("stale"), nullptr);

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -399,6 +399,37 @@ private slots:
         cleanup();
     }
 
+    void testStaleVirtualDirectoryWithoutDatabaseEntry()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        setupVfs(fakeFolder);
+        ItemCompletedSpy completeSpy(fakeFolder);
+
+        fakeFolder.remoteModifier().mkdir("stale");
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(dbRecord(fakeFolder, "stale")._type, ItemTypeVirtualDirectory);
+        QVERIFY(cfapi::findPlaceholderInfo(fakeFolder.localPath() + "stale"));
+
+        QVERIFY(fakeFolder.syncJournal().deleteFileRecord("stale"));
+        fakeFolder.remoteModifier().remove("stale");
+        fakeFolder.syncEngine().setLocalDiscoveryOptions(LocalDiscoveryStyle::FilesystemOnly);
+        completeSpy.clear();
+
+        QVERIFY(!fakeFolder.syncOnce());
+        QVERIFY(fakeFolder.syncOnce());
+
+        QCOMPARE(fakeFolder.remoteModifier().find("stale"), nullptr);
+        QVERIFY(!QFileInfo(fakeFolder.localPath() + "stale").exists());
+        QCOMPARE(completeSpy.findItem("stale")->_instruction, CSYNC_INSTRUCTION_REMOVE);
+        QVERIFY(!dbRecord(fakeFolder, "stale").isValid());
+
+        fakeFolder.localModifier().mkdir("new");
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(fakeFolder.remoteModifier().find("new"));
+        QCOMPARE(completeSpy.findItem("new")->_instruction, CSYNC_INSTRUCTION_NEW);
+    }
+
     void testWithNormalSync()
     {
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };

--- a/test/testsynccfapi.cpp
+++ b/test/testsynccfapi.cpp
@@ -430,6 +430,28 @@ private slots:
         QCOMPARE(completeSpy.findItem("new")->_instruction, CSYNC_INSTRUCTION_NEW);
     }
 
+    void testOnlineOnlyVirtualDirectoryRename()
+    {
+        FakeFolder fakeFolder{FileInfo{}};
+        auto vfs = setupVfs(fakeFolder);
+        ItemCompletedSpy completeSpy(fakeFolder);
+
+        fakeFolder.remoteModifier().mkdir("source");
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(dbRecord(fakeFolder, "source").isDirectory());
+
+        ::setPinState(fakeFolder.localPath() + "source", PinState::OnlineOnly, cfapi::NoRecurse);
+        fakeFolder.localModifier().rename("source", "destination");
+        completeSpy.clear();
+
+        QVERIFY(fakeFolder.syncOnce());
+
+        QVERIFY(!fakeFolder.remoteModifier().find("source"));
+        QVERIFY(fakeFolder.remoteModifier().find("destination"));
+        QCOMPARE(completeSpy.findItem("destination")->_instruction, CSYNC_INSTRUCTION_RENAME);
+        QCOMPARE(*vfs->pinState("destination"), PinState::OnlineOnly);
+    }
+
     void testWithNormalSync()
     {
         FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

There is a bug in which remotely-deleted folders can be reuploaded by the Windows VFS client. This fix detects a virtual directory with no database record and no remote entry and deletes the local entry instead. A normal folder created locally is reported as ItemTypeDirectory, so it still follows the normal upload path.

### TODO
- [ ] Test carefully in proper test env

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
