### PR TITLE
fix(webflow): keep dav_user constant and update webflow_user on re-auth

### DIFF
--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -15,6 +15,8 @@
 #include "networkjobs.h"
 
 #include <QAuthenticator>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QPointer>
@@ -170,12 +172,75 @@ void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user,
 
     qCInfo(lcWebFlowCredentials()) << "Obtained a new password";
 
+    // The account identity is the persistent, unique dav_user. The webflow_user
+    // (login name) returned by the browser flow may legitimately differ from it
+    // and may change between logins, so remember the current values and only
+    // commit the new credentials once we confirmed they still map to the same
+    // dav_user. Reading the "davUser" property gives the raw stored dav_user
+    // rather than the credentials-user fallback of Account::davUser().
+    const auto previousUser = _user;
+    const auto previousDavUser = _account->property("davUser").toString();
+
+    // Tentatively apply the new credentials so the identity check below can
+    // authenticate with them; they are only persisted once verified.
     _user = user;
     _password = pass;
     _ready = true;
     _credentialsValid = true;
-    persist();
-    emit asked();
+
+    verifyReAuthenticatedUser(previousDavUser, previousUser);
+}
+
+void WebFlowCredentials::verifyReAuthenticatedUser(const QString &previousDavUser, const QString &previousUser)
+{
+    auto *const job = new JsonApiJob(_account->sharedFromThis(), QStringLiteral("ocs/v1.php/cloud/user"), this);
+    connect(job, &JsonApiJob::jsonReceived, this, [this, previousDavUser, previousUser](const QJsonDocument &json, int statusCode) {
+        if (statusCode != 100) {
+            qCWarning(lcWebFlowCredentials) << "Could not fetch user id to verify re-authentication, status code:" << statusCode;
+        }
+
+        const auto objData = json.object().value(QLatin1String("ocs")).toObject().value(QLatin1String("data")).toObject();
+        const auto newDavUser = objData.value(QLatin1String("id")).toString();
+
+        if (newDavUser.isEmpty()) {
+            // We could not determine the identity: keep the freshly provided
+            // credentials rather than locking the user out, but leave dav_user
+            // untouched.
+            qCWarning(lcWebFlowCredentials) << "Server did not return a user id, keeping provided credentials without verification";
+            persist();
+            emit asked();
+            return;
+        }
+
+        if (previousDavUser.isEmpty()) {
+            // No dav_user was stored yet: adopt the fetched id as the persistent
+            // identity and keep the new webflow_user.
+            qCInfo(lcWebFlowCredentials) << "Establishing dav_user" << newDavUser << "for account" << _account->url();
+            _account->setDavUser(newDavUser);
+            persist();
+            emit asked();
+            return;
+        }
+
+        if (QString::compare(previousDavUser, newDavUser, Qt::CaseInsensitive) != 0) {
+            // dav_user must stay constant: the user authenticated as a different
+            // account. Reject the new credentials and ask again.
+            qCWarning(lcWebFlowCredentials) << "Authenticated with the wrong user! Expected dav_user" << previousDavUser << "but got" << newDavUser;
+            _user = previousUser;
+            _password.clear();
+            _ready = false;
+            _credentialsValid = false;
+            askFromUser();
+            return;
+        }
+
+        // Same account: dav_user is unchanged. The webflow_user (login name) may
+        // have changed and is written back to the configuration by persist().
+        qCInfo(lcWebFlowCredentials) << "Re-authenticated same dav_user" << newDavUser << "- updating stored login name if it changed";
+        persist();
+        emit asked();
+    });
+    job->start();
 }
 
 void WebFlowCredentials::slotAskFromUserCancelled() {

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -89,6 +89,21 @@ private:
     void readSingleClientCaCertPEM();
     void writeSingleClientCaCertPEM();
 
+    /** Confirms that freshly provided browser credentials still belong to the
+     * account's persistent dav_user before they are persisted.
+     *
+     * The dav_user is the unique, persistent account id and must stay constant.
+     * The webflow_user (login name) may legitimately differ from it and change
+     * between logins, so it is updated in the configuration while dav_user is
+     * kept. Fetches ocs/.../cloud/user with the new credentials and, on success,
+     * either persists them (same or first-seen dav_user) or rejects and re-asks
+     * (different dav_user).
+     *
+     * @param previousDavUser the account's stored dav_user, empty if never set.
+     * @param previousUser the webflow_user in use before this re-authentication.
+     */
+    void verifyReAuthenticatedUser(const QString &previousDavUser, const QString &previousUser);
+
     /*
      * Since we're limited by Windows limits, we just create our own
      * limit to avoid evil things happening by endless recursion

--- a/test/testbrowserreauthcontroller.cpp
+++ b/test/testbrowserreauthcontroller.cpp
@@ -99,9 +99,11 @@ QQuickWindow *findBrowserReAuthWindow()
     return window == windows.cend() ? nullptr : qobject_cast<QQuickWindow *>(*window);
 }
 
-void configureSuccessfulLoginFlow(FakeQNAM *networkAccessManager)
+void configureSuccessfulLoginFlow(FakeQNAM *networkAccessManager,
+                                  const QString &loginName = QStringLiteral("alice"),
+                                  const QString &davUserId = QStringLiteral("alice"))
 {
-    networkAccessManager->setOverride([networkAccessManager](
+    networkAccessManager->setOverride([networkAccessManager, loginName, davUserId](
                                           QNetworkAccessManager::Operation operation,
                                           const QNetworkRequest &request,
                                           QIODevice *) -> QNetworkReply * {
@@ -119,8 +121,26 @@ void configureSuccessfulLoginFlow(FakeQNAM *networkAccessManager)
         if (request.url().path() == QStringLiteral("/login/v2/poll")) {
             const auto response = QJsonObject {
                 {QStringLiteral("server"), QStringLiteral("http://cloud.example")},
-                {QStringLiteral("loginName"), QStringLiteral("alice")},
+                {QStringLiteral("loginName"), loginName},
                 {QStringLiteral("appPassword"), QStringLiteral("app-password")},
+            };
+            return new FakeJsonReply(operation, request, networkAccessManager, 200, QJsonDocument(response));
+        }
+
+        // The re-authentication verifies the identity by fetching the canonical
+        // dav_user (the persistent, unique account id) before persisting.
+        if (request.url().path() == QStringLiteral("/ocs/v1.php/cloud/user")) {
+            const auto response = QJsonObject {
+                {QStringLiteral("ocs"), QJsonObject {
+                                            {QStringLiteral("meta"), QJsonObject {
+                                                                         {QStringLiteral("status"), QStringLiteral("ok")},
+                                                                         {QStringLiteral("statuscode"), 100},
+                                                                     }},
+                                            {QStringLiteral("data"), QJsonObject {
+                                                                         {QStringLiteral("id"), davUserId},
+                                                                         {QStringLiteral("display-name"), davUserId},
+                                                                     }},
+                                        }},
             };
             return new FakeJsonReply(operation, request, networkAccessManager, 200, QJsonDocument(response));
         }
@@ -215,8 +235,104 @@ private slots:
         QCOMPARE(credentials->persistCount(), 1);
         QCOMPARE(credentials->persistedUser(), QStringLiteral("alice"));
         QCOMPARE(credentials->persistedPassword(), QStringLiteral("app-password"));
+        // The account had no dav_user yet, so the fetched id is adopted as the
+        // persistent identity.
+        QCOMPARE(account->davUser(), QStringLiteral("alice"));
         QCOMPARE(AccountManager::instance()->accounts().size(), registeredAccountCount);
         QTRY_VERIFY_WITH_TIMEOUT(windowGuard.isNull(), 5000);
+    }
+
+    void updatesWebflowUserWhileKeepingDavUserConstant()
+    {
+        BrowserOpeningHandler browserOpeningHandler;
+        QDesktopServices::setUrlHandler(
+            QStringLiteral("http"),
+            &browserOpeningHandler,
+            "openUrl");
+        QSignalSpy browserSpy(&browserOpeningHandler, &BrowserOpeningHandler::urlOpened);
+
+        const auto account = AccountManager::createAccount();
+        account->setUrl(QUrl(QStringLiteral("http://cloud.example")));
+        // The persistent, unique account id.
+        account->setDavUser(QStringLiteral("alice"));
+
+        auto *const networkAccessManager = new FakeQNAM({});
+        // The browser returns a different login name, but the server still maps
+        // it to the same canonical dav_user "alice".
+        configureSuccessfulLoginFlow(networkAccessManager, QStringLiteral("alice-renamed"), QStringLiteral("alice"));
+        auto *const credentials = new TestWebFlowCredentials(networkAccessManager);
+        account->setCredentials(credentials);
+
+        QSignalSpy askedSpy(credentials, &AbstractCredentials::asked);
+
+        credentials->askFromUser();
+
+        QQuickWindow *window = nullptr;
+        QTRY_VERIFY_WITH_TIMEOUT((window = findBrowserReAuthWindow()) != nullptr, 5000);
+        QTRY_COMPARE_WITH_TIMEOUT(browserSpy.count(), 1, 5000);
+
+        auto *const controller = window->property("controller").value<QObject *>();
+        QVERIFY(controller);
+        QVERIFY(QMetaObject::invokeMethod(controller, "pollNow"));
+
+        QTRY_COMPARE_WITH_TIMEOUT(askedSpy.count(), 1, 5000);
+        // webflow_user (login name) was updated to the new value...
+        QCOMPARE(credentials->user(), QStringLiteral("alice-renamed"));
+        QCOMPARE(credentials->persistCount(), 1);
+        QCOMPARE(credentials->persistedUser(), QStringLiteral("alice-renamed"));
+        // ...while the persistent dav_user stayed constant.
+        QCOMPARE(account->davUser(), QStringLiteral("alice"));
+    }
+
+    void rejectsReAuthenticationWithDifferentDavUser()
+    {
+        BrowserOpeningHandler browserOpeningHandler;
+        QDesktopServices::setUrlHandler(
+            QStringLiteral("http"),
+            &browserOpeningHandler,
+            "openUrl");
+        QSignalSpy browserSpy(&browserOpeningHandler, &BrowserOpeningHandler::urlOpened);
+
+        const auto account = AccountManager::createAccount();
+        account->setUrl(QUrl(QStringLiteral("http://cloud.example")));
+        account->setDavUser(QStringLiteral("alice"));
+
+        auto *const networkAccessManager = new FakeQNAM({});
+        // The user authenticated as a different account (canonical dav_user "bob").
+        configureSuccessfulLoginFlow(networkAccessManager, QStringLiteral("bob"), QStringLiteral("bob"));
+        auto *const credentials = new TestWebFlowCredentials(networkAccessManager);
+        account->setCredentials(credentials);
+
+        QSignalSpy askedSpy(credentials, &AbstractCredentials::asked);
+
+        credentials->askFromUser();
+
+        QQuickWindow *window = nullptr;
+        QTRY_VERIFY_WITH_TIMEOUT((window = findBrowserReAuthWindow()) != nullptr, 5000);
+        QTRY_COMPARE_WITH_TIMEOUT(browserSpy.count(), 1, 5000);
+
+        auto *const controller = window->property("controller").value<QObject *>();
+        QVERIFY(controller);
+        QVERIFY(QMetaObject::invokeMethod(controller, "pollNow"));
+
+        // dav_user must stay constant: the mismatching login is rejected and the
+        // re-authentication browser window is reopened.
+        QTRY_COMPARE_WITH_TIMEOUT(browserSpy.count(), 2, 5000);
+        QCOMPARE(askedSpy.count(), 0);
+        QCOMPARE(credentials->persistCount(), 0);
+        QCOMPARE(account->davUser(), QStringLiteral("alice"));
+        QCOMPARE(credentials->user(), QStringLiteral("old-user"));
+
+        // The rejection reopens a re-auth window; close every one and wait until
+        // it is destroyed so it does not leak into the next test (cleanup() only
+        // closes a single window and does not wait for its destruction).
+        const auto topLevelWindows = QGuiApplication::topLevelWindows();
+        for (auto *const topLevelWindow : topLevelWindows) {
+            if (topLevelWindow->property("controller").value<QObject *>() != nullptr) {
+                topLevelWindow->close();
+            }
+        }
+        QTRY_VERIFY_WITH_TIMEOUT(findBrowserReAuthWindow() == nullptr, 5000);
     }
 
     void closingQmlWindowCancelsWithoutReplacingCredentials()


### PR DESCRIPTION
When re-authenticating a webflow (browser-login) account, the client accepted whatever login name the browser flow returned as the new webflow_user without checking it against the account's persistent dav_user. A login name that no longer matched the stored dav_user kept UserInfo detecting a "wrong user" and re-triggering the browser re-auth on every launch, hammering the server until its brute-force protection disabled the account.

The dav_user is the unique, persistent account id and must stay constant, while the webflow_user (login name) may legitimately differ from it and change between logins. Enforce this in the login flow: once the browser login information is received, fetch the canonical dav_user with the new credentials before persisting and either

  - adopt it when no dav_user was stored yet,
  - keep dav_user unchanged and update the stored webflow_user when the same account re-authenticated, or
  - reject the credentials and ask again when a different account was used.

Add coverage in BrowserReAuthControllerTest for the same-account update and the different-account rejection.

Closes #10611.

Assisted-by: ClaudeCode:claude-opus-4-8

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
