### PR TITLE
fix(folderwatcher): harden Linux inotify event processing

### DIFF
--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -119,6 +119,8 @@ void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
     }
 }
 
+// Reads and processes pending inotify events for this watcher, updating
+// watches recursively for created/removed subfolders as needed.
 void FolderWatcherPrivate::slotReceivedNotification(int fd)
 {
     int len = 0;
@@ -127,24 +129,32 @@ void FolderWatcherPrivate::slotReceivedNotification(int fd)
     int error = 0;
     QVarLengthArray<char, 2048> buffer(2048);
 
-    len = read(fd, buffer.data(), buffer.size());
-    error = errno;
-    /**
-      * From inotify documentation:
-      *
-      * The behavior when the buffer given to read(2) is too
-      * small to return information about the next event
-      * depends on the kernel version: in kernels  before 2.6.21,
-      * read(2) returns 0; since kernel 2.6.21, read(2) fails with
-      * the error EINVAL.
-      */
-    while (len < 0 && error == EINVAL) {
-        // double the buffer size
-        buffer.resize(buffer.size() * 2);
-
-        /* and try again ... */
+    for (;;) {
         len = read(fd, buffer.data(), buffer.size());
+        if (len >= 0) {
+            break;
+        }
+
         error = errno;
+
+        if (error == EINTR) {
+            // Interrupted by a signal; just retry.
+            continue;
+        }
+
+        if (error == EAGAIN || error == EWOULDBLOCK) {
+            // No data available right now (only possible if fd were non-blocking).
+            return;
+        }
+
+        if (error != EINVAL) {
+            qCWarning(lcFolderWatcher)
+                << "Failed to read inotify events:" << strerror(error);
+            return;
+        }
+        
+        // Buffer too small for the next event: grow it and retry.
+        buffer.resize(buffer.size() * 2);
     }
 
     // iterate events in buffer

--- a/src/gui/folderwatcher_linux.cpp
+++ b/src/gui/folderwatcher_linux.cpp
@@ -6,6 +6,7 @@
 
 #include "config.h"
 
+#include <limits.h>
 #include <sys/inotify.h>
 
 #include "folder.h"
@@ -14,15 +15,39 @@
 #include <cerrno>
 #include <QStringList>
 #include <QObject>
-#include <QVarLengthArray>
 
 namespace OCC {
+
+namespace {
+
+// The inotify ABI guarantees that this is sufficient for one event,
+// including a maximum-length filename, its terminating NUL, and record
+// padding.
+constexpr size_t kWorstCaseInotifyEventSize = sizeof(struct inotify_event) + NAME_MAX + 1;
+
+// The inotify ABI guarantees that this is sufficient for one event,
+// including a maximum-length filename, its terminating NUL, and record
+// padding.
+constexpr size_t kInotifyRecordsPerRead = 64;
+
+constexpr size_t kInotifyReadBufferSize = kInotifyRecordsPerRead * kWorstCaseInotifyEventSize;
+
+static_assert(kInotifyRecordsPerRead >= 1);
+static_assert(kInotifyReadBufferSize >= kWorstCaseInotifyEventSize);
+
+} // namespace
 
 FolderWatcherPrivate::FolderWatcherPrivate(FolderWatcher *p, const QString &path)
     : QObject()
     , _parent(p)
     , _folder(path)
 {
+    // The buffer is allocated once per watcher and reused for every read.
+    _inotifyBuffer.resize(static_cast<qsizetype>(kInotifyReadBufferSize));
+
+    // Keep this descriptor blocking for now. The notification handler performs
+    // one read per activation and therefore does not attempt to read until
+    // EAGAIN.
     _fd = inotify_init();
     if (_fd != -1) {
         _socket.reset(new QSocketNotifier(_fd, QSocketNotifier::Read));
@@ -46,15 +71,19 @@ bool FolderWatcherPrivate::findFoldersBelow(const QDir &dir, QStringList &fullLi
     } else {
         QStringList nameFilter;
         nameFilter << QLatin1String("*");
-        QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Hidden;
+        
+        const QDir::Filters filter = QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Hidden;
         const QStringList paths = dir.entryList(nameFilter, filter);
 
         QStringList::const_iterator constIterator;
         for (constIterator = paths.constBegin(); constIterator != paths.constEnd();
              ++constIterator) {
             const QString fullPath(dir.path() + QLatin1String("/") + (*constIterator));
+
             fullList.append(fullPath);
-            ok = findFoldersBelow(QDir(fullPath), fullList);
+
+            // Preserve failures from earlier recursive calls.
+            ok = findFoldersBelow(QDir(fullPath), fullList) && ok;
         }
     }
 
@@ -123,111 +152,177 @@ void FolderWatcherPrivate::slotAddFolderRecursive(const QString &path)
 // watches recursively for created/removed subfolders as needed.
 void FolderWatcherPrivate::slotReceivedNotification(int fd)
 {
-    int len = 0;
-    struct inotify_event *event = nullptr;
-    size_t i = 0;
-    int error = 0;
-    QVarLengthArray<char, 2048> buffer(2048);
+    ssize_t len;
 
     for (;;) {
-        len = read(fd, buffer.data(), buffer.size());
+        len = read(fd, _inotifyBuffer.data(), static_cast<size_t>(_inotifyBuffer.size()));
         if (len >= 0) {
+            // Process the events returned by this read below.
             break;
         }
 
-        error = errno;
-
-        if (error == EINTR) {
+        if (errno == EINTR) {
             // Interrupted by a signal; just retry.
             continue;
         }
 
-        if (error == EAGAIN || error == EWOULDBLOCK) {
-            // No data available right now (only possible if fd were non-blocking).
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // No data available right now (if fd becomes non-blocking).
             return;
         }
 
-        if (error != EINVAL) {
+        if (errno == EINVAL) {
+            // The buffer is sized for at least one maximum-sized event.
+            // Keep this as a diagnostic if the ABI or sizing changes.
             qCWarning(lcFolderWatcher)
-                << "Failed to read inotify events:" << strerror(error);
+                << "Inotify read buffer is too small for an event";
+
+            // We cannot rely on the notification stream after an unexpected
+            // sizing failure, so request a full local discovery and do not
+            // process later records from this read.
+            emit _parent->lostChanges();
             return;
+        } else {
+            qCWarning(lcFolderWatcher)
+                << "Failed to read inotify events:" << strerror(errno);
         }
-        
-        // Buffer too small for the next event: grow it and retry.
-        buffer.resize(buffer.size() * 2);
+
+        return;
+    }
+
+    if (len == 0) {
+        qCWarning(lcFolderWatcher)
+            << "Inotify read returned zero bytes";
+        return;
     }
 
     // iterate events in buffer
-    unsigned int ulen = len;
-    for (i = 0; i + sizeof(inotify_event) <= ulen; i += sizeof(inotify_event) + (event ? event->len : 0)) {
-        // cast an inotify_event
-        event = (struct inotify_event *)&buffer[i];
-        if (!event) {
-            qCDebug(lcFolderWatcher) << "NULL event";
-            continue;
+    bool needsRescan = false;
+    size_t offset = 0;
+
+    while (offset < static_cast<size_t>(len)) {
+        const size_t remaining = static_cast<size_t>(len) - offset;
+
+        if (remaining < sizeof(struct inotify_event)) {
+            // Inotify should return complete records. Treat unexpected
+            // truncation as loss of reliable incremental state.
+            qCWarning(lcFolderWatcher)
+                << "Incomplete inotify event header";
+            needsRescan = true;
+            break;
         }
 
-        if (event->mask & IN_Q_OVERFLOW) {
+        const char *eventData = _inotifyBuffer.constData() + offset;
+
+        // Copy the fixed-size header into an aligned local object rather
+        // than dereferencing a potentially unaligned buffer pointer.
+        struct inotify_event eventHeader;
+        std::memcpy(&eventHeader, eventData, sizeof(eventHeader));
+
+        if (eventHeader.len > remaining - sizeof(struct inotify_event)) {
+            // Defensive check against a truncated or malformed record.
+            qCWarning(lcFolderWatcher)
+                << "Incomplete inotify event";
+            needsRescan = true;
+            break;
+        }
+
+        const size_t eventSize = sizeof(struct inotify_event) + eventHeader.len;
+
+        offset += eventSize;
+
+        if (eventHeader.mask & IN_Q_OVERFLOW) {
             qCWarning(lcFolderWatcher)
                 << "The inotify event queue overflowed; triggering a full local discovery";
-            emit _parent->lostChanges();
-            continue;
+            needsRescan = true;
+            // Incremental processing is no longer reliable after queue
+            // overflow, so do not process later records from this read.
+            break;
         }
 
-        // Fire event for the path that was changed.
-        if (event->len == 0 || event->wd <= -1)
+        // Events without a name are handled only through their mask.
+        if (eventHeader.len == 0 || eventHeader.wd <= -1)
             continue;
-        QByteArray fileName(event->name);
-        // Filter out journal changes - redundant with filtering in
-        // FolderWatcher::pathIsIgnored.
+        
+        const char *nameData = eventData + sizeof(struct inotify_event);
+
+        // eventHeader.len includes padding, so bound the search to the
+        // current record and do not assume a valid NUL terminator blindly.
+        const size_t nameLength = ::strnlen(nameData, eventHeader.len);
+
+        if (nameLength == eventHeader.len) {
+            qCWarning(lcFolderWatcher)
+                << "Inotify event name is not NUL-terminated";
+            needsRescan = true;
+            break;
+        }
+
+        const QByteArray fileName(nameData, static_cast<qsizetype>(nameLength));
+
+        // Filter out journal changes. This is redundant with filtering in
+        // FolderWatcher::pathIsIgnored(), but avoids unnecessary processing.
         if (fileName.startsWith("._sync_")
             || fileName.startsWith(".csync_journal.db")
             || fileName.startsWith(".sync_")) {
             continue;
         }
-        const auto watchPathIt = _watchToPath.constFind(event->wd);
+
+        const auto watchPathIt = _watchToPath.constFind(eventHeader.wd);
         if (watchPathIt == _watchToPath.cend()) {
-            qCDebug(lcFolderWatcher) << "Ignoring event for unknown watch descriptor" << event->wd << fileName;
+            qCDebug(lcFolderWatcher)
+                << "Ignoring event for unknown watch descriptor"
+                << eventHeader.wd << fileName;
             continue;
         }
 
         const QString p = *watchPathIt + '/' + fileName;
+
         _parent->changeDetected(p);
 
-        if ((event->mask & (IN_MOVED_TO | IN_CREATE))
+        if ((eventHeader.mask & (IN_MOVED_TO | IN_CREATE))
             && QFileInfo(p).isDir()
             && !_parent->pathIsIgnored(p)) {
             slotAddFolderRecursive(p);
         }
-        if (event->mask & (IN_MOVED_FROM | IN_DELETE)) {
+
+        if (eventHeader.mask & (IN_MOVED_FROM | IN_DELETE)) {
             removeFoldersBelow(p);
         }
+    }
+    
+    if (needsRescan) {
+        emit _parent->lostChanges();
     }
 }
 
 void FolderWatcherPrivate::removeFoldersBelow(const QString &path)
 {
     auto it = _pathToWatch.find(path);
+
     if (it == _pathToWatch.end())
         return;
 
-    QString pathSlash = path + '/';
+    const QString pathSlash = path + '/';
 
-    // Remove the entry and all subentries
+    // Remove the entry and all subentries.
     while (it != _pathToWatch.end()) {
-        auto itPath = it.key();
+        const auto itPath = it.key();
+
         if (!itPath.startsWith(path))
             break;
+
         if (itPath != path && !itPath.startsWith(pathSlash)) {
             // order is 'foo', 'foo bar', 'foo/bar'
             ++it;
             continue;
         }
 
-        auto wid = it.value();
+        const auto wid = it.value();
+
         inotify_rm_watch(_fd, wid);
         _watchToPath.remove(wid);
         it = _pathToWatch.erase(it);
+
         qCDebug(lcFolderWatcher) << "Removed watch for" << itPath;
     }
 }

--- a/src/gui/folderwatcher_linux.h
+++ b/src/gui/folderwatcher_linux.h
@@ -7,6 +7,7 @@
 #ifndef MIRALL_FOLDERWATCHER_LINUX_H
 #define MIRALL_FOLDERWATCHER_LINUX_H
 
+#include <QByteArray>
 #include <QObject>
 #include <QString>
 #include <QSocketNotifier>
@@ -33,7 +34,7 @@ public:
 
     [[nodiscard]] int testWatchCount() const { return _pathToWatch.size(); }
 
-    /// On linux the watcher is ready when the ctor finished.
+    // On Linux the watcher is ready when the constructor has finished.
     bool _ready = true;
 
 protected slots:
@@ -58,8 +59,10 @@ private:
     QHash<int, QString> _watchToPath;
     QMap<QString, int> _pathToWatch;
     QScopedPointer<QSocketNotifier> _socket;
+    QByteArray _inotifyBuffer;
     int _fd = 0;
 };
-}
+
+} // namespace OCC
 
 #endif


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
<!-- related github issue --> (hard to say with certainty)

## Summary

Harden Linux folder watcher handling of inotify reads and event records.

This updates `FolderWatcherPrivate::slotReceivedNotification()` to avoid  processing and undefined behavior on failed reads, use a reusable event buffer, validate inotify records defensively, and request a full local discovery when the incremental event stream can no longer be trusted.

### Changes

- Retry inotify reads interrupted by `EINTR`.
- Handle `EAGAIN`/`EWOULDBLOCK` without attempting to parse a failed read. (This is future-proofing while the descriptor remains blocking.)
- Log and return on unexpected read errors.
- Replace the dynamically growing per-call buffer with a reusable `QByteArray`.
- Size the buffer for 64 maximum-sized inotify records (approximately 17 KiB with typical Linux `inotify_event` and `NAME_MAX` values).
- Treat an unexpected `EINVAL` as an indication that the event stream cannot be trusted, request a full local discovery via `lostChanges()`, and avoid unbounded buffer growth.
- Parse records using explicit offsets and validate:
  - incomplete event headers;
  - truncated event records;
  - missing NUL termination in event names.
- Copy the fixed inotify header into an aligned local object before inspecting it, avoiding potentially unaligned structure access.
- Stop incremental processing after `IN_Q_OVERFLOW` and emit `lostChanges()` at most once for the notification batch.
- Preserve failures encountered during recursive folder traversal.
- Reuse the inotify buffer across notification callbacks to avoid repeated allocations.

### Problem

Previously, a negative result from `read()` could fall through to event processing. Converting that negative value to an unsigned length could cause the parser to inspect bytes beyond the data returned by `read()`, resulting in undefined behavior, invalid event processing, or a crash.

The previous `EINVAL` handling also resized the buffer repeatedly without a fixed upper bound.

### TODO

- [ ] Build the Linux folder watcher changes.
- [ ] Run the relevant folder watcher tests.
- [ ] Verify normal file and directory create, delete, and move handling.
- [ ] Verify recovery after an inotify queue overflow.
- [ ] Add or run coverage for interrupted reads, unavailable reads, malformed records, and unexpected read errors.

### Follow-up: non-blocking inotify

`inotify_init()` is currently used, so the descriptor is blocking and `EAGAIN`/`EWOULDBLOCK` are not expected during normal operation. The defensive branch is retained for a possible future switch to `inotify_init1(IN_NONBLOCK | IN_CLOEXEC)`.

A non-blocking descriptor would allow the handler to drain notifications until `EAGAIN`, provided the read loop is updated accordingly. That change is intentionally outside the scope of this pull request.

## Checklist
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
