### PR TITLE
fix(mac-crafter): Verify all components are signed with matching team identifiers

### DIFF
--- a/.github/workflows/mac-crafter-ci.yml
+++ b/.github/workflows/mac-crafter-ci.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+name: mac-crafter CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    name: Test mac-crafter
+    timeout-minutes: 15
+    runs-on: macos-26
+    defaults:
+      run:
+        working-directory: admin/osx/mac-crafter
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+
+      - name: Run tests
+        run: swift test

--- a/admin/osx/mac-crafter/Package.swift
+++ b/admin/osx/mac-crafter/Package.swift
@@ -26,5 +26,9 @@ let package = Package(
                 .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
+        .testTarget(
+            name: "mac-crafter-tests",
+            dependencies: ["mac-crafter"]
+        ),
     ]
 )

--- a/admin/osx/mac-crafter/Sources/Commands/Build.swift
+++ b/admin/osx/mac-crafter/Sources/Commands/Build.swift
@@ -434,7 +434,10 @@ struct Build: AsyncParsableCommand {
             try await Signer.signMainBundle(
                 at: clientAppURL,
                 codeSignIdentity: codeSignIdentity,
-                entitlements: entitlements
+                entitlements: entitlements,
+                expectedTeamIdentifier: try CMakeConfiguration.developmentTeamIdentifier(
+                    at: repoRootURL.appendingPathComponent("NEXTCLOUD.cmake")
+                )
             )
         }
         

