### PR TITLE
fix(folderwatcher): align overflow handling across platforms

### DIFF
--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -157,6 +157,13 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
             continue;
         }
 
+        if (event->mask & IN_Q_OVERFLOW) {
+            qCWarning(lcFolderWatcher)
+                << "The inotify event queue overflowed; triggering a full local discovery";
+            emit _parent->lostChanges();
+            continue;
+        }
+
         // Fire event for the path that was changed.
         if (event->len == 0 || event->wd <= -1)
             continue;

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -149,7 +149,7 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
 
     // iterate events in buffer
     unsigned int ulen = len;
-    for (i = 0; i + sizeof(inotify_event) < ulen; i += sizeof(inotify_event) + (event ? event->len : 0)) {
+    for (i = 0; i + sizeof(inotify_event) <= ulen; i += sizeof(inotify_event) + (event ? event->len : 0)) {
         // cast an inotify_event
         event = (struct inotify_event *)&buffer[i];
         if (!event) {

--- a/src/gui/folderwatcher_win.cpp
+++ b/src/gui/folderwatcher_win.cpp
@@ -72,6 +72,7 @@ void WatcherThread::watchChanges(size_t fileNotifyBufferSize,
             const DWORD errorCode = GetLastError();
             if (errorCode == ERROR_NOTIFY_ENUM_DIR) {
                 qCDebug(lcFolderWatcher) << "The buffer for changes overflowed! Triggering a generic change and resizing";
+                emit lostChanges();
                 emit changed(_path);
                 *increaseBufferSize = true;
             } else {


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

Align Linux and Windows folder watcher overflow handling with the existing cross-platform recovery behavior:

- Handle Linux `IN_Q_OVERFLOW` events by emitting `lostChanges()`.
- Process exact-size inotify event records.
- Emit `lostChanges()` for the initial Windows `ERROR_NOTIFY_ENUM_DIR` path.

When filesystem notifications are dropped, incremental change tracking is no longer reliable. Signaling `lostChanges()` forces a full local discovery, ensuring missed changes are reconciled instead of silently ignored. This brings Linux and Windows behavior closer to the macOS implementation, which performs a full rescan when FSEvents reports dropped or incomplete notifications.

Based on my understanding from reading the docs/etc I believe this is the appropriate behavior here, but I may be missing something in the bigger picture specific to the client.

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
