### PR TITLE
fix(macOS): compare FinderSync broker application versions

### DIFF
--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncBroker/main.swift
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncBroker/main.swift
@@ -51,7 +51,7 @@ private func readBundleIdentity() -> BundleIdentity? {
     return BundleIdentity(serviceName: serviceName,
                           teamIdentifier: team,
                           applicationRevDomain: revDomain,
-                          version: info["CFBundleVersion"] as? String ?? "0")
+                          version: info["CFBundleShortVersionString"] as? String ?? "")
 }
 
 /// Prove the listener is actually reachable, rather than assuming it is.

--- a/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncBrokerProtocol.h
+++ b/shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncBrokerProtocol.h
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
  * unregister completion handler before re-registering, because registering too early
  * fails with SMAppServiceErrorDomain code 1.
  *
- * @param reply Invoked with the broker's CFBundleVersion.
+ * @param reply Invoked with the broker's CFBundleShortVersionString.
  */
 - (void)brokerVersionWithReply:(void(^)(NSString *version))reply;
 

--- a/src/gui/macOS/findersyncxpc_mac.mm
+++ b/src/gui/macOS/findersyncxpc_mac.mm
@@ -4,6 +4,7 @@
  */
 
 #include "findersyncxpc.h"
+#include "version.h"
 
 #import <Foundation/Foundation.h>
 #import "../../../shell_integration/MacOSX/NextcloudIntegration/FinderSyncExt/Services/FinderSyncProtocol.h"
@@ -332,11 +333,7 @@ void FinderSyncXPC::publishEndpointToBroker()
     // and we would go on talking to last version's broker indefinitely.
     [broker brokerVersionWithReply:^(NSString *version) {
         const auto brokerVersion = QString::fromNSString(version);
-        // Deliberately the literal key rather than kCFBundleVersionKey: that constant would add
-        // a CoreFoundation data symbol to this translation unit for no benefit, and the other
-        // Info.plist reads here use literals too.
-        const auto ourVersion = QString::fromNSString(
-            [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]);
+        const auto ourVersion = QString::fromLatin1(MIRALL_STRINGIFY(MIRALL_VERSION));
 
         if (brokerVersion == ourVersion) {
             qCDebug(lcFinderSyncXPC) << "Broker version matches ours:" << brokerVersion;


### PR DESCRIPTION
- The FinderSync broker reported CFBundleVersion, which was 0 when MIRALL_VERSION_BUILD was not supplied (which is the case in brander as of qt6)
- The client compared this with its full bundle version, causing a false mismatch on every startup:
  - Broker is running version "0" but we are "34.0.50.0" - restarting it
  - Already restarted the broker for version "0" and it came back the same

- Use CFBundleShortVersionString on the broker side and compare it with the client's compiled MIRALL_VERSION. Both sides now compare the application version, such as 34.0.50, without requiring build-ID propagation.

Assisted-by: Codex:GPT-5