--- a/admin/osx/mac-crafter/Sources/Utils/CMakeConfiguration.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/CMakeConfiguration.swift
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+///
+/// Reads signing-related values from the client's CMake configuration.
+///
+enum CMakeConfiguration {
+    static func developmentTeamIdentifier(at file: URL) throws -> String {
+        let contents: String
+
+        do {
+            contents = try String(contentsOf: file, encoding: .utf8)
+        } catch {
+            throw MacCrafterError.signing("Unable to read \(file.path): \(error.localizedDescription)")
+        }
+
+        let pattern = #"(?m)^[ \t]*set[ \t]*\([ \t]*DEVELOPMENT_TEAM[ \t]+[\"]?([^\"\s\)]+)"#
+        guard let expression = try? NSRegularExpression(pattern: pattern),
+              let match = expression.firstMatch(
+                  in: contents,
+                  range: NSRange(contents.startIndex..., in: contents)
+              ),
+              let teamIdentifierRange = Range(match.range(at: 1), in: contents)
+        else {
+            throw MacCrafterError.signing("Unable to find DEVELOPMENT_TEAM in \(file.path)")
+        }
+
+        return String(contents[teamIdentifierRange])
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/CodeSignatureVerifier.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/CodeSignatureVerifier.swift
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+///
+/// Discovers signed code components and verifies their team identifiers.
+///
+enum CodeSignatureVerifier {
+    static func verify(at location: URL) throws {
+        try verify(
+            at: location,
+            isMachO: { isMachO($0) },
+            signatureDetails: { try codesignDetails(at: $0) }
+        )
+    }
+
+    static func verify(
+        at location: URL,
+        isMachO: (URL) -> Bool,
+        signatureDetails: (URL) throws -> String
+    ) throws {
+        let components = try discoverCodeComponents(at: location, isMachO: isMachO)
+        let signatures = try components.map { component in
+            (
+                location: component.path,
+                teamIdentifier: TeamIdentifierVerifier.teamIdentifier(from: try signatureDetails(component))
+            )
+        }
+
+        if let error = TeamIdentifierVerifier.validationError(for: signatures) {
+            throw MacCrafterError.signing(error)
+        }
+
+        Log.info("Verified matching TeamIdentifier for \(signatures.count) code components")
+    }
+
+    static func discoverCodeComponents(at url: URL, isMachO: (URL) -> Bool) throws -> [URL] {
+        let codeBundleExtensions = ["app", "appex", "framework", "xpc"]
+        let codeSearchDirectories = ["/Contents/MacOS/", "/Contents/Frameworks/", "/Contents/PlugIns/"]
+        var components = [URL]()
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            throw MacCrafterError.environmentError("Failed to get enumerator for: \(url.path)")
+        }
+
+        for case let candidate as URL in enumerator {
+            let pathExtension = candidate.pathExtension.lowercased()
+
+            if codeBundleExtensions.contains(pathExtension) || pathExtension == "dylib" {
+                components.append(candidate)
+                continue
+            }
+
+            guard codeSearchDirectories.contains(where: candidate.path.contains),
+                  try candidate.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true,
+                  isMachO(candidate)
+            else {
+                continue
+            }
+
+            components.append(candidate)
+        }
+
+        return [url] + components.sorted { $0.path < $1.path }
+    }
+
+    private static func isMachO(_ file: URL) -> Bool {
+        let task = Process()
+        let outputPipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/file")
+        task.arguments = ["-b", file.path]
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+        } catch {
+            return false
+        }
+
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        task.waitUntilExit()
+        return task.terminationStatus == 0 && output.contains("Mach-O")
+    }
+
+    private static func codesignDetails(at location: URL) throws -> String {
+        let task = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        task.arguments = ["--display", "--verbose=4", location.path]
+        task.standardOutput = standardOutput
+        task.standardError = standardError
+
+        do {
+            try task.run()
+        } catch {
+            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(error.localizedDescription)")
+        }
+
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+
+        guard task.terminationStatus == 0 else {
+            let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown codesign error"
+            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(errorOutput)")
+        }
+
+        return [outputData, errorData]
+            .compactMap { String(data: $0, encoding: .utf8) }
+            .joined(separator: "\n")
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/CodeSignatureVerifier.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/CodeSignatureVerifier.swift
@@ -7,9 +7,10 @@ import Foundation
 /// Discovers signed code components and verifies their team identifiers.
 ///
 enum CodeSignatureVerifier {
-    static func verify(at location: URL) throws {
+    static func verify(at location: URL, expectedTeamIdentifier: String? = nil) throws {
         try verify(
             at: location,
+            expectedTeamIdentifier: expectedTeamIdentifier,
             isMachO: { isMachO($0) },
             signatureDetails: { try codesignDetails(at: $0) }
         )
@@ -17,6 +18,7 @@ enum CodeSignatureVerifier {
 
     static func verify(
         at location: URL,
+        expectedTeamIdentifier: String? = nil,
         isMachO: (URL) -> Bool,
         signatureDetails: (URL) throws -> String
     ) throws {
@@ -29,6 +31,15 @@ enum CodeSignatureVerifier {
         }
 
         if let error = TeamIdentifierVerifier.validationError(for: signatures) {
+            throw MacCrafterError.signing(error)
+        }
+
+        if let expectedTeamIdentifier,
+           let error = TeamIdentifierVerifier.validationError(
+               for: signatures,
+               expectedTeamIdentifier: expectedTeamIdentifier
+           )
+        {
             throw MacCrafterError.signing(error)
         }
 

--- a/admin/osx/mac-crafter/Sources/Utils/Signer.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Signer.swift
@@ -11,44 +11,6 @@ protocol Signing {
 }
 
 ///
-/// Team identifier verification helpers.
-///
-enum TeamIdentifierVerifier {
-    static func teamIdentifier(from codesignOutput: String) -> String? {
-        let prefix = "TeamIdentifier="
-
-        guard let line = codesignOutput.split(whereSeparator: \.isNewline).first(where: { $0.hasPrefix(prefix) }) else {
-            return nil
-        }
-
-        let teamIdentifier = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
-        return teamIdentifier == "not set" || teamIdentifier.isEmpty ? nil : teamIdentifier
-    }
-
-    static func validationError(for components: [(location: String, teamIdentifier: String?)]) -> String? {
-        guard let firstComponent = components.first else {
-            return "Signing verification failed because no signed code components were found"
-        }
-
-        guard let expectedTeamIdentifier = firstComponent.teamIdentifier else {
-            return "Signing verification failed because \(firstComponent.location) has no TeamIdentifier"
-        }
-
-        for component in components.dropFirst() {
-            guard let teamIdentifier = component.teamIdentifier else {
-                return "Signing verification failed because \(component.location) has no TeamIdentifier"
-            }
-
-            guard teamIdentifier == expectedTeamIdentifier else {
-                return "Signing verification failed because \(component.location) has TeamIdentifier \(teamIdentifier), expected \(expectedTeamIdentifier) from \(firstComponent.location)"
-            }
-        }
-
-        return nil
-    }
-}
-
-///
 /// Used as a namespace for stateless signing methods.
 ///
 enum Signer: Signing {
@@ -331,112 +293,6 @@ enum Signer: Signing {
         }
     }
 
-    ///
-    /// Find code objects whose signatures must belong to the app's signing team.
-    ///
-    private static func findCodeComponents(at url: URL) throws -> [URL] {
-        let codeBundleExtensions = ["app", "appex", "framework", "xpc"]
-        let codeSearchDirectories = ["/Contents/MacOS/", "/Contents/Frameworks/", "/Contents/PlugIns/"]
-        var components = [url]
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: url,
-            includingPropertiesForKeys: [.isRegularFileKey]
-        ) else {
-            throw MacCrafterError.environmentError("Failed to get enumerator for: \(url.path)")
-        }
-
-        for case let candidate as URL in enumerator {
-            let pathExtension = candidate.pathExtension.lowercased()
-
-            if codeBundleExtensions.contains(pathExtension) || pathExtension == "dylib" {
-                components.append(candidate)
-                continue
-            }
-
-            guard codeSearchDirectories.contains(where: candidate.path.contains),
-                  try candidate.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true,
-                  isMachO(candidate)
-            else {
-                continue
-            }
-
-            components.append(candidate)
-        }
-
-        return components.sorted { $0.path < $1.path }
-    }
-
-    ///
-    /// Check whether a file contains a Mach-O code object.
-    ///
-    private static func isMachO(_ file: URL) -> Bool {
-        let task = Process()
-        let outputPipe = Pipe()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/file")
-        task.arguments = ["-b", file.path]
-        task.standardOutput = outputPipe
-        task.standardError = Pipe()
-
-        do {
-            try task.run()
-        } catch {
-            return false
-        }
-
-        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        task.waitUntilExit()
-        return task.terminationStatus == 0 && output.contains("Mach-O")
-    }
-
-    ///
-    /// Read the code-signing metadata for a code object.
-    ///
-    private static func codesignDetails(at location: URL) throws -> String {
-        let task = Process()
-        let standardOutput = Pipe()
-        let standardError = Pipe()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
-        task.arguments = ["--display", "--verbose=4", location.path]
-        task.standardOutput = standardOutput
-        task.standardError = standardError
-
-        do {
-            try task.run()
-        } catch {
-            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(error.localizedDescription)")
-        }
-
-        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
-        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
-
-        guard task.terminationStatus == 0 else {
-            let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown codesign error"
-            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(errorOutput)")
-        }
-
-        return [outputData, errorData]
-            .compactMap { String(data: $0, encoding: .utf8) }
-            .joined(separator: "\n")
-    }
-
-    private static func verifyTeamIdentifiers(at location: URL) throws {
-        let components = try findCodeComponents(at: location)
-        let signatures = try components.map { component in
-            (
-                location: component.path,
-                teamIdentifier: TeamIdentifierVerifier.teamIdentifier(from: try codesignDetails(at: component))
-            )
-        }
-
-        if let error = TeamIdentifierVerifier.validationError(for: signatures) {
-            throw MacCrafterError.signing(error)
-        }
-
-        Log.info("Verified matching TeamIdentifier for \(signatures.count) code components")
-    }
-
     private static func verify(at location: URL) async throws {
         Log.info("Verifying: \(location.path)")
         let code = await shell("codesign --verify --deep --strict --verbose=2 \"\(location.path)\"")
@@ -445,7 +301,7 @@ enum Signer: Signing {
             throw MacCrafterError.signing("Signing verification failed because the codesign command terminated with code \(code)")
         }
 
-        try verifyTeamIdentifiers(at: location)
+        try CodeSignatureVerifier.verify(at: location)
     }
 
     // MARK: - Public

--- a/admin/osx/mac-crafter/Sources/Utils/Signer.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Signer.swift
@@ -11,6 +11,44 @@ protocol Signing {
 }
 
 ///
+/// Team identifier verification helpers.
+///
+enum TeamIdentifierVerifier {
+    static func teamIdentifier(from codesignOutput: String) -> String? {
+        let prefix = "TeamIdentifier="
+
+        guard let line = codesignOutput.split(whereSeparator: \.isNewline).first(where: { $0.hasPrefix(prefix) }) else {
+            return nil
+        }
+
+        let teamIdentifier = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        return teamIdentifier == "not set" || teamIdentifier.isEmpty ? nil : teamIdentifier
+    }
+
+    static func validationError(for components: [(location: String, teamIdentifier: String?)]) -> String? {
+        guard let firstComponent = components.first else {
+            return "Signing verification failed because no signed code components were found"
+        }
+
+        guard let expectedTeamIdentifier = firstComponent.teamIdentifier else {
+            return "Signing verification failed because \(firstComponent.location) has no TeamIdentifier"
+        }
+
+        for component in components.dropFirst() {
+            guard let teamIdentifier = component.teamIdentifier else {
+                return "Signing verification failed because \(component.location) has no TeamIdentifier"
+            }
+
+            guard teamIdentifier == expectedTeamIdentifier else {
+                return "Signing verification failed because \(component.location) has TeamIdentifier \(teamIdentifier), expected \(expectedTeamIdentifier) from \(firstComponent.location)"
+            }
+        }
+
+        return nil
+    }
+}
+
+///
 /// Used as a namespace for stateless signing methods.
 ///
 enum Signer: Signing {
@@ -293,6 +331,112 @@ enum Signer: Signing {
         }
     }
 
+    ///
+    /// Find code objects whose signatures must belong to the app's signing team.
+    ///
+    private static func findCodeComponents(at url: URL) throws -> [URL] {
+        let codeBundleExtensions = ["app", "appex", "framework", "xpc"]
+        let codeSearchDirectories = ["/Contents/MacOS/", "/Contents/Frameworks/", "/Contents/PlugIns/"]
+        var components = [url]
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            throw MacCrafterError.environmentError("Failed to get enumerator for: \(url.path)")
+        }
+
+        for case let candidate as URL in enumerator {
+            let pathExtension = candidate.pathExtension.lowercased()
+
+            if codeBundleExtensions.contains(pathExtension) || pathExtension == "dylib" {
+                components.append(candidate)
+                continue
+            }
+
+            guard codeSearchDirectories.contains(where: candidate.path.contains),
+                  try candidate.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true,
+                  isMachO(candidate)
+            else {
+                continue
+            }
+
+            components.append(candidate)
+        }
+
+        return components.sorted { $0.path < $1.path }
+    }
+
+    ///
+    /// Check whether a file contains a Mach-O code object.
+    ///
+    private static func isMachO(_ file: URL) -> Bool {
+        let task = Process()
+        let outputPipe = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/file")
+        task.arguments = ["-b", file.path]
+        task.standardOutput = outputPipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+        } catch {
+            return false
+        }
+
+        let output = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        task.waitUntilExit()
+        return task.terminationStatus == 0 && output.contains("Mach-O")
+    }
+
+    ///
+    /// Read the code-signing metadata for a code object.
+    ///
+    private static func codesignDetails(at location: URL) throws -> String {
+        let task = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        task.arguments = ["--display", "--verbose=4", location.path]
+        task.standardOutput = standardOutput
+        task.standardError = standardError
+
+        do {
+            try task.run()
+        } catch {
+            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(error.localizedDescription)")
+        }
+
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let errorData = standardError.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+
+        guard task.terminationStatus == 0 else {
+            let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown codesign error"
+            throw MacCrafterError.signing("Unable to inspect the code signature of \(location.path): \(errorOutput)")
+        }
+
+        return [outputData, errorData]
+            .compactMap { String(data: $0, encoding: .utf8) }
+            .joined(separator: "\n")
+    }
+
+    private static func verifyTeamIdentifiers(at location: URL) throws {
+        let components = try findCodeComponents(at: location)
+        let signatures = try components.map { component in
+            (
+                location: component.path,
+                teamIdentifier: TeamIdentifierVerifier.teamIdentifier(from: try codesignDetails(at: component))
+            )
+        }
+
+        if let error = TeamIdentifierVerifier.validationError(for: signatures) {
+            throw MacCrafterError.signing(error)
+        }
+
+        Log.info("Verified matching TeamIdentifier for \(signatures.count) code components")
+    }
+
     private static func verify(at location: URL) async throws {
         Log.info("Verifying: \(location.path)")
         let code = await shell("codesign --verify --deep --strict --verbose=2 \"\(location.path)\"")
@@ -300,6 +444,8 @@ enum Signer: Signing {
         if code > 0 {
             throw MacCrafterError.signing("Signing verification failed because the codesign command terminated with code \(code)")
         }
+
+        try verifyTeamIdentifiers(at: location)
     }
 
     // MARK: - Public

--- a/admin/osx/mac-crafter/Sources/Utils/Signer.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/Signer.swift
@@ -293,7 +293,7 @@ enum Signer: Signing {
         }
     }
 
-    private static func verify(at location: URL) async throws {
+    private static func verify(at location: URL, expectedTeamIdentifier: String?) async throws {
         Log.info("Verifying: \(location.path)")
         let code = await shell("codesign --verify --deep --strict --verbose=2 \"\(location.path)\"")
 
@@ -301,7 +301,7 @@ enum Signer: Signing {
             throw MacCrafterError.signing("Signing verification failed because the codesign command terminated with code \(code)")
         }
 
-        try CodeSignatureVerifier.verify(at: location)
+        try CodeSignatureVerifier.verify(at: location, expectedTeamIdentifier: expectedTeamIdentifier)
     }
 
     // MARK: - Public
@@ -312,7 +312,8 @@ enum Signer: Signing {
     static func signMainBundle(
         at location: URL,
         codeSignIdentity: String,
-        entitlements: [String: URL]
+        entitlements: [String: URL],
+        expectedTeamIdentifier: String? = nil
     ) async throws {
         // Signing is inside-out: nested code first, the containing bundle last. Login items come
         // before the app for that reason, and the outer sign is deliberately not --deep.
@@ -392,7 +393,7 @@ enum Signer: Signing {
         }
 
         await sign(at: location, with: codeSignIdentity, entitlements: mainAppEntitlements)
-        try await verify(at: location)
+        try await verify(at: location, expectedTeamIdentifier: expectedTeamIdentifier)
     }
     
     ///

--- a/admin/osx/mac-crafter/Sources/Utils/TeamIdentifierVerifier.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/TeamIdentifierVerifier.swift
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+///
+/// Team identifier verification helpers.
+///
+enum TeamIdentifierVerifier {
+    static func teamIdentifier(from codesignOutput: String) -> String? {
+        let prefix = "TeamIdentifier="
+
+        guard let line = codesignOutput.split(whereSeparator: \.isNewline).first(where: { $0.hasPrefix(prefix) }) else {
+            return nil
+        }
+
+        let teamIdentifier = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        return teamIdentifier == "not set" || teamIdentifier.isEmpty ? nil : teamIdentifier
+    }
+
+    static func validationError(for components: [(location: String, teamIdentifier: String?)]) -> String? {
+        guard let firstComponent = components.first else {
+            return "Signing verification failed because no signed code components were found"
+        }
+
+        guard let expectedTeamIdentifier = firstComponent.teamIdentifier else {
+            return "Signing verification failed because \(firstComponent.location) has no TeamIdentifier"
+        }
+
+        for component in components.dropFirst() {
+            guard let teamIdentifier = component.teamIdentifier else {
+                return "Signing verification failed because \(component.location) has no TeamIdentifier"
+            }
+
+            guard teamIdentifier == expectedTeamIdentifier else {
+                return "Signing verification failed because \(component.location) has TeamIdentifier \(teamIdentifier), expected \(expectedTeamIdentifier) from \(firstComponent.location)"
+            }
+        }
+
+        return nil
+    }
+}

--- a/admin/osx/mac-crafter/Sources/Utils/TeamIdentifierVerifier.swift
+++ b/admin/osx/mac-crafter/Sources/Utils/TeamIdentifierVerifier.swift
@@ -39,4 +39,23 @@ enum TeamIdentifierVerifier {
 
         return nil
     }
+
+    static func validationError(
+        for components: [(location: String, teamIdentifier: String?)],
+        expectedTeamIdentifier: String
+    ) -> String? {
+        guard let component = components.first else {
+            return "Signing verification failed because no signed code components were found"
+        }
+
+        guard let teamIdentifier = component.teamIdentifier else {
+            return "Signing verification failed because \(component.location) has no TeamIdentifier"
+        }
+
+        guard teamIdentifier == expectedTeamIdentifier else {
+            return "Signing verification failed because \(component.location) has TeamIdentifier \(teamIdentifier), expected \(expectedTeamIdentifier) from NEXTCLOUD.cmake"
+        }
+
+        return nil
+    }
 }

--- a/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
+++ b/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
@@ -78,6 +78,67 @@ struct TeamIdentifierVerifierTests {
     }
 
     @Test
+    func acceptsExpectedTeamIdentifier() {
+        let components = [
+            (location: "/Nextcloud.app", teamIdentifier: Optional("C4QUVLMPQU")),
+        ]
+
+        #expect(
+            TeamIdentifierVerifier.validationError(
+                for: components,
+                expectedTeamIdentifier: "C4QUVLMPQU"
+            ) == nil
+        )
+    }
+
+    @Test
+    func rejectsUnexpectedExpectedTeamIdentifier() {
+        let components = [
+            (location: "/Nextcloud.app", teamIdentifier: Optional("NKUJUXUJ3B")),
+        ]
+
+        let error = TeamIdentifierVerifier.validationError(
+            for: components,
+            expectedTeamIdentifier: "C4QUVLMPQU"
+        )
+
+        #expect(error?.contains("expected C4QUVLMPQU from NEXTCLOUD.cmake") == true)
+    }
+
+    @Test
+    func rejectsSignatureWithTeamIdentifierDifferentFromCMakeConfiguration() throws {
+        let fixture = try makeCodeBundleFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        do {
+            try CodeSignatureVerifier.verify(
+                at: fixture.root,
+                expectedTeamIdentifier: "C4QUVLMPQU",
+                isMachO: { fixture.machOFiles.contains($0.resolvingSymlinksInPath().path) },
+                signatureDetails: { _ in "TeamIdentifier=NKUJUXUJ3B" }
+            )
+            Issue.record("Expected verification to reject the TeamIdentifier from the signature")
+        } catch let error as MacCrafterError {
+            #expect(error.description.contains("expected C4QUVLMPQU from NEXTCLOUD.cmake"))
+        }
+    }
+
+    @Test
+    func readsDevelopmentTeamFromCMakeConfiguration() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NEXTCLOUD-\(UUID().uuidString).cmake")
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        try #"set( DEVELOPMENT_TEAM "C4QUVLMPQU" CACHE STRING "Apple Development Team ID" )"#.write(
+            to: file,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        #expect(try CMakeConfiguration.developmentTeamIdentifier(at: file) == "C4QUVLMPQU")
+    }
+
+    @Test
     func discoversBundlesDylibsAndMachOExecutables() throws {
         let fixture = try makeCodeBundleFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }

--- a/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
+++ b/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
@@ -1,10 +1,37 @@
 // SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import Foundation
 import Testing
 @testable import mac_crafter
 
 struct TeamIdentifierVerifierTests {
+    private func makeCodeBundleFixture() throws -> (root: URL, machOFiles: Set<String>) {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("mac-crafter-tests-\(UUID().uuidString)")
+
+        let machOPaths = [
+            root.appendingPathComponent("Contents/MacOS/Nextcloud"),
+            root.appendingPathComponent("Contents/Frameworks/QtCore.framework/Versions/A/QtCore"),
+            root.appendingPathComponent("Contents/PlugIns/FileProviderExt.appex/Contents/MacOS/FileProviderExt"),
+            root.appendingPathComponent("Contents/PlugIns/Helper.xpc/Contents/MacOS/Helper"),
+        ]
+        let files = machOPaths + [
+            root.appendingPathComponent("Contents/Frameworks/libexample.dylib"),
+        ]
+
+        for file in files {
+            try fileManager.createDirectory(
+                at: file.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            fileManager.createFile(atPath: file.path, contents: Data())
+        }
+
+        return (root, Set(machOPaths.map { $0.resolvingSymlinksInPath().path }))
+    }
+
     @Test
     func parsesTeamIdentifier() {
         let output = "Identifier=org.nextcloud.desktopclient\nTeamIdentifier=NKUJUXUJ3B\n"
@@ -48,5 +75,53 @@ struct TeamIdentifierVerifierTests {
         ]
 
         #expect(TeamIdentifierVerifier.validationError(for: components) == nil)
+    }
+
+    @Test
+    func discoversBundlesDylibsAndMachOExecutables() throws {
+        let fixture = try makeCodeBundleFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let components = try CodeSignatureVerifier.discoverCodeComponents(
+            at: fixture.root,
+            isMachO: { fixture.machOFiles.contains($0.resolvingSymlinksInPath().path) }
+        )
+        let normalize: (URL) -> String = { $0.resolvingSymlinksInPath().path }
+        let discoveredPaths = Set(components.map(normalize))
+        let expectedPaths = Set([
+            fixture.root.path,
+            fixture.root.appendingPathComponent("Contents/Frameworks/QtCore.framework").path,
+            fixture.root.appendingPathComponent("Contents/Frameworks/libexample.dylib").path,
+            fixture.root.appendingPathComponent("Contents/MacOS/Nextcloud").path,
+            fixture.root.appendingPathComponent("Contents/PlugIns/FileProviderExt.appex").path,
+            fixture.root.appendingPathComponent("Contents/PlugIns/FileProviderExt.appex/Contents/MacOS/FileProviderExt").path,
+            fixture.root.appendingPathComponent("Contents/PlugIns/Helper.xpc").path,
+            fixture.root.appendingPathComponent("Contents/PlugIns/Helper.xpc/Contents/MacOS/Helper").path,
+            fixture.root.appendingPathComponent("Contents/Frameworks/QtCore.framework/Versions/A/QtCore").path,
+        ].map { normalize(URL(fileURLWithPath: $0)) })
+
+        #expect(discoveredPaths == expectedPaths)
+    }
+
+    @Test
+    func rejectsMismatchedDiscoveredComponent() throws {
+        let fixture = try makeCodeBundleFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        do {
+            try CodeSignatureVerifier.verify(
+                at: fixture.root,
+                isMachO: { fixture.machOFiles.contains($0.resolvingSymlinksInPath().path) },
+                signatureDetails: { component in
+                    component.path.hasSuffix("QtCore.framework")
+                        ? "TeamIdentifier=QTTEAMID"
+                        : "TeamIdentifier=NKUJUXUJ3B"
+                }
+            )
+            Issue.record("Expected verification to reject a mismatched discovered component")
+        } catch let error as MacCrafterError {
+            #expect(error.description.contains("QTTEAMID"))
+            #expect(error.description.contains("expected NKUJUXUJ3B"))
+        }
     }
 }

--- a/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
+++ b/admin/osx/mac-crafter/Tests/mac-crafter-tests/TeamIdentifierVerifierTests.swift
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Testing
+@testable import mac_crafter
+
+struct TeamIdentifierVerifierTests {
+    @Test
+    func parsesTeamIdentifier() {
+        let output = "Identifier=org.nextcloud.desktopclient\nTeamIdentifier=NKUJUXUJ3B\n"
+
+        #expect(TeamIdentifierVerifier.teamIdentifier(from: output) == "NKUJUXUJ3B")
+    }
+
+    @Test
+    func treatsAdHocSignatureAsMissingTeamIdentifier() {
+        #expect(TeamIdentifierVerifier.teamIdentifier(from: "Signature=adhoc\nTeamIdentifier=not set\n") == nil)
+    }
+
+    @Test
+    func rejectsMissingTeamIdentifier() {
+        let components = [
+            (location: "/Nextcloud.app", teamIdentifier: Optional("NKUJUXUJ3B")),
+            (location: "/Nextcloud.app/Contents/Frameworks/QtCore.framework", teamIdentifier: Optional<String>.none),
+        ]
+
+        #expect(TeamIdentifierVerifier.validationError(for: components)?.contains("has no TeamIdentifier") == true)
+    }
+
+    @Test
+    func rejectsMismatchedTeamIdentifier() {
+        let components = [
+            (location: "/Nextcloud.app", teamIdentifier: Optional("NKUJUXUJ3B")),
+            (location: "/Nextcloud.app/Contents/Frameworks/QtCore.framework", teamIdentifier: Optional("QTTEAMID")),
+        ]
+
+        let error = TeamIdentifierVerifier.validationError(for: components)
+
+        #expect(error?.contains("QTTEAMID") == true)
+        #expect(error?.contains("expected NKUJUXUJ3B") == true)
+    }
+
+    @Test
+    func acceptsMatchingTeamIdentifiers() {
+        let components = [
+            (location: "/Nextcloud.app", teamIdentifier: Optional("NKUJUXUJ3B")),
+            (location: "/Nextcloud.app/Contents/Frameworks/QtCore.framework", teamIdentifier: Optional("NKUJUXUJ3B")),
+        ]
+
+        #expect(TeamIdentifierVerifier.validationError(for: components) == nil)
+    }
+}

--- a/shell_integration/MacOSX/CMakeLists.txt
+++ b/shell_integration/MacOSX/CMakeLists.txt
@@ -78,6 +78,7 @@ if(APPLE)
             "OC_APPLICATION_VENDOR=${APPLICATION_VENDOR}"
             "OC_APPLICATION_NAME=${APPLICATION_NAME}"
             "OC_APPLICATION_REV_DOMAIN=${APPLICATION_REV_DOMAIN}"
+            "DEVELOPMENT_TEAM=${DEVELOPMENT_TEAM}"
             COMMENT building macOS File Provider extension
             VERBATIM)
 
@@ -95,6 +96,7 @@ if(APPLE)
             "OC_APPLICATION_VENDOR=${APPLICATION_VENDOR}"
             "OC_APPLICATION_NAME=${APPLICATION_NAME}"
             "OC_APPLICATION_REV_DOMAIN=${APPLICATION_REV_DOMAIN}"
+            "DEVELOPMENT_TEAM=${DEVELOPMENT_TEAM}"
             DEPENDS mac_fileproviderplugin
             COMMENT building macOS File Provider UI extension
             VERBATIM)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

Even when all components are signed with a valid signature, signing with mismatched team identifiers will prevent the final client app bundle from being executed correctly.

This PR adds a verification step to mac-crafter that checks that team identifiers all match.

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
