### PR TITLE
fix(warnings): ensure compilation without warnings with gcc 16

### DIFF
--- a/.github/workflows/linux-clang-compile-tests.yml
+++ b/.github/workflows/linux-clang-compile-tests.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     name: Linux Clang compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/linux-gcc-compile-tests.yml
+++ b/.github/workflows/linux-gcc-compile-tests.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     name: Linux GCC compilation and tests
     runs-on: ubuntu-latest
-    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2
+    container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-4
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
+
+#include "syncjournaldb.h"
+
+#include "version.h"
+#include "filesystembase.h"
+#include "common/asserts.h"
+#include "common/checksums.h"
+#include "common/preparedsqlquerymanager.h"
+#include "common/c_jhash.h"
+
 #include <QCryptographicHash>
 #include <QFile>
 #include <QJsonArray>
@@ -13,17 +23,10 @@
 #include <QElapsedTimer>
 #include <QUrl>
 #include <QDir>
+
 #include <sqlite3.h>
+
 #include <cstring>
-
-#include "common/syncjournaldb.h"
-#include "version.h"
-#include "filesystembase.h"
-#include "common/asserts.h"
-#include "common/checksums.h"
-#include "common/preparedsqlquerymanager.h"
-
-#include "common/c_jhash.h"
 
 // SQL expression to check whether path.startswith(prefix + '/')
 // Note: '/' + 1 == '0'
@@ -3314,3 +3317,5 @@ QDebug& operator<<(QDebug &stream, const SyncJournalFileRecord::EncryptionStatus
 }
 
 } // namespace OCC
+
+#include "moc_syncjournaldb.cpp"

--- a/src/gui/socketapi/CMakeLists.txt
+++ b/src/gui/socketapi/CMakeLists.txt
@@ -4,6 +4,7 @@
 target_sources(nextcloudCore PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/socketapi.h
     ${CMAKE_CURRENT_SOURCE_DIR}/socketapi.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/socketapi_p.h
 )
 
 if( APPLE )

--- a/src/gui/socketapi/socketapi.cpp
+++ b/src/gui/socketapi/socketapi.cpp
@@ -1764,3 +1764,4 @@ void SocketApiJob::reject(const QString &response)
 } // namespace OCC
 
 #include "socketapi.moc"
+#include "moc_socketapi_p.cpp"

--- a/src/gui/socketapi/socketapi_p.h
+++ b/src/gui/socketapi/socketapi_p.h
@@ -7,16 +7,16 @@
 #ifndef SOCKETAPI_P_H
 #define SOCKETAPI_P_H
 
-#include <functional>
 #include <QBitArray>
 #include <QIODevice>
 #include <QPointer>
-
 #include <QJsonDocument>
 #include <QJsonObject>
-
-#include <memory>
 #include <QTimer>
+#include <QLoggingCategory>
+
+#include <functional>
+#include <memory>
 
 namespace OCC {
 

--- a/src/libsync/basepropagateremotedeleteencrypted.cpp
+++ b/src/libsync/basepropagateremotedeleteencrypted.cpp
@@ -197,3 +197,5 @@ const QByteArray BasePropagateRemoteDeleteEncrypted::folderToken() const
 }
 
 } // namespace OCC
+
+#include "moc_basepropagateremotedeleteencrypted.cpp"

--- a/src/libsync/bulkpropagatordownloadjob.cpp
+++ b/src/libsync/bulkpropagatordownloadjob.cpp
@@ -165,3 +165,5 @@ void BulkPropagatorDownloadJob::abortWithError(SyncFileItemPtr item, SyncFileIte
 }
 
 }
+
+#include "moc_bulkpropagatordownloadjob.cpp"

--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -819,3 +819,5 @@ void BulkPropagatorJob::handleJobDoneErrors(SyncFileItemPtr item,
 }
 
 }
+
+#include "moc_bulkpropagatorjob.cpp"

