### PR TITLE
fix(nix): update nix flake for desktop client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,7 @@ theme.qrc
 
 # Swift Package Manager Build Artifacts
 .swiftpm_codeql_detected_source_root
+
+# Nix
+result
+flake.lock

--- a/admin/nix/flake.nix
+++ b/admin/nix/flake.nix
@@ -25,7 +25,7 @@
           inherit system;
         };
 
-        inherit (pkgs.lib.lists) optional optionals;
+        inherit (pkgs.lib.lists) optionals;
         inherit (pkgs.lib.strings) optionalString;
 
         buildMacOSSymlinks = pkgs.runCommand "nextcloud-build-symlinks" { } ''
@@ -37,51 +37,54 @@
           with pkgs;
           [
             cmake
-            extra-cmake-modules
-            pkg-config
             inkscape
-            qt5.wrapQtAppsHook
+            pkg-config
+
+            qt6Packages.wrapQtAppsHook
+
+            kdePackages.extra-cmake-modules
           ]
-          ++ optionals stdenv.isDarwin [
+          ++ optionals stdenv.hostPlatform.isDarwin [
             buildMacOSSymlinks
           ];
 
         buildInputs =
           with pkgs;
           [
-            sqlite
+            kdsingleapplication
+            libp11
+            libsysprof-capture
             openssl
-            pcre
+            pcre2
+            sqlite
 
-            qt5.qtbase
-            qt5.qtquickcontrols2
-            qt5.qtsvg
-            qt5.qtgraphicaleffects
-            qt5.qtdeclarative
-            qt5.qttools
-            qt5.qtwebsockets
+            qt6Packages.qt5compat
+            qt6Packages.qtbase
+            qt6Packages.qtdeclarative
+            qt6Packages.qtkeychain
+            qt6Packages.qtsvg
+            qt6Packages.qttools
+            qt6Packages.qtwayland
+            qt6Packages.qtwebsockets
 
-            libsForQt5.karchive
-            libsForQt5.qtkeychain
+            kdePackages.karchive
           ]
-          ++ optionals stdenv.isLinux [
+          ++ optionals stdenv.hostPlatform.isLinux [
             inotify-tools
             libcloudproviders
             libsecret
 
-            libsForQt5.breeze-icons
-            libsForQt5.qqc2-desktop-style
-            libsForQt5.kio
+            kdePackages.breeze-icons
+            kdePackages.kio
+            kdePackages.qqc2-desktop-style
           ]
-          ++ optionals stdenv.isDarwin [
-            libsForQt5.qt5.qtmacextras
-
+          ++ optionals stdenv.hostPlatform.isDarwin [
             darwin.apple_sdk.frameworks.UserNotifications
           ];
 
         packages.default =
           with pkgs;
-          stdenv.mkDerivation rec {
+          stdenv.mkDerivation {
             inherit nativeBuildInputs buildInputs;
             pname = "nextcloud-client";
             version = "dev";
@@ -92,41 +95,39 @@
             separateDebugInfo = false;
             enableParallelBuilding = true;
 
-            preConfigure =
-              optionals stdenv.isLinux [
-                ''
-                  substituteInPlace shell_integration/libcloudproviders/CMakeLists.txt \
-                    --replace "PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)" "set(_install_dir "\$\{CMAKE_INSTALL_DATADIR\}/dbus-1/service")"
-                ''
-              ]
-              ++ optionals stdenv.isDarwin [
-                ''
-                  substituteInPlace shell_integration/MacOSX/CMakeLists.txt \
-                    --replace "-target FinderSyncExt -configuration Release" "-scheme FinderSyncExt -configuration Release -derivedDataPath $ENV{NIX_BUILD_TOP}/derivedData"
-                ''
-              ];
+            cmakeFlags = [
+              "-DBUILD_UPDATER=off"
+              "-DMIRALL_VERSION_SUFFIX=" # remove git suffix from version
+            ]
+            ++ optionals stdenv.hostPlatform.isLinux [
+              "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
+              "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
+            ]
+            ++ optionals stdenv.hostPlatform.isDarwin [
+              "-DQT_ENABLE_VERBOSE_DEPLOYMENT=TRUE"
+              "-DBUILD_OWNCLOUD_OSX_BUNDLE=OFF"
+            ];
+            postPatch = ''
+              substituteInPlace src/common/utility_unix.cpp \
+                --replace-fail \
+                  'QLatin1String("Exec=\"") << executablePath << "\" --background\n"' \
+                  'QLatin1String("Exec=\"") << "nextcloud --background\n"'
+            ''
+            + optionalString stdenv.hostPlatform.isLinux ''
+              substituteInPlace CMakeLists.txt \
+                --replace-fail '"''${SYSTEMD_USER_UNIT_DIR}"' "\"$out/lib/systemd/user\""
 
-            cmakeFlags =
-              optionals stdenv.isLinux [
-                "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
-                "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
-              ]
-              ++ optionals stdenv.isDarwin [
-                "-DQT_ENABLE_VERBOSE_DEPLOYMENT=TRUE"
-                "-DBUILD_OWNCLOUD_OSX_BUNDLE=OFF"
-              ];
-            postPatch = optionalString stdenv.isLinux ''
               for file in src/libsync/vfs/*/CMakeLists.txt; do
                 substituteInPlace $file \
-                  --replace "PLUGINDIR" "KDE_INSTALL_PLUGINDIR"
+                  --replace-fail "PLUGINDIR" "KDE_INSTALL_PLUGINDIR"
               done
             '';
-            postFixup = optionalString stdenv.isLinux ''
-              wrapProgram "$out/bin/nextcloud" \
-                --set LD_LIBRARY_PATH ${lib.makeLibraryPath [ libsecret ]} \
-                --set PATH ${lib.makeBinPath [ xdg-utils ]} \
-                --set QML_DISABLE_DISK_CACHE "1"
-            '';
+            qtWrapperArgs = [
+              "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret ]}"
+              # make xdg-open overridable at runtime
+              "--suffix PATH : ${lib.makeBinPath [ xdg-utils ]}"
+              "--set QML_DISABLE_DISK_CACHE 1"
+            ];
           };
 
         apps.default = mkApp {
@@ -142,7 +143,7 @@
           nativeBuildInputs =
             with pkgs;
             nativeBuildInputs
-            ++ optionals (stdenv.isLinux) [
+            ++ optionals (stdenv.hostPlatform.isLinux) [
               gdb
               qtcreator
             ];

--- a/admin/nix/flake.nix
+++ b/admin/nix/flake.nix
@@ -1,7 +1,7 @@
 /*
- * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: GPL-2.0-or-later
- */
+  SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+  SPDX-License-Identifier: GPL-2.0-or-later
+*/
 
 {
   description = "A flake for the Nextcloud desktop client";
@@ -11,33 +11,44 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
     with flake-utils.lib;
-    eachSystem [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ] (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-          };
+    eachSystem [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ] (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
 
-          inherit (pkgs.lib.lists) optional optionals;
-          inherit (pkgs.lib.strings) optionalString;
+        inherit (pkgs.lib.lists) optional optionals;
+        inherit (pkgs.lib.strings) optionalString;
 
-          buildMacOSSymlinks = pkgs.runCommand "nextcloud-build-symlinks" {} ''
-            mkdir -p $out/bin
-            ln -s /usr/bin/xcrun /usr/bin/xcodebuild /usr/bin/iconutil $out/bin
-          '';
+        buildMacOSSymlinks = pkgs.runCommand "nextcloud-build-symlinks" { } ''
+          mkdir -p $out/bin
+          ln -s /usr/bin/xcrun /usr/bin/xcodebuild /usr/bin/iconutil $out/bin
+        '';
 
-          nativeBuildInputs = with pkgs; [
+        nativeBuildInputs =
+          with pkgs;
+          [
             cmake
             extra-cmake-modules
             pkg-config
             inkscape
             qt5.wrapQtAppsHook
-          ] ++ optionals stdenv.isDarwin [
+          ]
+          ++ optionals stdenv.isDarwin [
             buildMacOSSymlinks
           ];
 
-          buildInputs = with pkgs; [
+        buildInputs =
+          with pkgs;
+          [
             sqlite
             openssl
             pcre
@@ -52,7 +63,8 @@
 
             libsForQt5.karchive
             libsForQt5.qtkeychain
-          ] ++ optionals stdenv.isLinux [
+          ]
+          ++ optionals stdenv.isLinux [
             inotify-tools
             libcloudproviders
             libsecret
@@ -60,13 +72,16 @@
             libsForQt5.breeze-icons
             libsForQt5.qqc2-desktop-style
             libsForQt5.kio
-          ] ++ optionals stdenv.isDarwin [
+          ]
+          ++ optionals stdenv.isDarwin [
             libsForQt5.qt5.qtmacextras
 
             darwin.apple_sdk.frameworks.UserNotifications
           ];
 
-          packages.default = with pkgs; stdenv.mkDerivation rec {
+        packages.default =
+          with pkgs;
+          stdenv.mkDerivation rec {
             inherit nativeBuildInputs buildInputs;
             pname = "nextcloud-client";
             version = "dev";
@@ -77,25 +92,29 @@
             separateDebugInfo = false;
             enableParallelBuilding = true;
 
-            preConfigure = optionals stdenv.isLinux [
-            ''
-              substituteInPlace shell_integration/libcloudproviders/CMakeLists.txt \
-                --replace "PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)" "set(_install_dir "\$\{CMAKE_INSTALL_DATADIR\}/dbus-1/service")"
-            ''
-            ] ++ optionals stdenv.isDarwin [
-            ''
-              substituteInPlace shell_integration/MacOSX/CMakeLists.txt \
-                --replace "-target FinderSyncExt -configuration Release" "-scheme FinderSyncExt -configuration Release -derivedDataPath $ENV{NIX_BUILD_TOP}/derivedData"
-            ''
-            ];
+            preConfigure =
+              optionals stdenv.isLinux [
+                ''
+                  substituteInPlace shell_integration/libcloudproviders/CMakeLists.txt \
+                    --replace "PKGCONFIG_GETVAR(dbus-1 session_bus_services_dir _install_dir)" "set(_install_dir "\$\{CMAKE_INSTALL_DATADIR\}/dbus-1/service")"
+                ''
+              ]
+              ++ optionals stdenv.isDarwin [
+                ''
+                  substituteInPlace shell_integration/MacOSX/CMakeLists.txt \
+                    --replace "-target FinderSyncExt -configuration Release" "-scheme FinderSyncExt -configuration Release -derivedDataPath $ENV{NIX_BUILD_TOP}/derivedData"
+                ''
+              ];
 
-            cmakeFlags = optionals stdenv.isLinux [
-              "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
-              "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
-            ] ++ optionals stdenv.isDarwin [
-              "-DQT_ENABLE_VERBOSE_DEPLOYMENT=TRUE"
-              "-DBUILD_OWNCLOUD_OSX_BUNDLE=OFF"
-            ];
+            cmakeFlags =
+              optionals stdenv.isLinux [
+                "-DCMAKE_INSTALL_LIBDIR=lib" # expected to be prefix-relative by build code setting RPATH
+                "-DNO_SHIBBOLETH=1" # allows to compile without qtwebkit
+              ]
+              ++ optionals stdenv.isDarwin [
+                "-DQT_ENABLE_VERBOSE_DEPLOYMENT=TRUE"
+                "-DBUILD_OWNCLOUD_OSX_BUNDLE=OFF"
+              ];
             postPatch = optionalString stdenv.isLinux ''
               for file in src/libsync/vfs/*/CMakeLists.txt; do
                 substituteInPlace $file \
@@ -110,21 +129,25 @@
             '';
           };
 
-          apps.default = mkApp {
-            name = "nextcloud";
-            drv = packages.default;
-          };
+        apps.default = mkApp {
+          name = "nextcloud";
+          drv = packages.default;
+        };
 
-        in {
-          inherit packages apps;
-          devShell = pkgs.mkShell {
-            inherit buildInputs;
-            nativeBuildInputs = with pkgs; nativeBuildInputs ++ optionals (stdenv.isLinux) [
+      in
+      {
+        inherit packages apps;
+        devShell = pkgs.mkShell {
+          inherit buildInputs;
+          nativeBuildInputs =
+            with pkgs;
+            nativeBuildInputs
+            ++ optionals (stdenv.isLinux) [
               gdb
               qtcreator
             ];
-            name = "nextcloud-client-dev-shell";
-          };
-        }
+          name = "nextcloud-client-dev-shell";
+        };
+      }
     );
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

This makes a few changes to get this working again on the latest version. A lot of this is based off of the [nextcloud-client in nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ne/nextcloud-client/package.nix) maintained by @SuperSandro2000. I haven't tested Darwin, but it does build fine on Linux. Could be some stuff that may or may not be necessary so I'm open to feedback.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