--- a/src/libsync/creds/abstractcredentials.cpp
+++ b/src/libsync/creds/abstractcredentials.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+#include "abstractcredentials.h"
+
 #include <QLoggingCategory>
 #include <QString>
 #include <QCoreApplication>
 
 #include "common/asserts.h"
-#include "creds/abstractcredentials.h"
 
 namespace OCC {
 
@@ -59,3 +60,5 @@ QString AbstractCredentials::keychainKey(const QString &url, const QString &user
     return key;
 }
 } // namespace OCC
+
+#include "moc_abstractcredentials.cpp"

--- a/src/libsync/creds/dummycredentials.cpp
+++ b/src/libsync/creds/dummycredentials.cpp
@@ -58,3 +58,5 @@ void DummyCredentials::persist()
 }
 
 } // namespace OCC
+
+#include "moc_dummycredentials.cpp"

--- a/src/libsync/creds/httpcredentials.cpp
+++ b/src/libsync/creds/httpcredentials.cpp
@@ -555,3 +555,5 @@ bool HttpCredentials::unpackClientCertBundle()
 }
 
 } // namespace OCC
+
+#include "moc_httpcredentials.cpp"

--- a/src/libsync/discovery.cpp
+++ b/src/libsync/discovery.cpp
@@ -2560,3 +2560,5 @@ bool ProcessDirectoryJob::checkNewDeleteConflict(const SyncFileItemPtr &item) co
 }
 
 }
+
+#include "moc_discovery.cpp"

--- a/src/libsync/encryptedfoldermetadatahandler.cpp
+++ b/src/libsync/encryptedfoldermetadatahandler.cpp
@@ -394,3 +394,5 @@ bool EncryptedFolderMetadataHandler::isFolderLocked() const
 }
 
 }
+
+#include "moc_encryptedfoldermetadatahandler.cpp"

--- a/src/libsync/encryptfolderjob.cpp
+++ b/src/libsync/encryptfolderjob.cpp
@@ -148,3 +148,5 @@ void EncryptFolderJob::slotUploadMetadataFinished(int statusCode, const QString 
 }
 
 }
+
+#include "moc_encryptfolderjob.cpp"

--- a/src/libsync/foldermetadata.cpp
+++ b/src/libsync/foldermetadata.cpp
@@ -1270,3 +1270,5 @@ bool FolderMetadata::verifyMetadataKey(const QByteArray &metadataKey) const
     return _keyChecksums.contains(calcSha256(metadataKeyLimitedLength)) || _keyChecksums.isEmpty();
 }
 }
+
+#include "moc_foldermetadata.cpp"

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -1840,3 +1840,5 @@ void PropagateVfsUpdateMetadataJob::start()
 }
 
 }
+
+#include "moc_owncloudpropagator.cpp"

--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -1394,3 +1394,5 @@ void PropagateDownloadFile::abort(PropagatorJob::AbortType abortType)
     }
 }
 }
+
+#include "moc_propagatedownload.cpp"

--- a/src/libsync/propagatedownloadencrypted.cpp
+++ b/src/libsync/propagatedownloadencrypted.cpp
@@ -119,3 +119,5 @@ QString PropagateDownloadEncrypted::errorString() const
 }
 
 }
+
+#include "moc_propagatedownloadencrypted.cpp"

--- a/src/libsync/propagateremotedelete.cpp
+++ b/src/libsync/propagateremotedelete.cpp
@@ -130,3 +130,5 @@ void PropagateRemoteDelete::slotDeleteJobFinished()
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }
 }
+
+#include "moc_propagateremotedelete.cpp"

--- a/src/libsync/propagateremotedeleteencrypted.cpp
+++ b/src/libsync/propagateremotedeleteencrypted.cpp
@@ -74,3 +74,5 @@ void PropagateRemoteDeleteEncrypted::slotUpdateMetadataJobFinished(int statusCod
     Q_UNUSED(message);
     deleteRemoteItem(_item->_encryptedFileName);
 }
+
+#include "moc_propagateremotedeleteencrypted.cpp"

--- a/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
+++ b/src/libsync/propagateremotedeleteencryptedrootfolder.cpp
@@ -196,3 +196,5 @@ void PropagateRemoteDeleteEncryptedRootFolder::decryptAndRemoteDelete()
     });
     job->start();
 }
+
+#include "moc_propagateremotedeleteencryptedrootfolder.cpp"

--- a/src/libsync/propagateremotemkdir.cpp
+++ b/src/libsync/propagateremotemkdir.cpp
@@ -285,3 +285,5 @@ void PropagateRemoteMkdir::success()
     done(SyncFileItem::Success, {}, ErrorCategory::NoError);
 }
 }
+
+#include "moc_propagateremotemkdir.cpp"

--- a/src/libsync/propagateremotemove.cpp
+++ b/src/libsync/propagateremotemove.cpp
@@ -341,3 +341,5 @@ bool PropagateRemoteMove::adjustSelectiveSync(SyncJournalDb *journal, const QStr
     return true;
 }
 }
+
+#include "moc_propagateremotemove.cpp"

--- a/src/libsync/propagateupload.cpp
+++ b/src/libsync/propagateupload.cpp
@@ -925,3 +925,5 @@ void PropagateUploadFileCommon::abortNetworkJobs(
         Q_EMIT abortFinished();
 }
 }
+
+#include "moc_propagateupload.cpp"

--- a/src/libsync/propagateuploadencrypted.cpp
+++ b/src/libsync/propagateuploadencrypted.cpp
@@ -195,3 +195,5 @@ void PropagateUploadEncrypted::slotUploadMetadataFinished(int statusCode, const 
 }
 
 } // namespace OCC
+
+#include "moc_propagateuploadencrypted.cpp"

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -590,3 +590,5 @@ bool PropagateLocalRename::deleteOldDbRecord(const QString &fileName)
     return true;
 }
 }
+
+#include "moc_propagatorjobs.cpp"

--- a/src/libsync/putmultifilejob.cpp
+++ b/src/libsync/putmultifilejob.cpp
@@ -112,3 +112,5 @@ std::chrono::milliseconds PutMultiFileJob::msSinceStart() const
 }
 
 }
+
+#include "moc_putmultifilejob.cpp"

--- a/src/libsync/updatee2eefoldermetadatajob.cpp
+++ b/src/libsync/updatee2eefoldermetadatajob.cpp
@@ -167,3 +167,5 @@ void UpdateE2eeFolderMetadataJob::unlockFolder(const EncryptedFolderMetadataHand
 }
 
 }
+
+#include "moc_updatee2eefoldermetadatajob.cpp"

--- a/src/libsync/updatee2eefolderusersmetadatajob.cpp
+++ b/src/libsync/updatee2eefolderusersmetadatajob.cpp
@@ -365,3 +365,5 @@ const QByteArray UpdateE2eeFolderUsersMetadataJob::folderToken() const
 }
 
 }
+
+#include "moc_updatee2eefolderusersmetadatajob.cpp"

--- a/src/libsync/updatemigratede2eemetadatajob.cpp
+++ b/src/libsync/updatemigratede2eemetadatajob.cpp
@@ -87,3 +87,5 @@ void UpdateMigratedE2eeMetadataJob::addSubJobItem(const QString &key, const Sync
 }
 
 }
+
+#include "moc_updatemigratede2eemetadatajob.cpp"


### PR DESCRIPTION
the new gcc 16 will trigger new warnings related to https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-Wsfinae-incomplete

makes sure to fix them

cleaned come include to ensure logical order of inclusions (from most specific to most generic ones)

also makes incremental compilation faster by spliting MOC generated code into files related to each headers instead of a big one see https://forum.qt.io/topic/164690/gcc-16-warnings-about-incomplete-types-in-an-sfinae-context/2?_=1786535933996 also https://www.kdab.com/save-re-compile-time-include-moc-files-in-source-files-video/

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
