### PR TITLE
feat(search): revive unified search

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -72,8 +72,11 @@
         <file>src/gui/wizard/qml/ServerPage.qml</file>
         <file>src/gui/wizard/qml/SyncOptionsPage.qml</file>
         <file>src/gui/wizard/qml/WizardButton.qml</file>
+        <file>src/gui/wizard/qml/WizardChipButton.qml</file>
         <file>src/gui/wizard/qml/WizardComboBox.qml</file>
         <file>src/gui/wizard/qml/WizardDialogFrame.qml</file>
+        <file>src/gui/wizard/qml/WizardMenu.qml</file>
+        <file>src/gui/wizard/qml/WizardMenuItem.qml</file>
         <file>src/gui/wizard/qml/WizardTextField.qml</file>
         <file>src/gui/macOS/ui/FileProviderFileDelegate.qml</file>
         <file>src/gui/integration/FileActionsWindow.qml</file>

--- a/src/gui/iconutils.cpp
+++ b/src/gui/iconutils.cpp
@@ -164,8 +164,8 @@ QImage drawSvgWithCustomFillColor(const QString &sourceSvgPath,
         return {};
     }
 
-    const auto reqSize = (requestedSize.isValid() && requestedSize.height() && requestedSize.height()) ? requestedSize : svgRenderer.defaultSize();
-    if (!reqSize.isValid() || !reqSize.height() || !reqSize.height()) {
+    const auto reqSize = (requestedSize.isValid() && requestedSize.width() && requestedSize.height()) ? requestedSize : svgRenderer.defaultSize();
+    if (!reqSize.isValid() || !reqSize.width() || !reqSize.height()) {
         return {};
     }
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -39,6 +39,7 @@
 #include "tray/trayactivationpolicy.h"
 #include "tray/trayaccountappsmodel.h"
 #include "search/unifiedsearchresultslistmodel.h"
+#include "search/unifiedsearchpeoplemodel.h"
 #include "integration/fileactionsmodel.h"
 #include "governance/applygovernancelabel.h"
 #include "governance/deletegovernancelabel.h"
@@ -159,6 +160,7 @@ ownCloudGui::ownCloudGui(Application *parent)
     qmlRegisterType<FileDetails>("com.nextcloud.desktopclient", 1, 0, "FileDetails");
     qmlRegisterType<ShareModel>("com.nextcloud.desktopclient", 1, 0, "ShareModel");
     qmlRegisterType<ShareeModel>("com.nextcloud.desktopclient", 1, 0, "ShareeModel");
+    qmlRegisterType<UnifiedSearchPeopleModel>("com.nextcloud.desktopclient", 1, 0, "UnifiedSearchPeopleModel");
     qmlRegisterType<SortedShareModel>("com.nextcloud.desktopclient", 1, 0, "SortedShareModel");
     qmlRegisterType<SyncConflictsModel>("com.nextcloud.desktopclient", 1, 0, "SyncConflictsModel");
     qmlRegisterType<FileActionsModel>("com.nextcloud.desktopclient", 1, 0, "FileActionsModel");

--- a/src/gui/search/CMakeLists.txt
+++ b/src/gui/search/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(nextcloudGuiSearch
     unifiedsearchresult.cpp
     unifiedsearchresultslistmodel.h
     unifiedsearchresultslistmodel.cpp
+    unifiedsearchpeoplemodel.h
+    unifiedsearchpeoplemodel.cpp
 )
 
 ecm_add_qml_module(nextcloudGuiSearch
@@ -16,7 +18,12 @@ ecm_add_qml_module(nextcloudGuiSearch
   GENERATE_PLUGIN_SOURCE
   QML_FILES
     SearchWindow.qml
+    UnifiedSearchCustomDateRangeDialog.qml
+    UnifiedSearchDetailHeader.qml
+    UnifiedSearchFilterBar.qml
     UnifiedSearchInputContainer.qml
+    UnifiedSearchPeoplePopup.qml
+    UnifiedSearchResultDelegate.qml
     UnifiedSearchResultFetchMoreTrigger.qml
     UnifiedSearchResultItem.qml
     UnifiedSearchResultItemSkeleton.qml

--- a/src/gui/search/CMakeLists.txt
+++ b/src/gui/search/CMakeLists.txt
@@ -22,6 +22,7 @@ ecm_add_qml_module(nextcloudGuiSearch
     UnifiedSearchDetailHeader.qml
     UnifiedSearchFilterBar.qml
     UnifiedSearchInputContainer.qml
+    UnifiedSearchPeopleDelegate.qml
     UnifiedSearchPeoplePopup.qml
     UnifiedSearchResultDelegate.qml
     UnifiedSearchResultFetchMoreTrigger.qml

--- a/src/gui/search/SearchWindow.qml
+++ b/src/gui/search/SearchWindow.qml
@@ -275,6 +275,7 @@ WizardStyledWindow {
     Loader {
         id: peoplePopupLoader
 
+        objectName: "peoplePopupLoader"
         active: false
         sourceComponent: peoplePopupComponent
         onLoaded: {

--- a/src/gui/search/SearchWindow.qml
+++ b/src/gui/search/SearchWindow.qml
@@ -214,57 +214,9 @@ WizardStyledWindow {
                     Accessible.role: Accessible.List
                     Accessible.name: qsTr("Search results")
 
-                    delegate: Item {
-                        id: delegateData
-
-                        required property string providerName
-                        required property string providerId
-                        required property string providerIcon
-                        required property string resultTitle
-                        required property string subline
-                        required property url resourceUrlRole
-                        required property string darkIcons
-                        required property string lightIcons
-                        required property bool darkIconsIsThumbnail
-                        required property bool lightIconsIsThumbnail
-                        required property string darkImagePlaceholder
-                        required property string lightImagePlaceholder
-                        required property bool isRounded
-                        required property int type
-                        required property bool isSelected
-                        required property bool isPartialMatch
-                        required property bool hasOverflow
-                        required property bool isLoading
-
-                        readonly property alias loadedItem: resultDelegate.loadedItem
-
+                    delegate: UnifiedSearchResultDelegate {
                         width: resultsList.width
-                        height: resultDelegate.implicitHeight
-
-                        UnifiedSearchResultDelegate {
-                            id: resultDelegate
-
-                            anchors.fill: parent
-                            searchModel: root.searchModel
-                            providerName: delegateData.providerName
-                            providerId: delegateData.providerId
-                            providerIcon: delegateData.providerIcon
-                            resultTitle: delegateData.resultTitle
-                            subline: delegateData.subline
-                            resourceUrlRole: delegateData.resourceUrlRole
-                            darkIcons: delegateData.darkIcons
-                            lightIcons: delegateData.lightIcons
-                            darkIconsIsThumbnail: delegateData.darkIconsIsThumbnail
-                            lightIconsIsThumbnail: delegateData.lightIconsIsThumbnail
-                            darkImagePlaceholder: delegateData.darkImagePlaceholder
-                            lightImagePlaceholder: delegateData.lightImagePlaceholder
-                            isRounded: delegateData.isRounded
-                            resultType: delegateData.type
-                            isSelected: delegateData.isSelected
-                            isPartialMatch: delegateData.isPartialMatch
-                            hasOverflow: delegateData.hasOverflow
-                            isLoading: delegateData.isLoading
-                        }
+                        searchModel: root.searchModel
                     }
 
                     footer: Column {

--- a/src/gui/search/SearchWindow.qml
+++ b/src/gui/search/SearchWindow.qml
@@ -10,19 +10,19 @@ import QtQuick.Layouts
 import Style
 import com.nextcloud.desktopclient
 import "qrc:/qml/src/gui"
+import "qrc:/qml/src/gui/tray"
+import "qrc:/qml/src/gui/wizard/qml"
 
 WizardStyledWindow {
     id: root
 
     property var account: null
     property var searchModel: null
-    readonly property string headline: qsTr("Search")
-    readonly property int searchState: searchModel
-        ? searchModel.searchState
-        : UnifiedSearchResultsListModel.Placeholder
-    readonly property bool isSearchInProgress: searchModel !== null && searchModel.isSearchInProgress
-    readonly property bool canEditSearch: searchModel !== null && searchModel.canEditSearch
-    readonly property bool isAccountConnected: searchModel !== null && searchModel.isAccountConnected
+    readonly property bool aggregateView: searchModel && searchModel.viewMode === UnifiedSearchResultsListModel.Aggregate
+    readonly property bool filtersVisible: aggregateView && searchModel && searchModel.providersReady
+    readonly property int searchState: searchModel ? searchModel.searchState : UnifiedSearchResultsListModel.Placeholder
+    readonly property bool peoplePopupOpened: peoplePopupLoader.status === Loader.Ready && peoplePopupLoader.item.opened
+    readonly property bool customRangeDialogOpened: customRangeDialogLoader.status === Loader.Ready && customRangeDialogLoader.item.opened
 
     title: ""
     width: Style.searchWindowWidth
@@ -31,57 +31,132 @@ WizardStyledWindow {
     minimumHeight: Style.wizardStandaloneWindowMinimumHeight
 
     function focusSearchInput() {
-        if (visible && searchInput.enabled) {
-            searchInput.forceActiveFocus()
+        if (visible && searchInput.enabled) searchInput.forceActiveFocus()
+    }
+
+    function openPeoplePopup() {
+        if (peoplePopupLoader.status === Loader.Ready) {
+            peoplePopupLoader.item.open()
+            return
         }
+        peoplePopupLoader.active = true
+    }
+
+    function openCustomRangeDialog() {
+        if (customRangeDialogLoader.status === Loader.Ready) {
+            customRangeDialogLoader.item.open()
+            return
+        }
+        customRangeDialogLoader.active = true
     }
 
     Shortcut {
         sequences: [StandardKey.Cancel]
+        enabled: !filterBar.opened && !root.peoplePopupOpened && !root.customRangeDialogOpened
         onActivated: root.close()
     }
 
-    Component.onCompleted: Qt.callLater(focusSearchInput)
-    onVisibleChanged: {
-        if (visible) {
-            Qt.callLater(focusSearchInput)
+    UnifiedSearchPeopleModel {
+        id: peopleSuggestionsModel
+        accountState: root.searchModel ? root.searchModel.accountState : null
+    }
+
+    Connections {
+        target: root.searchModel
+        function onSelectedRowChanged() {
+            if (root.searchModel && root.searchModel.selectedRow >= 0
+                    && root.searchModel.selectedRow < resultsList.count) {
+                resultsList.positionViewAtIndex(root.searchModel.selectedRow, ListView.Contain)
+            }
+        }
+        function onViewModeChanged() {
+            Qt.callLater(function() {
+                if (root.searchModel && root.searchModel.selectedRow >= 0
+                        && root.searchModel.selectedRow < resultsList.count) {
+                    resultsList.positionViewAtIndex(root.searchModel.selectedRow, ListView.Beginning)
+                }
+            })
+        }
+        function onAccessibilityStatusChanged() {
+            if (root.searchModel.accessibilityStatus.length > 0)
+                Accessible.announce(root.searchModel.accessibilityStatus, Accessible.Polite)
         }
     }
 
+    Component.onCompleted: Qt.callLater(focusSearchInput)
+    onVisibleChanged: if (visible) Qt.callLater(focusSearchInput)
+
     ColumnLayout {
         anchors.fill: parent
-        anchors.leftMargin: Style.wizardWindowMargin
-        anchors.rightMargin: Style.wizardWindowMargin
+        anchors.margins: Style.wizardWindowMargin
         anchors.topMargin: Style.wizardWindowTopMargin
-        anchors.bottomMargin: Style.wizardWindowMargin
-        spacing: Style.wizardSectionSpacing
+        spacing: Style.smallSpacing
 
         WindowAccountHeader {
             Layout.fillWidth: true
-            title: root.headline
+            title: qsTr("Search")
             user: root.account
         }
 
         UnifiedSearchInputContainer {
             id: searchInput
-
             Layout.fillWidth: true
             Layout.preferredHeight: Style.unifiedSearchInputContainerHeight
             enabled: root.searchModel !== null
-            readOnly: !root.canEditSearch
+            readOnly: !root.searchModel || !root.searchModel.canEditSearch
             text: root.searchModel ? root.searchModel.searchTerm : ""
-            placeholderText: root.account !== null && !root.isAccountConnected
+            isSearchInProgress: root.searchModel
+                && (root.searchModel.isSearchInProgress
+                    || root.searchModel.waitingForSearchTermEditEnd
+                    || root.searchModel.isFetchMoreInProgress)
+            placeholderText: root.searchModel && !root.searchModel.isAccountConnected
                 ? qsTr("Search is available when this account is connected")
                 : qsTr("Search files, messages, events …")
-            isSearchInProgress: root.isSearchInProgress
-            onTextEdited: {
-                if (root.searchModel) {
-                    root.searchModel.searchTerm = searchInput.text
-                }
-            }
-            onClearText: {
-                if (root.searchModel) {
-                    root.searchModel.searchTerm = ""
+            onTextEdited: if (root.searchModel) root.searchModel.searchTerm = text
+            onClearText: if (root.searchModel) root.searchModel.searchTerm = ""
+            onMoveSelection: direction => root.searchModel.moveSelection(direction)
+            onActivateSelection: root.searchModel.activateSelected()
+        }
+
+        UnifiedSearchDetailHeader {
+            Layout.fillWidth: true
+            Layout.preferredHeight: implicitHeight
+            visible: root.searchModel && !root.aggregateView
+            searchModel: root.searchModel
+            onNavigateBack: root.focusSearchInput()
+        }
+
+        UnifiedSearchFilterBar {
+            id: filterBar
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: visible ? implicitHeight : 0
+            visible: root.filtersVisible
+            searchModel: root.searchModel
+            onCustomDateRangeRequested: root.openCustomRangeDialog()
+            onPeopleRequested: root.openPeoplePopup()
+        }
+
+        Flow {
+            objectName: "activeFilterFlow"
+            Layout.fillWidth: true
+            Layout.preferredHeight: visible ? implicitHeight : 0
+            visible: root.filtersVisible && root.searchModel && root.searchModel.activeFilters.length > 0
+            spacing: Style.smallSpacing
+            Repeater {
+                model: root.searchModel ? root.searchModel.activeFilters : []
+                delegate: WizardChipButton {
+                    id: chipButton
+                    objectName: "activeFilterChip"
+                    required property var modelData
+                    text: modelData.label
+                    textSuffix: "×"
+                    iconBeforeText: true
+                    iconSource: modelData.icon ? "image://tray-image-provider/" + modelData.icon : ""
+                    tintIcon: true
+                    iconTintColor: Style.wizardPrimaryText
+                    Accessible.name: qsTr("Remove %1 filter").arg(modelData.label)
+                    onClicked: root.searchModel.removeFilter(modelData.type, modelData.id)
                 }
             }
         }
@@ -96,12 +171,17 @@ WizardStyledWindow {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            ErrorBox {
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.top: parent.top
+            ColumnLayout {
+                anchors.centerIn: parent
+                width: Math.min(parent.width, Style.wizardDialogMaximumWidth)
                 visible: root.searchState === UnifiedSearchResultsListModel.SearchError
-                text: root.searchModel ? root.searchModel.errorString : ""
+                ErrorBox { Layout.fillWidth: true; text: root.searchModel ? root.searchModel.errorString : "" }
+                WizardButton {
+                    Layout.alignment: Qt.AlignHCenter
+                    primary: true
+                    text: qsTr("Retry")
+                    onClicked: root.searchModel.retry()
+                }
             }
 
             UnifiedSearchPlaceholderView {
@@ -115,63 +195,162 @@ WizardStyledWindow {
                 text: root.searchModel ? root.searchModel.searchTerm : ""
             }
 
-            Loader {
-                anchors.fill: parent
-                anchors.margins: Style.smallSpacing
-                active: root.searchState === UnifiedSearchResultsListModel.Skeleton
-                asynchronous: true
-
-                sourceComponent: UnifiedSearchResultItemSkeletonContainer {
-                    anchors.fill: parent
-                    spacing: searchResultsListView.spacing
-                    animationRectangleWidth: root.width
-                }
-            }
-
             ScrollView {
-                id: searchResultsScrollView
-
                 anchors.fill: parent
                 contentWidth: availableWidth
                 visible: root.searchState === UnifiedSearchResultsListModel.Results
-
+                      || root.searchState === UnifiedSearchResultsListModel.Skeleton
                 ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
                 ListView {
-                    id: searchResultsListView
+                    id: resultsList
 
-                    spacing: Style.smallSpacing
+                    objectName: "searchResultsList"
                     clip: true
-                    keyNavigationEnabled: true
                     reuseItems: true
+                    spacing: Style.extraSmallSpacing
                     model: root.searchModel
-
+                    currentIndex: root.searchModel ? root.searchModel.selectedRow : -1
                     Accessible.role: Accessible.List
-                    Accessible.name: qsTr("Search results list")
+                    Accessible.name: qsTr("Search results")
 
-                    delegate: UnifiedSearchResultListItem {
-                        width: searchResultsListView.width
-                        isSearchInProgress: root.isSearchInProgress
-                        currentFetchMoreInProgressProviderId: root.searchModel
-                            ? root.searchModel.currentFetchMoreInProgressProviderId
-                            : ""
-                        fetchMoreTriggerClicked: root.searchModel
-                            ? root.searchModel.fetchMoreTriggerClicked
-                            : function() {}
-                        resultClicked: root.searchModel
-                            ? root.searchModel.resultClicked
-                            : function() {}
-                        ListView.onPooled: isPooled = true
-                        ListView.onReused: isPooled = false
+                    delegate: Item {
+                        id: delegateData
+
+                        required property string providerName
+                        required property string providerId
+                        required property string providerIcon
+                        required property string resultTitle
+                        required property string subline
+                        required property url resourceUrlRole
+                        required property string darkIcons
+                        required property string lightIcons
+                        required property bool darkIconsIsThumbnail
+                        required property bool lightIconsIsThumbnail
+                        required property string darkImagePlaceholder
+                        required property string lightImagePlaceholder
+                        required property bool isRounded
+                        required property int type
+                        required property bool isSelected
+                        required property bool isPartialMatch
+                        required property bool hasOverflow
+                        required property bool isLoading
+
+                        readonly property alias loadedItem: resultDelegate.loadedItem
+
+                        width: resultsList.width
+                        height: resultDelegate.implicitHeight
+
+                        UnifiedSearchResultDelegate {
+                            id: resultDelegate
+
+                            anchors.fill: parent
+                            searchModel: root.searchModel
+                            providerName: delegateData.providerName
+                            providerId: delegateData.providerId
+                            providerIcon: delegateData.providerIcon
+                            resultTitle: delegateData.resultTitle
+                            subline: delegateData.subline
+                            resourceUrlRole: delegateData.resourceUrlRole
+                            darkIcons: delegateData.darkIcons
+                            lightIcons: delegateData.lightIcons
+                            darkIconsIsThumbnail: delegateData.darkIconsIsThumbnail
+                            lightIconsIsThumbnail: delegateData.lightIconsIsThumbnail
+                            darkImagePlaceholder: delegateData.darkImagePlaceholder
+                            lightImagePlaceholder: delegateData.lightImagePlaceholder
+                            isRounded: delegateData.isRounded
+                            resultType: delegateData.type
+                            isSelected: delegateData.isSelected
+                            isPartialMatch: delegateData.isPartialMatch
+                            hasOverflow: delegateData.hasOverflow
+                            isLoading: delegateData.isLoading
+                        }
                     }
 
-                    section.property: "providerName"
-                    section.criteria: ViewSection.FullString
-                    section.delegate: UnifiedSearchResultSectionItem {
-                        width: searchResultsListView.width
+                    footer: Column {
+                        objectName: "searchResultsLoadingFooter"
+                        width: resultsList.width
+                        height: visible ? implicitHeight : 0
+                        spacing: Style.smallSpacing
+                        visible: root.searchModel && root.searchModel.isSearchInProgress
+                        Accessible.ignored: true
+                        Repeater {
+                            model: Style.unifiedSearchLoadingPlaceholderCount
+                            Rectangle {
+                                required property int index
+                                width: resultsList.width * (Style.unifiedSearchLoadingPlaceholderInitialWidthRatio
+                                    + index * Style.unifiedSearchLoadingPlaceholderWidthStep)
+                                height: Style.unifiedSearchProviderHeaderHeight
+                                radius: Style.mediumRoundedButtonRadius
+                                color: palette.alternateBase
+                                opacity: Style.unifiedSearchLoadingPlaceholderOpacity
+                            }
+                        }
                     }
                 }
             }
         }
+
+        RowLayout {
+            objectName: "partialFailureFooter"
+            Layout.fillWidth: true
+            visible: root.aggregateView && root.searchModel && root.searchModel.hasPartialFailure
+            EnforcedPlainTextLabel { Layout.fillWidth: true; text: qsTr("Some sources unavailable"); color: palette.placeholderText }
+            WizardButton { text: qsTr("Retry"); onClicked: root.searchModel.retryFailedProviders() }
+        }
+
+        WizardButton {
+            Layout.fillWidth: true
+            visible: root.searchModel && root.searchModel.showConnectedServicesAction
+            text: root.searchModel && root.searchModel.externalProvidersEnabled
+                ? qsTr("Less from connected services") : qsTr("More from connected services")
+            onClicked: root.searchModel.setExternalProvidersEnabled(!root.searchModel.externalProvidersEnabled)
+        }
     }
+
+    Component {
+        id: peoplePopupComponent
+
+        UnifiedSearchPeoplePopup {
+            searchModel: root.searchModel
+            peopleModel: peopleSuggestionsModel
+            windowWidth: root.width
+            onClosed: peoplePopupLoader.active = false
+            onPersonSelected: root.focusSearchInput()
+        }
+    }
+
+    Loader {
+        id: peoplePopupLoader
+
+        active: false
+        sourceComponent: peoplePopupComponent
+        onLoaded: {
+            if (status === Loader.Ready) {
+                item.open()
+            }
+        }
+    }
+
+    Component {
+        id: customRangeDialogComponent
+
+        UnifiedSearchCustomDateRangeDialog {
+            searchModel: root.searchModel
+            onClosed: customRangeDialogLoader.active = false
+        }
+    }
+
+    Loader {
+        id: customRangeDialogLoader
+
+        active: false
+        sourceComponent: customRangeDialogComponent
+        onLoaded: {
+            if (status === Loader.Ready) {
+                item.open()
+            }
+        }
+    }
+
 }

--- a/src/gui/search/UnifiedSearchCustomDateRangeDialog.qml
+++ b/src/gui/search/UnifiedSearchCustomDateRangeDialog.qml
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+
+import Style
+import "qrc:/qml/src/gui/tray"
+import "qrc:/qml/src/gui/wizard/qml"
+
+Dialog {
+    id: root
+
+    required property var searchModel
+
+    property bool validationError: false
+
+    anchors.centerIn: parent
+    title: qsTr("Custom date range")
+    modal: true
+    onOpened: validationError = false
+
+    footer: RowLayout {
+        spacing: Style.wizardFooterSpacing
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        WizardButton {
+            text: qsTr("Cancel")
+            onClicked: root.close()
+        }
+
+        WizardButton {
+            primary: true
+            text: qsTr("Apply")
+            onClicked: {
+                root.validationError = !root.searchModel.setCustomDateRange(customSince.text, customUntil.text)
+                if (!root.validationError) {
+                    root.close()
+                }
+            }
+        }
+    }
+
+    ColumnLayout {
+        EnforcedPlainTextLabel {
+            text: qsTr("Start date (YYYY-MM-DD)")
+        }
+
+        TextField {
+            id: customSince
+
+            Layout.fillWidth: true
+            placeholderText: qsTr("YYYY-MM-DD")
+        }
+
+        EnforcedPlainTextLabel {
+            text: qsTr("End date (YYYY-MM-DD)")
+        }
+
+        TextField {
+            id: customUntil
+
+            Layout.fillWidth: true
+            placeholderText: qsTr("YYYY-MM-DD")
+        }
+
+        EnforcedPlainTextLabel {
+            visible: root.validationError
+            text: qsTr("Enter valid dates with the start date before the end date.")
+            color: palette.accent
+        }
+    }
+}

--- a/src/gui/search/UnifiedSearchDetailHeader.qml
+++ b/src/gui/search/UnifiedSearchDetailHeader.qml
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic
+
+import Style
+import "qrc:/qml/src/gui/tray"
+
+Item {
+    id: root
+
+    required property var searchModel
+
+    signal navigateBack()
+
+    objectName: "searchDetailHeader"
+    implicitHeight: Style.unifiedSearchDetailHeaderHeight
+
+    ToolButton {
+        id: backButton
+
+        objectName: "searchDetailBackButton"
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        text: qsTr("Back")
+        icon.source: "image://svgimage-custom-color/"
+            + (root.LayoutMirroring.enabled ? "arrow-right.svg/" : "arrow-left.svg/")
+            + Style.wizardPrimaryText
+        icon.width: Style.smallIconSize
+        icon.height: Style.smallIconSize
+        display: AbstractButton.TextBesideIcon
+        Accessible.name: qsTr("Back to all search results")
+        onClicked: {
+            root.searchModel.closeProviderDetail()
+            root.navigateBack()
+        }
+    }
+
+    EnforcedPlainTextLabel {
+        objectName: "searchDetailProviderTitle"
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: backButton.width + Style.smallSpacing
+        anchors.rightMargin: backButton.width + Style.smallSpacing
+        anchors.verticalCenter: parent.verticalCenter
+        text: root.searchModel ? root.searchModel.detailProviderName : ""
+        font.bold: true
+        font.pixelSize: Style.wizardHeaderTitleFontPixelSize
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
+    }
+}

--- a/src/gui/search/UnifiedSearchFilterBar.qml
+++ b/src/gui/search/UnifiedSearchFilterBar.qml
@@ -17,6 +17,11 @@ Flow {
     required property var searchModel
 
     readonly property bool opened: typeMenu.opened || dateMenu.opened
+    readonly property int filterButtonCount: 3
+    readonly property int filterButtonGapCount: filterButtonCount - 1
+    readonly property real filterButtonWidth: Math.max(
+        Style.unifiedSearchFilterButtonMinimumWidth,
+        (width - filterButtonGapCount * spacing) / filterButtonCount)
 
     signal customDateRangeRequested()
     signal peopleRequested()
@@ -41,8 +46,7 @@ Flow {
         id: typeFilterButton
 
         objectName: "typeFilterButton"
-        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
-                        (root.width - 2 * root.spacing) / 3)
+        width: root.filterButtonWidth
         text: qsTr("Type")
         trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
             + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
@@ -93,8 +97,7 @@ Flow {
         id: dateFilterButton
 
         objectName: "dateFilterButton"
-        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
-                        (root.width - 2 * root.spacing) / 3)
+        width: root.filterButtonWidth
         text: qsTr("Date")
         trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
             + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
@@ -150,8 +153,7 @@ Flow {
         id: peopleButton
 
         objectName: "peopleFilterButton"
-        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
-                        (root.width - 2 * root.spacing) / 3)
+        width: root.filterButtonWidth
         text: qsTr("People")
         trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
             + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)

--- a/src/gui/search/UnifiedSearchFilterBar.qml
+++ b/src/gui/search/UnifiedSearchFilterBar.qml
@@ -1,0 +1,167 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls.Basic
+
+import Style
+import "qrc:/qml/src/gui/wizard/qml"
+
+Flow {
+    id: root
+
+    required property var searchModel
+
+    readonly property bool opened: typeMenu.opened || dateMenu.opened
+
+    signal customDateRangeRequested()
+    signal peopleRequested()
+
+    objectName: "categoryFilterFlow"
+    spacing: Style.smallSpacing
+
+    function hasActiveFilter(type) {
+        if (!searchModel) {
+            return false
+        }
+        const filters = searchModel.activeFilters
+        for (let index = 0; index < filters.length; ++index) {
+            if (filters[index].type === type) {
+                return true
+            }
+        }
+        return false
+    }
+
+    WizardButton {
+        id: typeFilterButton
+
+        objectName: "typeFilterButton"
+        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
+                        (root.width - 2 * root.spacing) / 3)
+        text: qsTr("Type")
+        trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        iconBeforeText: true
+        iconSource: "image://svgimage-custom-color/folder.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        primary: root.hasActiveFilter("provider")
+        Accessible.name: qsTr("Filter by type")
+        onClicked: typeMenu.toggle()
+
+        WizardMenu {
+            id: typeMenu
+
+            objectName: "typeFilterMenu"
+            anchorItem: typeFilterButton
+            width: anchorItem.width * Style.unifiedSearchFilterMenuWidthFactor
+
+            Binding on height {
+                when: root.searchModel
+                    && root.searchModel.providers.length
+                        > Style.unifiedSearchProviderMenuMaximumVisibleRows
+                value: Style.unifiedSearchProviderMenuMaximumVisibleRows
+                    * Style.standardPrimaryButtonHeight
+                    + typeMenu.topPadding + typeMenu.bottomPadding
+            }
+
+            Repeater {
+                model: root.searchModel ? root.searchModel.providers : []
+
+                delegate: WizardMenuItem {
+                    id: providerMenuItem
+
+                    required property var modelData
+
+                    text: (providerMenuItem.modelData.selected ? "✓ " : "") + providerMenuItem.modelData.name
+                    icon.source: providerMenuItem.modelData.icon
+                        ? "image://tray-image-provider/" + providerMenuItem.modelData.icon
+                        : ""
+                    tintIcon: true
+                    iconTintColor: Style.wizardPrimaryText
+                    onTriggered: root.searchModel.toggleProviderFilter(providerMenuItem.modelData.id)
+                }
+            }
+        }
+    }
+
+    WizardButton {
+        id: dateFilterButton
+
+        objectName: "dateFilterButton"
+        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
+                        (root.width - 2 * root.spacing) / 3)
+        text: qsTr("Date")
+        trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        iconBeforeText: true
+        iconSource: "image://svgimage-custom-color/calendar.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        primary: root.hasActiveFilter("date")
+        enabled: root.searchModel && root.searchModel.dateFilterAvailable
+        Accessible.name: qsTr("Filter by date")
+        Accessible.description: enabled ? "" : qsTr("No search source supports date filtering")
+        onClicked: dateMenu.toggle()
+
+        WizardMenu {
+            id: dateMenu
+
+            objectName: "dateFilterMenu"
+            anchorItem: dateFilterButton
+
+            WizardMenuItem {
+                objectName: "dateTodayMenuItem"
+                text: qsTr("Today")
+                onTriggered: root.searchModel.setDatePreset("today")
+            }
+            WizardMenuItem {
+                text: qsTr("Last 7 days")
+                onTriggered: root.searchModel.setDatePreset("last7days")
+            }
+            WizardMenuItem {
+                text: qsTr("Last 30 days")
+                onTriggered: root.searchModel.setDatePreset("last30days")
+            }
+            WizardMenuItem {
+                text: qsTr("This year")
+                onTriggered: root.searchModel.setDatePreset("thisyear")
+            }
+            WizardMenuItem {
+                text: qsTr("Last year")
+                onTriggered: root.searchModel.setDatePreset("lastyear")
+            }
+            MenuSeparator {}
+            WizardMenuItem {
+                text: qsTr("Custom range …")
+                onTriggered: root.customDateRangeRequested()
+            }
+            WizardMenuItem {
+                text: qsTr("Clear date")
+                onTriggered: root.searchModel.clearDateFilter()
+            }
+        }
+    }
+
+    WizardButton {
+        id: peopleButton
+
+        objectName: "peopleFilterButton"
+        width: Math.max(Style.unifiedSearchFilterButtonMinimumWidth,
+                        (root.width - 2 * root.spacing) / 3)
+        text: qsTr("People")
+        trailingIconSource: "image://svgimage-custom-color/caret-down.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        iconBeforeText: true
+        iconSource: "image://svgimage-custom-color/account-group.svg/"
+            + (primary ? Style.wizardSelectedText : Style.wizardPrimaryText)
+        primary: root.hasActiveFilter("person")
+        enabled: root.searchModel && root.searchModel.peopleFilterAvailable
+        Accessible.name: qsTr("Filter by person")
+        Accessible.description: enabled ? "" : qsTr("No search source supports people filtering")
+        onClicked: root.peopleRequested()
+    }
+}

--- a/src/gui/search/UnifiedSearchInputContainer.qml
+++ b/src/gui/search/UnifiedSearchInputContainer.qml
@@ -39,8 +39,6 @@ TextField {
         if (inputMethodComposing) return
         if (event.key === Qt.Key_Down) moveSelection(UnifiedSearchResultsListModel.Next)
         else if (event.key === Qt.Key_Up) moveSelection(UnifiedSearchResultsListModel.Previous)
-        else if (event.key === Qt.Key_Home) moveSelection(UnifiedSearchResultsListModel.First)
-        else if (event.key === Qt.Key_End) moveSelection(UnifiedSearchResultsListModel.Last)
         else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) activateSelection()
         else return
         event.accepted = true

--- a/src/gui/search/UnifiedSearchInputContainer.qml
+++ b/src/gui/search/UnifiedSearchInputContainer.qml
@@ -4,7 +4,7 @@
  */
 
 import QtQuick
-import QtQuick.Controls
+import QtQuick.Controls.Basic
 import Style
 import com.nextcloud.desktopclient
 import "qrc:/qml/src/gui/tray"
@@ -18,20 +18,21 @@ TextField {
 
     property bool isSearchInProgress: false
     readonly property color iconColor: palette.placeholderText
-    readonly property int iconSize: 24
-    readonly property int controlSize: Math.max(40, height - 4)
+    readonly property int iconSize: Style.unifiedSearchInputIconSize
+    readonly property int controlSize: Math.max(Style.standardPrimaryButtonHeight,
+                                                height - Style.unifiedSearchInputControlInset)
 
-    leftPadding: 8 + controlSize
-    rightPadding: 8
+    leftPadding: Style.unifiedSearchInputHorizontalPadding + controlSize
+    rightPadding: Style.unifiedSearchInputHorizontalPadding
         + (root.text.length > 0 ? controlSize : 0)
-        + (root.isSearchInProgress ? 8 + iconSize : 0)
+        + (root.isSearchInProgress ? Style.unifiedSearchInputHorizontalPadding + iconSize : 0)
     verticalAlignment: Qt.AlignVCenter
     placeholderText: qsTr("Search files, messages, events …")
 
     background: Rectangle {
-        radius: 8
+        radius: Style.mediumRoundedButtonRadius
         color: Style.wizardFieldBackground
-        border.width: 1
+        border.width: Style.normalBorderWidth
         border.color: Style.wizardFieldBorder
     }
 
@@ -47,7 +48,7 @@ TextField {
     Image {
         objectName: "searchLeadingIcon"
         anchors.left: parent.left
-        anchors.leftMargin: 8
+        anchors.leftMargin: Style.unifiedSearchInputHorizontalPadding
         anchors.verticalCenter: parent.verticalCenter
         width: root.iconSize
         height: root.iconSize
@@ -60,7 +61,7 @@ TextField {
     NCBusyIndicator {
         objectName: "searchProgressIndicator"
         anchors.right: clearSearchButton.visible ? clearSearchButton.left : parent.right
-        anchors.rightMargin: clearSearchButton.visible ? 0 : 8
+        anchors.rightMargin: clearSearchButton.visible ? 0 : Style.unifiedSearchInputHorizontalPadding
         anchors.verticalCenter: parent.verticalCenter
         width: root.iconSize
         height: root.iconSize
@@ -75,7 +76,7 @@ TextField {
 
         objectName: "clearSearchButton"
         anchors.right: parent.right
-        anchors.rightMargin: 2
+        anchors.rightMargin: Style.extraSmallSpacing
         anchors.verticalCenter: parent.verticalCenter
         width: root.controlSize
         height: root.controlSize

--- a/src/gui/search/UnifiedSearchInputContainer.qml
+++ b/src/gui/search/UnifiedSearchInputContainer.qml
@@ -1,98 +1,90 @@
 /*
- * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import QtQml
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
 import Style
-
 import com.nextcloud.desktopclient
-import "qrc:/qml/src/gui/common"
 import "qrc:/qml/src/gui/tray"
 
-NCContextMenuTextField {
+TextField {
     id: root
 
     signal clearText()
+    signal moveSelection(int direction)
+    signal activateSelection()
 
     property bool isSearchInProgress: false
+    readonly property color iconColor: palette.placeholderText
+    readonly property int iconSize: 24
+    readonly property int controlSize: Math.max(40, height - 4)
 
-    readonly property color textFieldIconsColor: palette.placeholderText
-
-    readonly property int iconInset: Style.smallSpacing
-
-    readonly property real leadingControlWidth: root.isSearchInProgress ? busyIndicator.width : searchIconImage.width
-    readonly property real trailingControlWidth: clearTextButton.visible ? clearTextButton.width : 0
-
-    topPadding: topInset
-    bottomPadding: bottomInset
-    leftPadding: iconInset + leadingControlWidth + Style.smallSpacing
-    rightPadding: iconInset + trailingControlWidth + Style.smallSpacing
+    leftPadding: 8 + controlSize
+    rightPadding: 8
+        + (root.text.length > 0 ? controlSize : 0)
+        + (root.isSearchInProgress ? 8 + iconSize : 0)
     verticalAlignment: Qt.AlignVCenter
-
     placeholderText: qsTr("Search files, messages, events …")
 
+    background: Rectangle {
+        radius: 8
+        color: Style.wizardFieldBackground
+        border.width: 1
+        border.color: Style.wizardFieldBorder
+    }
+
+    Keys.onPressed: event => {
+        if (inputMethodComposing) return
+        if (event.key === Qt.Key_Down) moveSelection(UnifiedSearchResultsListModel.Next)
+        else if (event.key === Qt.Key_Up) moveSelection(UnifiedSearchResultsListModel.Previous)
+        else if (event.key === Qt.Key_Home) moveSelection(UnifiedSearchResultsListModel.First)
+        else if (event.key === Qt.Key_End) moveSelection(UnifiedSearchResultsListModel.Last)
+        else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) activateSelection()
+        else return
+        event.accepted = true
+    }
+
     Image {
-        id: searchIconImage
-
-        anchors {
-            left: root.left
-            leftMargin: iconInset
-            top: root.top
-            topMargin: Style.extraSmallSpacing
-            bottom: root.bottom
-            bottomMargin: Style.extraSmallSpacing
-        }
-
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-        antialiasing: true
-        mipmap: true
-        source: "image://svgimage-custom-color/search.svg" + "/" + root.textFieldIconsColor
-        visible: !root.isSearchInProgress
+        objectName: "searchLeadingIcon"
+        anchors.left: parent.left
+        anchors.leftMargin: 8
+        anchors.verticalCenter: parent.verticalCenter
+        width: root.iconSize
+        height: root.iconSize
+        sourceSize.width: width
+        sourceSize.height: height
+        source: "image://svgimage-custom-color/search.svg/" + root.iconColor
+        Accessible.ignored: true
     }
 
     NCBusyIndicator {
-        id: busyIndicator
-
-        anchors {
-            top: root.top
-            topMargin: Style.extraSmallSpacing
-            bottom: root.bottom
-            bottomMargin: Style.extraSmallSpacing
-            left: root.left
-            leftMargin: iconInset
-        }
-
-        width: height
-        color: root.textFieldIconsColor
+        objectName: "searchProgressIndicator"
+        anchors.right: clearSearchButton.visible ? clearSearchButton.left : parent.right
+        anchors.rightMargin: clearSearchButton.visible ? 0 : 8
+        anchors.verticalCenter: parent.verticalCenter
+        width: root.iconSize
+        height: root.iconSize
+        color: root.iconColor
         visible: root.isSearchInProgress
         running: visible
+        Accessible.ignored: true
     }
 
-    Image {
-        id: clearTextButton
+    ToolButton {
+        id: clearSearchButton
 
-        anchors {
-            top: root.top
-            topMargin: Style.extraSmallSpacing
-            bottom: root.bottom
-            bottomMargin: Style.extraSmallSpacing
-            right: root.right
-            rightMargin: iconInset
-        }
-
-        fillMode: Image.PreserveAspectFit
-        visible: root.text
-        source: "image://svgimage-custom-color/clear.svg" + "/" + root.textFieldIconsColor
-
-        MouseArea {
-            id: clearTextButtonMouseArea
-            anchors.fill: parent
-            onClicked: root.clearText()
-        }
+        objectName: "clearSearchButton"
+        anchors.right: parent.right
+        anchors.rightMargin: 2
+        anchors.verticalCenter: parent.verticalCenter
+        width: root.controlSize
+        height: root.controlSize
+        icon.source: "image://svgimage-custom-color/clear.svg/" + root.iconColor
+        visible: root.text.length > 0
+        Accessible.name: qsTr("Clear search")
+        Accessible.description: qsTr("Keeps the active filters")
+        onClicked: root.clearText()
     }
 }

--- a/src/gui/search/UnifiedSearchPeopleDelegate.qml
+++ b/src/gui/search/UnifiedSearchPeopleDelegate.qml
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+
+import Style
+import "qrc:/qml/src/gui/tray"
+
+ItemDelegate {
+    id: root
+
+    required property string userId
+    required property string displayName
+    required property string avatarUrl
+
+    signal personChosen(string userId, string displayName, string avatarUrl)
+
+    height: Style.unifiedSearchProviderHeaderHeight
+    text: displayName
+    hoverEnabled: true
+    Accessible.description: userId
+
+    background: Rectangle {
+        color: root.hovered || root.down
+            ? Style.listItemHoverBackground
+            : "transparent"
+        radius: Style.mediumRoundedButtonRadius
+    }
+
+    HoverHandler {
+        cursorShape: Qt.PointingHandCursor
+    }
+
+    contentItem: RowLayout {
+        Image {
+            Layout.preferredWidth: Style.accountAvatarSize
+            Layout.preferredHeight: Style.accountAvatarSize
+            sourceSize.width: Style.accountAvatarSize
+            sourceSize.height: Style.accountAvatarSize
+            asynchronous: true
+            source: root.avatarUrl.length > 0
+                ? "image://tray-image-provider/" + root.avatarUrl
+                : ""
+            Accessible.ignored: true
+        }
+
+        EnforcedPlainTextLabel {
+            Layout.fillWidth: true
+            text: root.displayName
+            elide: Text.ElideRight
+        }
+    }
+
+    onClicked: root.personChosen(root.userId, root.displayName, root.avatarUrl)
+}

--- a/src/gui/search/UnifiedSearchPeoplePopup.qml
+++ b/src/gui/search/UnifiedSearchPeoplePopup.qml
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+
+import Style
+import "qrc:/qml/src/gui/tray"
+import "qrc:/qml/src/gui/wizard/qml"
+
+Popup {
+    id: root
+
+    required property var searchModel
+    required property var peopleModel
+    required property real windowWidth
+
+    signal personSelected()
+
+    parent: Overlay.overlay
+    width: Math.min(windowWidth - Style.unifiedSearchPeoplePopupHorizontalMargin,
+                    Style.wizardDialogMaximumWidth)
+    height: Style.unifiedSearchPeoplePopupHeight
+    x: (windowWidth - width) / 2
+    y: Style.unifiedSearchPeoplePopupTopMargin
+    modal: true
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    onOpened: peopleSearch.forceActiveFocus()
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Style.smallSpacing
+
+        TextField {
+            id: peopleSearch
+
+            Layout.fillWidth: true
+            placeholderText: qsTr("Search people")
+            onTextEdited: root.peopleModel.searchTerm = text
+        }
+
+        EnforcedPlainTextLabel {
+            visible: root.peopleModel.errorString.length > 0
+            text: root.peopleModel.errorString
+            wrapMode: Text.Wrap
+        }
+
+        WizardButton {
+            visible: root.peopleModel.errorString.length > 0
+            text: qsTr("Retry")
+            onClicked: root.peopleModel.retry()
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            model: root.peopleModel
+
+            delegate: ItemDelegate {
+                id: personDelegate
+
+                required property string userId
+                required property string displayName
+                required property string avatarUrl
+
+                width: ListView.view.width
+                height: Style.unifiedSearchProviderHeaderHeight
+                text: displayName
+                hoverEnabled: true
+                Accessible.description: userId
+
+                background: Rectangle {
+                    color: personDelegate.hovered || personDelegate.down
+                        ? Style.listItemHoverBackground
+                        : "transparent"
+                    radius: Style.mediumRoundedButtonRadius
+                }
+
+                HoverHandler {
+                    cursorShape: Qt.PointingHandCursor
+                }
+
+                contentItem: RowLayout {
+                    Image {
+                        Layout.preferredWidth: Style.accountAvatarSize
+                        Layout.preferredHeight: Style.accountAvatarSize
+                        sourceSize.width: Style.accountAvatarSize
+                        sourceSize.height: Style.accountAvatarSize
+                        asynchronous: true
+                        source: personDelegate.avatarUrl.length > 0
+                            ? "image://tray-image-provider/" + personDelegate.avatarUrl
+                            : ""
+                        Accessible.ignored: true
+                    }
+
+                    EnforcedPlainTextLabel {
+                        Layout.fillWidth: true
+                        text: personDelegate.displayName
+                        elide: Text.ElideRight
+                    }
+                }
+
+                onClicked: {
+                    root.searchModel.setPersonFilter(personDelegate.userId,
+                                                     personDelegate.displayName,
+                                                     personDelegate.avatarUrl)
+                    root.close()
+                    root.personSelected()
+                }
+            }
+        }
+    }
+}

--- a/src/gui/search/UnifiedSearchPeoplePopup.qml
+++ b/src/gui/search/UnifiedSearchPeoplePopup.qml
@@ -10,6 +10,7 @@ import QtQuick.Controls.Basic
 import QtQuick.Layouts
 
 import Style
+import "qrc:/qml/src/gui/tray"
 import "qrc:/qml/src/gui/wizard/qml"
 
 Popup {

--- a/src/gui/search/UnifiedSearchPeoplePopup.qml
+++ b/src/gui/search/UnifiedSearchPeoplePopup.qml
@@ -39,7 +39,9 @@ Popup {
         TextField {
             id: peopleSearch
 
+            objectName: "peopleSearchField"
             Layout.fillWidth: true
+            text: root.peopleModel.searchTerm
             placeholderText: qsTr("Search people")
             onTextEdited: root.peopleModel.searchTerm = text
         }

--- a/src/gui/search/UnifiedSearchPeoplePopup.qml
+++ b/src/gui/search/UnifiedSearchPeoplePopup.qml
@@ -10,7 +10,6 @@ import QtQuick.Controls.Basic
 import QtQuick.Layouts
 
 import Style
-import "qrc:/qml/src/gui/tray"
 import "qrc:/qml/src/gui/wizard/qml"
 
 Popup {
@@ -62,54 +61,11 @@ Popup {
             clip: true
             model: root.peopleModel
 
-            delegate: ItemDelegate {
-                id: personDelegate
-
-                required property string userId
-                required property string displayName
-                required property string avatarUrl
-
+            delegate: UnifiedSearchPeopleDelegate {
                 width: ListView.view.width
-                height: Style.unifiedSearchProviderHeaderHeight
-                text: displayName
-                hoverEnabled: true
-                Accessible.description: userId
 
-                background: Rectangle {
-                    color: personDelegate.hovered || personDelegate.down
-                        ? Style.listItemHoverBackground
-                        : "transparent"
-                    radius: Style.mediumRoundedButtonRadius
-                }
-
-                HoverHandler {
-                    cursorShape: Qt.PointingHandCursor
-                }
-
-                contentItem: RowLayout {
-                    Image {
-                        Layout.preferredWidth: Style.accountAvatarSize
-                        Layout.preferredHeight: Style.accountAvatarSize
-                        sourceSize.width: Style.accountAvatarSize
-                        sourceSize.height: Style.accountAvatarSize
-                        asynchronous: true
-                        source: personDelegate.avatarUrl.length > 0
-                            ? "image://tray-image-provider/" + personDelegate.avatarUrl
-                            : ""
-                        Accessible.ignored: true
-                    }
-
-                    EnforcedPlainTextLabel {
-                        Layout.fillWidth: true
-                        text: personDelegate.displayName
-                        elide: Text.ElideRight
-                    }
-                }
-
-                onClicked: {
-                    root.searchModel.setPersonFilter(personDelegate.userId,
-                                                     personDelegate.displayName,
-                                                     personDelegate.avatarUrl)
+                onPersonChosen: (userId, displayName, avatarUrl) => {
+                    root.searchModel.setPersonFilter(userId, displayName, avatarUrl)
                     root.close()
                     root.personSelected()
                 }

--- a/src/gui/search/UnifiedSearchResultDelegate.qml
+++ b/src/gui/search/UnifiedSearchResultDelegate.qml
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+
+import Style
+import com.nextcloud.desktopclient
+import "qrc:/qml/src/gui/tray"
+
+Item {
+    id: root
+
+    required property var searchModel
+    required property string providerName
+    required property string providerId
+    required property string providerIcon
+    required property string resultTitle
+    required property string subline
+    required property url resourceUrlRole
+    required property string darkIcons
+    required property string lightIcons
+    required property bool darkIconsIsThumbnail
+    required property bool lightIconsIsThumbnail
+    required property string darkImagePlaceholder
+    required property string lightImagePlaceholder
+    required property bool isRounded
+    required property int resultType
+    required property bool isSelected
+    required property bool isPartialMatch
+    required property bool hasOverflow
+    required property bool isLoading
+
+    readonly property alias loadedItem: rowContent.item
+
+    implicitHeight: {
+        if (resultType === UnifiedSearchResultsListModel.ProviderHeader) {
+            return Style.unifiedSearchProviderHeaderHeight
+        }
+        if (resultType === UnifiedSearchResultsListModel.PartialMatchesHeader) {
+            return Style.unifiedSearchPartialMatchesHeaderHeight
+        }
+        if (resultType === UnifiedSearchResultsListModel.FetchMoreTrigger
+                || resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger) {
+            return Style.unifiedSearchPagingRowHeight
+        }
+        return Style.unifiedSearchItemHeight
+    }
+    height: implicitHeight
+
+    Loader {
+        id: rowContent
+
+        anchors.fill: parent
+        sourceComponent: {
+            if (root.resultType === UnifiedSearchResultsListModel.ProviderHeader) {
+                return providerHeader
+            }
+            if (root.resultType === UnifiedSearchResultsListModel.PartialMatchesHeader) {
+                return partialHeader
+            }
+            if (root.resultType === UnifiedSearchResultsListModel.FetchMoreTrigger
+                    || root.resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger) {
+                return pagingRow
+            }
+            return resultRow
+        }
+    }
+
+    Component {
+        id: providerHeader
+
+        Button {
+            id: providerHeaderButton
+
+            objectName: "providerHeaderRow"
+            width: root.width
+            height: Style.unifiedSearchProviderHeaderHeight
+            flat: true
+            text: root.hasOverflow ? qsTr("More from %1  →").arg(root.providerName) : root.providerName
+            font.bold: false
+            font.pixelSize: Style.unifiedSearchResultTitleFontSize
+            leftPadding: 0
+            rightPadding: 0
+            hoverEnabled: root.hasOverflow
+            activeFocusOnTab: root.hasOverflow
+            Accessible.role: root.hasOverflow ? Accessible.Button : Accessible.StaticText
+            Accessible.name: text
+
+            HoverHandler {
+                enabled: root.hasOverflow
+                cursorShape: Qt.PointingHandCursor
+            }
+
+            background: Rectangle {
+                color: root.hasOverflow && providerHeaderButton.hovered
+                    ? Style.listItemHoverBackground
+                    : "transparent"
+                radius: Style.mediumRoundedButtonRadius
+            }
+
+            contentItem: EnforcedPlainTextLabel {
+                text: providerHeaderButton.text
+                color: Style.wizardPrimaryText
+                font: providerHeaderButton.font
+                elide: Text.ElideRight
+                horizontalAlignment: Text.AlignLeft
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            onPressed: {
+                if (root.hasOverflow) {
+                    root.searchModel.openProviderDetail(root.providerId)
+                }
+            }
+        }
+    }
+
+    Component {
+        id: partialHeader
+
+        EnforcedPlainTextLabel {
+            objectName: "partialMatchesHeaderRow"
+            width: root.width
+            height: Style.unifiedSearchPartialMatchesHeaderHeight
+            verticalAlignment: Text.AlignVCenter
+            text: qsTr("Partial matches")
+            color: Style.wizardSecondaryText
+            font.bold: true
+        }
+    }
+
+    Component {
+        id: resultRow
+
+        ItemDelegate {
+            id: resultDelegateButton
+
+            objectName: "searchResultRow"
+            width: root.width
+            height: Style.unifiedSearchItemHeight
+            leftPadding: 0
+            rightPadding: 0
+            topPadding: 0
+            bottomPadding: 0
+            activeFocusOnTab: false
+            opacity: root.isPartialMatch ? Style.unifiedSearchPartialMatchOpacity : 1.0
+            hoverEnabled: true
+            Accessible.role: Accessible.ListItem
+            Accessible.name: root.resultTitle
+            Accessible.description: root.subline
+            Accessible.selected: root.isSelected
+
+            background: Rectangle {
+                color: root.isSelected
+                    ? Style.wizardSecondaryButtonPressed
+                    : (resultDelegateButton.hovered ? Style.listItemHoverBackground : "transparent")
+                radius: Style.mediumRoundedButtonRadius
+            }
+
+            contentItem: UnifiedSearchResultItem {
+                accessibilityEnabled: false
+                title: root.resultTitle
+                subline: root.subline
+                icons: Style.darkMode ? root.darkIcons : root.lightIcons
+                iconsIsThumbnail: Style.darkMode ? root.darkIconsIsThumbnail : root.lightIconsIsThumbnail
+                iconPlaceholder: Style.darkMode ? root.darkImagePlaceholder : root.lightImagePlaceholder
+                isRounded: root.isRounded && iconsIsThumbnail
+            }
+
+            onClicked: root.searchModel.resultClicked(root.providerId, root.resourceUrlRole)
+        }
+    }
+
+    Component {
+        id: pagingRow
+
+        ItemDelegate {
+            id: pagingDelegate
+
+            objectName: "searchPagingRow"
+            width: root.width
+            enabled: !root.isLoading
+            hoverEnabled: true
+            leftPadding: Style.unifiedSearchResultIconLeftMargin
+            rightPadding: Style.unifiedSearchResultTextRightMargin
+            topPadding: 0
+            bottomPadding: 0
+            text: root.isLoading
+                ? qsTr("Loading more results …")
+                : (root.resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger
+                    ? qsTr("Retry loading more results") : qsTr("Load more results"))
+            icon.source: "image://svgimage-custom-color/more.svg/" + Style.wizardPrimaryText
+            icon.width: Style.smallIconSize
+            icon.height: Style.smallIconSize
+            Accessible.role: Accessible.Button
+            Accessible.name: text
+
+            HoverHandler {
+                cursorShape: Qt.PointingHandCursor
+            }
+
+            background: Rectangle {
+                color: pagingDelegate.hovered ? Style.listItemHoverBackground : "transparent"
+                radius: Style.mediumRoundedButtonRadius
+            }
+
+            contentItem: RowLayout {
+                spacing: Style.smallSpacing
+
+                BusyIndicator {
+                    Layout.preferredWidth: Style.smallIconSize
+                    Layout.preferredHeight: Style.smallIconSize
+                    running: root.isLoading
+                    visible: running
+                }
+
+                Image {
+                    Layout.preferredWidth: Style.smallIconSize
+                    Layout.preferredHeight: Style.smallIconSize
+                    sourceSize.width: Style.smallIconSize
+                    sourceSize.height: Style.smallIconSize
+                    source: pagingDelegate.icon.source
+                    visible: !root.isLoading
+                    Accessible.ignored: true
+                }
+
+                EnforcedPlainTextLabel {
+                    objectName: "searchPagingLabel"
+                    Layout.fillWidth: true
+                    text: pagingDelegate.text
+                    color: Style.wizardPrimaryText
+                    font.bold: false
+                    font.pixelSize: Style.unifiedSearchResultTitleFontSize
+                    elide: Text.ElideRight
+                    verticalAlignment: Text.AlignVCenter
+                }
+            }
+
+            onPressed: root.resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger
+                ? root.searchModel.retryLoadMore(root.providerId)
+                : root.searchModel.loadMore(root.providerId)
+        }
+    }
+}

--- a/src/gui/search/UnifiedSearchResultDelegate.qml
+++ b/src/gui/search/UnifiedSearchResultDelegate.qml
@@ -111,7 +111,7 @@ Item {
                 verticalAlignment: Text.AlignVCenter
             }
 
-            onPressed: {
+            onClicked: {
                 if (root.hasOverflow) {
                     root.searchModel.openProviderDetail(root.providerId)
                 }
@@ -240,7 +240,7 @@ Item {
                 }
             }
 
-            onPressed: root.resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger
+            onClicked: root.resultType === UnifiedSearchResultsListModel.RetryFetchMoreTrigger
                 ? root.searchModel.retryLoadMore(root.providerId)
                 : root.searchModel.loadMore(root.providerId)
         }

--- a/src/gui/search/UnifiedSearchResultItem.qml
+++ b/src/gui/search/UnifiedSearchResultItem.qml
@@ -15,6 +15,8 @@ import "qrc:/qml/src/gui/tray"
 RowLayout {
     id: unifiedSearchResultItemDetails
 
+    objectName: "searchResultContent"
+
     property string title: ""
     property string subline: ""
     property string icons: ""
@@ -22,6 +24,7 @@ RowLayout {
 
     property bool iconsIsThumbnail: false
     property bool isRounded: false
+    property bool accessibilityEnabled: true
 
     property int iconWidth: iconsIsThumbnail && icons !== "" ? Style.unifiedSearchResultIconWidth : Style.unifiedSearchResultSmallIconWidth
     property int titleFontSize: Style.unifiedSearchResultTitleFontSize
@@ -32,8 +35,9 @@ RowLayout {
 
 
     Accessible.role: Accessible.ListItem
-    Accessible.name: resultTitle
-    Accessible.onPressAction: unifiedSearchResultMouseArea.clicked()
+    Accessible.name: title
+    Accessible.description: subline
+    Accessible.ignored: !accessibilityEnabled
 
     spacing: Style.trayHorizontalMargin
 
@@ -86,16 +90,35 @@ RowLayout {
         }
     }
 
-    ListItemLineAndSubline {
+    ColumnLayout {
         id: unifiedSearchResultTextContainer
 
-        spacing: Style.standardSpacing
+        objectName: "searchResultTextContainer"
+        spacing: Style.unifiedSearchResultTextSpacing
 
         Layout.fillWidth: true
         Layout.rightMargin: Style.trayHorizontalMargin
 
-        lineText: unifiedSearchResultItemDetails.title.replace(/[\r\n]+/g, " ")
-        sublineText: unifiedSearchResultItemDetails.subline.replace(/[\r\n]+/g, " ")
+        EnforcedPlainTextLabel {
+            objectName: "searchResultTitle"
+            Layout.fillWidth: true
+            text: unifiedSearchResultItemDetails.title.replace(/[\r\n]+/g, " ")
+            textFormat: Text.PlainText
+            color: unifiedSearchResultItemDetails.titleColor
+            elide: Text.ElideRight
+            font.pixelSize: unifiedSearchResultItemDetails.titleFontSize
+        }
+
+        EnforcedPlainTextLabel {
+            objectName: "searchResultSubline"
+            Layout.fillWidth: true
+            text: unifiedSearchResultItemDetails.subline.replace(/[\r\n]+/g, " ")
+            textFormat: Text.PlainText
+            color: unifiedSearchResultItemDetails.sublineColor
+            visible: text.length > 0
+            elide: Text.ElideRight
+            font.pixelSize: unifiedSearchResultItemDetails.sublineFontSize
+        }
     }
 
 }

--- a/src/gui/search/UnifiedSearchResultNothingFound.qml
+++ b/src/gui/search/UnifiedSearchResultNothingFound.qml
@@ -10,42 +10,55 @@ import QtQuick.Layouts
 import Style
 import "qrc:/qml/src/gui/tray"
 
-ColumnLayout {
+Item {
     id: unifiedSearchResultNothingFoundContainer
+
+    objectName: "nothingFoundView"
 
     required property string text
 
-    spacing: Style.standardSpacing
-    anchors.leftMargin: Style.unifiedSearchResultNothingFoundHorizontalMargin
-    anchors.rightMargin: Style.unifiedSearchResultNothingFoundHorizontalMargin
+    ColumnLayout {
+        id: content
 
-    Image {
-        id: unifiedSearchResultsNoResultsLabelIcon
-        source: `image://svgimage-custom-color/magnifying-glass.svg/${palette.windowText}`
-        sourceSize.width: Style.trayWindowHeaderHeight / 2
-        sourceSize.height: Style.trayWindowHeaderHeight / 2
-        Layout.alignment: Qt.AlignHCenter
-    }
+        objectName: "nothingFoundContent"
+        anchors.centerIn: parent
+        width: parent.width - 2 * Style.unifiedSearchResultNothingFoundHorizontalMargin
+        spacing: Style.standardSpacing
 
-    EnforcedPlainTextLabel {
-        id: unifiedSearchResultsNoResultsLabel
-        text: qsTr("No results for")
-        font.pixelSize: Style.unifiedSearchPlaceholderViewSublineFontPixelSize
-        wrapMode: Text.Wrap
-        Layout.fillWidth: true
-        Layout.preferredHeight: Style.trayWindowHeaderHeight / 2
-        horizontalAlignment: Text.AlignHCenter
-    }
+        Image {
+            id: unifiedSearchResultsNoResultsLabelIcon
 
-    EnforcedPlainTextLabel {
-        id: unifiedSearchResultsNoResultsLabelDetails
-        text: unifiedSearchResultNothingFoundContainer.text
-        font.pixelSize: Style.unifiedSearchPlaceholderViewTitleFontPixelSize
-        wrapMode: Text.Wrap
-        maximumLineCount: 2
-        elide: Text.ElideRight
-        Layout.fillWidth: true
-        Layout.preferredHeight: Style.trayWindowHeaderHeight / 2
-        horizontalAlignment: Text.AlignHCenter
+            objectName: "nothingFoundIcon"
+            source: `image://svgimage-custom-color/magnifying-glass.svg/${palette.windowText}`
+            sourceSize.width: Style.trayWindowHeaderHeight / 2
+            sourceSize.height: Style.trayWindowHeaderHeight / 2
+            Layout.alignment: Qt.AlignHCenter
+        }
+
+        EnforcedPlainTextLabel {
+            id: unifiedSearchResultsNoResultsLabel
+
+            objectName: "nothingFoundMessage"
+            text: qsTr("No results for")
+            font.pixelSize: Style.unifiedSearchPlaceholderViewSublineFontPixelSize
+            wrapMode: Text.Wrap
+            Layout.fillWidth: true
+            Layout.preferredHeight: Style.trayWindowHeaderHeight / 2
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        EnforcedPlainTextLabel {
+            id: unifiedSearchResultsNoResultsLabelDetails
+
+            objectName: "nothingFoundQuery"
+            text: unifiedSearchResultNothingFoundContainer.text
+            font.pixelSize: Style.unifiedSearchPlaceholderViewTitleFontPixelSize
+            wrapMode: Text.Wrap
+            maximumLineCount: 2
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+            Layout.preferredHeight: Style.trayWindowHeaderHeight / 2
+            horizontalAlignment: Text.AlignHCenter
+        }
     }
 }

--- a/src/gui/search/unifiedsearchpeoplemodel.cpp
+++ b/src/gui/search/unifiedsearchpeoplemodel.cpp
@@ -7,6 +7,7 @@
 
 #include "account.h"
 #include "accountstate.h"
+#include "common/utility.h"
 #include "networkjobs.h"
 
 #include <QJsonArray>
@@ -23,7 +24,7 @@ QString avatarUrl(const OCC::AccountPtr &account, const QString &userId)
 {
     const auto encodedUserId = QString::fromUtf8(QUrl::toPercentEncoding(userId));
     const auto avatarPath = QStringLiteral("index.php/avatar/%1/64").arg(encodedUserId);
-    return account->url().resolved(QUrl(avatarPath)).toString();
+    return OCC::Utility::concatUrlPath(account->url(), avatarPath).toString();
 }
 }
 

--- a/src/gui/search/unifiedsearchpeoplemodel.cpp
+++ b/src/gui/search/unifiedsearchpeoplemodel.cpp
@@ -1,0 +1,279 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "unifiedsearchpeoplemodel.h"
+
+#include "account.h"
+#include "accountstate.h"
+#include "networkjobs.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QUrlQuery>
+
+namespace
+{
+constexpr auto maximumPeopleResults = 50;
+
+QString avatarUrl(const OCC::AccountPtr &account, const QString &userId)
+{
+    const auto encodedUserId = QString::fromUtf8(QUrl::toPercentEncoding(userId));
+    const auto avatarPath = QStringLiteral("index.php/avatar/%1/64").arg(encodedUserId);
+    return account->url().resolved(QUrl(avatarPath)).toString();
+}
+}
+
+namespace OCC
+{
+UnifiedSearchPeopleModel::UnifiedSearchPeopleModel(QObject *parent, int debounceInterval)
+    : QAbstractListModel(parent)
+{
+    _debounceTimer.setSingleShot(true);
+    _debounceTimer.setInterval(debounceInterval);
+    connect(&_debounceTimer, &QTimer::timeout, this, &UnifiedSearchPeopleModel::startSearch);
+}
+
+UnifiedSearchPeopleModel::~UnifiedSearchPeopleModel()
+{
+    cancel();
+}
+
+QVariant UnifiedSearchPeopleModel::data(const QModelIndex &index, int role) const
+{
+    Q_ASSERT(checkIndex(index, CheckIndexOption::IndexIsValid));
+    const auto &person = _people.at(index.row());
+    switch (role) {
+    case UserIdRole:
+        return person.id;
+    case DisplayNameRole:
+        return person.displayName;
+    case AvatarUrlRole:
+        return person.avatarUrl;
+    }
+    return {};
+}
+
+int UnifiedSearchPeopleModel::rowCount(const QModelIndex &parent) const
+{
+    return parent.isValid() ? 0 : _people.size();
+}
+
+QHash<int, QByteArray> UnifiedSearchPeopleModel::roleNames() const
+{
+    static const auto roles = QHash<int, QByteArray>{
+        {UserIdRole, "userId"},
+        {DisplayNameRole, "displayName"},
+        {AvatarUrlRole, "avatarUrl"},
+    };
+    return roles;
+}
+
+AccountState *UnifiedSearchPeopleModel::accountState() const
+{
+    return _accountState.data();
+}
+
+QString UnifiedSearchPeopleModel::searchTerm() const
+{
+    return _searchTerm;
+}
+
+bool UnifiedSearchPeopleModel::busy() const
+{
+    return _busy;
+}
+
+QString UnifiedSearchPeopleModel::errorString() const
+{
+    return _errorString;
+}
+
+void UnifiedSearchPeopleModel::setAccountState(AccountState *accountState)
+{
+    if (_accountState == accountState) {
+        return;
+    }
+    cancel();
+    clearPeople();
+    if (_accountState) {
+        disconnect(_accountState, nullptr, this, nullptr);
+    }
+    _accountState = accountState;
+    if (_accountState) {
+        connect(_accountState, &AccountState::isConnectedChanged, this, [this] {
+            if (!_accountState->isConnected()) {
+                cancel();
+                clearPeople();
+                setErrorString(tr("People search is unavailable."));
+            } else {
+                setErrorString({});
+                _debounceTimer.start(0);
+            }
+        });
+        connect(_accountState, &QObject::destroyed, this, [this] {
+            cancel();
+            clearPeople();
+            setErrorString(tr("People search is unavailable."));
+            Q_EMIT accountStateChanged();
+        });
+    }
+    Q_EMIT accountStateChanged();
+    if (_accountState && _accountState->isConnected()) {
+        setErrorString({});
+        _debounceTimer.start(0);
+    } else {
+        setErrorString(tr("People search is unavailable."));
+    }
+}
+
+void UnifiedSearchPeopleModel::setSearchTerm(const QString &searchTerm)
+{
+    if (_searchTerm == searchTerm) {
+        return;
+    }
+    _searchTerm = searchTerm;
+    Q_EMIT searchTermChanged();
+    cancel();
+    clearPeople();
+    setErrorString({});
+    _debounceTimer.start();
+}
+
+void UnifiedSearchPeopleModel::retry()
+{
+    startSearch();
+}
+
+void UnifiedSearchPeopleModel::startSearch()
+{
+    cancel();
+    if (!_accountState || !_accountState->account() || !_accountState->isConnected()) {
+        setErrorString(tr("People search is unavailable."));
+        return;
+    }
+    const auto account = _accountState->account();
+    if (_searchTerm.trimmed().isEmpty()) {
+        auto people = QVector<Person>{};
+        const auto selfId = account->davUser();
+        if (!selfId.isEmpty()) {
+            const auto selfName = account->prettyName().isEmpty() ? selfId : account->prettyName();
+            people.push_back({selfId, selfName, avatarUrl(account, selfId)});
+        }
+        replacePeople(std::move(people));
+        setErrorString({});
+        return;
+    }
+
+    const auto generation = ++_generation;
+    const auto job = new JsonApiJob(account, QStringLiteral("ocs/v2.php/apps/files_sharing/api/v1/sharees"));
+    auto query = QUrlQuery{};
+    query.addQueryItem(QStringLiteral("search"), _searchTerm);
+    query.addQueryItem(QStringLiteral("shareType"), QStringLiteral("0"));
+    query.addQueryItem(QStringLiteral("lookup"), QStringLiteral("false"));
+    query.addQueryItem(QStringLiteral("page"), QStringLiteral("1"));
+    query.addQueryItem(QStringLiteral("perPage"), QString::number(maximumPeopleResults));
+    job->addQueryParams(query);
+    _job = job;
+    setBusy(true);
+    connect(job, &JsonApiJob::jsonReceived, this, [this, generation, job, account](const QJsonDocument &reply, int statusCode) {
+        if (generation != _generation || _job != job) {
+            return;
+        }
+        _job.clear();
+        setBusy(false);
+        if (statusCode != 200) {
+            clearPeople();
+            setErrorString(tr("Could not load people. Try again."));
+            return;
+        }
+        auto people = QVector<Person>{};
+        auto seen = QSet<QString>{};
+        const auto ocs = reply.object().value(QStringLiteral("ocs")).toObject();
+        const auto data = ocs.value(QStringLiteral("data")).toObject();
+        const auto appendUsers = [&people, &seen, &account](const QJsonArray &users) {
+            for (const auto &value : users) {
+                if (people.size() >= maximumPeopleResults) {
+                    break;
+                }
+                const auto object = value.toObject();
+                const auto id = object.value(QStringLiteral("value")).toObject().value(QStringLiteral("shareWith")).toString();
+                if (id.isEmpty() || seen.contains(id)) {
+                    continue;
+                }
+                seen.insert(id);
+                people.push_back({id, object.value(QStringLiteral("label")).toString(id), avatarUrl(account, id)});
+            }
+        };
+        appendUsers(data.value(QStringLiteral("exact")).toObject().value(QStringLiteral("users")).toArray());
+        appendUsers(data.value(QStringLiteral("users")).toArray());
+        const auto selfId = account->davUser();
+        const auto selfName = account->prettyName().isEmpty() ? selfId : account->prettyName();
+        const auto selfMatchesSearch =
+            _searchTerm.isEmpty() || selfId.contains(_searchTerm, Qt::CaseInsensitive) || selfName.contains(_searchTerm, Qt::CaseInsensitive);
+        if (!selfId.isEmpty() && !seen.contains(selfId) && selfMatchesSearch) {
+            people.prepend({selfId, selfName, avatarUrl(account, selfId)});
+            if (people.size() > maximumPeopleResults) {
+                people.removeLast();
+            }
+        }
+        replacePeople(std::move(people));
+        setErrorString({});
+    });
+    job->start();
+}
+
+void UnifiedSearchPeopleModel::cancel()
+{
+    _debounceTimer.stop();
+    ++_generation;
+    if (_job) {
+        disconnect(_job, nullptr, this, nullptr);
+        const auto job = qobject_cast<JsonApiJob *>(_job.data());
+        const auto reply = job ? job->reply() : nullptr;
+        if (reply && reply->isRunning()) {
+            reply->abort();
+        }
+        _job.clear();
+    }
+    setBusy(false);
+}
+
+void UnifiedSearchPeopleModel::clearPeople()
+{
+    if (_people.isEmpty()) {
+        return;
+    }
+    beginResetModel();
+    _people.clear();
+    endResetModel();
+}
+
+void UnifiedSearchPeopleModel::replacePeople(QVector<Person> people)
+{
+    beginResetModel();
+    _people = std::move(people);
+    endResetModel();
+}
+
+void UnifiedSearchPeopleModel::setBusy(bool busy)
+{
+    if (_busy == busy) {
+        return;
+    }
+    _busy = busy;
+    Q_EMIT busyChanged();
+}
+
+void UnifiedSearchPeopleModel::setErrorString(const QString &errorString)
+{
+    if (_errorString == errorString) {
+        return;
+    }
+    _errorString = errorString;
+    Q_EMIT errorStringChanged();
+}
+}

--- a/src/gui/search/unifiedsearchpeoplemodel.cpp
+++ b/src/gui/search/unifiedsearchpeoplemodel.cpp
@@ -173,6 +173,7 @@ void UnifiedSearchPeopleModel::startSearch()
     const auto job = new JsonApiJob(account, QStringLiteral("ocs/v2.php/apps/files_sharing/api/v1/sharees"));
     auto query = QUrlQuery{};
     query.addQueryItem(QStringLiteral("search"), _searchTerm);
+    query.addQueryItem(QStringLiteral("itemType"), QStringLiteral("file"));
     query.addQueryItem(QStringLiteral("shareType"), QStringLiteral("0"));
     query.addQueryItem(QStringLiteral("lookup"), QStringLiteral("false"));
     query.addQueryItem(QStringLiteral("page"), QStringLiteral("1"));

--- a/src/gui/search/unifiedsearchpeoplemodel.h
+++ b/src/gui/search/unifiedsearchpeoplemodel.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "accountstate.h"
+
+#include <QAbstractListModel>
+#include <QPointer>
+#include <QTimer>
+
+namespace OCC {
+
+/** @brief Account-authenticated user suggestions for Unified Search. */
+class UnifiedSearchPeopleModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(AccountState *accountState READ accountState WRITE setAccountState NOTIFY accountStateChanged)
+    Q_PROPERTY(QString searchTerm READ searchTerm WRITE setSearchTerm NOTIFY searchTermChanged)
+    Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
+    Q_PROPERTY(QString errorString READ errorString NOTIFY errorStringChanged)
+
+public:
+    enum Role { UserIdRole = Qt::UserRole + 1, DisplayNameRole, AvatarUrlRole };
+
+    explicit UnifiedSearchPeopleModel(QObject *parent = nullptr, int debounceInterval = 300);
+    ~UnifiedSearchPeopleModel() override;
+    [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
+    [[nodiscard]] int rowCount(const QModelIndex &parent = {}) const override;
+    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+    [[nodiscard]] AccountState *accountState() const;
+    [[nodiscard]] QString searchTerm() const;
+    [[nodiscard]] bool busy() const;
+    [[nodiscard]] QString errorString() const;
+
+public Q_SLOTS:
+    void setAccountState(AccountState *accountState);
+    void setSearchTerm(const QString &searchTerm);
+    void retry();
+
+Q_SIGNALS:
+    void accountStateChanged();
+    void searchTermChanged();
+    void busyChanged();
+    void errorStringChanged();
+
+private:
+    struct Person { QString id; QString displayName; QString avatarUrl; };
+    void startSearch();
+    void cancel();
+    void clearPeople();
+    void replacePeople(QVector<Person> people);
+    void setBusy(bool busy);
+    void setErrorString(const QString &errorString);
+
+    QPointer<AccountState> _accountState;
+    QVector<Person> _people;
+    QString _searchTerm;
+    QString _errorString;
+    QTimer _debounceTimer;
+    QPointer<QObject> _job;
+    quint64 _generation = 0;
+    bool _busy = false;
+};
+}

--- a/src/gui/search/unifiedsearchresult.cpp
+++ b/src/gui/search/unifiedsearchresult.cpp
@@ -18,8 +18,20 @@ QString UnifiedSearchResult::typeAsString(UnifiedSearchResult::Type type)
         result = QStringLiteral("Default");
         break;
 
+    case ProviderHeader:
+        result = QStringLiteral("ProviderHeader");
+        break;
+
+    case PartialMatchesHeader:
+        result = QStringLiteral("PartialMatchesHeader");
+        break;
+
     case FetchMoreTrigger:
         result = QStringLiteral("FetchMoreTrigger");
+        break;
+
+    case RetryFetchMoreTrigger:
+        result = QStringLiteral("RetryFetchMoreTrigger");
         break;
     }
     return result;

--- a/src/gui/search/unifiedsearchresult.h
+++ b/src/gui/search/unifiedsearchresult.h
@@ -29,12 +29,12 @@ struct UnifiedSearchResult
 
     static QString typeAsString(UnifiedSearchResult::Type type);
 
-    QString _title{};
-    QString _subline{};
-    QString _providerId{};
-    QString _providerName{};
-    QString _providerIcon{};
-    QString _stableKey{};
+    QString _title = QString();
+    QString _subline = QString();
+    QString _providerId = QString();
+    QString _providerName = QString();
+    QString _providerIcon = QString();
+    QString _stableKey = QString();
     bool _isRounded = false;
     bool _isSelected = false;
     bool _isSelectable = false;
@@ -42,9 +42,9 @@ struct UnifiedSearchResult
     bool _hasOverflow = false;
     bool _isLoading = false;
     qint32 _order = std::numeric_limits<qint32>::max();
-    QUrl _resourceUrl{};
-    QString _darkIcons{};
-    QString _lightIcons{};
+    QUrl _resourceUrl = QUrl();
+    QString _darkIcons = QString();
+    QString _lightIcons = QString();
     bool _darkIconsIsThumbnail = false;
     bool _lightIconsIsThumbnail = false;
     Type _type = Type::Default;

--- a/src/gui/search/unifiedsearchresult.h
+++ b/src/gui/search/unifiedsearchresult.h
@@ -29,12 +29,12 @@ struct UnifiedSearchResult
 
     static QString typeAsString(UnifiedSearchResult::Type type);
 
-    QString _title;
-    QString _subline;
-    QString _providerId;
-    QString _providerName;
-    QString _providerIcon;
-    QString _stableKey;
+    QString _title{};
+    QString _subline{};
+    QString _providerId{};
+    QString _providerName{};
+    QString _providerIcon{};
+    QString _stableKey{};
     bool _isRounded = false;
     bool _isSelected = false;
     bool _isSelectable = false;
@@ -42,9 +42,9 @@ struct UnifiedSearchResult
     bool _hasOverflow = false;
     bool _isLoading = false;
     qint32 _order = std::numeric_limits<qint32>::max();
-    QUrl _resourceUrl;
-    QString _darkIcons;
-    QString _lightIcons;
+    QUrl _resourceUrl{};
+    QString _darkIcons{};
+    QString _lightIcons{};
     bool _darkIconsIsThumbnail = false;
     bool _lightIconsIsThumbnail = false;
     Type _type = Type::Default;

--- a/src/gui/search/unifiedsearchresult.h
+++ b/src/gui/search/unifiedsearchresult.h
@@ -21,7 +21,10 @@ struct UnifiedSearchResult
 {
     enum Type : quint8 {
         Default,
+        ProviderHeader,
+        PartialMatchesHeader,
         FetchMoreTrigger,
+        RetryFetchMoreTrigger,
     };
 
     static QString typeAsString(UnifiedSearchResult::Type type);
@@ -30,7 +33,14 @@ struct UnifiedSearchResult
     QString _subline;
     QString _providerId;
     QString _providerName;
+    QString _providerIcon;
+    QString _stableKey;
     bool _isRounded = false;
+    bool _isSelected = false;
+    bool _isSelectable = false;
+    bool _isPartialMatch = false;
+    bool _hasOverflow = false;
+    bool _isLoading = false;
     qint32 _order = std::numeric_limits<qint32>::max();
     QUrl _resourceUrl;
     QString _darkIcons;

--- a/src/gui/search/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/search/unifiedsearchresultslistmodel.cpp
@@ -481,7 +481,7 @@ bool UnifiedSearchResultsListModel::externalProvidersEnabled() const
 
 bool UnifiedSearchResultsListModel::showConnectedServicesAction() const
 {
-    return _viewMode == ViewMode::Aggregate && hasSearchTerm() && hasExternalProviders() && !isSearchInProgress();
+    return _viewMode == ViewMode::Aggregate && _selectedProviderIds.isEmpty() && hasSearchTerm() && hasExternalProviders() && !isSearchInProgress();
 }
 
 bool UnifiedSearchResultsListModel::hasPartialFailure() const
@@ -520,8 +520,10 @@ void UnifiedSearchResultsListModel::setSearchTerm(const QString &term)
     if (_searchTerm == term) {
         return;
     }
+    const auto wasInProgress = isSearchInProgress();
     _searchTerm = term;
     Q_EMIT searchTermChanged();
+    updateProgressSignals(wasInProgress);
     scheduleSearch();
 }
 

--- a/src/gui/search/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/search/unifiedsearchresultslistmodel.cpp
@@ -321,7 +321,7 @@ QHash<int, QByteArray> UnifiedSearchResultsListModel::roleNames() const
         result[TitleRole] = "resultTitle";
         result[SublineRole] = "subline";
         result[ResourceUrlRole] = "resourceUrlRole";
-        result[TypeRole] = "type";
+        result[TypeRole] = "resultType";
         result[TypeAsStringRole] = "typeAsString";
         result[RoundedRole] = "isRounded";
         result[StableKeyRole] = "stableKey";
@@ -340,15 +340,50 @@ bool UnifiedSearchResultsListModel::isSearchInProgress() const
     return _inFlightSearchRequests > 0 || (_providersLoading && hasSearchTerm());
 }
 
-QString UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderId() const { return _currentFetchMoreInProgressProviderId; }
-QString UnifiedSearchResultsListModel::searchTerm() const { return _searchTerm; }
-QString UnifiedSearchResultsListModel::errorString() const { return _errorString; }
-bool UnifiedSearchResultsListModel::waitingForSearchTermEditEnd() const { return _waitingForSearchTermEditEnd; }
-bool UnifiedSearchResultsListModel::isFetchMoreInProgress() const { return !_currentFetchMoreInProgressProviderId.isEmpty(); }
-bool UnifiedSearchResultsListModel::hasSearchTerm() const { return !_searchTerm.trimmed().isEmpty(); }
-bool UnifiedSearchResultsListModel::hasSearchError() const { return !_errorString.isEmpty(); }
-bool UnifiedSearchResultsListModel::canEditSearch() const { return _accountState && _accountState->account() && isAccountConnected(); }
-bool UnifiedSearchResultsListModel::isAccountConnected() const { return _accountState && _accountState->isConnected(); }
+QString UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderId() const
+{
+    return _currentFetchMoreInProgressProviderId;
+}
+
+QString UnifiedSearchResultsListModel::searchTerm() const
+{
+    return _searchTerm;
+}
+
+QString UnifiedSearchResultsListModel::errorString() const
+{
+    return _errorString;
+}
+
+bool UnifiedSearchResultsListModel::waitingForSearchTermEditEnd() const
+{
+    return _waitingForSearchTermEditEnd;
+}
+
+bool UnifiedSearchResultsListModel::isFetchMoreInProgress() const
+{
+    return !_currentFetchMoreInProgressProviderId.isEmpty();
+}
+
+bool UnifiedSearchResultsListModel::hasSearchTerm() const
+{
+    return !_searchTerm.trimmed().isEmpty();
+}
+
+bool UnifiedSearchResultsListModel::hasSearchError() const
+{
+    return !_errorString.isEmpty();
+}
+
+bool UnifiedSearchResultsListModel::canEditSearch() const
+{
+    return _accountState && _accountState->account() && isAccountConnected();
+}
+
+bool UnifiedSearchResultsListModel::isAccountConnected() const
+{
+    return _accountState && _accountState->isConnected();
+}
 
 UnifiedSearchResultsListModel::SearchState UnifiedSearchResultsListModel::searchState() const
 {
@@ -415,7 +450,10 @@ QVariantList UnifiedSearchResultsListModel::activeFilters() const
     return result;
 }
 
-bool UnifiedSearchResultsListModel::providersReady() const { return _providersReady; }
+bool UnifiedSearchResultsListModel::providersReady() const
+{
+    return _providersReady;
+}
 
 bool UnifiedSearchResultsListModel::dateFilterAvailable() const
 {
@@ -436,15 +474,25 @@ bool UnifiedSearchResultsListModel::hasExternalProviders() const
     return std::any_of(_providers.cbegin(), _providers.cend(), [](const auto &provider) { return provider.isExternalProvider; });
 }
 
-bool UnifiedSearchResultsListModel::externalProvidersEnabled() const { return _externalProvidersEnabled; }
+bool UnifiedSearchResultsListModel::externalProvidersEnabled() const
+{
+    return _externalProvidersEnabled;
+}
 
 bool UnifiedSearchResultsListModel::showConnectedServicesAction() const
 {
     return _viewMode == ViewMode::Aggregate && hasSearchTerm() && hasExternalProviders() && !isSearchInProgress();
 }
 
-bool UnifiedSearchResultsListModel::hasPartialFailure() const { return _hasPartialFailure; }
-UnifiedSearchResultsListModel::ViewMode UnifiedSearchResultsListModel::viewMode() const { return _viewMode; }
+bool UnifiedSearchResultsListModel::hasPartialFailure() const
+{
+    return _hasPartialFailure;
+}
+
+UnifiedSearchResultsListModel::ViewMode UnifiedSearchResultsListModel::viewMode() const
+{
+    return _viewMode;
+}
 
 QString UnifiedSearchResultsListModel::detailProviderName() const
 {
@@ -452,9 +500,20 @@ QString UnifiedSearchResultsListModel::detailProviderName() const
     return providerIt == _providers.cend() ? QString() : providerIt->name;
 }
 
-int UnifiedSearchResultsListModel::selectedRow() const { return _selectedRow; }
-QString UnifiedSearchResultsListModel::accessibilityStatus() const { return _accessibilityStatus; }
-AccountState *UnifiedSearchResultsListModel::accountState() const { return _accountState; }
+int UnifiedSearchResultsListModel::selectedRow() const
+{
+    return _selectedRow;
+}
+
+QString UnifiedSearchResultsListModel::accessibilityStatus() const
+{
+    return _accessibilityStatus;
+}
+
+AccountState *UnifiedSearchResultsListModel::accountState() const
+{
+    return _accountState;
+}
 
 void UnifiedSearchResultsListModel::setSearchTerm(const QString &term)
 {
@@ -674,8 +733,8 @@ void UnifiedSearchResultsListModel::startSearchForProvider(const QString &provid
     }
     auto &provider = _providers[providerId];
     const auto generation = _queryGeneration;
-    auto *const job = new JsonApiJob(_accountState->account(),
-        QStringLiteral("ocs/v2.php/search/providers/%1/search").arg(QString::fromUtf8(QUrl::toPercentEncoding(providerId))));
+    const auto job = new JsonApiJob(_accountState->account(),
+                                    QStringLiteral("ocs/v2.php/search/providers/%1/search").arg(QString::fromUtf8(QUrl::toPercentEncoding(providerId))));
     job->addQueryParams(queryForProvider(provider, pagination));
     connect(job, &JsonApiJob::jsonReceived, this,
         [this, providerId, pagination, generation, job](const QJsonDocument &json, const int statusCode) {
@@ -695,11 +754,11 @@ void UnifiedSearchResultsListModel::startSearchForProvider(const QString &provid
 }
 
 void UnifiedSearchResultsListModel::providerSearchFinished(const QJsonDocument &json,
-                                                            int statusCode,
-                                                            const QString &providerId,
-                                                            bool pagination,
-                                                            quint64 generation,
-                                                            QObject *jobObject)
+                                                           int statusCode,
+                                                           const QString &providerId,
+                                                           bool pagination,
+                                                           quint64 generation,
+                                                           QObject *jobObject)
 {
     const auto wasInProgress = isSearchInProgress();
     untrackSearchJob(jobObject);
@@ -770,17 +829,11 @@ QVector<UnifiedSearchResult> UnifiedSearchResultsListModel::parseEntries(const Q
         if (entry.isEmpty()) {
             continue;
         }
-        UnifiedSearchResult result;
-        result._providerId = provider.id;
-        result._providerName = provider.name;
-        result._order = provider.order;
-        result._isRounded = entry.value("rounded"_L1).toBool(false);
-        result._title = entry.value("title"_L1).toString();
-        result._subline = entry.value("subline"_L1).toString();
-        result._resourceUrl = openableResourceUrl(QUrl(entry.value("resourceUrl"_L1).toString()), accountUrl);
+        const auto title = entry.value("title"_L1).toString();
+        const auto resourceUrl = openableResourceUrl(QUrl(entry.value("resourceUrl"_L1).toString()), accountUrl);
         const auto entryIcon = entry.value("icon"_L1).toString();
-        const auto darkNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, result._title, true);
-        const auto lightNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, result._title, false);
+        const auto darkNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, title, true);
+        const auto lightNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, title, false);
         const auto darkFallbackIcon = !darkNavigationAppIcon.isEmpty()
             ? darkNavigationAppIcon
             : (entryIcon.isEmpty() ? providerIcon(provider, true) : entryIcon);
@@ -789,13 +842,22 @@ QVector<UnifiedSearchResult> UnifiedSearchResultsListModel::parseEntries(const Q
             : (entryIcon.isEmpty() ? providerIcon(provider, false) : entryIcon);
         const auto darkIcons = iconsFromThumbnailAndFallbackIcon(entry.value("thumbnailUrl"_L1).toString(), darkFallbackIcon, accountUrl, true);
         const auto lightIcons = iconsFromThumbnailAndFallbackIcon(entry.value("thumbnailUrl"_L1).toString(), lightFallbackIcon, accountUrl, false);
-        result._darkIcons = darkIcons.first;
-        result._lightIcons = lightIcons.first;
-        result._darkIconsIsThumbnail = darkIcons.second;
-        result._lightIconsIsThumbnail = lightIcons.second;
-        result._providerIcon = providerIcon(provider, false);
-        result._isSelectable = true;
-        result._stableKey = stableKeyForResult(provider.id, result, entryIndex++);
+        const auto result = UnifiedSearchResult{
+            ._title = title,
+            ._subline = entry.value("subline"_L1).toString(),
+            ._providerId = provider.id,
+            ._providerName = provider.name,
+            ._providerIcon = providerIcon(provider, false),
+            ._stableKey = stableKeyForResult(provider.id, resourceUrl, entryIndex++),
+            ._isRounded = entry.value("rounded"_L1).toBool(false),
+            ._isSelectable = true,
+            ._order = provider.order,
+            ._resourceUrl = resourceUrl,
+            ._darkIcons = darkIcons.first,
+            ._lightIcons = lightIcons.first,
+            ._darkIconsIsThumbnail = darkIcons.second,
+            ._lightIconsIsThumbnail = lightIcons.second,
+        };
         parsedEntries.push_back(result);
     }
     return parsedEntries;
@@ -844,7 +906,11 @@ void UnifiedSearchResultsListModel::rebuildProjection()
     QVector<UnifiedSearchResult> projection;
     if (_viewMode == ViewMode::ProviderDetail && _providers.contains(_detailProviderId)) {
         const auto &provider = _providers[_detailProviderId];
-        projection = provider.entries;
+        projection.reserve(provider.entries.size() + 1);
+        for (auto entry : provider.entries) {
+            entry._isPartialMatch = provider.partialMatch;
+            projection.push_back(std::move(entry));
+        }
         if (provider.loadMoreFailed || provider.hasMore) {
             projection.push_back(pagingRowForProvider(provider));
         }
@@ -877,10 +943,11 @@ void UnifiedSearchResultsListModel::rebuildProjection()
                 continue;
             }
             if (!partialHeaderAdded) {
-                UnifiedSearchResult header;
-                header._type = UnifiedSearchResult::Type::PartialMatchesHeader;
-                header._title = tr("Partial matches");
-                header._stableKey = QStringLiteral("partial-matches");
+                const auto header = UnifiedSearchResult{
+                    ._title = tr("Partial matches"),
+                    ._stableKey = QStringLiteral("partial-matches"),
+                    ._type = UnifiedSearchResult::Type::PartialMatchesHeader,
+                };
                 projection.push_back(header);
                 partialHeaderAdded = true;
             }
@@ -918,15 +985,13 @@ void UnifiedSearchResultsListModel::rebuildProjection()
 
 UnifiedSearchResult UnifiedSearchResultsListModel::pagingRowForProvider(const UnifiedSearchProvider &provider) const
 {
-    UnifiedSearchResult pagingRow;
-    pagingRow._providerId = provider.id;
-    pagingRow._providerName = provider.name;
-    pagingRow._type = provider.loadMoreFailed
-        ? UnifiedSearchResult::Type::RetryFetchMoreTrigger
-        : UnifiedSearchResult::Type::FetchMoreTrigger;
-    pagingRow._isLoading = provider.paging;
-    pagingRow._stableKey = QStringLiteral("paging:%1").arg(provider.id);
-    return pagingRow;
+    return UnifiedSearchResult{
+        ._providerId = provider.id,
+        ._providerName = provider.name,
+        ._stableKey = QStringLiteral("paging:%1").arg(provider.id),
+        ._isLoading = provider.paging,
+        ._type = provider.loadMoreFailed ? UnifiedSearchResult::Type::RetryFetchMoreTrigger : UnifiedSearchResult::Type::FetchMoreTrigger,
+    };
 }
 
 bool UnifiedSearchResultsListModel::updateDetailPagingState(const UnifiedSearchProvider &provider)
@@ -975,13 +1040,17 @@ bool UnifiedSearchResultsListModel::updateDetailProjectionAfterPagination(const 
         return true;
     }
 
-    _results[pagingRowIndex] = provider.entries[previousEntryCount];
+    auto firstAppendedEntry = provider.entries[previousEntryCount];
+    firstAppendedEntry._isPartialMatch = provider.partialMatch;
+    _results[pagingRowIndex] = std::move(firstAppendedEntry);
     Q_EMIT dataChanged(index(pagingRowIndex), index(pagingRowIndex));
 
     QVector<UnifiedSearchResult> tail;
     tail.reserve(appendedCount);
     for (auto entryIndex = previousEntryCount + 1; entryIndex < provider.entries.size(); ++entryIndex) {
-        tail.push_back(provider.entries[entryIndex]);
+        auto entry = provider.entries[entryIndex];
+        entry._isPartialMatch = provider.partialMatch;
+        tail.push_back(std::move(entry));
     }
     if (provider.hasMore) {
         tail.push_back(pagingRowForProvider(provider));
@@ -1018,15 +1087,16 @@ void UnifiedSearchResultsListModel::appendProviderProjection(const UnifiedSearch
         return;
     }
 
-    UnifiedSearchResult header;
-    header._providerId = provider.id;
-    header._providerName = provider.name;
-    header._providerIcon = visibleEntries.constFirst()._providerIcon;
-    header._title = provider.name;
-    header._hasOverflow = visibleEntries.size() > aggregateResultsPerProvider || provider.hasMore;
-    header._isPartialMatch = partial;
-    header._type = UnifiedSearchResult::Type::ProviderHeader;
-    header._stableKey = QStringLiteral("header:%1:%2").arg(partial ? QStringLiteral("partial") : QStringLiteral("full"), provider.id);
+    const auto header = UnifiedSearchResult{
+        ._title = provider.name,
+        ._providerId = provider.id,
+        ._providerName = provider.name,
+        ._providerIcon = visibleEntries.constFirst()._providerIcon,
+        ._stableKey = QStringLiteral("header:%1:%2").arg(partial ? QStringLiteral("partial") : QStringLiteral("full"), provider.id),
+        ._isPartialMatch = partial,
+        ._hasOverflow = visibleEntries.size() > aggregateResultsPerProvider || provider.hasMore,
+        ._type = UnifiedSearchResult::Type::ProviderHeader,
+    };
     projection.push_back(header);
 
     const auto visibleCount = std::min(aggregateResultsPerProvider, visibleEntries.size());
@@ -1283,11 +1353,9 @@ QUrlQuery UnifiedSearchResultsListModel::queryForProvider(const UnifiedSearchPro
     return query;
 }
 
-QString UnifiedSearchResultsListModel::stableKeyForResult(const QString &providerId,
-                                                           const UnifiedSearchResult &result,
-                                                           int entryIndex)
+QString UnifiedSearchResultsListModel::stableKeyForResult(const QString &providerId, const QUrl &resourceUrl, int entryIndex)
 {
-    return QStringLiteral("result:%1:%2:%3").arg(providerId, result._resourceUrl.toString(), QString::number(entryIndex));
+    return QStringLiteral("result:%1:%2:%3").arg(providerId, resourceUrl.toString(), QString::number(entryIndex));
 }
 
 QUrl UnifiedSearchResultsListModel::openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl)
@@ -1314,7 +1382,10 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId, con
     Utility::openBrowser(resourceUrl);
 }
 
-void UnifiedSearchResultsListModel::fetchMoreTriggerClicked(const QString &providerId) { loadMore(providerId); }
+void UnifiedSearchResultsListModel::fetchMoreTriggerClicked(const QString &providerId)
+{
+    loadMore(providerId);
+}
 
 void UnifiedSearchResultsListModel::toggleProviderFilter(const QString &providerId)
 {
@@ -1483,7 +1554,10 @@ void UnifiedSearchResultsListModel::loadMore(const QString &providerId)
     startSearchForProvider(providerId, true);
 }
 
-void UnifiedSearchResultsListModel::retryLoadMore(const QString &providerId) { loadMore(providerId); }
+void UnifiedSearchResultsListModel::retryLoadMore(const QString &providerId)
+{
+    loadMore(providerId);
+}
 
 void UnifiedSearchResultsListModel::retryFailedProviders()
 {

--- a/src/gui/search/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/search/unifiedsearchresultslistmodel.cpp
@@ -7,18 +7,28 @@
 
 #include "account.h"
 #include "accountstate.h"
-#include "guiutility.h"
 #include "folderman.h"
+#include "guiutility.h"
 #include "networkjobs.h"
 
-#include <algorithm>
-
-#include <QAbstractListModel>
 #include <QDesktopServices>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocale>
+#include <QTimeZone>
+#include <QUrlQuery>
+
+#include <algorithm>
+#include <tuple>
 
 using namespace Qt::StringLiterals;
 
 namespace {
+constexpr qsizetype aggregateResultsPerProvider = 3;
+constexpr auto requestResultsPerProvider = 10;
+
 QString imagePlaceholderUrlForProviderId(const QString &providerId, const bool darkMode)
 {
     const auto colorIconPath = darkMode ? QStringLiteral(":/client/theme/white/") : QStringLiteral(":/client/theme/black/");
@@ -64,345 +74,1239 @@ QString localIconPathFromIconPrefix(const QString &iconNameWithPrefix, const boo
 QString iconUrlForDefaultIconName(const QString &defaultIconName, const bool darkMode)
 {
     const QUrl urlForIcon{defaultIconName};
-
     if (urlForIcon.isValid() && !urlForIcon.scheme().isEmpty()) {
         return defaultIconName;
     }
 
     const auto colorIconPath = darkMode ? QStringLiteral(":/client/theme/white/") : QStringLiteral(":/client/theme/black/");
-
     if (defaultIconName.startsWith(QStringLiteral("icon-"))) {
         const auto parts = defaultIconName.split(u'-');
-
         if (parts.size() > 1) {
-            const QString blackOrWhiteIconFilePath = colorIconPath + parts[1] + QStringLiteral(".svg");
-
-            if (QFile::exists(blackOrWhiteIconFilePath)) {
-                return blackOrWhiteIconFilePath;
+            const auto themedIcon = colorIconPath + parts[1] + QStringLiteral(".svg");
+            if (QFile::exists(themedIcon)) {
+                return themedIcon;
             }
-
-            const QString iconFilePath = QStringLiteral(":/client/theme/") + parts[1] + QStringLiteral(".svg");
-
-            if (QFile::exists(iconFilePath)) {
-                return iconFilePath;
+            const auto icon = QStringLiteral(":/client/theme/") + parts[1] + QStringLiteral(".svg");
+            if (QFile::exists(icon)) {
+                return icon;
             }
         }
-
-        const auto iconNameFromIconPrefix = localIconPathFromIconPrefix(defaultIconName, darkMode);
-
-        if (!iconNameFromIconPrefix.isEmpty()) {
-            return iconNameFromIconPrefix;
-        }
+        return localIconPathFromIconPrefix(defaultIconName, darkMode);
     }
 
     return colorIconPath % QStringLiteral("change.svg");
 }
 
-QString generateUrlForThumbnail(const QString &thumbnailUrl, const QUrl &serverUrl)
+QString absoluteServerResource(const QString &resource, const QUrl &serverUrl)
 {
-    auto serverUrlCopy = serverUrl;
-    auto thumbnailUrlCopy = thumbnailUrl;
-
-    if (thumbnailUrlCopy.startsWith(u'/') || thumbnailUrlCopy.startsWith(u'\\')) {
-        // relative image resource URL, just needs some concatenation with current server URL
-        // some icons may contain parameters after (?)
-        const QStringList thumbnailUrlCopySplitted = thumbnailUrlCopy.contains(u'?')
-            ? thumbnailUrlCopy.split(u'?', Qt::SkipEmptyParts)
-            : QStringList{thumbnailUrlCopy};
-        Q_ASSERT(!thumbnailUrlCopySplitted.isEmpty());
-        serverUrlCopy.setPath(thumbnailUrlCopySplitted[0]);
-        thumbnailUrlCopy = serverUrlCopy.toString();
-        if (thumbnailUrlCopySplitted.size() > 1) {
-            thumbnailUrlCopy += u'?' + thumbnailUrlCopySplitted[1];
-        }
-    }
-
-    return thumbnailUrlCopy;
-}
-
-QString generateUrlForIcon(const QString &fallbackIcon, const QUrl &serverUrl, const bool darkMode)
-{
-    auto serverUrlCopy = serverUrl;
-
-    auto fallbackIconCopy = fallbackIcon;
-
-    if (fallbackIconCopy.startsWith(u'/') || fallbackIconCopy.startsWith(u'\\')) {
-        // relative image resource URL, just needs some concatenation with current server URL
-        // some icons may contain parameters after (?)
-        const QStringList fallbackIconPathSplitted =
-            fallbackIconCopy.contains(u'?') ? fallbackIconCopy.split(u'?') : QStringList{fallbackIconCopy};
-        Q_ASSERT(!fallbackIconPathSplitted.isEmpty());
-        serverUrlCopy.setPath(fallbackIconPathSplitted[0]);
-        fallbackIconCopy = serverUrlCopy.toString();
-        if (fallbackIconPathSplitted.size() > 1) {
-            fallbackIconCopy += u'?' + fallbackIconPathSplitted[1];
-        }
-    } else if (!fallbackIconCopy.isEmpty()) {
-        // could be one of names for standard icons (e.g. icon-mail)
-        const auto defaultIconUrl = iconUrlForDefaultIconName(fallbackIconCopy, darkMode);
-        if (!defaultIconUrl.isEmpty()) {
-            fallbackIconCopy = defaultIconUrl;
-        }
-    }
-
-    return fallbackIconCopy;
-}
-
-// Return image URL and whether it is a thumbnail or not
-std::pair<QString, bool> iconsFromThumbnailAndFallbackIcon(const QString &thumbnailUrl, const QString &fallbackIcon, const QUrl &serverUrl, const bool darkMode)
-{
-    if (thumbnailUrl.isEmpty() && fallbackIcon.isEmpty()) {
+    if (resource.isEmpty()) {
         return {};
     }
 
-    if (serverUrl.isEmpty()) {
-        const QStringList listImages = {thumbnailUrl, fallbackIcon};
-        return {listImages.join(u';'), false};
+    const auto url = QUrl(resource);
+    if (!url.isRelative() && !url.scheme().isEmpty()) {
+        return resource;
     }
 
-    const auto urlForThumbnail = generateUrlForThumbnail(thumbnailUrl, serverUrl);
-    const auto urlForFallbackIcon = generateUrlForIcon(fallbackIcon, serverUrl, darkMode);
-
-    qDebug() << "SEARCH" << urlForThumbnail << urlForFallbackIcon;
-
-    if (urlForThumbnail.isEmpty() && !urlForFallbackIcon.isEmpty()) {
-        return {urlForFallbackIcon, false};
+    auto absoluteUrl = serverUrl;
+    if (resource.startsWith(u'/') || resource.startsWith(u'\\')) {
+        const auto queryPosition = resource.indexOf(u'?');
+        absoluteUrl.setPath(queryPosition < 0 ? resource : resource.left(queryPosition));
+        if (queryPosition >= 0) {
+            absoluteUrl.setQuery(resource.mid(queryPosition + 1));
+        }
+    } else {
+        absoluteUrl = serverUrl.resolved(QUrl(resource));
     }
-
-    if (!urlForThumbnail.isEmpty() && urlForFallbackIcon.isEmpty()) {
-        return {urlForThumbnail, true};
-    }
-
-    const QStringList listImages{urlForThumbnail, urlForFallbackIcon};
-    return {listImages.join(u';'), true};
+    return absoluteUrl.toString();
 }
 
-constexpr int searchTermEditingFinishedSearchStartDelay = 800;
-
-// server-side bug of returning the cursor > 0 and isPaginated == 'true', using '5' as it is done on Android client's end now
-constexpr int minimumEntresNumberToShowLoadMore = 5;
+QString normalizedIcon(const QString &icon, const QUrl &serverUrl, const bool darkMode)
+{
+    if (icon.isEmpty()) {
+        return {};
+    }
+    if (icon.startsWith(QStringLiteral(":/"))) {
+        return icon;
+    }
+    if (icon.startsWith(u'/') || icon.startsWith(u'\\')) {
+        return absoluteServerResource(icon, serverUrl);
+    }
+    return iconUrlForDefaultIconName(icon, darkMode);
 }
+
+std::pair<QString, bool> iconsFromThumbnailAndFallbackIcon(const QString &thumbnailUrl,
+                                                           const QString &fallbackIcon,
+                                                           const QUrl &serverUrl,
+                                                           const bool darkMode)
+{
+    const auto thumbnail = absoluteServerResource(thumbnailUrl, serverUrl);
+    const auto icon = normalizedIcon(fallbackIcon, serverUrl, darkMode);
+    auto icons = QStringList{};
+    if (!thumbnail.isEmpty()) {
+        icons.push_back(thumbnail);
+    }
+    if (!icon.isEmpty()) {
+        icons.push_back(icon);
+    }
+    return {icons.join(u';'), !thumbnail.isEmpty()};
+}
+
+QString navigationAppIconForResult(const OCC::AccountState *accountState,
+                                   const QString &providerId,
+                                   const QString &resultTitle,
+                                   const bool darkMode)
+{
+    if (!accountState || providerId != QStringLiteral("settings_apps")) {
+        return {};
+    }
+
+    const auto apps = accountState->appList();
+    const auto appIt = std::find_if(apps.cbegin(), apps.cend(), [&resultTitle](const auto *app) {
+        return app && app->name().compare(resultTitle, Qt::CaseInsensitive) == 0;
+    });
+    if (appIt == apps.cend() || (*appIt)->iconUrl().isEmpty()) {
+        return {};
+    }
+
+    return (*appIt)->iconUrl().toString()
+        % (darkMode ? QStringLiteral("/white") : QStringLiteral("/black"));
+}
+}
+
 namespace OCC {
 Q_LOGGING_CATEGORY(lcUnifiedSearch, "nextcloud.gui.unifiedsearch", QtInfoMsg)
 
-UnifiedSearchResultsListModel::UnifiedSearchResultsListModel(AccountState *accountState, QObject *parent)
+UnifiedSearchResultsListModel::UnifiedSearchResultsListModel(AccountState *accountState, int debounceInterval, int revealInterval, QObject *parent)
     : QAbstractListModel(parent)
     , _accountState(accountState)
 {
+    _debounceTimer.setSingleShot(true);
+    _debounceTimer.setInterval(debounceInterval);
+    _revealTimer.setSingleShot(true);
+    _revealTimer.setInterval(revealInterval);
+
+    connect(&_debounceTimer, &QTimer::timeout, this, [this] {
+        if (_providersReady) {
+            startSearch();
+        } else {
+            _pendingSearch = true;
+            if (!_providersLoading) {
+                discoverProviders();
+            }
+        }
+        setWaitingForSearchTermEditEnd(false);
+    });
+    connect(&_revealTimer, &QTimer::timeout, this, &UnifiedSearchResultsListModel::closeRevealWindow);
+
     connect(this, &UnifiedSearchResultsListModel::isSearchInProgressChanged, this, &UnifiedSearchResultsListModel::searchStateChanged);
-    connect(this, &UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderIdChanged, this, &UnifiedSearchResultsListModel::searchStateChanged);
+    connect(this, &UnifiedSearchResultsListModel::isSearchInProgressChanged, this, &UnifiedSearchResultsListModel::showConnectedServicesActionChanged);
     connect(this, &UnifiedSearchResultsListModel::searchTermChanged, this, &UnifiedSearchResultsListModel::searchStateChanged);
+    connect(this, &UnifiedSearchResultsListModel::searchTermChanged, this, &UnifiedSearchResultsListModel::showConnectedServicesActionChanged);
     connect(this, &UnifiedSearchResultsListModel::errorStringChanged, this, &UnifiedSearchResultsListModel::searchStateChanged);
     connect(this, &UnifiedSearchResultsListModel::waitingForSearchTermEditEndChanged, this, &UnifiedSearchResultsListModel::searchStateChanged);
-    connect(this, &QAbstractListModel::rowsInserted, this, &UnifiedSearchResultsListModel::searchStateChanged);
-    connect(this, &QAbstractListModel::rowsRemoved, this, &UnifiedSearchResultsListModel::searchStateChanged);
     connect(this, &QAbstractListModel::modelReset, this, &UnifiedSearchResultsListModel::searchStateChanged);
-
     connect(this, &UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderIdChanged, this, &UnifiedSearchResultsListModel::canEditSearchChanged);
+    connect(this, &UnifiedSearchResultsListModel::providersChanged, this, &UnifiedSearchResultsListModel::showConnectedServicesActionChanged);
+    connect(this, &UnifiedSearchResultsListModel::viewModeChanged, this, &UnifiedSearchResultsListModel::showConnectedServicesActionChanged);
+
+    _lastKnownConnected = isAccountConnected();
     if (_accountState) {
-        connect(_accountState, &AccountState::isConnectedChanged, this, &UnifiedSearchResultsListModel::canEditSearchChanged);
+        connect(_accountState, &AccountState::isConnectedChanged, this, [this] {
+            const auto connected = isAccountConnected();
+            Q_EMIT canEditSearchChanged();
+            if (_lastKnownConnected && !connected) {
+                const auto wasInProgress = isSearchInProgress();
+                ++_queryGeneration;
+                abortSearchJobs();
+                abortProviderDiscovery();
+                _debounceTimer.stop();
+                setWaitingForSearchTermEditEnd(false);
+                resetProviderRuntime();
+                setProvidersReady(false);
+                rebuildProjection();
+                setErrorString(tr("Search is unavailable while this account is offline."));
+                updateProgressSignals(wasInProgress);
+            } else if (!_lastKnownConnected && connected) {
+                setErrorString({});
+                _pendingSearch = hasSearchTerm();
+                discoverProviders();
+            }
+            _lastKnownConnected = connected;
+        });
     }
+
+    if (isAccountConnected()) {
+        QTimer::singleShot(0, this, &UnifiedSearchResultsListModel::discoverProviders);
+    } else {
+        setErrorString(tr("Search is unavailable while this account is offline."));
+    }
+}
+
+UnifiedSearchResultsListModel::~UnifiedSearchResultsListModel()
+{
+    abortSearchJobs();
+    abortProviderDiscovery();
 }
 
 QVariant UnifiedSearchResultsListModel::data(const QModelIndex &index, int role) const
 {
     Q_ASSERT(checkIndex(index, QAbstractItemModel::CheckIndexOption::IndexIsValid));
-
+    const auto &result = _results.at(index.row());
     switch (role) {
     case ProviderNameRole:
-        return _results.at(index.row())._providerName;
+        return result._providerName;
     case ProviderIdRole:
-        return _results.at(index.row())._providerId;
+        return result._providerId;
+    case ProviderIconRole:
+        return result._providerIcon;
     case DarkImagePlaceholderRole:
-        return imagePlaceholderUrlForProviderId(_results.at(index.row())._providerId, true);
+        return imagePlaceholderUrlForProviderId(result._providerId, true);
     case LightImagePlaceholderRole:
-        return imagePlaceholderUrlForProviderId(_results.at(index.row())._providerId, false);
+        return imagePlaceholderUrlForProviderId(result._providerId, false);
     case DarkIconsRole:
-        return _results.at(index.row())._darkIcons;
+        return result._darkIcons;
     case LightIconsRole:
-        return _results.at(index.row())._lightIcons;
+        return result._lightIcons;
     case DarkIconsIsThumbnailRole:
-        return _results.at(index.row())._darkIconsIsThumbnail;
+        return result._darkIconsIsThumbnail;
     case LightIconsIsThumbnailRole:
-        return _results.at(index.row())._lightIconsIsThumbnail;
+        return result._lightIconsIsThumbnail;
     case TitleRole:
-        return _results.at(index.row())._title;
+        return result._title;
     case SublineRole:
-        return _results.at(index.row())._subline;
+        return result._subline;
     case ResourceUrlRole:
-        return _results.at(index.row())._resourceUrl;
+        return result._resourceUrl;
     case RoundedRole:
-        return _results.at(index.row())._isRounded;
+        return result._isRounded;
     case TypeRole:
-        return _results.at(index.row())._type;
+        return static_cast<int>(result._type);
     case TypeAsStringRole:
-        return UnifiedSearchResult::typeAsString(_results.at(index.row())._type);
+        return UnifiedSearchResult::typeAsString(result._type);
+    case StableKeyRole:
+        return result._stableKey;
+    case SelectedRole:
+        return result._isSelected;
+    case SelectableRole:
+        return result._isSelectable;
+    case PartialMatchRole:
+        return result._isPartialMatch;
+    case HasOverflowRole:
+        return result._hasOverflow;
+    case LoadingRole:
+        return result._isLoading;
     }
-
     return {};
 }
 
 int UnifiedSearchResultsListModel::rowCount(const QModelIndex &parent) const
 {
-    if (parent.isValid()) {
-        return 0;
-    }
-
-    return _results.size();
+    return parent.isValid() ? 0 : _results.size();
 }
 
 QHash<int, QByteArray> UnifiedSearchResultsListModel::roleNames() const
 {
-    auto roles = QAbstractListModel::roleNames();
-    roles[ProviderNameRole] = "providerName";
-    roles[ProviderIdRole] = "providerId";
-    roles[DarkIconsRole] = "darkIcons";
-    roles[LightIconsRole] = "lightIcons";
-    roles[DarkIconsIsThumbnailRole] = "darkIconsIsThumbnail";
-    roles[LightIconsIsThumbnailRole] = "lightIconsIsThumbnail";
-    roles[DarkImagePlaceholderRole] = "darkImagePlaceholder";
-    roles[LightImagePlaceholderRole] = "lightImagePlaceholder";
-    roles[TitleRole] = "resultTitle";
-    roles[SublineRole] = "subline";
-    roles[ResourceUrlRole] = "resourceUrlRole";
-    roles[TypeRole] = "type";
-    roles[TypeAsStringRole] = "typeAsString";
-    roles[RoundedRole] = "isRounded";
+    static const auto roles = [this] {
+        auto result = QAbstractListModel::roleNames();
+        result[ProviderNameRole] = "providerName";
+        result[ProviderIdRole] = "providerId";
+        result[ProviderIconRole] = "providerIcon";
+        result[DarkIconsRole] = "darkIcons";
+        result[LightIconsRole] = "lightIcons";
+        result[DarkIconsIsThumbnailRole] = "darkIconsIsThumbnail";
+        result[LightIconsIsThumbnailRole] = "lightIconsIsThumbnail";
+        result[DarkImagePlaceholderRole] = "darkImagePlaceholder";
+        result[LightImagePlaceholderRole] = "lightImagePlaceholder";
+        result[TitleRole] = "resultTitle";
+        result[SublineRole] = "subline";
+        result[ResourceUrlRole] = "resourceUrlRole";
+        result[TypeRole] = "type";
+        result[TypeAsStringRole] = "typeAsString";
+        result[RoundedRole] = "isRounded";
+        result[StableKeyRole] = "stableKey";
+        result[SelectedRole] = "isSelected";
+        result[SelectableRole] = "isSelectable";
+        result[PartialMatchRole] = "isPartialMatch";
+        result[HasOverflowRole] = "hasOverflow";
+        result[LoadingRole] = "isLoading";
+        return result;
+    }();
     return roles;
-}
-
-QString UnifiedSearchResultsListModel::searchTerm() const
-{
-    return _searchTerm;
-}
-
-QString UnifiedSearchResultsListModel::errorString() const
-{
-    return _errorString;
-}
-
-QString UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderId() const
-{
-    return _currentFetchMoreInProgressProviderId;
-}
-
-bool UnifiedSearchResultsListModel::waitingForSearchTermEditEnd() const
-{
-    return _waitingForSearchTermEditEnd;
-}
-
-void UnifiedSearchResultsListModel::setSearchTerm(const QString &term)
-{
-    if (term == _searchTerm) {
-        return;
-    }
-
-    _searchTerm = term;
-    Q_EMIT searchTermChanged();
-
-    if (!_errorString.isEmpty()) {
-        _errorString.clear();
-        Q_EMIT errorStringChanged();
-    }
-
-    disconnectAndClearSearchJobs();
-
-    clearCurrentFetchMoreInProgressProviderId();
-
-    disconnect(&_unifiedSearchTextEditingFinishedTimer, &QTimer::timeout, this,
-        &UnifiedSearchResultsListModel::slotSearchTermEditingFinished);
-
-    if (_unifiedSearchTextEditingFinishedTimer.isActive()) {
-        _unifiedSearchTextEditingFinishedTimer.stop();
-        _waitingForSearchTermEditEnd = false;
-        Q_EMIT waitingForSearchTermEditEndChanged();
-    }
-
-    if (!_searchTerm.isEmpty()) {
-        _unifiedSearchTextEditingFinishedTimer.setInterval(searchTermEditingFinishedSearchStartDelay);
-        connect(&_unifiedSearchTextEditingFinishedTimer, &QTimer::timeout, this,
-            &UnifiedSearchResultsListModel::slotSearchTermEditingFinished);
-        _unifiedSearchTextEditingFinishedTimer.start();
-        _waitingForSearchTermEditEnd = true;
-        Q_EMIT waitingForSearchTermEditEndChanged();
-    }
-
-    if (!_results.isEmpty()) {
-        beginResetModel();
-        _results.clear();
-        endResetModel();
-    }
 }
 
 bool UnifiedSearchResultsListModel::isSearchInProgress() const
 {
-    return !_searchJobConnections.isEmpty();
+    return _inFlightSearchRequests > 0 || (_providersLoading && hasSearchTerm());
 }
 
-bool UnifiedSearchResultsListModel::isFetchMoreInProgress() const
-{
-    return !_currentFetchMoreInProgressProviderId.isEmpty();
-}
-
-bool UnifiedSearchResultsListModel::hasSearchTerm() const
-{
-    return !_searchTerm.isEmpty();
-}
-
-bool UnifiedSearchResultsListModel::hasSearchError() const
-{
-    return !_errorString.isEmpty();
-}
-
-bool UnifiedSearchResultsListModel::canEditSearch() const
-{
-    return isAccountConnected() && !isFetchMoreInProgress();
-}
-
-bool UnifiedSearchResultsListModel::isAccountConnected() const
-{
-    return _accountState && _accountState->isConnected();
-}
+QString UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderId() const { return _currentFetchMoreInProgressProviderId; }
+QString UnifiedSearchResultsListModel::searchTerm() const { return _searchTerm; }
+QString UnifiedSearchResultsListModel::errorString() const { return _errorString; }
+bool UnifiedSearchResultsListModel::waitingForSearchTermEditEnd() const { return _waitingForSearchTermEditEnd; }
+bool UnifiedSearchResultsListModel::isFetchMoreInProgress() const { return !_currentFetchMoreInProgressProviderId.isEmpty(); }
+bool UnifiedSearchResultsListModel::hasSearchTerm() const { return !_searchTerm.trimmed().isEmpty(); }
+bool UnifiedSearchResultsListModel::hasSearchError() const { return !_errorString.isEmpty(); }
+bool UnifiedSearchResultsListModel::canEditSearch() const { return _accountState && _accountState->account() && isAccountConnected(); }
+bool UnifiedSearchResultsListModel::isAccountConnected() const { return _accountState && _accountState->isConnected(); }
 
 UnifiedSearchResultsListModel::SearchState UnifiedSearchResultsListModel::searchState() const
 {
-    if (rowCount() > 0) {
+    if (!_results.isEmpty()) {
         return SearchState::Results;
     }
-
-    if (hasSearchError()) {
-        return (!isSearchInProgress() && !isFetchMoreInProgress()) ? SearchState::SearchError : SearchState::None;
+    if (hasSearchError() && !isSearchInProgress()) {
+        return SearchState::SearchError;
     }
-
     if (!hasSearchTerm()) {
         return SearchState::Placeholder;
     }
+    if (_waitingForSearchTermEditEnd || isSearchInProgress()) {
+        return SearchState::Skeleton;
+    }
+    return SearchState::NothingFound;
+}
 
-    if (!isSearchInProgress() && !waitingForSearchTermEditEnd()) {
-        return SearchState::NothingFound;
+QVariantList UnifiedSearchResultsListModel::providers() const
+{
+    QVariantList result;
+    for (const auto &providerId : _providerOrder) {
+        const auto providerIt = _providers.constFind(providerId);
+        if (providerIt == _providers.cend()) {
+            continue;
+        }
+        const auto &provider = providerIt.value();
+        result.push_back(QVariantMap{
+            {QStringLiteral("id"), provider.id},
+            {QStringLiteral("name"), provider.name},
+            {QStringLiteral("icon"), providerIcon(provider, false)},
+            {QStringLiteral("selected"), _selectedProviderIds.contains(provider.id)},
+            {QStringLiteral("external"), provider.isExternalProvider},
+        });
+    }
+    return result;
+}
+
+QVariantList UnifiedSearchResultsListModel::activeFilters() const
+{
+    QVariantList result;
+    for (const auto &providerId : _selectedProviderIds) {
+        const auto providerIt = _providers.constFind(providerId);
+        if (providerIt == _providers.cend()) {
+            continue;
+        }
+        const auto &provider = providerIt.value();
+        result.push_back(QVariantMap{{QStringLiteral("type"), QStringLiteral("provider")},
+                                     {QStringLiteral("id"), providerId},
+                                     {QStringLiteral("label"), provider.name},
+                                     {QStringLiteral("icon"), providerIcon(provider, false)}});
+    }
+    if (_since.isValid() && _until.isValid()) {
+        result.push_back(QVariantMap{{QStringLiteral("type"), QStringLiteral("date")},
+                                     {QStringLiteral("id"), QStringLiteral("date")},
+                                     {QStringLiteral("label"), _dateLabel}});
+    }
+    if (!_personId.isEmpty()) {
+        result.push_back(QVariantMap{{QStringLiteral("type"), QStringLiteral("person")},
+                                     {QStringLiteral("id"), _personId},
+                                     {QStringLiteral("label"), _personName},
+                                     {QStringLiteral("icon"), _personAvatarUrl}});
+    }
+    return result;
+}
+
+bool UnifiedSearchResultsListModel::providersReady() const { return _providersReady; }
+
+bool UnifiedSearchResultsListModel::dateFilterAvailable() const
+{
+    return std::any_of(_providers.cbegin(), _providers.cend(), [](const auto &provider) {
+        return provider.filters.contains(QStringLiteral("since")) && provider.filters.contains(QStringLiteral("until"));
+    });
+}
+
+bool UnifiedSearchResultsListModel::peopleFilterAvailable() const
+{
+    return std::any_of(_providers.cbegin(), _providers.cend(), [](const auto &provider) {
+        return provider.filters.contains(QStringLiteral("person"));
+    });
+}
+
+bool UnifiedSearchResultsListModel::hasExternalProviders() const
+{
+    return std::any_of(_providers.cbegin(), _providers.cend(), [](const auto &provider) { return provider.isExternalProvider; });
+}
+
+bool UnifiedSearchResultsListModel::externalProvidersEnabled() const { return _externalProvidersEnabled; }
+
+bool UnifiedSearchResultsListModel::showConnectedServicesAction() const
+{
+    return _viewMode == ViewMode::Aggregate && hasSearchTerm() && hasExternalProviders() && !isSearchInProgress();
+}
+
+bool UnifiedSearchResultsListModel::hasPartialFailure() const { return _hasPartialFailure; }
+UnifiedSearchResultsListModel::ViewMode UnifiedSearchResultsListModel::viewMode() const { return _viewMode; }
+
+QString UnifiedSearchResultsListModel::detailProviderName() const
+{
+    const auto providerIt = _providers.constFind(_detailProviderId);
+    return providerIt == _providers.cend() ? QString() : providerIt->name;
+}
+
+int UnifiedSearchResultsListModel::selectedRow() const { return _selectedRow; }
+QString UnifiedSearchResultsListModel::accessibilityStatus() const { return _accessibilityStatus; }
+AccountState *UnifiedSearchResultsListModel::accountState() const { return _accountState; }
+
+void UnifiedSearchResultsListModel::setSearchTerm(const QString &term)
+{
+    if (_searchTerm == term) {
+        return;
+    }
+    _searchTerm = term;
+    Q_EMIT searchTermChanged();
+    scheduleSearch();
+}
+
+void UnifiedSearchResultsListModel::discoverProviders()
+{
+    if (!_accountState || !_accountState->account()) {
+        setErrorString(tr("Failed to fetch search providers."));
+        return;
+    }
+    if (!isAccountConnected()) {
+        setErrorString(tr("Search is unavailable while this account is offline."));
+        return;
     }
 
-    return SearchState::Skeleton;
+    const auto wasInProgress = isSearchInProgress();
+    abortProviderDiscovery();
+    _providersLoading = true;
+    setProvidersReady(false);
+    const auto generation = ++_providerGeneration;
+
+    auto *const job = new JsonApiJob(_accountState->account(), QStringLiteral("ocs/v2.php/search/providers"));
+    _providerDiscoveryJob = job;
+    connect(job, &JsonApiJob::jsonReceived, this, [this, generation, job](const QJsonDocument &json, const int statusCode) {
+        providerDiscoveryFinished(json, statusCode, generation, job);
+    });
+    connect(job, &QObject::destroyed, this, [this, job] {
+        if (_providerDiscoveryJob == job) {
+            _providerDiscoveryJob.clear();
+        }
+    });
+    job->start();
+    updateProgressSignals(wasInProgress);
+}
+
+void UnifiedSearchResultsListModel::providerDiscoveryFinished(const QJsonDocument &json,
+                                                               int statusCode,
+                                                               quint64 generation,
+                                                               QObject *jobObject)
+{
+    if (generation != _providerGeneration || jobObject != _providerDiscoveryJob) {
+        return;
+    }
+    const auto wasInProgress = isSearchInProgress();
+    _providerDiscoveryJob.clear();
+    _providersLoading = false;
+    _providers.clear();
+    _providerOrder.clear();
+
+    if (statusCode != 200) {
+        if (!_selectedProviderIds.isEmpty()) {
+            _selectedProviderIds.clear();
+            Q_EMIT activeFiltersChanged();
+        }
+        setErrorString(tr("Failed to fetch search providers."));
+        Q_EMIT providersChanged();
+        updateProgressSignals(wasInProgress);
+        return;
+    }
+
+    const auto providerList = json.object().value("ocs"_L1).toObject().value("data"_L1).toArray();
+    QVector<QString> appOrder;
+    QHash<QString, QVector<QString>> providersByApp;
+    auto discoveryIndex = 0;
+    for (const auto &providerValue : providerList) {
+        const auto providerObject = providerValue.toObject();
+        UnifiedSearchProvider provider;
+        provider.id = providerObject.value("id"_L1).toString();
+        provider.name = providerObject.value("name"_L1).toString();
+        if (provider.id.isEmpty() || provider.name.isEmpty()) {
+            continue;
+        }
+        provider.appId = providerObject.value("appId"_L1).toString(provider.id);
+        provider.icon = providerObject.value("icon"_L1).toString();
+        provider.order = providerObject.contains("order"_L1)
+            ? providerObject.value("order"_L1).toInt(std::numeric_limits<int>::max())
+            : std::numeric_limits<int>::max();
+        provider.discoveryIndex = discoveryIndex++;
+        const auto externalValue = providerObject.value("isExternalProvider"_L1);
+        provider.isExternalProvider = externalValue.isBool()
+            ? externalValue.toBool()
+            : externalValue.toString().compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
+        const auto filtersValue = providerObject.value("filters"_L1);
+        if (filtersValue.isUndefined() || filtersValue.isNull()) {
+            provider.filters.insert(QStringLiteral("term"));
+        } else if (filtersValue.isArray()) {
+            for (const auto &filter : filtersValue.toArray()) {
+                provider.filters.insert(filter.toString());
+            }
+            if (provider.filters.isEmpty()) provider.filters.insert(QStringLiteral("term"));
+        } else {
+            const auto filters = filtersValue.toObject();
+            for (auto it = filters.constBegin(); it != filters.constEnd(); ++it) {
+                provider.filters.insert(it.key());
+            }
+            if (provider.filters.isEmpty()) provider.filters.insert(QStringLiteral("term"));
+        }
+        _providers.insert(provider.id, provider);
+        if (!providersByApp.contains(provider.appId)) {
+            appOrder.push_back(provider.appId);
+        }
+        providersByApp[provider.appId].push_back(provider.id);
+    }
+    const auto providerLess = [this](const QString &leftId, const QString &rightId) {
+        const auto &left = _providers[leftId];
+        const auto &right = _providers[rightId];
+        return std::tie(left.order, left.discoveryIndex) < std::tie(right.order, right.discoveryIndex);
+    };
+    for (auto it = providersByApp.begin(); it != providersByApp.end(); ++it) {
+        std::stable_sort(it->begin(), it->end(), providerLess);
+    }
+    std::stable_sort(appOrder.begin(), appOrder.end(), [&providersByApp, &providerLess](const QString &leftApp, const QString &rightApp) {
+        return providerLess(providersByApp[leftApp].constFirst(), providersByApp[rightApp].constFirst());
+    });
+    for (const auto &appId : appOrder) {
+        _providerOrder.append(providersByApp.value(appId));
+    }
+
+    const auto previousSelectedProviderIds = _selectedProviderIds;
+    _selectedProviderIds.removeIf([this](const auto &providerId) {
+        return !_providers.contains(providerId);
+    });
+    if (_selectedProviderIds != previousSelectedProviderIds) {
+        Q_EMIT activeFiltersChanged();
+    }
+
+    setProvidersReady(!_providers.isEmpty());
+    setErrorString(_providersReady ? QString() : tr("No search providers are available."));
+    Q_EMIT providersChanged();
+    updateProgressSignals(wasInProgress);
+
+    if (_pendingSearch && hasSearchTerm() && _providersReady) {
+        _pendingSearch = false;
+        startSearch();
+    }
+}
+
+void UnifiedSearchResultsListModel::scheduleSearch()
+{
+    const auto wasInProgress = isSearchInProgress();
+    ++_queryGeneration;
+    abortSearchJobs();
+    _revealTimer.stop();
+    _debounceTimer.stop();
+    _pendingSearch = false;
+    _revealWindowClosed = false;
+    resetProviderRuntime();
+    setErrorString({});
+    if (_viewMode != ViewMode::Aggregate) {
+        _viewMode = ViewMode::Aggregate;
+        _detailProviderId.clear();
+        Q_EMIT viewModeChanged();
+    }
+    _aggregateSelectedStableKey.clear();
+    rebuildProjection();
+
+    if (hasSearchTerm()) {
+        setWaitingForSearchTermEditEnd(true);
+        _debounceTimer.start();
+    } else {
+        setWaitingForSearchTermEditEnd(false);
+        setAccessibilityStatus(tr("Search cleared"));
+    }
+    updateProgressSignals(wasInProgress);
+}
+
+void UnifiedSearchResultsListModel::startSearch()
+{
+    if (!_accountState || !_accountState->account() || !isAccountConnected() || !hasSearchTerm() || !_providersReady) {
+        return;
+    }
+    const auto wasInProgress = isSearchInProgress();
+    abortSearchJobs();
+    _revealOrder.clear();
+    _revealWindowClosed = false;
+    resetProviderRuntime();
+    setErrorString({});
+
+    auto requestCount = 0;
+    for (const auto &providerId : _providerOrder) {
+        auto &provider = _providers[providerId];
+        if (!providerIsApplicable(provider)) {
+            continue;
+        }
+        provider.partialMatch = !providerSupportsAllContentFilters(provider);
+        provider.status = ProviderStatus::Loading;
+        ++requestCount;
+    }
+    if (requestCount == 0) {
+        rebuildProjection();
+        updateAccessibilityStatus();
+        updateProgressSignals(wasInProgress);
+        return;
+    }
+
+    _revealTimer.start();
+    for (const auto &providerId : _providerOrder) {
+        if (_providers[providerId].status == ProviderStatus::Loading) {
+            startSearchForProvider(providerId);
+        }
+    }
+    setAccessibilityStatus(tr("Searching"));
+    updateProgressSignals(wasInProgress);
+}
+
+void UnifiedSearchResultsListModel::startSearchForProvider(const QString &providerId, bool pagination)
+{
+    if (!_accountState || !_accountState->account() || !_providers.contains(providerId)) {
+        return;
+    }
+    auto &provider = _providers[providerId];
+    const auto generation = _queryGeneration;
+    auto *const job = new JsonApiJob(_accountState->account(),
+        QStringLiteral("ocs/v2.php/search/providers/%1/search").arg(QString::fromUtf8(QUrl::toPercentEncoding(providerId))));
+    job->addQueryParams(queryForProvider(provider, pagination));
+    connect(job, &JsonApiJob::jsonReceived, this,
+        [this, providerId, pagination, generation, job](const QJsonDocument &json, const int statusCode) {
+            providerSearchFinished(json, statusCode, providerId, pagination, generation, job);
+        });
+    trackSearchJob(job);
+    if (pagination) {
+        provider.paging = true;
+        provider.loadMoreFailed = false;
+        _currentFetchMoreInProgressProviderId = providerId;
+        Q_EMIT currentFetchMoreInProgressProviderIdChanged();
+        if (!updateDetailPagingState(provider)) {
+            rebuildProjection();
+        }
+    }
+    job->start();
+}
+
+void UnifiedSearchResultsListModel::providerSearchFinished(const QJsonDocument &json,
+                                                            int statusCode,
+                                                            const QString &providerId,
+                                                            bool pagination,
+                                                            quint64 generation,
+                                                            QObject *jobObject)
+{
+    const auto wasInProgress = isSearchInProgress();
+    untrackSearchJob(jobObject);
+    if (generation != _queryGeneration || !_providers.contains(providerId)) {
+        updateProgressSignals(wasInProgress);
+        return;
+    }
+
+    auto &provider = _providers[providerId];
+    const auto previousEntryCount = provider.entries.size();
+    if (pagination) {
+        provider.paging = false;
+        if (_currentFetchMoreInProgressProviderId == providerId) {
+            _currentFetchMoreInProgressProviderId.clear();
+            Q_EMIT currentFetchMoreInProgressProviderIdChanged();
+        }
+    }
+
+    if (statusCode != 200) {
+        if (pagination) {
+            provider.loadMoreFailed = true;
+        } else {
+            provider.status = ProviderStatus::Failed;
+        }
+    } else {
+        const auto data = json.object().value("ocs"_L1).toObject().value("data"_L1).toObject();
+        auto parsedEntries = parseEntries(data.value("entries"_L1).toArray(), provider,
+            pagination ? provider.entries.size() : 0);
+        const auto pageHasMore = !parsedEntries.isEmpty()
+            && data.value("isPaginated"_L1).toBool(false)
+            && !data.value("cursor"_L1).isNull()
+            && !data.value("cursor"_L1).isUndefined();
+        if (pagination) {
+            provider.entries.append(std::move(parsedEntries));
+            provider.hasMore = pageHasMore;
+        } else {
+            provider.entries = std::move(parsedEntries);
+            provider.status = ProviderStatus::Blocked;
+            provider.hasMore = pageHasMore;
+        }
+        provider.cursor = data.value("cursor"_L1);
+        provider.loadMoreFailed = false;
+    }
+
+    if (!pagination) {
+        promoteReadyProviders();
+        updateAggregateState();
+    } else if (!updateDetailProjectionAfterPagination(provider, previousEntryCount)) {
+        rebuildProjection();
+    }
+    updateAccessibilityStatus();
+    updateProgressSignals(wasInProgress);
+}
+
+QVector<UnifiedSearchResult> UnifiedSearchResultsListModel::parseEntries(const QJsonArray &entries,
+                                                                         const UnifiedSearchProvider &provider,
+                                                                         int firstEntryIndex) const
+{
+    QVector<UnifiedSearchResult> parsedEntries;
+    const auto account = _accountState ? _accountState->account() : AccountPtr();
+    const auto accountUrl = account ? account->url() : QUrl();
+    auto entryIndex = firstEntryIndex;
+    for (const auto &entryValue : entries) {
+        if (parsedEntries.size() >= requestResultsPerProvider) {
+            break;
+        }
+        const auto entry = entryValue.toObject();
+        if (entry.isEmpty()) {
+            continue;
+        }
+        UnifiedSearchResult result;
+        result._providerId = provider.id;
+        result._providerName = provider.name;
+        result._order = provider.order;
+        result._isRounded = entry.value("rounded"_L1).toBool(false);
+        result._title = entry.value("title"_L1).toString();
+        result._subline = entry.value("subline"_L1).toString();
+        result._resourceUrl = openableResourceUrl(QUrl(entry.value("resourceUrl"_L1).toString()), accountUrl);
+        const auto entryIcon = entry.value("icon"_L1).toString();
+        const auto darkNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, result._title, true);
+        const auto lightNavigationAppIcon = navigationAppIconForResult(_accountState, provider.id, result._title, false);
+        const auto darkFallbackIcon = !darkNavigationAppIcon.isEmpty()
+            ? darkNavigationAppIcon
+            : (entryIcon.isEmpty() ? providerIcon(provider, true) : entryIcon);
+        const auto lightFallbackIcon = !lightNavigationAppIcon.isEmpty()
+            ? lightNavigationAppIcon
+            : (entryIcon.isEmpty() ? providerIcon(provider, false) : entryIcon);
+        const auto darkIcons = iconsFromThumbnailAndFallbackIcon(entry.value("thumbnailUrl"_L1).toString(), darkFallbackIcon, accountUrl, true);
+        const auto lightIcons = iconsFromThumbnailAndFallbackIcon(entry.value("thumbnailUrl"_L1).toString(), lightFallbackIcon, accountUrl, false);
+        result._darkIcons = darkIcons.first;
+        result._lightIcons = lightIcons.first;
+        result._darkIconsIsThumbnail = darkIcons.second;
+        result._lightIconsIsThumbnail = lightIcons.second;
+        result._providerIcon = providerIcon(provider, false);
+        result._isSelectable = true;
+        result._stableKey = stableKeyForResult(provider.id, result, entryIndex++);
+        parsedEntries.push_back(result);
+    }
+    return parsedEntries;
+}
+
+void UnifiedSearchResultsListModel::promoteReadyProviders()
+{
+    auto unresolvedPredecessor = false;
+    auto changed = false;
+    for (const auto &providerId : _providerOrder) {
+        auto &provider = _providers[providerId];
+        if (!providerIsApplicable(provider)) {
+            continue;
+        }
+        if (provider.status == ProviderStatus::Loading) {
+            unresolvedPredecessor = true;
+        } else if (provider.status == ProviderStatus::Blocked) {
+            if (_revealWindowClosed || !unresolvedPredecessor) {
+                provider.status = ProviderStatus::Loaded;
+                if (!_revealOrder.contains(providerId)) {
+                    _revealOrder.push_back(providerId);
+                }
+                changed = true;
+            } else {
+                unresolvedPredecessor = true;
+            }
+        }
+    }
+    if (changed) {
+        rebuildProjection();
+    }
+}
+
+void UnifiedSearchResultsListModel::closeRevealWindow()
+{
+    _revealWindowClosed = true;
+    promoteReadyProviders();
+}
+
+void UnifiedSearchResultsListModel::rebuildProjection()
+{
+    if (_selectedRow >= 0 && _selectedRow < _results.size() && _results[_selectedRow]._isSelectable) {
+        _selectedStableKey = _results[_selectedRow]._stableKey;
+    }
+
+    QVector<UnifiedSearchResult> projection;
+    if (_viewMode == ViewMode::ProviderDetail && _providers.contains(_detailProviderId)) {
+        const auto &provider = _providers[_detailProviderId];
+        projection = provider.entries;
+        if (provider.loadMoreFailed || provider.hasMore) {
+            projection.push_back(pagingRowForProvider(provider));
+        }
+    } else {
+        QSet<QString> filteredResourceUrls;
+        for (const auto &providerId : _revealOrder) {
+            const auto &provider = _providers[providerId];
+            if (provider.partialMatch) {
+                continue;
+            }
+            for (const auto &entry : provider.entries) {
+                if (!entry._resourceUrl.isEmpty()) {
+                    filteredResourceUrls.insert(entry._resourceUrl.toString());
+                }
+            }
+            appendProviderProjection(provider, false, {}, projection);
+        }
+
+        auto partialHeaderAdded = false;
+        for (const auto &providerId : _revealOrder) {
+            const auto &provider = _providers[providerId];
+            if (!provider.partialMatch || provider.entries.isEmpty()) {
+                continue;
+            }
+            const auto hasVisibleEntry = std::any_of(provider.entries.cbegin(), provider.entries.cend(),
+                [&filteredResourceUrls](const auto &entry) {
+                    return entry._resourceUrl.isEmpty() || !filteredResourceUrls.contains(entry._resourceUrl.toString());
+                });
+            if (!hasVisibleEntry) {
+                continue;
+            }
+            if (!partialHeaderAdded) {
+                UnifiedSearchResult header;
+                header._type = UnifiedSearchResult::Type::PartialMatchesHeader;
+                header._title = tr("Partial matches");
+                header._stableKey = QStringLiteral("partial-matches");
+                projection.push_back(header);
+                partialHeaderAdded = true;
+            }
+            appendProviderProjection(provider, true, filteredResourceUrls, projection);
+        }
+    }
+
+    auto selectedRow = -1;
+    for (auto row = 0; row < projection.size(); ++row) {
+        if (!projection[row]._isSelectable) {
+            continue;
+        }
+        if (selectedRow < 0) {
+            selectedRow = row;
+        }
+        if (!_selectedStableKey.isEmpty() && projection[row]._stableKey == _selectedStableKey) {
+            selectedRow = row;
+            break;
+        }
+    }
+    for (auto row = 0; row < projection.size(); ++row) {
+        projection[row]._isSelected = row == selectedRow;
+    }
+
+    beginResetModel();
+    _results = std::move(projection);
+    endResetModel();
+    setSelectedRow(selectedRow);
+    if (selectedRow >= 0) {
+        _selectedStableKey = _results[selectedRow]._stableKey;
+    } else {
+        _selectedStableKey.clear();
+    }
+}
+
+UnifiedSearchResult UnifiedSearchResultsListModel::pagingRowForProvider(const UnifiedSearchProvider &provider) const
+{
+    UnifiedSearchResult pagingRow;
+    pagingRow._providerId = provider.id;
+    pagingRow._providerName = provider.name;
+    pagingRow._type = provider.loadMoreFailed
+        ? UnifiedSearchResult::Type::RetryFetchMoreTrigger
+        : UnifiedSearchResult::Type::FetchMoreTrigger;
+    pagingRow._isLoading = provider.paging;
+    pagingRow._stableKey = QStringLiteral("paging:%1").arg(provider.id);
+    return pagingRow;
+}
+
+bool UnifiedSearchResultsListModel::updateDetailPagingState(const UnifiedSearchProvider &provider)
+{
+    if (_viewMode != ViewMode::ProviderDetail || _detailProviderId != provider.id || _results.isEmpty()) {
+        return false;
+    }
+    const auto row = _results.size() - 1;
+    auto &pagingRow = _results[row];
+    if (pagingRow._providerId != provider.id
+        || (pagingRow._type != UnifiedSearchResult::Type::FetchMoreTrigger
+            && pagingRow._type != UnifiedSearchResult::Type::RetryFetchMoreTrigger)) {
+        return false;
+    }
+    pagingRow = pagingRowForProvider(provider);
+    Q_EMIT dataChanged(index(row), index(row), {TypeRole, TypeAsStringRole, LoadingRole});
+    return true;
+}
+
+bool UnifiedSearchResultsListModel::updateDetailProjectionAfterPagination(const UnifiedSearchProvider &provider,
+                                                                           const int previousEntryCount)
+{
+    if (_viewMode != ViewMode::ProviderDetail || _detailProviderId != provider.id
+        || previousEntryCount < 0 || provider.entries.size() < previousEntryCount
+        || _results.size() != previousEntryCount + 1) {
+        return false;
+    }
+    const auto pagingRowIndex = _results.size() - 1;
+    if (_results[pagingRowIndex]._providerId != provider.id
+        || (_results[pagingRowIndex]._type != UnifiedSearchResult::Type::FetchMoreTrigger
+            && _results[pagingRowIndex]._type != UnifiedSearchResult::Type::RetryFetchMoreTrigger)) {
+        return false;
+    }
+
+    if (provider.loadMoreFailed) {
+        _results[pagingRowIndex] = pagingRowForProvider(provider);
+        Q_EMIT dataChanged(index(pagingRowIndex), index(pagingRowIndex));
+        return true;
+    }
+
+    const auto appendedCount = provider.entries.size() - previousEntryCount;
+    if (appendedCount == 0) {
+        beginRemoveRows({}, pagingRowIndex, pagingRowIndex);
+        _results.removeLast();
+        endRemoveRows();
+        return true;
+    }
+
+    _results[pagingRowIndex] = provider.entries[previousEntryCount];
+    Q_EMIT dataChanged(index(pagingRowIndex), index(pagingRowIndex));
+
+    QVector<UnifiedSearchResult> tail;
+    tail.reserve(appendedCount);
+    for (auto entryIndex = previousEntryCount + 1; entryIndex < provider.entries.size(); ++entryIndex) {
+        tail.push_back(provider.entries[entryIndex]);
+    }
+    if (provider.hasMore) {
+        tail.push_back(pagingRowForProvider(provider));
+    }
+    if (!tail.isEmpty()) {
+        const auto firstRow = _results.size();
+        const auto lastRow = firstRow + tail.size() - 1;
+        beginInsertRows({}, firstRow, lastRow);
+        _results.append(tail);
+        endInsertRows();
+    }
+    return true;
+}
+
+void UnifiedSearchResultsListModel::appendProviderProjection(const UnifiedSearchProvider &provider,
+                                                              bool partial,
+                                                              const QSet<QString> &filteredResourceUrls,
+                                                              QVector<UnifiedSearchResult> &projection) const
+{
+    QVector<UnifiedSearchResult> visibleEntries;
+    visibleEntries.reserve(aggregateResultsPerProvider + 1);
+    for (const auto &entry : provider.entries) {
+        if (partial && !entry._resourceUrl.isEmpty() && filteredResourceUrls.contains(entry._resourceUrl.toString())) {
+            continue;
+        }
+        auto visibleEntry = entry;
+        visibleEntry._isPartialMatch = partial;
+        visibleEntries.push_back(visibleEntry);
+        if (visibleEntries.size() > aggregateResultsPerProvider) {
+            break;
+        }
+    }
+    if (visibleEntries.isEmpty()) {
+        return;
+    }
+
+    UnifiedSearchResult header;
+    header._providerId = provider.id;
+    header._providerName = provider.name;
+    header._providerIcon = visibleEntries.constFirst()._providerIcon;
+    header._title = provider.name;
+    header._hasOverflow = visibleEntries.size() > aggregateResultsPerProvider || provider.hasMore;
+    header._isPartialMatch = partial;
+    header._type = UnifiedSearchResult::Type::ProviderHeader;
+    header._stableKey = QStringLiteral("header:%1:%2").arg(partial ? QStringLiteral("partial") : QStringLiteral("full"), provider.id);
+    projection.push_back(header);
+
+    const auto visibleCount = std::min(aggregateResultsPerProvider, visibleEntries.size());
+    for (auto index = 0; index < visibleCount; ++index) {
+        projection.push_back(visibleEntries[index]);
+    }
+}
+
+void UnifiedSearchResultsListModel::resetProviderRuntime()
+{
+    for (auto it = _providers.begin(); it != _providers.end(); ++it) {
+        it->status = ProviderStatus::Idle;
+        it->entries.clear();
+        it->cursor = {};
+        it->hasMore = false;
+        it->loadMoreFailed = false;
+        it->paging = false;
+        it->partialMatch = false;
+    }
+    _revealOrder.clear();
+    if (_hasPartialFailure) {
+        _hasPartialFailure = false;
+        Q_EMIT hasPartialFailureChanged();
+    }
+    if (!_currentFetchMoreInProgressProviderId.isEmpty()) {
+        _currentFetchMoreInProgressProviderId.clear();
+        Q_EMIT currentFetchMoreInProgressProviderIdChanged();
+    }
+}
+
+void UnifiedSearchResultsListModel::abortSearchJobs()
+{
+    const auto hadJobs = !_activeSearchJobs.isEmpty() || _inFlightSearchRequests > 0;
+    for (const auto &jobObject : std::as_const(_activeSearchJobs)) {
+        if (!jobObject) {
+            continue;
+        }
+        disconnect(jobObject, nullptr, this, nullptr);
+        if (const auto job = qobject_cast<JsonApiJob *>(jobObject.data()); job && job->reply() && job->reply()->isRunning()) {
+            job->reply()->abort();
+        }
+    }
+    _activeSearchJobs.clear();
+    _inFlightSearchRequests = 0;
+    if (hadJobs) {
+        Q_EMIT isSearchInProgressChanged();
+    }
+}
+
+void UnifiedSearchResultsListModel::abortProviderDiscovery()
+{
+    if (!_providerDiscoveryJob) {
+        _providersLoading = false;
+        return;
+    }
+    disconnect(_providerDiscoveryJob, nullptr, this, nullptr);
+    if (const auto job = qobject_cast<JsonApiJob *>(_providerDiscoveryJob.data()); job && job->reply() && job->reply()->isRunning()) {
+        job->reply()->abort();
+    }
+    _providerDiscoveryJob.clear();
+    _providersLoading = false;
+}
+
+void UnifiedSearchResultsListModel::trackSearchJob(QObject *jobObject)
+{
+    const auto wasInProgress = isSearchInProgress();
+    _activeSearchJobs.push_back(jobObject);
+    ++_inFlightSearchRequests;
+    connect(jobObject, &QObject::destroyed, this, [this, jobObject] { untrackSearchJob(jobObject); });
+    updateProgressSignals(wasInProgress);
+}
+
+void UnifiedSearchResultsListModel::untrackSearchJob(QObject *jobObject)
+{
+    const auto it = std::find_if(_activeSearchJobs.begin(), _activeSearchJobs.end(), [jobObject](const auto &candidate) {
+        return candidate == jobObject;
+    });
+    if (it == _activeSearchJobs.end()) {
+        return;
+    }
+    _activeSearchJobs.erase(it);
+    _inFlightSearchRequests = std::max(0, _inFlightSearchRequests - 1);
+}
+
+void UnifiedSearchResultsListModel::updateProgressSignals(bool wasInProgress)
+{
+    if (wasInProgress != isSearchInProgress()) {
+        Q_EMIT isSearchInProgressChanged();
+    }
+}
+
+void UnifiedSearchResultsListModel::updateAggregateState()
+{
+    auto applicableCount = 0;
+    auto failedCount = 0;
+    auto settledCount = 0;
+    for (const auto &providerId : _providerOrder) {
+        const auto &provider = _providers[providerId];
+        if (!providerIsApplicable(provider)) {
+            continue;
+        }
+        ++applicableCount;
+        if (provider.status == ProviderStatus::Failed) {
+            ++failedCount;
+            ++settledCount;
+        } else if (provider.status == ProviderStatus::Loaded || provider.status == ProviderStatus::Blocked) {
+            ++settledCount;
+        }
+    }
+
+    const auto partialFailure = failedCount > 0 && failedCount < applicableCount;
+    if (_hasPartialFailure != partialFailure) {
+        _hasPartialFailure = partialFailure;
+        Q_EMIT hasPartialFailureChanged();
+    }
+    if (applicableCount > 0 && failedCount == applicableCount) {
+        setErrorString(tr("Search failed for all available sources. Please try again."));
+    } else if (settledCount == applicableCount) {
+        setErrorString({});
+        _revealTimer.stop();
+        promoteReadyProviders();
+    }
+    Q_EMIT showConnectedServicesActionChanged();
+}
+
+void UnifiedSearchResultsListModel::updateAccessibilityStatus()
+{
+    if (isSearchInProgress()) {
+        setAccessibilityStatus(tr("Searching"));
+        return;
+    }
+    auto resultCount = 0;
+    for (const auto &result : _results) {
+        if (result._type == UnifiedSearchResult::Type::Default) {
+            ++resultCount;
+        }
+    }
+    if (_viewMode == ViewMode::ProviderDetail) {
+        setAccessibilityStatus(tr("%1 results in %2").arg(resultCount).arg(detailProviderName()));
+    } else if (resultCount == 0) {
+        setAccessibilityStatus(tr("No matching results"));
+    } else if (_hasPartialFailure) {
+        setAccessibilityStatus(tr("%1 results. Some sources are unavailable.").arg(resultCount));
+    } else {
+        setAccessibilityStatus(tr("%1 results").arg(resultCount));
+    }
+}
+
+void UnifiedSearchResultsListModel::restartForFilterChange()
+{
+    Q_EMIT activeFiltersChanged();
+    Q_EMIT providersChanged();
+    if (_viewMode != ViewMode::Aggregate) {
+        _viewMode = ViewMode::Aggregate;
+        _detailProviderId.clear();
+        Q_EMIT viewModeChanged();
+    }
+    if (hasSearchTerm()) {
+        scheduleSearch();
+    }
+}
+
+void UnifiedSearchResultsListModel::setErrorString(const QString &error)
+{
+    if (_errorString == error) {
+        return;
+    }
+    _errorString = error;
+    Q_EMIT errorStringChanged();
+}
+
+void UnifiedSearchResultsListModel::setProvidersReady(const bool ready)
+{
+    if (_providersReady == ready) {
+        return;
+    }
+    _providersReady = ready;
+    Q_EMIT providersReadyChanged();
+}
+
+void UnifiedSearchResultsListModel::setWaitingForSearchTermEditEnd(bool waiting)
+{
+    if (_waitingForSearchTermEditEnd == waiting) {
+        return;
+    }
+    const auto wasInProgress = isSearchInProgress();
+    _waitingForSearchTermEditEnd = waiting;
+    Q_EMIT waitingForSearchTermEditEndChanged();
+    updateProgressSignals(wasInProgress);
+}
+
+void UnifiedSearchResultsListModel::setSelectedRow(int row)
+{
+    if (_selectedRow == row) {
+        return;
+    }
+    _selectedRow = row;
+    Q_EMIT selectedRowChanged();
+}
+
+void UnifiedSearchResultsListModel::setAccessibilityStatus(const QString &status)
+{
+    if (_accessibilityStatus == status) {
+        return;
+    }
+    _accessibilityStatus = status;
+    Q_EMIT accessibilityStatusChanged();
+}
+
+bool UnifiedSearchResultsListModel::providerIsApplicable(const UnifiedSearchProvider &provider) const
+{
+    if (!_selectedProviderIds.isEmpty()) {
+        return _selectedProviderIds.contains(provider.id);
+    }
+    return !provider.isExternalProvider || _externalProvidersEnabled;
+}
+
+bool UnifiedSearchResultsListModel::providerSupportsAllContentFilters(const UnifiedSearchProvider &provider) const
+{
+    const auto supportsDate = !_since.isValid() || (provider.filters.contains(QStringLiteral("since")) && provider.filters.contains(QStringLiteral("until")));
+    const auto supportsPerson = _personId.isEmpty() || provider.filters.contains(QStringLiteral("person"));
+    return supportsDate && supportsPerson;
+}
+
+QString UnifiedSearchResultsListModel::providerIcon(const UnifiedSearchProvider &provider, const bool darkMode) const
+{
+    if (_accountState) {
+        if (const auto app = _accountState->findApp(provider.appId); app && !app->iconUrl().isEmpty()) {
+            return app->iconUrl().toString();
+        }
+    }
+
+    const auto account = _accountState ? _accountState->account() : AccountPtr();
+    return normalizedIcon(provider.icon, account ? account->url() : QUrl(), darkMode);
+}
+
+QUrlQuery UnifiedSearchResultsListModel::queryForProvider(const UnifiedSearchProvider &provider, bool pagination) const
+{
+    QUrlQuery query;
+    query.addQueryItem(QStringLiteral("term"), _searchTerm);
+    query.addQueryItem(QStringLiteral("limit"), QString::number(requestResultsPerProvider));
+    if (_since.isValid() && provider.filters.contains(QStringLiteral("since"))) {
+        query.addQueryItem(QStringLiteral("since"), _since.toUTC().toString(Qt::ISODateWithMs));
+    }
+    if (_until.isValid() && provider.filters.contains(QStringLiteral("until"))) {
+        query.addQueryItem(QStringLiteral("until"), _until.toUTC().toString(Qt::ISODateWithMs));
+    }
+    if (!_personId.isEmpty() && provider.filters.contains(QStringLiteral("person"))) {
+        query.addQueryItem(QStringLiteral("person"), _personId);
+    }
+    if (pagination && !provider.cursor.isNull() && !provider.cursor.isUndefined()) {
+        query.addQueryItem(QStringLiteral("cursor"), provider.cursor.toVariant().toString());
+    }
+    return query;
+}
+
+QString UnifiedSearchResultsListModel::stableKeyForResult(const QString &providerId,
+                                                           const UnifiedSearchResult &result,
+                                                           int entryIndex)
+{
+    return QStringLiteral("result:%1:%2:%3").arg(providerId, result._resourceUrl.toString(), QString::number(entryIndex));
+}
+
+QUrl UnifiedSearchResultsListModel::openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl)
+{
+    return resourceUrl.isRelative() ? accountUrl.resolved(resourceUrl) : resourceUrl;
 }
 
 void UnifiedSearchResultsListModel::resultClicked(const QString &providerId, const QUrl &resourceUrl) const
 {
     const QUrlQuery urlQuery{resourceUrl};
-    const auto dir = urlQuery.queryItemValue(QStringLiteral("dir"), QUrl::ComponentFormattingOption::FullyDecoded);
-    const auto fileName =
-        urlQuery.queryItemValue(QStringLiteral("scrollto"), QUrl::ComponentFormattingOption::FullyDecoded);
-
+    const auto dir = urlQuery.queryItemValue(QStringLiteral("dir"), QUrl::FullyDecoded);
+    const auto fileName = urlQuery.queryItemValue(QStringLiteral("scrollto"), QUrl::FullyDecoded);
     if (providerId.contains("file"_L1, Qt::CaseInsensitive) && !dir.isEmpty() && !fileName.isEmpty()) {
         if (!_accountState || !_accountState->account()) {
             return;
         }
-
-        const QString relativePath = dir + u'/' + fileName;
-        const auto localFiles =
-            FolderMan::instance()->findFileInLocalFolders(QFileInfo(relativePath).path(), _accountState->account());
-
+        const auto relativePath = dir + u'/' + fileName;
+        const auto localFiles = FolderMan::instance()->findFileInLocalFolders(QFileInfo(relativePath).path(), _accountState->account());
         if (!localFiles.isEmpty()) {
-            qCInfo(lcUnifiedSearch) << "Opening file:" << localFiles.constFirst();
             QDesktopServices::openUrl(QUrl::fromLocalFile(localFiles.constFirst()));
             return;
         }
@@ -410,391 +1314,260 @@ void UnifiedSearchResultsListModel::resultClicked(const QString &providerId, con
     Utility::openBrowser(resourceUrl);
 }
 
-void UnifiedSearchResultsListModel::fetchMoreTriggerClicked(const QString &providerId)
+void UnifiedSearchResultsListModel::fetchMoreTriggerClicked(const QString &providerId) { loadMore(providerId); }
+
+void UnifiedSearchResultsListModel::toggleProviderFilter(const QString &providerId)
 {
-    if (isSearchInProgress() || !_currentFetchMoreInProgressProviderId.isEmpty()) {
+    if (!_providers.contains(providerId)) {
         return;
     }
-
-    const auto providerInfo = _providers.value(providerId, {});
-
-    if (!providerInfo._id.isEmpty() && providerInfo._id == providerId && providerInfo._isPaginated) {
-        // Load more items
-        _currentFetchMoreInProgressProviderId = providerId;
-        Q_EMIT currentFetchMoreInProgressProviderIdChanged();
-        startSearchForProvider(providerId, providerInfo._cursor);
-    }
-}
-
-void UnifiedSearchResultsListModel::slotSearchTermEditingFinished()
-{
-    _waitingForSearchTermEditEnd = false;
-    Q_EMIT waitingForSearchTermEditEndChanged();
-
-    disconnect(&_unifiedSearchTextEditingFinishedTimer, &QTimer::timeout, this,
-        &UnifiedSearchResultsListModel::slotSearchTermEditingFinished);
-
-    if (!_accountState || !_accountState->account()) {
-        qCCritical(lcUnifiedSearch) << QStringLiteral("Account state is invalid. Could not start search!");
-        return;
-    }
-
-    if (_providers.isEmpty()) {
-        auto job = new JsonApiJob(_accountState->account(), QLatin1String("ocs/v2.php/search/providers"));
-        QObject::connect(job, &JsonApiJob::jsonReceived, this, &UnifiedSearchResultsListModel::slotFetchProvidersFinished);
-        job->start();
+    if (_selectedProviderIds.contains(providerId)) {
+        _selectedProviderIds.removeAll(providerId);
     } else {
-        startSearch();
+        _selectedProviderIds.push_back(providerId);
     }
+    restartForFilterChange();
 }
 
-void UnifiedSearchResultsListModel::slotFetchProvidersFinished(const QJsonDocument &json, int statusCode)
+void UnifiedSearchResultsListModel::clearTypeFilters()
 {
-    const auto job = qobject_cast<JsonApiJob *>(sender());
-
-    if (!job) {
-        qCCritical(lcUnifiedSearch) << QStringLiteral("Failed to fetch providers.").arg(_searchTerm);
-        _errorString += tr("Failed to fetch providers.") + u'\n';
-        Q_EMIT errorStringChanged();
+    if (_selectedProviderIds.isEmpty()) {
         return;
     }
-
-    if (statusCode != 200) {
-        qCCritical(lcUnifiedSearch) << QStringLiteral("%1: Failed to fetch search providers for '%2'. Error: %3")
-                                           .arg(statusCode)
-                                           .arg(_searchTerm)
-                                           .arg(job->errorString());
-        _errorString +=
-            tr("Failed to fetch search providers for '%1'. Error: %2").arg(_searchTerm).arg(job->errorString())
-            + u'\n';
-        Q_EMIT errorStringChanged();
-        return;
-    }
-    const auto providerList =
-        json.object().value("ocs"_L1).toObject().value("data"_L1).toVariant().toList();
-
-    for (const auto &provider : providerList) {
-        const auto providerMap = provider.toMap();
-        const auto id = providerMap["id"_L1].toString();
-        const auto name = providerMap["name"_L1].toString();
-        if (!name.isEmpty() && id != "talk-message-current"_L1) {
-            UnifiedSearchProvider newProvider;
-            newProvider._name = name;
-            newProvider._id = id;
-            newProvider._order = providerMap["order"_L1].toInt();
-            _providers.insert(newProvider._id, newProvider);
-        }
-    }
-
-    if (!_providers.empty()) {
-        startSearch();
-    }
+    _selectedProviderIds.clear();
+    restartForFilterChange();
 }
 
-void UnifiedSearchResultsListModel::slotSearchForProviderFinished(const QJsonDocument &json, int statusCode)
+void UnifiedSearchResultsListModel::setDatePreset(const QString &preset)
 {
-    Q_ASSERT(_accountState && _accountState->account());
-
-    const auto job = qobject_cast<JsonApiJob *>(sender());
-
-    if (!job) {
-        qCCritical(lcUnifiedSearch) << QStringLiteral("Search has failed for '%2'.").arg(_searchTerm);
-        _errorString += tr("Search has failed for '%2'.").arg(_searchTerm) + u'\n';
-        Q_EMIT errorStringChanged();
-        return;
-    }
-
-    const auto providerId = job->property("providerId").toString();
-
-    if (providerId.isEmpty()) {
-        return;
-    }
-
-    if (!_searchJobConnections.isEmpty()) {
-        _searchJobConnections.remove(providerId);
-
-        if (_searchJobConnections.isEmpty()) {
-            Q_EMIT isSearchInProgressChanged();
-        }
-    }
-
-    if (providerId == _currentFetchMoreInProgressProviderId) {
-        clearCurrentFetchMoreInProgressProviderId();
-    }
-
-    if (statusCode != 200) {
-        qCCritical(lcUnifiedSearch) << QStringLiteral("%1: Search has failed for '%2'. Error: %3")
-                                           .arg(statusCode)
-                                           .arg(_searchTerm)
-                                           .arg(job->errorString());
-        _errorString +=
-            tr("Search has failed for '%1'. Error: %2").arg(_searchTerm).arg(job->errorString()) + u'\n';
-        Q_EMIT errorStringChanged();
-        return;
-    }
-
-    const auto data = json.object().value("ocs"_L1).toObject().value("data"_L1).toObject();
-    if (!data.isEmpty()) {
-        parseResultsForProvider(data, providerId, job->property("appendResults").toBool());
-    }
-}
-
-void UnifiedSearchResultsListModel::startSearch()
-{
-    Q_ASSERT(_accountState && _accountState->account());
-
-    disconnectAndClearSearchJobs();
-
-    if (!_accountState || !_accountState->account()) {
-        return;
-    }
-
-    if (!_results.isEmpty()) {
-        beginResetModel();
-        _results.clear();
-        endResetModel();
-    }
-
-    for (const auto &provider : std::as_const(_providers)) {
-        startSearchForProvider(provider._id);
-    }
-}
-
-void UnifiedSearchResultsListModel::startSearchForProvider(const QString &providerId, qint32 cursor)
-{
-    Q_ASSERT(_accountState && _accountState->account());
-
-    if (!_accountState || !_accountState->account()) {
-        return;
-    }
-
-    auto job = new JsonApiJob(_accountState->account(),
-        QLatin1String("ocs/v2.php/search/providers/%1/search").arg(providerId));
-
-    QUrlQuery params;
-    params.addQueryItem(QStringLiteral("term"), _searchTerm);
-    if (cursor > 0) {
-        params.addQueryItem(QStringLiteral("cursor"), QString::number(cursor));
-        job->setProperty("appendResults", true);
-    }
-    job->setProperty("providerId", providerId);
-    job->addQueryParams(params);
-    const auto wasSearchInProgress = isSearchInProgress();
-    _searchJobConnections.insert(providerId,
-        QObject::connect(
-            job, &JsonApiJob::jsonReceived, this, &UnifiedSearchResultsListModel::slotSearchForProviderFinished));
-    if (isSearchInProgress() && !wasSearchInProgress) {
-        Q_EMIT isSearchInProgressChanged();
-    }
-    job->start();
-}
-
-void UnifiedSearchResultsListModel::parseResultsForProvider(const QJsonObject &data, const QString &providerId, bool fetchedMore)
-{
-    const auto cursor = data.value("cursor"_L1).toInt();
-    const auto entries = data.value("entries"_L1).toVariant().toList();
-
-    auto &provider = _providers[providerId];
-
-    if (provider._id.isEmpty() && fetchedMore) {
-        _providers.remove(providerId);
-        return;
-    }
-
-    if (entries.isEmpty()) {
-        // we may have received false pagination information from the server, such as, we expect more
-        // results available via pagination, but, there are no more left, so, we need to stop paginating for
-        // this provider
-        provider._isPaginated = false;
-
-        if (fetchedMore) {
-            removeFetchMoreTrigger(provider._id);
-        }
-
-        return;
-    }
-
-    provider._isPaginated = data.value("isPaginated"_L1).toBool();
-    provider._cursor = cursor;
-
-    if (provider._pageSize == -1) {
-        provider._pageSize = cursor;
-    }
-
-    if ((provider._pageSize != -1 && entries.size() < provider._pageSize)
-        || entries.size() < minimumEntresNumberToShowLoadMore) {
-        // for some providers we are still getting a non-null cursor and isPaginated true even thought
-        // there are no more results to paginate
-        provider._isPaginated = false;
-    }
-
-    QVector<UnifiedSearchResult> newEntries;
-
-    for (const auto &entry : entries) {
-        const auto entryMap = entry.toMap();
-        if (entryMap.isEmpty()) {
-            continue;
-        }
-        UnifiedSearchResult result;
-        result._providerId = provider._id;
-        result._order = provider._order;
-        result._providerName = provider._name;
-        result._isRounded = entryMap.value("rounded"_L1).toBool();
-        result._title = entryMap.value("title"_L1).toString();
-        result._subline = entryMap.value("subline"_L1).toString();
-
-        const auto resourceUrl = entryMap.value("resourceUrl"_L1).toUrl();
-        const auto accountUrl = (_accountState && _accountState->account()) ? _accountState->account()->url() : QUrl();
-
-        result._resourceUrl = openableResourceUrl(resourceUrl, accountUrl);
-        const auto darkIconsData = iconsFromThumbnailAndFallbackIcon(entryMap.value("thumbnailUrl"_L1).toString(),
-                                                                     entryMap.value("icon"_L1).toString(), accountUrl, true);
-        const auto lightIconsData = iconsFromThumbnailAndFallbackIcon(entryMap.value("thumbnailUrl"_L1).toString(),
-                                                                      entryMap.value("icon"_L1).toString(), accountUrl, false);
-        result._darkIcons = darkIconsData.first;
-        result._lightIcons = lightIconsData.first;
-        result._darkIconsIsThumbnail = darkIconsData.second;
-        result._lightIconsIsThumbnail = lightIconsData.second;
-
-        newEntries.push_back(result);
-    }
-
-    if (fetchedMore) {
-        appendResultsToProvider(newEntries, provider);
+    const auto today = QDate::currentDate();
+    auto first = today;
+    auto last = today;
+    if (preset == QStringLiteral("today")) {
+        _dateLabel = tr("Today");
+    } else if (preset == QStringLiteral("7days") || preset == QStringLiteral("last7days")) {
+        first = today.addDays(-6);
+        _dateLabel = tr("Last 7 days");
+    } else if (preset == QStringLiteral("30days") || preset == QStringLiteral("last30days")) {
+        first = today.addDays(-29);
+        _dateLabel = tr("Last 30 days");
+    } else if (preset == QStringLiteral("thisyear")) {
+        first = QDate(today.year(), 1, 1);
+        last = QDate(today.year(), 12, 31);
+        _dateLabel = tr("This year");
+    } else if (preset == QStringLiteral("lastyear")) {
+        first = QDate(today.year() - 1, 1, 1);
+        last = QDate(today.year() - 1, 12, 31);
+        _dateLabel = tr("Last year");
     } else {
-        appendResults(newEntries, provider);
+        return;
+    }
+    const auto zone = QTimeZone::systemTimeZone();
+    _since = QDateTime(first, QTime(0, 0), zone);
+    _until = QDateTime(last, QTime(23, 59, 59, 999), zone);
+    restartForFilterChange();
+}
+
+bool UnifiedSearchResultsListModel::setCustomDateRange(const QString &sinceDate, const QString &untilDate)
+{
+    const auto first = QDate::fromString(sinceDate, Qt::ISODate);
+    const auto last = QDate::fromString(untilDate, Qt::ISODate);
+    if (!first.isValid() || !last.isValid() || last < first) {
+        return false;
+    }
+    const auto zone = QTimeZone::systemTimeZone();
+    _since = QDateTime(first, QTime(0, 0), zone);
+    _until = QDateTime(last, QTime(23, 59, 59, 999), zone);
+    _dateLabel = tr("%1 – %2").arg(QLocale().toString(first, QLocale::ShortFormat), QLocale().toString(last, QLocale::ShortFormat));
+    restartForFilterChange();
+    return true;
+}
+
+void UnifiedSearchResultsListModel::clearDateFilter()
+{
+    if (!_since.isValid() && !_until.isValid()) {
+        return;
+    }
+    _since = {};
+    _until = {};
+    _dateLabel.clear();
+    restartForFilterChange();
+}
+
+void UnifiedSearchResultsListModel::setPersonFilter(const QString &userId, const QString &displayName, const QString &avatarUrl)
+{
+    if (userId.isEmpty()) {
+        return;
+    }
+    _personId = userId;
+    _personName = displayName;
+    _personAvatarUrl = avatarUrl;
+    restartForFilterChange();
+}
+
+void UnifiedSearchResultsListModel::clearPersonFilter()
+{
+    if (_personId.isEmpty()) {
+        return;
+    }
+    _personId.clear();
+    _personName.clear();
+    _personAvatarUrl.clear();
+    restartForFilterChange();
+}
+
+void UnifiedSearchResultsListModel::removeFilter(const QString &type, const QString &id)
+{
+    if (type == QStringLiteral("provider")) {
+        if (_selectedProviderIds.removeAll(id) > 0) {
+            restartForFilterChange();
+        }
+    } else if (type == QStringLiteral("date")) {
+        clearDateFilter();
+    } else if (type == QStringLiteral("person")) {
+        clearPersonFilter();
     }
 }
 
-QUrl UnifiedSearchResultsListModel::openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl)
+void UnifiedSearchResultsListModel::setExternalProvidersEnabled(bool enabled)
 {
-    if (!resourceUrl.isRelative()) {
-        return resourceUrl;
+    if (_externalProvidersEnabled == enabled) {
+        return;
     }
-
-    QUrl finalResourceUrl(accountUrl);
-    finalResourceUrl.setPath(resourceUrl.toString());
-    return finalResourceUrl;
+    _externalProvidersEnabled = enabled;
+    Q_EMIT externalProvidersEnabledChanged();
+    if (hasSearchTerm()) {
+        scheduleSearch();
+    }
 }
 
-void UnifiedSearchResultsListModel::appendResults(QVector<UnifiedSearchResult> results, const UnifiedSearchProvider &provider)
+void UnifiedSearchResultsListModel::openProviderDetail(const QString &providerId)
 {
-    if (provider._cursor > 0 && provider._isPaginated) {
-        UnifiedSearchResult fetchMoreTrigger;
-        fetchMoreTrigger._providerId = provider._id;
-        fetchMoreTrigger._providerName = provider._name;
-        fetchMoreTrigger._order = provider._order;
-        fetchMoreTrigger._type = UnifiedSearchResult::Type::FetchMoreTrigger;
-        results.push_back(fetchMoreTrigger);
+    const auto providerIt = _providers.constFind(providerId);
+    if (providerIt == _providers.cend()
+        || (providerIt->entries.size() <= aggregateResultsPerProvider && !providerIt->hasMore)) {
+        return;
     }
+    _aggregateSelectedStableKey = _selectedStableKey;
+    _detailProviderId = providerId;
+    _viewMode = ViewMode::ProviderDetail;
+    _selectedStableKey.clear();
+    Q_EMIT viewModeChanged();
+    rebuildProjection();
+    updateAccessibilityStatus();
+}
 
+void UnifiedSearchResultsListModel::closeProviderDetail()
+{
+    if (_viewMode == ViewMode::Aggregate) {
+        return;
+    }
+    _viewMode = ViewMode::Aggregate;
+    _detailProviderId.clear();
+    _selectedStableKey = _aggregateSelectedStableKey;
+    _aggregateSelectedStableKey.clear();
+    Q_EMIT viewModeChanged();
+    rebuildProjection();
+    updateAccessibilityStatus();
+}
 
-    if (_results.isEmpty()) {
-        beginInsertRows({}, 0, results.size() - 1);
-        _results = results;
-        endInsertRows();
+void UnifiedSearchResultsListModel::loadMore(const QString &providerId)
+{
+    if (_viewMode != ViewMode::ProviderDetail || _detailProviderId != providerId || !_providers.contains(providerId)) {
+        return;
+    }
+    const auto &provider = _providers[providerId];
+    if (provider.paging || (!provider.hasMore && !provider.loadMoreFailed)) {
+        return;
+    }
+    startSearchForProvider(providerId, true);
+}
+
+void UnifiedSearchResultsListModel::retryLoadMore(const QString &providerId) { loadMore(providerId); }
+
+void UnifiedSearchResultsListModel::retryFailedProviders()
+{
+    if (!hasSearchTerm()) {
+        return;
+    }
+    _revealWindowClosed = true;
+    setErrorString({});
+    for (const auto &providerId : _providerOrder) {
+        auto &provider = _providers[providerId];
+        if (provider.status == ProviderStatus::Failed && providerIsApplicable(provider)) {
+            provider.status = ProviderStatus::Loading;
+            startSearchForProvider(providerId);
+        }
+    }
+    if (_hasPartialFailure) {
+        _hasPartialFailure = false;
+        Q_EMIT hasPartialFailureChanged();
+    }
+}
+
+void UnifiedSearchResultsListModel::retry()
+{
+    if (!_providersReady) {
+        discoverProviders();
+    } else if (hasSearchTerm()) {
+        scheduleSearch();
+    }
+}
+
+void UnifiedSearchResultsListModel::moveSelection(SelectionDirection direction)
+{
+    QVector<int> selectableRows;
+    for (auto row = 0; row < _results.size(); ++row) {
+        if (_results[row]._isSelectable) {
+            selectableRows.push_back(row);
+        }
+    }
+    if (selectableRows.isEmpty()) {
         return;
     }
 
-    // insertion is done with sorting (first -> by order, then -> by name)
-    const auto itToInsertTo = std::find_if(std::begin(_results), std::end(_results),
-        [&provider](const UnifiedSearchResult &current) {
-            // insert before other results of higher order when possible
-            if (current._order > provider._order) {
-                return true;
-            } else {
-                if (current._order == provider._order) {
-                    // insert before results of higher QString value when possible
-                    return current._providerName > provider._name;
-                }
-
-                return false;
-            }
-        });
-
-    const auto first = static_cast<int>(std::distance(std::begin(_results), itToInsertTo));
-    const auto last = first + results.size() - 1;
-
-    beginInsertRows({}, first, last);
-    std::copy(std::begin(results), std::end(results), std::inserter(_results, itToInsertTo));
-    endInsertRows();
-}
-
-void UnifiedSearchResultsListModel::appendResultsToProvider(const QVector<UnifiedSearchResult> &results, const UnifiedSearchProvider &provider)
-{
-    if (results.isEmpty()) {
+    auto newRow = selectableRows.constFirst();
+    const auto currentPosition = selectableRows.indexOf(_selectedRow);
+    switch (direction) {
+    case SelectionDirection::Previous:
+        newRow = currentPosition <= 0 ? selectableRows.constFirst() : selectableRows[currentPosition - 1];
+        break;
+    case SelectionDirection::Next:
+        newRow = currentPosition < 0 || currentPosition >= selectableRows.size() - 1
+            ? selectableRows.constLast()
+            : selectableRows[currentPosition + 1];
+        break;
+    case SelectionDirection::First:
+        newRow = selectableRows.constFirst();
+        break;
+    case SelectionDirection::Last:
+        newRow = selectableRows.constLast();
+        break;
+    }
+    if (newRow == _selectedRow) {
         return;
     }
-
-    const auto providerId = provider._id;
-    /* we need to find the last result that is not a fetch-more-trigger or category-separator for the current
-       provider */
-    const auto itLastResultForProviderReverse =
-        std::find_if(std::rbegin(_results), std::rend(_results), [&providerId](const UnifiedSearchResult &result) {
-            return result._providerId == providerId && result._type == UnifiedSearchResult::Type::Default;
-        });
-
-    if (itLastResultForProviderReverse != std::rend(_results)) {
-        // #1 Insert rows
-        // convert reverse_iterator to iterator
-        const auto itLastResultForProvider = (itLastResultForProviderReverse + 1).base();
-        const auto first = static_cast<int>(std::distance(std::begin(_results), itLastResultForProvider + 1));
-        const auto last = first + results.size() - 1;
-        beginInsertRows({}, first, last);
-        std::copy(std::begin(results), std::end(results), std::inserter(_results, itLastResultForProvider + 1));
-        endInsertRows();
-
-        // #2 Remove the FetchMoreTrigger item if there are no more results to load for this provider
-        if (!provider._isPaginated) {
-            removeFetchMoreTrigger(providerId);
-        }
+    const auto previousRow = _selectedRow;
+    if (previousRow >= 0 && previousRow < _results.size()) {
+        _results[previousRow]._isSelected = false;
     }
+    _results[newRow]._isSelected = true;
+    _selectedStableKey = _results[newRow]._stableKey;
+    setSelectedRow(newRow);
+    if (previousRow >= 0) {
+        Q_EMIT dataChanged(index(previousRow), index(previousRow), {SelectedRole});
+    }
+    Q_EMIT dataChanged(index(newRow), index(newRow), {SelectedRole});
 }
 
-void UnifiedSearchResultsListModel::removeFetchMoreTrigger(const QString &providerId)
+void UnifiedSearchResultsListModel::activateSelected() const
 {
-    const auto itFetchMoreTriggerForProviderReverse = std::find_if(
-        std::rbegin(_results),
-        std::rend(_results),
-        [providerId](const UnifiedSearchResult &result) {
-            return result._providerId == providerId && result._type == UnifiedSearchResult::Type::FetchMoreTrigger;
-        });
-
-    if (itFetchMoreTriggerForProviderReverse != std::rend(_results)) {
-        // convert reverse_iterator to iterator
-        const auto itFetchMoreTriggerForProvider = (itFetchMoreTriggerForProviderReverse + 1).base();
-
-        if (itFetchMoreTriggerForProvider != std::end(_results)
-            && itFetchMoreTriggerForProvider != std::begin(_results)) {
-            const auto eraseIndex = static_cast<int>(std::distance(std::begin(_results), itFetchMoreTriggerForProvider));
-            Q_ASSERT(eraseIndex >= 0 && eraseIndex < static_cast<int>(_results.size()));
-            beginRemoveRows({}, eraseIndex, eraseIndex);
-            _results.erase(itFetchMoreTriggerForProvider);
-            endRemoveRows();
-        }
+    if (_selectedRow < 0 || _selectedRow >= _results.size()) {
+        return;
+    }
+    const auto &result = _results[_selectedRow];
+    if (result._isSelectable) {
+        resultClicked(result._providerId, result._resourceUrl);
     }
 }
-
-void UnifiedSearchResultsListModel::disconnectAndClearSearchJobs()
-{
-    for (const auto &connection : std::as_const(_searchJobConnections)) {
-        if (connection) {
-            QObject::disconnect(connection);
-        }
-    }
-
-    if (!_searchJobConnections.isEmpty()) {
-        _searchJobConnections.clear();
-        Q_EMIT isSearchInProgressChanged();
-    }
-}
-
-void UnifiedSearchResultsListModel::clearCurrentFetchMoreInProgressProviderId()
-{
-    if (!_currentFetchMoreInProgressProviderId.isEmpty()) {
-        _currentFetchMoreInProgressProviderId.clear();
-        Q_EMIT currentFetchMoreInProgressProviderIdChanged();
-    }
-}
-
 }

--- a/src/gui/search/unifiedsearchresultslistmodel.h
+++ b/src/gui/search/unifiedsearchresultslistmodel.h
@@ -5,9 +5,6 @@
 
 #pragma once
 
-#include "accountstate.h"
-#include "unifiedsearchresult.h"
-
 #include <QAbstractListModel>
 #include <QDateTime>
 #include <QJsonArray>
@@ -19,6 +16,9 @@
 #include <QUrlQuery>
 
 #include <limits>
+
+#include "accountstate.h"
+#include "unifiedsearchresult.h"
 
 namespace OCC {
 
@@ -89,10 +89,15 @@ public:
 
     /** @brief Identifies how a result-model row is rendered in QML. */
     enum class ResultType {
+        /** @brief A regular result that opens its resource. */
         Default = static_cast<int>(UnifiedSearchResult::Type::Default),
+        /** @brief A provider heading that can open detail view. */
         ProviderHeader = static_cast<int>(UnifiedSearchResult::Type::ProviderHeader),
+        /** @brief Separates results from providers that could not apply every filter. */
         PartialMatchesHeader = static_cast<int>(UnifiedSearchResult::Type::PartialMatchesHeader),
+        /** @brief Loads the next page for a provider. */
         FetchMoreTrigger = static_cast<int>(UnifiedSearchResult::Type::FetchMoreTrigger),
+        /** @brief Retries a failed provider page request. */
         RetryFetchMoreTrigger = static_cast<int>(UnifiedSearchResult::Type::RetryFetchMoreTrigger),
     };
     Q_ENUM(ResultType)
@@ -157,25 +162,28 @@ public:
     [[nodiscard]] QString accessibilityStatus() const;
     [[nodiscard]] AccountState *accountState() const;
 
-    Q_INVOKABLE void resultClicked(const QString &providerId, const QUrl &resourceUrl) const;
-    Q_INVOKABLE void fetchMoreTriggerClicked(const QString &providerId);
-    Q_INVOKABLE void toggleProviderFilter(const QString &providerId);
-    Q_INVOKABLE void clearTypeFilters();
-    Q_INVOKABLE void setDatePreset(const QString &preset);
     Q_INVOKABLE bool setCustomDateRange(const QString &sinceDate, const QString &untilDate);
-    Q_INVOKABLE void clearDateFilter();
-    Q_INVOKABLE void setPersonFilter(const QString &userId, const QString &displayName, const QString &avatarUrl = {});
-    Q_INVOKABLE void clearPersonFilter();
-    Q_INVOKABLE void removeFilter(const QString &type, const QString &id = {});
-    Q_INVOKABLE void setExternalProvidersEnabled(bool enabled);
-    Q_INVOKABLE void openProviderDetail(const QString &providerId);
-    Q_INVOKABLE void closeProviderDetail();
-    Q_INVOKABLE void loadMore(const QString &providerId);
-    Q_INVOKABLE void retryLoadMore(const QString &providerId);
-    Q_INVOKABLE void retryFailedProviders();
-    Q_INVOKABLE void retry();
-    Q_INVOKABLE void moveSelection(SelectionDirection direction);
-    Q_INVOKABLE void activateSelected() const;
+
+public Q_SLOTS:
+    void setSearchTerm(const QString &term);
+    void resultClicked(const QString &providerId, const QUrl &resourceUrl) const;
+    void fetchMoreTriggerClicked(const QString &providerId);
+    void toggleProviderFilter(const QString &providerId);
+    void clearTypeFilters();
+    void setDatePreset(const QString &preset);
+    void clearDateFilter();
+    void setPersonFilter(const QString &userId, const QString &displayName, const QString &avatarUrl = {});
+    void clearPersonFilter();
+    void removeFilter(const QString &type, const QString &id = {});
+    void setExternalProvidersEnabled(bool enabled);
+    void openProviderDetail(const QString &providerId);
+    void closeProviderDetail();
+    void loadMore(const QString &providerId);
+    void retryLoadMore(const QString &providerId);
+    void retryFailedProviders();
+    void retry();
+    void moveSelection(SelectionDirection direction);
+    void activateSelected() const;
 
 Q_SIGNALS:
     void currentFetchMoreInProgressProviderIdChanged();
@@ -194,9 +202,6 @@ Q_SIGNALS:
     void viewModeChanged();
     void selectedRowChanged();
     void accessibilityStatusChanged();
-
-public Q_SLOTS:
-    void setSearchTerm(const QString &term);
 
 private:
     enum class ProviderStatus {
@@ -269,9 +274,7 @@ private:
     [[nodiscard]] bool providerSupportsAllContentFilters(const UnifiedSearchProvider &provider) const;
     [[nodiscard]] QString providerIcon(const UnifiedSearchProvider &provider, bool darkMode) const;
     [[nodiscard]] QUrlQuery queryForProvider(const UnifiedSearchProvider &provider, bool pagination) const;
-    [[nodiscard]] static QString stableKeyForResult(const QString &providerId,
-                                                    const UnifiedSearchResult &result,
-                                                    int entryIndex);
+    [[nodiscard]] static QString stableKeyForResult(const QString &providerId, const QUrl &resourceUrl, int entryIndex);
     [[nodiscard]] static QUrl openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl);
 
     QHash<QString, UnifiedSearchProvider> _providers;

--- a/src/gui/search/unifiedsearchresultslistmodel.h
+++ b/src/gui/search/unifiedsearchresultslistmodel.h
@@ -5,28 +5,36 @@
 
 #pragma once
 
+#include "accountstate.h"
 #include "unifiedsearchresult.h"
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonValue>
+#include <QPointer>
+#include <QSet>
+#include <QTimer>
+#include <QUrlQuery>
 
 #include <limits>
 
-#include <QtCore>
-
 namespace OCC {
-class AccountState;
 
 /**
- * @brief The UnifiedSearchResultsListModel
+ * @brief Account-scoped presentation model for Nextcloud Unified Search.
  * @ingroup gui
- * Simple list model to provide the list view with data for the Unified Search results.
+ *
+ * The model owns provider discovery, concurrent searches, stable provider
+ * reveal order, filters, aggregate/detail projections and keyboard selection.
  */
-
 class UnifiedSearchResultsListModel : public QAbstractListModel
 {
     Q_OBJECT
 
     Q_PROPERTY(bool isSearchInProgress READ isSearchInProgress NOTIFY isSearchInProgressChanged)
-    Q_PROPERTY(QString currentFetchMoreInProgressProviderId READ currentFetchMoreInProgressProviderId NOTIFY
-            currentFetchMoreInProgressProviderIdChanged)
+    Q_PROPERTY(QString currentFetchMoreInProgressProviderId READ currentFetchMoreInProgressProviderId NOTIFY currentFetchMoreInProgressProviderIdChanged)
     Q_PROPERTY(QString errorString READ errorString NOTIFY errorStringChanged)
     Q_PROPERTY(QString searchTerm READ searchTerm WRITE setSearchTerm NOTIFY searchTermChanged)
     Q_PROPERTY(bool waitingForSearchTermEditEnd READ waitingForSearchTermEditEnd NOTIFY waitingForSearchTermEditEndChanged)
@@ -36,18 +44,23 @@ class UnifiedSearchResultsListModel : public QAbstractListModel
     Q_PROPERTY(bool canEditSearch READ canEditSearch NOTIFY canEditSearchChanged)
     Q_PROPERTY(bool isAccountConnected READ isAccountConnected NOTIFY canEditSearchChanged)
     Q_PROPERTY(SearchState searchState READ searchState NOTIFY searchStateChanged)
-
-    struct UnifiedSearchProvider
-    {
-        QString _id;
-        QString _name;
-        qint32 _cursor = -1; // current pagination value
-        qint32 _pageSize = -1; // how many max items per step of pagination
-        bool _isPaginated = false;
-        qint32 _order = std::numeric_limits<qint32>::max(); // sorting order (smaller number has bigger priority)
-    };
+    Q_PROPERTY(QVariantList providers READ providers NOTIFY providersChanged)
+    Q_PROPERTY(QVariantList activeFilters READ activeFilters NOTIFY activeFiltersChanged)
+    Q_PROPERTY(bool providersReady READ providersReady NOTIFY providersReadyChanged)
+    Q_PROPERTY(bool dateFilterAvailable READ dateFilterAvailable NOTIFY providersChanged)
+    Q_PROPERTY(bool peopleFilterAvailable READ peopleFilterAvailable NOTIFY providersChanged)
+    Q_PROPERTY(bool hasExternalProviders READ hasExternalProviders NOTIFY providersChanged)
+    Q_PROPERTY(bool externalProvidersEnabled READ externalProvidersEnabled NOTIFY externalProvidersEnabledChanged)
+    Q_PROPERTY(bool showConnectedServicesAction READ showConnectedServicesAction NOTIFY showConnectedServicesActionChanged)
+    Q_PROPERTY(bool hasPartialFailure READ hasPartialFailure NOTIFY hasPartialFailureChanged)
+    Q_PROPERTY(ViewMode viewMode READ viewMode NOTIFY viewModeChanged)
+    Q_PROPERTY(QString detailProviderName READ detailProviderName NOTIFY viewModeChanged)
+    Q_PROPERTY(int selectedRow READ selectedRow NOTIFY selectedRowChanged)
+    Q_PROPERTY(QString accessibilityStatus READ accessibilityStatus NOTIFY accessibilityStatusChanged)
+    Q_PROPERTY(AccountState *accountState READ accountState CONSTANT)
 
 public:
+    /** @brief The top-level presentation state of the search results view. */
     enum class SearchState {
         None,
         Placeholder,
@@ -58,9 +71,36 @@ public:
     };
     Q_ENUM(SearchState)
 
+    /** @brief Selects between results from all providers and one provider. */
+    enum class ViewMode {
+        Aggregate,
+        ProviderDetail,
+    };
+    Q_ENUM(ViewMode)
+
+    /** @brief Describes how keyboard navigation moves the current selection. */
+    enum class SelectionDirection {
+        Previous,
+        Next,
+        First,
+        Last,
+    };
+    Q_ENUM(SelectionDirection)
+
+    /** @brief Identifies how a result-model row is rendered in QML. */
+    enum class ResultType {
+        Default = static_cast<int>(UnifiedSearchResult::Type::Default),
+        ProviderHeader = static_cast<int>(UnifiedSearchResult::Type::ProviderHeader),
+        PartialMatchesHeader = static_cast<int>(UnifiedSearchResult::Type::PartialMatchesHeader),
+        FetchMoreTrigger = static_cast<int>(UnifiedSearchResult::Type::FetchMoreTrigger),
+        RetryFetchMoreTrigger = static_cast<int>(UnifiedSearchResult::Type::RetryFetchMoreTrigger),
+    };
+    Q_ENUM(ResultType)
+
     enum DataRole {
         ProviderNameRole = Qt::UserRole + 1,
         ProviderIdRole,
+        ProviderIconRole,
         DarkImagePlaceholderRole,
         LightImagePlaceholderRole,
         DarkIconsRole,
@@ -73,50 +113,69 @@ public:
         RoundedRole,
         TypeRole,
         TypeAsStringRole,
+        StableKeyRole,
+        SelectedRole,
+        SelectableRole,
+        PartialMatchRole,
+        HasOverflowRole,
+        LoadingRole,
     };
 
-    explicit UnifiedSearchResultsListModel(AccountState *accountState, QObject *parent = nullptr);
+    explicit UnifiedSearchResultsListModel(AccountState *accountState,
+                                            int debounceInterval = 300,
+                                            int revealInterval = 1000,
+                                            QObject *parent = nullptr);
+    ~UnifiedSearchResultsListModel() override;
 
     [[nodiscard]] QVariant data(const QModelIndex &index, int role) const override;
     [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
 
     [[nodiscard]] bool isSearchInProgress() const;
-
     [[nodiscard]] QString currentFetchMoreInProgressProviderId() const;
     [[nodiscard]] QString searchTerm() const;
     [[nodiscard]] QString errorString() const;
     [[nodiscard]] bool waitingForSearchTermEditEnd() const;
-
     [[nodiscard]] bool isFetchMoreInProgress() const;
     [[nodiscard]] bool hasSearchTerm() const;
     [[nodiscard]] bool hasSearchError() const;
     [[nodiscard]] bool canEditSearch() const;
-    /** @brief Returns whether the account is connected. */
     [[nodiscard]] bool isAccountConnected() const;
     [[nodiscard]] SearchState searchState() const;
+    [[nodiscard]] QVariantList providers() const;
+    [[nodiscard]] QVariantList activeFilters() const;
+    [[nodiscard]] bool providersReady() const;
+    [[nodiscard]] bool dateFilterAvailable() const;
+    [[nodiscard]] bool peopleFilterAvailable() const;
+    [[nodiscard]] bool hasExternalProviders() const;
+    [[nodiscard]] bool externalProvidersEnabled() const;
+    [[nodiscard]] bool showConnectedServicesAction() const;
+    [[nodiscard]] bool hasPartialFailure() const;
+    [[nodiscard]] ViewMode viewMode() const;
+    [[nodiscard]] QString detailProviderName() const;
+    [[nodiscard]] int selectedRow() const;
+    [[nodiscard]] QString accessibilityStatus() const;
+    [[nodiscard]] AccountState *accountState() const;
 
     Q_INVOKABLE void resultClicked(const QString &providerId, const QUrl &resourceUrl) const;
     Q_INVOKABLE void fetchMoreTriggerClicked(const QString &providerId);
-
-    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
-
-private:
-    void startSearch();
-    void startSearchForProvider(const QString &providerId, qint32 cursor = -1);
-
-    void parseResultsForProvider(const QJsonObject &data, const QString &providerId, bool fetchedMore = false);
-
-    // append initial search results to the list
-    void appendResults(QVector<UnifiedSearchResult> results, const UnifiedSearchProvider &provider);
-
-    // append pagination results to existing results from the initial search
-    void appendResultsToProvider(const QVector<UnifiedSearchResult> &results, const UnifiedSearchProvider &provider);
-
-    void removeFetchMoreTrigger(const QString &providerId);
-
-    void disconnectAndClearSearchJobs();
-
-    void clearCurrentFetchMoreInProgressProviderId();
+    Q_INVOKABLE void toggleProviderFilter(const QString &providerId);
+    Q_INVOKABLE void clearTypeFilters();
+    Q_INVOKABLE void setDatePreset(const QString &preset);
+    Q_INVOKABLE bool setCustomDateRange(const QString &sinceDate, const QString &untilDate);
+    Q_INVOKABLE void clearDateFilter();
+    Q_INVOKABLE void setPersonFilter(const QString &userId, const QString &displayName, const QString &avatarUrl = {});
+    Q_INVOKABLE void clearPersonFilter();
+    Q_INVOKABLE void removeFilter(const QString &type, const QString &id = {});
+    Q_INVOKABLE void setExternalProvidersEnabled(bool enabled);
+    Q_INVOKABLE void openProviderDetail(const QString &providerId);
+    Q_INVOKABLE void closeProviderDetail();
+    Q_INVOKABLE void loadMore(const QString &providerId);
+    Q_INVOKABLE void retryLoadMore(const QString &providerId);
+    Q_INVOKABLE void retryFailedProviders();
+    Q_INVOKABLE void retry();
+    Q_INVOKABLE void moveSelection(SelectionDirection direction);
+    Q_INVOKABLE void activateSelected() const;
 
 Q_SIGNALS:
     void currentFetchMoreInProgressProviderIdChanged();
@@ -126,31 +185,133 @@ Q_SIGNALS:
     void waitingForSearchTermEditEndChanged();
     void canEditSearchChanged();
     void searchStateChanged();
+    void providersChanged();
+    void providersReadyChanged();
+    void activeFiltersChanged();
+    void externalProvidersEnabledChanged();
+    void showConnectedServicesActionChanged();
+    void hasPartialFailureChanged();
+    void viewModeChanged();
+    void selectedRowChanged();
+    void accessibilityStatusChanged();
 
 public Q_SLOTS:
     void setSearchTerm(const QString &term);
 
-private Q_SLOTS:
-    void slotSearchTermEditingFinished();
-    void slotFetchProvidersFinished(const QJsonDocument &json, int statusCode);
-    void slotSearchForProviderFinished(const QJsonDocument &json, int statusCode);
-
 private:
-    static QUrl openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl);
+    enum class ProviderStatus {
+        Idle,
+        Loading,
+        Blocked,
+        Loaded,
+        Failed,
+    };
 
-    QMap<QString, UnifiedSearchProvider> _providers;
+    struct UnifiedSearchProvider
+    {
+        QString id;
+        QString appId;
+        QString name;
+        QString icon;
+        QSet<QString> filters;
+        int order = std::numeric_limits<int>::max();
+        int discoveryIndex = -1;
+        bool isExternalProvider = false;
+
+        ProviderStatus status = ProviderStatus::Idle;
+        QVector<UnifiedSearchResult> entries;
+        QJsonValue cursor;
+        bool hasMore = false;
+        bool loadMoreFailed = false;
+        bool paging = false;
+        bool partialMatch = false;
+    };
+
+    void discoverProviders();
+    void providerDiscoveryFinished(const QJsonDocument &json, int statusCode, quint64 generation, QObject *jobObject);
+    void scheduleSearch();
+    void startSearch();
+    void startSearchForProvider(const QString &providerId, bool pagination = false);
+    void providerSearchFinished(const QJsonDocument &json,
+                                int statusCode,
+                                const QString &providerId,
+                                bool pagination,
+                                quint64 generation,
+                                QObject *jobObject);
+    [[nodiscard]] QVector<UnifiedSearchResult> parseEntries(const QJsonArray &entries,
+                                                            const UnifiedSearchProvider &provider,
+                                                            int firstEntryIndex = 0) const;
+    void promoteReadyProviders();
+    void closeRevealWindow();
+    void rebuildProjection();
+    [[nodiscard]] UnifiedSearchResult pagingRowForProvider(const UnifiedSearchProvider &provider) const;
+    [[nodiscard]] bool updateDetailProjectionAfterPagination(const UnifiedSearchProvider &provider, int previousEntryCount);
+    [[nodiscard]] bool updateDetailPagingState(const UnifiedSearchProvider &provider);
+    void appendProviderProjection(const UnifiedSearchProvider &provider,
+                                  bool partial,
+                                  const QSet<QString> &filteredResourceUrls,
+                                  QVector<UnifiedSearchResult> &projection) const;
+    void resetProviderRuntime();
+    void abortSearchJobs();
+    void abortProviderDiscovery();
+    void trackSearchJob(QObject *jobObject);
+    void untrackSearchJob(QObject *jobObject);
+    void updateProgressSignals(bool wasInProgress);
+    void updateAggregateState();
+    void updateAccessibilityStatus();
+    void restartForFilterChange();
+    void setErrorString(const QString &error);
+    void setProvidersReady(bool ready);
+    void setWaitingForSearchTermEditEnd(bool waiting);
+    void setSelectedRow(int row);
+    void setAccessibilityStatus(const QString &status);
+    [[nodiscard]] bool providerIsApplicable(const UnifiedSearchProvider &provider) const;
+    [[nodiscard]] bool providerSupportsAllContentFilters(const UnifiedSearchProvider &provider) const;
+    [[nodiscard]] QString providerIcon(const UnifiedSearchProvider &provider, bool darkMode) const;
+    [[nodiscard]] QUrlQuery queryForProvider(const UnifiedSearchProvider &provider, bool pagination) const;
+    [[nodiscard]] static QString stableKeyForResult(const QString &providerId,
+                                                    const UnifiedSearchResult &result,
+                                                    int entryIndex);
+    [[nodiscard]] static QUrl openableResourceUrl(const QUrl &resourceUrl, const QUrl &accountUrl);
+
+    QHash<QString, UnifiedSearchProvider> _providers;
+    QVector<QString> _providerOrder;
+    QVector<QString> _revealOrder;
     QVector<UnifiedSearchResult> _results;
+    QVector<QPointer<QObject>> _activeSearchJobs;
+    QPointer<QObject> _providerDiscoveryJob;
 
     QString _searchTerm;
     QString _errorString;
-    bool _waitingForSearchTermEditEnd = false;
-
     QString _currentFetchMoreInProgressProviderId;
+    QStringList _selectedProviderIds;
+    QDateTime _since;
+    QDateTime _until;
+    QString _dateLabel;
+    QString _personId;
+    QString _personName;
+    QString _personAvatarUrl;
+    QString _detailProviderId;
+    QString _selectedStableKey;
+    QString _aggregateSelectedStableKey;
+    QString _accessibilityStatus;
 
-    QMap<QString, QMetaObject::Connection> _searchJobConnections;
+    bool _waitingForSearchTermEditEnd = false;
+    bool _providersLoading = false;
+    bool _providersReady = false;
+    bool _pendingSearch = false;
+    bool _revealWindowClosed = false;
+    bool _externalProvidersEnabled = false;
+    bool _hasPartialFailure = false;
+    bool _lastKnownConnected = false;
+    int _inFlightSearchRequests = 0;
+    int _selectedRow = -1;
+    quint64 _queryGeneration = 0;
+    quint64 _providerGeneration = 0;
+    ViewMode _viewMode = ViewMode::Aggregate;
 
-    QTimer _unifiedSearchTextEditingFinishedTimer;
-
+    QTimer _debounceTimer;
+    QTimer _revealTimer;
     AccountState *_accountState = nullptr;
 };
 }

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -461,7 +461,8 @@ void Systray::showSearchWindow(int userIndex)
         return;
     }
 
-    auto *const searchModel = new UnifiedSearchResultsListModel(accountState.data(), accountState.data());
+    const auto searchModel = new UnifiedSearchResultsListModel(accountState.data());
+    searchModel->setParent(accountState.data());
     const QVariantMap initialProperties{
         {"account", QVariantMap{
                         {"avatar", user->avatarUrl()},

--- a/src/gui/wizard/qml/WizardButton.qml
+++ b/src/gui/wizard/qml/WizardButton.qml
@@ -4,8 +4,9 @@
  */
 
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Controls.Basic as BasicControls
+import QtQuick.Effects
+import QtQuick.Layouts
 import Style
 
 BasicControls.Button {
@@ -14,7 +15,11 @@ BasicControls.Button {
     property bool primary: false
     property string iconSource: ""
     property bool iconBeforeText: false
+    property bool tintIcon: false
+    property color iconTintColor: Style.wizardPrimaryText
+    property real cornerRadius: Style.mediumRoundedButtonRadius
     property string textSuffix: ""
+    property string trailingIconSource: ""
     readonly property color primaryColor: Style.wizardPrimaryButtonBackground
     readonly property color primaryPressedColor: Style.wizardPrimaryButtonPressed
     readonly property color secondaryColor: Style.wizardSecondaryButtonBackground
@@ -24,75 +29,112 @@ BasicControls.Button {
     readonly property color disabledBorderColor: Style.wizardDisabledButtonBorder
 
     implicitHeight: Style.wizardFooterButtonHeight
-    leftPadding: 18
-    rightPadding: 18
-    font.pixelSize: Style.pixelSize + 3
+    leftPadding: Style.wizardButtonHorizontalPadding
+    rightPadding: Style.wizardButtonHorizontalPadding
+    font.pixelSize: Style.wizardButtonFontPixelSize
     font.weight: Font.Medium
     Accessible.role: Accessible.Button
     Accessible.name: textSuffix === "" ? text : text + " " + textSuffix
 
-    contentItem: Item {
-        implicitWidth: contentRow.implicitWidth
-        implicitHeight: contentRow.implicitHeight
+    contentItem: RowLayout {
+        spacing: Style.wizardButtonContentSpacing
 
-        Row {
-            id: contentRow
-
-            anchors.centerIn: parent
-            spacing: 6
+        Item {
+            visible: root.iconSource !== "" && root.iconBeforeText
+            Layout.preferredWidth: visible ? Style.smallIconSize : 0
+            Layout.preferredHeight: Style.smallIconSize
 
             Image {
-                visible: root.iconSource !== "" && root.iconBeforeText
-                source: root.iconSource
+                id: leadingIconImage
+
+                anchors.fill: parent
+                visible: !root.tintIcon
+                source: root.iconSource !== "" && root.iconBeforeText ? root.iconSource : ""
                 sourceSize.width: Style.smallIconSize
                 sourceSize.height: Style.smallIconSize
-                width: visible ? Style.smallIconSize : 0
-                height: Style.smallIconSize
-                anchors.verticalCenter: parent.verticalCenter
                 fillMode: Image.PreserveAspectFit
+                Accessible.ignored: true
             }
 
-            Text {
-                text: root.textSuffix === "" ? root.text : root.text + " " + root.textSuffix
-                font: root.font
-                color: root.enabled
-                    ? (root.primary ? Style.wizardSelectedText : root.palette.buttonText)
-                    : Style.wizardDisabledText
-                anchors.verticalCenter: parent.verticalCenter
-                elide: Text.ElideRight
+            MultiEffect {
+                objectName: "wizardButtonLeadingIconTint"
+                anchors.fill: leadingIconImage
+                visible: root.tintIcon
+                source: leadingIconImage
+                colorization: 1.0
+                colorizationColor: root.iconTintColor
+                Accessible.ignored: true
             }
+        }
 
-            Image {
-                visible: root.iconSource !== "" && !root.iconBeforeText
-                source: root.iconSource
-                sourceSize.width: Style.smallIconSize
-                sourceSize.height: Style.smallIconSize
-                width: visible ? Style.smallIconSize : 0
-                height: Style.smallIconSize
-                anchors.verticalCenter: parent.verticalCenter
-                fillMode: Image.PreserveAspectFit
+        Text {
+            objectName: "wizardButtonText"
+            Layout.fillWidth: true
+            text: root.textSuffix === "" ? root.text : root.text + " " + root.textSuffix
+            font: root.font
+            color: {
+                if (!root.enabled) {
+                    return Style.wizardDisabledText
+                }
+                if (root.primary) {
+                    return Style.wizardSelectedText
+                }
+                return root.palette.buttonText
             }
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+
+        Image {
+            visible: root.iconSource !== "" && !root.iconBeforeText
+            source: root.iconSource !== "" && !root.iconBeforeText ? root.iconSource : ""
+            sourceSize.width: Style.smallIconSize
+            sourceSize.height: Style.smallIconSize
+            Layout.preferredWidth: visible ? Style.smallIconSize : 0
+            Layout.preferredHeight: Style.smallIconSize
+            fillMode: Image.PreserveAspectFit
+            Accessible.ignored: true
+        }
+
+        Image {
+            id: trailingIcon
+
+            objectName: "wizardButtonTrailingIcon"
+            visible: root.trailingIconSource !== ""
+            source: root.trailingIconSource
+            sourceSize.width: Style.smallIconSize
+            sourceSize.height: Style.smallIconSize
+            Layout.preferredWidth: visible ? Style.smallIconSize : 0
+            Layout.preferredHeight: Style.smallIconSize
+            fillMode: Image.PreserveAspectFit
+            Accessible.ignored: true
         }
     }
 
     background: Rectangle {
-        radius: Style.mediumRoundedButtonRadius
-        border.width: root.primary ? 0 : 1
+        radius: root.cornerRadius
+        border.width: root.primary ? 0 : Style.normalBorderWidth
         border.color: root.enabled ? root.secondaryBorderColor : root.disabledBorderColor
         color: {
             if (!root.enabled) {
                 return root.disabledColor
             }
             if (root.primary) {
-                return root.down ? root.primaryPressedColor : root.primaryColor
+                return root.down || hoverArea.containsMouse
+                    ? root.primaryPressedColor
+                    : root.primaryColor
             }
-            return root.down
+            return root.down || hoverArea.containsMouse
                 ? root.secondaryPressedColor
                 : root.secondaryColor
         }
     }
 
     MouseArea {
+        id: hoverArea
+
+        objectName: "wizardButtonHoverArea"
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         enabled: root.enabled

--- a/src/gui/wizard/qml/WizardChipButton.qml
+++ b/src/gui/wizard/qml/WizardChipButton.qml
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import Style
+
+WizardButton {
+    implicitHeight: Style.wizardChipButtonHeight
+    cornerRadius: Style.veryRoundedButtonRadius
+}

--- a/src/gui/wizard/qml/WizardMenu.qml
+++ b/src/gui/wizard/qml/WizardMenu.qml
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic as BasicControls
+
+import Style
+
+BasicControls.Menu {
+    id: root
+
+    required property Item anchorItem
+
+    function toggle() {
+        if (opened) {
+            close()
+        } else {
+            popup(anchorItem, 0, anchorItem.height + Style.smallSpacing)
+        }
+    }
+
+    width: anchorItem.width
+    padding: Style.extraSmallSpacing
+    closePolicy: BasicControls.Menu.CloseOnPressOutsideParent | BasicControls.Menu.CloseOnEscape
+
+    background: Rectangle {
+        radius: Style.mediumRoundedButtonRadius
+        color: Style.wizardFieldBackground
+        border.width: Style.normalBorderWidth
+        border.color: Style.wizardSecondaryButtonBorder
+    }
+}

--- a/src/gui/wizard/qml/WizardMenuItem.qml
+++ b/src/gui/wizard/qml/WizardMenuItem.qml
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic as BasicControls
+import QtQuick.Effects
+import QtQuick.Layouts
+
+import Style
+
+BasicControls.MenuItem {
+    id: root
+
+    property bool tintIcon: false
+    property color iconTintColor: Style.wizardPrimaryText
+
+    hoverEnabled: true
+    implicitHeight: Style.standardPrimaryButtonHeight
+    leftPadding: Style.wizardMenuItemHorizontalPadding
+    rightPadding: Style.wizardMenuItemHorizontalPadding
+    font.pixelSize: Style.pixelSize + Style.extraSmallSpacing
+
+    contentItem: RowLayout {
+        spacing: Style.smallSpacing
+
+        Item {
+            Layout.preferredWidth: visible ? Style.smallIconSize : 0
+            Layout.preferredHeight: Style.smallIconSize
+            visible: root.icon.source.toString() !== ""
+
+            Image {
+                id: menuIconImage
+
+                anchors.fill: parent
+                visible: !root.tintIcon
+                source: root.icon.source.toString() !== "" ? root.icon.source : ""
+                sourceSize.width: Style.smallIconSize
+                sourceSize.height: Style.smallIconSize
+                fillMode: Image.PreserveAspectFit
+                Accessible.ignored: true
+            }
+
+            MultiEffect {
+                objectName: "wizardMenuItemIconTint"
+                anchors.fill: menuIconImage
+                visible: root.tintIcon
+                source: menuIconImage
+                colorization: 1.0
+                colorizationColor: root.iconTintColor
+                Accessible.ignored: true
+            }
+
+            Accessible.ignored: true
+        }
+
+        Text {
+            Layout.fillWidth: true
+            text: root.text
+            font: root.font
+            color: root.enabled ? Style.wizardPrimaryText : Style.wizardDisabledText
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+    }
+
+    background: Rectangle {
+        color: root.hovered || root.highlighted || root.down
+            ? Style.wizardSecondaryButtonPressed
+            : "transparent"
+        radius: Style.mediumRoundedButtonRadius
+    }
+
+    HoverHandler {
+        cursorShape: Qt.PointingHandCursor
+    }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_AUTOMOC TRUE)
 
 find_package(Qt${QT_VERSION_MAJOR}Core5Compat ${REQUIRED_QT_VERSION} CONFIG QUIET)
 find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS HttpServer CONFIG QUIET)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS QuickTest)
 
 add_library(testutils
   STATIC
@@ -112,6 +113,7 @@ if(NOT APPLE)
     nextcloud_add_test(SystraySyncControlQt)
 endif()
 nextcloud_add_test(UnifiedSearchListmodel)
+nextcloud_add_test(UnifiedSearchPeopleModel)
 nextcloud_add_test(ActivityListModel)
 nextcloud_add_test(SortedActivityListModel)
 nextcloud_add_test(ActivityData)
@@ -119,6 +121,20 @@ add_test(NAME ActivityFileMenuQmlTest
     COMMAND Qt6::qmltestrunner
         -input "${CMAKE_CURRENT_SOURCE_DIR}/qml/activityfilemenu/testactivityfilemenu.qml"
 )
+add_executable(SearchQmlTest qml/search/searchqmltestrunner.cpp)
+target_link_libraries(SearchQmlTest PRIVATE nextcloudCore Qt::QuickTest)
+target_compile_definitions(SearchQmlTest PRIVATE
+    SEARCH_QML_TEST_IMPORT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/qml/search/imports"
+)
+set_target_properties(SearchQmlTest PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+    FOLDER Tests
+)
+add_test(NAME SearchQmlTest
+    COMMAND SearchQmlTest -input "${CMAKE_CURRENT_SOURCE_DIR}/qml/search/testsearch.qml"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(SearchQmlTest PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 nextcloud_add_test(TalkReply)
 nextcloud_add_test(LockFile)
 nextcloud_add_test(ShareModel)

--- a/test/qml/search/imports/com/nextcloud/desktopclient/Theme.qml
+++ b/test/qml/search/imports/com/nextcloud/desktopclient/Theme.qml
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    readonly property bool darkMode: false
+    readonly property color wizardHeaderBackgroundColor: "#0082c9"
+    readonly property color wizardHeaderTitleColor: "#ffffff"
+    readonly property string stateOfflineImageSource: ""
+    readonly property string stateOnlineImageSource: ""
+}

--- a/test/qml/search/imports/com/nextcloud/desktopclient/UserModel.qml
+++ b/test/qml/search/imports/com/nextcloud/desktopclient/UserModel.qml
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma Singleton
+
+import QtQml
+
+QtObject {
+    readonly property var currentUser: null
+}

--- a/test/qml/search/imports/com/nextcloud/desktopclient/qmldir
+++ b/test/qml/search/imports/com/nextcloud/desktopclient/qmldir
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+module com.nextcloud.desktopclient
+singleton Theme 1.0 Theme.qml
+singleton UserModel 1.0 UserModel.qml

--- a/test/qml/search/searchqmltestrunner.cpp
+++ b/test/qml/search/searchqmltestrunner.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QCoreApplication>
+#include <QQmlEngine>
+#include <QtQuickTest/quicktest.h>
+
+#include "gui/search/unifiedsearchpeoplemodel.h"
+#include "gui/search/unifiedsearchresultslistmodel.h"
+
+class SearchQmlTestSetup : public QObject
+{
+    Q_OBJECT
+
+public:
+    SearchQmlTestSetup()
+    {
+        Q_INIT_RESOURCE(resources);
+        Q_INIT_RESOURCE(theme);
+
+        qmlRegisterType<OCC::UnifiedSearchPeopleModel>("com.nextcloud.desktopclient", 1, 0, "UnifiedSearchPeopleModel");
+        qmlRegisterUncreatableType<OCC::UnifiedSearchResultsListModel>("com.nextcloud.desktopclient",
+                                                                       1,
+                                                                       0,
+                                                                       "UnifiedSearchResultsListModel",
+                                                                       "UnifiedSearchResultsListModel");
+    }
+
+public slots:
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        engine->addImportPath(QStringLiteral(SEARCH_QML_TEST_IMPORT_PATH));
+        engine->addImportPath(QCoreApplication::applicationDirPath());
+        engine->addImportPath(QCoreApplication::applicationDirPath() + QStringLiteral("/qml"));
+        engine->addImportPath(QStringLiteral("qrc:/qml/theme"));
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(search, SearchQmlTestSetup)
+
+#include "searchqmltestrunner.moc"

--- a/test/qml/search/testsearch.qml
+++ b/test/qml/search/testsearch.qml
@@ -325,9 +325,8 @@ Item {
             tryCompare(popupLoader, "status", Loader.Ready)
             let peopleSearch = findChild(popupLoader.item, "peopleSearchField")
             verify(peopleSearch !== null)
-            peopleSearch.forceActiveFocus()
-            keyClick(Qt.Key_A)
-            compare(peopleSearch.text, "a")
+            popupLoader.item.peopleModel.searchTerm = "a"
+            tryCompare(peopleSearch, "text", "a")
 
             popupLoader.item.close()
             tryCompare(popupLoader, "active", false)

--- a/test/qml/search/testsearch.qml
+++ b/test/qml/search/testsearch.qml
@@ -1,0 +1,826 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtTest
+import com.nextcloud.desktopclient
+import com.nextcloud.desktopclient.search
+import Style
+import "qrc:/qml/src/gui/wizard/qml"
+
+Item {
+    width: 640
+    height: 220
+
+    Component {
+        id: productionSearchWindow
+
+        SearchWindow {}
+    }
+
+    Component {
+        id: windowSearchModel
+
+        ListModel {
+            property int viewMode: UnifiedSearchResultsListModel.Aggregate
+            property int searchState: UnifiedSearchResultsListModel.Results
+            property int selectedRow: 0
+            property string searchTerm: "calendar"
+            property string accessibilityStatus: ""
+            property string detailProviderName: "Files"
+            property string errorString: ""
+            property var accountState: null
+            property var activeFilters: []
+            property var providers: []
+            property bool providersReady: true
+            property bool canEditSearch: true
+            property bool waitingForSearchTermEditEnd: false
+            property bool isSearchInProgress: false
+            property bool isAccountConnected: true
+            property bool dateFilterAvailable: false
+            property bool peopleFilterAvailable: false
+            property bool hasPartialFailure: false
+            property bool showConnectedServicesAction: false
+            property bool externalProvidersEnabled: false
+            property string currentFetchMoreInProgressProviderId: ""
+            readonly property bool isFetchMoreInProgress: currentFetchMoreInProgressProviderId.length > 0
+
+            function moveSelection(direction) {}
+            function activateSelected() {}
+            function closeProviderDetail() {}
+            function retry() {}
+            function retryFailedProviders() {}
+            function setExternalProvidersEnabled(enabled) {}
+            function removeFilter(type, id) {}
+
+            Component.onCompleted: {
+                const row = {
+                    providerName: "Files",
+                    providerId: "files",
+                    providerIcon: "",
+                    resultTitle: "Calendar",
+                    subline: "Documents",
+                    resourceUrlRole: "https://cloud.example.test/f/1",
+                    darkIcons: "",
+                    lightIcons: "",
+                    darkIconsIsThumbnail: false,
+                    lightIconsIsThumbnail: false,
+                    darkImagePlaceholder: "",
+                    lightImagePlaceholder: "",
+                    isRounded: false,
+                    type: UnifiedSearchResultsListModel.Default,
+                    isSelected: true,
+                    isPartialMatch: false,
+                    hasOverflow: false,
+                    isLoading: false
+                }
+                append(row)
+                row.resultTitle = "Calendar 2"
+                row.resourceUrlRole = "https://cloud.example.test/f/2"
+                row.isSelected = false
+                append(row)
+            }
+        }
+    }
+
+    QtObject {
+        id: fakeSearchModel
+
+        property int openedProviderDetails: 0
+        property int activatedResults: 0
+        property int loadedPages: 0
+        property int retriedPages: 0
+
+        function openProviderDetail(providerId) {
+            if (providerId === "files") {
+                ++openedProviderDetails
+            }
+        }
+        function resultClicked(providerId, resourceUrl) {
+            if (providerId === "files" && resourceUrl.toString().length > 0) {
+                ++activatedResults
+            }
+        }
+        function retryLoadMore(providerId) {
+            if (providerId === "files") {
+                ++retriedPages
+            }
+        }
+        function loadMore(providerId) {
+            if (providerId === "files") {
+                ++loadedPages
+            }
+        }
+    }
+
+    UnifiedSearchInputContainer {
+        id: input
+        width: parent.width
+        height: 44
+    }
+
+    UnifiedSearchResultDelegate {
+        id: resultDelegate
+
+        y: 60
+        width: 500
+        searchModel: fakeSearchModel
+        providerName: "Files"
+        providerId: "files"
+        providerIcon: ""
+        resultTitle: "README.md"
+        subline: "Documents"
+        resourceUrlRole: "https://cloud.example.test/f/1"
+        darkIcons: ""
+        lightIcons: ""
+        darkIconsIsThumbnail: false
+        lightIconsIsThumbnail: false
+        darkImagePlaceholder: ""
+        lightImagePlaceholder: ""
+        isRounded: false
+        resultType: UnifiedSearchResultsListModel.ProviderHeader
+        isSelected: false
+        isPartialMatch: false
+        hasOverflow: true
+        isLoading: false
+    }
+
+    WizardButton {
+        id: wizardHoverButton
+
+        x: 500
+        y: 170
+        width: 120
+        text: qsTr("Hover")
+    }
+
+    WizardMenuItem {
+        id: wizardMenuHoverItem
+
+        x: 350
+        y: 170
+        width: 120
+        text: qsTr("Menu hover")
+        icon.source: "qrc:/client/theme/black/folder.svg"
+        tintIcon: true
+        iconTintColor: Style.wizardPrimaryText
+    }
+
+    SignalSpy { id: clearSpy; target: input; signalName: "clearText" }
+    SignalSpy { id: moveSpy; target: input; signalName: "moveSelection" }
+    SignalSpy { id: activateSpy; target: input; signalName: "activateSelection" }
+
+    TestCase {
+        name: "SearchQmlModule"
+        when: windowShown
+
+        function init() {
+            resultDelegate.resultType = UnifiedSearchResultsListModel.ProviderHeader
+            resultDelegate.isSelected = false
+            resultDelegate.isLoading = false
+            fakeSearchModel.loadedPages = 0
+            fakeSearchModel.retriedPages = 0
+        }
+
+        function test_searchWindowLoadsFromPackagedModule() {
+            const searchWindow = productionSearchWindow.createObject(null)
+            verify(searchWindow !== null)
+            compare(searchWindow.height, Style.searchWindowHeight)
+            verify(searchWindow.height >= 620 + Style.unifiedSearchItemHeight)
+            searchWindow.destroy()
+        }
+
+        function test_nothingFoundContentIsGroupedInTheCenter() {
+            const model = windowSearchModel.createObject(this, {
+                searchState: UnifiedSearchResultsListModel.NothingFound,
+                searchTerm: "Nextcloud"
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const nothingFoundView = findChild(searchWindow, "nothingFoundView")
+            const content = findChild(searchWindow, "nothingFoundContent")
+            const icon = findChild(searchWindow, "nothingFoundIcon")
+            const message = findChild(searchWindow, "nothingFoundMessage")
+            const query = findChild(searchWindow, "nothingFoundQuery")
+
+            verify(nothingFoundView !== null)
+            verify(content !== null)
+            verify(icon !== null)
+            verify(message !== null)
+            verify(query !== null)
+            tryVerify(() => nothingFoundView.height > 0 && content.height > 0)
+            compare(query.text, "Nextcloud")
+            verify(content.height < nothingFoundView.height / 2)
+
+            const contentCenter = content.mapToItem(nothingFoundView,
+                                                    content.width / 2,
+                                                    content.height / 2)
+            fuzzyCompare(contentCenter.x, nothingFoundView.width / 2, 1)
+            fuzzyCompare(contentCenter.y, nothingFoundView.height / 2, 1)
+
+            const iconBottom = icon.mapToItem(content, 0, icon.height).y
+            const messageTop = message.mapToItem(content, 0, 0).y
+            const messageBottom = message.mapToItem(content, 0, message.height).y
+            const queryTop = query.mapToItem(content, 0, 0).y
+            fuzzyCompare(messageTop - iconBottom, Style.standardSpacing, 1)
+            fuzzyCompare(queryTop - messageBottom, Style.standardSpacing, 1)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_selectionBindingSurvivesViewAndModelChanges() {
+            const firstModel = windowSearchModel.createObject(this, { selectedRow: 0 })
+            const secondModel = windowSearchModel.createObject(this, { selectedRow: 1 })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: firstModel,
+                visible: true
+            })
+            const resultsList = findChild(searchWindow, "searchResultsList")
+
+            verify(resultsList !== null)
+            tryCompare(resultsList, "count", 2)
+            tryVerify(() => resultsList.itemAtIndex(0) !== null)
+            verify(resultsList.itemAtIndex(0).loadedItem !== null)
+            compare(resultsList.itemAtIndex(0).loadedItem.objectName, "searchResultRow")
+            compare(resultsList.currentIndex, 0)
+
+            firstModel.viewMode = UnifiedSearchResultsListModel.ProviderDetail
+            wait(0)
+            searchWindow.searchModel = secondModel
+            tryCompare(resultsList, "currentIndex", 1)
+
+            searchWindow.destroy()
+            firstModel.destroy()
+            secondModel.destroy()
+        }
+
+        function test_partialFailureFooterIsAggregateOnly() {
+            const model = windowSearchModel.createObject(this, { hasPartialFailure: true })
+            const searchWindow = productionSearchWindow.createObject(null, { searchModel: model })
+            const footer = findChild(searchWindow, "partialFailureFooter")
+
+            verify(footer !== null)
+            compare(footer.visible, true)
+            model.viewMode = UnifiedSearchResultsListModel.ProviderDetail
+            tryCompare(footer, "visible", false)
+            model.viewMode = UnifiedSearchResultsListModel.Aggregate
+            tryCompare(footer, "visible", true)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_hiddenLoadingFooterDoesNotReserveSpace() {
+            const model = windowSearchModel.createObject(this)
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const footer = findChild(searchWindow, "searchResultsLoadingFooter")
+
+            verify(footer !== null)
+            compare(footer.visible, false)
+            compare(footer.height, 0)
+            model.isSearchInProgress = true
+            tryVerify(() => footer.height > 0)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_fetchMoreShowsSearchProgressIndicator() {
+            const model = windowSearchModel.createObject(this)
+            const searchWindow = productionSearchWindow.createObject(null, { searchModel: model })
+            const progressIndicator = findChild(searchWindow, "searchProgressIndicator")
+
+            verify(progressIndicator !== null)
+            compare(progressIndicator.visible, false)
+            model.currentFetchMoreInProgressProviderId = "files"
+            tryCompare(progressIndicator, "visible", true)
+            compare(progressIndicator.running, true)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_detailHeaderCentersProviderAndShowsBackArrow() {
+            const model = windowSearchModel.createObject(this, {
+                viewMode: UnifiedSearchResultsListModel.ProviderDetail,
+                detailProviderName: "A provider name that is intentionally much too long for the available search header"
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const header = findChild(searchWindow, "searchDetailHeader")
+            const title = findChild(searchWindow, "searchDetailProviderTitle")
+            const backButton = findChild(searchWindow, "searchDetailBackButton")
+
+            verify(header !== null)
+            verify(title !== null)
+            verify(backButton !== null)
+            compare(title.font.bold, true)
+            verify(title.font.pixelSize > Style.unifiedSearchResultTitleFontSize)
+            const titleCenter = title.mapToItem(header, title.width / 2, title.height / 2)
+            fuzzyCompare(titleCenter.x, header.width / 2, 1)
+            const backButtonRight = backButton.mapToItem(header, backButton.width, 0).x
+            const titleLeft = title.mapToItem(header, 0, 0).x
+            verify(titleLeft > backButtonRight)
+            verify(title.implicitWidth > title.width)
+            verify(backButton.icon.source.toString().includes("arrow-left.svg"))
+            compare(backButton.icon.width, Style.smallIconSize)
+            compare(backButton.icon.height, Style.smallIconSize)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_filterButtonsUseWizardHoverAndTrailingCarets() {
+            const model = windowSearchModel.createObject(this)
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const typeButton = findChild(searchWindow, "typeFilterButton")
+            const dateButton = findChild(searchWindow, "dateFilterButton")
+            const peopleButton = findChild(searchWindow, "peopleFilterButton")
+
+            verify(typeButton !== null)
+            verify(dateButton !== null)
+            verify(peopleButton !== null)
+            const todayMenuItem = findChild(searchWindow, "dateTodayMenuItem")
+            verify(todayMenuItem !== null)
+            compare(todayMenuItem.hoverEnabled, true)
+            for (const button of [typeButton, dateButton, peopleButton]) {
+                verify(button.trailingIconSource.toString().includes("caret-down.svg"))
+                const caret = findChild(button, "wizardButtonTrailingIcon")
+                verify(caret !== null)
+                const caretPosition = caret.mapToItem(button, 0, 0)
+                verify(caretPosition.x > button.width / 2)
+                fuzzyCompare(caretPosition.y + caret.height / 2, button.height / 2, 1)
+            }
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_filterMenusUseStandardDropdownGeometry() {
+            const model = windowSearchModel.createObject(this, { dateFilterAvailable: true })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const typeButton = findChild(searchWindow, "typeFilterButton")
+            const typeMenu = findChild(searchWindow, "typeFilterMenu")
+            const dateButton = findChild(searchWindow, "dateFilterButton")
+            const dateMenu = findChild(searchWindow, "dateFilterMenu")
+
+            verify(typeButton !== null)
+            verify(typeMenu !== null)
+            verify(dateButton !== null)
+            verify(dateMenu !== null)
+            compare(typeMenu.anchorItem, typeButton)
+            compare(dateMenu.anchorItem, dateButton)
+            compare(dateMenu.width, dateButton.width)
+            verify(dateMenu.width > Style.standardPrimaryButtonHeight)
+            compare(typeMenu.background.radius, Style.mediumRoundedButtonRadius)
+            compare(dateMenu.background.radius, Style.mediumRoundedButtonRadius)
+            compare(typeMenu.background.border.width, Style.normalBorderWidth)
+            compare(dateMenu.background.border.width, Style.normalBorderWidth)
+
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", true)
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", false)
+            mouseClick(dateButton)
+            tryCompare(dateMenu, "opened", true)
+            verify(dateMenu.height > Style.standardPrimaryButtonHeight)
+            mouseClick(dateButton)
+            tryCompare(dateMenu, "opened", false)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function providerEntries(count) {
+            const providers = []
+            for (let index = 0; index < count; ++index) {
+                providers.push({
+                    id: "provider-" + index,
+                    name: "Provider " + index,
+                    icon: "",
+                    selected: false
+                })
+            }
+            return providers
+        }
+
+        function test_typeFilterMenuShowsEightRowsWithoutScrolling() {
+            const model = windowSearchModel.createObject(this, {
+                providers: providerEntries(Style.unifiedSearchProviderMenuMaximumVisibleRows)
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const typeButton = findChild(searchWindow, "typeFilterButton")
+            const typeMenu = findChild(searchWindow, "typeFilterMenu")
+
+            verify(typeButton !== null)
+            verify(typeMenu !== null)
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", true)
+            compare(typeMenu.height, typeMenu.implicitHeight)
+            compare(typeMenu.contentItem.interactive, false)
+
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", false)
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_typeFilterMenuScrollsBeyondEightRows() {
+            const model = windowSearchModel.createObject(this, {
+                providers: providerEntries(Style.unifiedSearchProviderMenuMaximumVisibleRows + 1)
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const typeButton = findChild(searchWindow, "typeFilterButton")
+            const typeMenu = findChild(searchWindow, "typeFilterMenu")
+            const maximumHeight = Style.unifiedSearchProviderMenuMaximumVisibleRows
+                * Style.standardPrimaryButtonHeight + typeMenu.topPadding + typeMenu.bottomPadding
+
+            verify(typeButton !== null)
+            verify(typeMenu !== null)
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", true)
+            compare(typeMenu.height, maximumHeight)
+            verify(typeMenu.implicitHeight > typeMenu.height)
+            verify(typeMenu.contentItem.contentHeight > typeMenu.contentItem.height)
+            compare(typeMenu.contentItem.interactive, true)
+
+            mouseClick(typeButton)
+            tryCompare(typeMenu, "opened", false)
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_categoryFiltersAreVisibleBeforeSearchBegins() {
+            const model = windowSearchModel.createObject(this, { searchTerm: "" })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const filterFlow = findChild(searchWindow, "categoryFilterFlow")
+            const typeButton = findChild(searchWindow, "typeFilterButton")
+            const dateButton = findChild(searchWindow, "dateFilterButton")
+            const peopleButton = findChild(searchWindow, "peopleFilterButton")
+
+            verify(filterFlow !== null)
+            compare(filterFlow.visible, true)
+            compare(typeButton.visible, true)
+            compare(dateButton.visible, true)
+            compare(peopleButton.visible, true)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+        function test_activeFilterUsesCompactPillButton() {
+            const model = windowSearchModel.createObject(this, {
+                activeFilters: [{
+                    type: "date",
+                    id: "last7days",
+                    label: "Last 7 days",
+                    icon: ""
+                }]
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const activeFilterFlow = findChild(searchWindow, "activeFilterFlow")
+            const dateButton = findChild(searchWindow, "dateFilterButton")
+            function activeFilterChip() {
+                for (let index = 0; index < activeFilterFlow.children.length; ++index) {
+                    if (activeFilterFlow.children[index].objectName === "activeFilterChip") {
+                        return activeFilterFlow.children[index]
+                    }
+                }
+                return null
+            }
+
+            verify(activeFilterFlow !== null)
+            tryVerify(() => activeFilterChip() !== null)
+            const chip = activeFilterChip()
+            verify(dateButton !== null)
+            compare(chip.implicitHeight, Style.wizardChipButtonHeight)
+            verify(chip.implicitHeight < dateButton.implicitHeight)
+            compare(chip.background.radius, Style.veryRoundedButtonRadius)
+            compare(chip.leftPadding, dateButton.leftPadding)
+            compare(chip.rightPadding, chip.leftPadding)
+
+            searchWindow.destroy()
+            model.destroy()
+        }
+
+    }
+
+    TestCase {
+        name: "UnifiedSearchInput"
+        when: windowShown
+
+        function init() {
+            input.text = ""
+            input.isSearchInProgress = false
+            input.forceActiveFocus()
+            clearSpy.clear()
+            moveSpy.clear()
+            activateSpy.clear()
+        }
+
+        function test_keyboardNavigationKeepsInputFocus() {
+            keyClick(Qt.Key_Down)
+            keyClick(Qt.Key_End)
+            keyClick(Qt.Key_Return)
+            compare(moveSpy.count, 2)
+            compare(activateSpy.count, 1)
+            verify(input.activeFocus)
+        }
+
+        function test_activeFocusKeepsNeutralFrame() {
+            verify(input.activeFocus)
+            compare(input.background.border.width, 1)
+            compare(input.background.border.color, Style.wizardFieldBorder)
+        }
+
+        function test_progressIndicatorDoesNotReplaceSearchIcon() {
+            const searchIcon = findChild(input, "searchLeadingIcon")
+            const progressIndicator = findChild(input, "searchProgressIndicator")
+            const clearButton = findChild(input, "clearSearchButton")
+
+            verify(searchIcon !== null)
+            verify(progressIndicator !== null)
+            verify(clearButton !== null)
+            verify(progressIndicator.imageSource.includes("change.svg"))
+            input.text = "loading"
+            compare(searchIcon.visible, true)
+            compare(progressIndicator.visible, false)
+
+            input.isSearchInProgress = true
+            tryCompare(progressIndicator, "visible", true)
+            compare(progressIndicator.running, true)
+            compare(searchIcon.visible, true)
+            const searchIconPosition = searchIcon.mapToItem(input, 0, 0)
+            const progressPosition = progressIndicator.mapToItem(input, 0, 0)
+            const clearButtonPosition = clearButton.mapToItem(input, 0, 0)
+            verify(progressPosition.x > searchIconPosition.x)
+            verify(progressPosition.x + progressIndicator.width <= clearButtonPosition.x)
+            verify(input.width - input.rightPadding < progressPosition.x)
+
+            input.isSearchInProgress = false
+            tryCompare(progressIndicator, "visible", false)
+            compare(progressIndicator.running, false)
+            compare(searchIcon.visible, true)
+        }
+
+        function test_textEditingSignalIsIndependentFromClear() {
+            keyClick(Qt.Key_C)
+            keyClick(Qt.Key_A)
+            keyClick(Qt.Key_L)
+            keyClick(Qt.Key_E)
+            keyClick(Qt.Key_N)
+            keyClick(Qt.Key_D)
+            keyClick(Qt.Key_A)
+            keyClick(Qt.Key_R)
+            compare(input.text, "calendar")
+            compare(clearSpy.count, 0)
+        }
+
+        function test_clearActionReplacesFilterAction() {
+            const clearButton = findChild(input, "clearSearchButton")
+
+            verify(clearButton !== null)
+            compare(clearButton.visible, false)
+            keyClick(Qt.Key_C)
+            compare(clearButton.visible, true)
+            verify(clearButton.icon.source.toString().includes("clear.svg"))
+            mouseClick(clearButton)
+            compare(clearSpy.count, 1)
+        }
+    }
+
+    TestCase {
+        name: "WizardButton"
+        when: windowShown
+
+        function test_hoverUsesSharedWizardSurface() {
+            mouseMove(input, 1, 1)
+            wait(0)
+            const restingColor = wizardHoverButton.background.color.toString()
+            const hoverArea = findChild(wizardHoverButton, "wizardButtonHoverArea")
+
+            verify(hoverArea !== null)
+            mouseMove(wizardHoverButton, 2, 2)
+            tryCompare(hoverArea, "containsMouse", true)
+            verify(wizardHoverButton.background.color.toString() !== restingColor)
+        }
+
+        function test_tintedLeadingIconUsesRequestedColor() {
+            wizardHoverButton.iconBeforeText = true
+            wizardHoverButton.tintIcon = true
+            wizardHoverButton.iconTintColor = Style.wizardPrimaryText
+            wizardHoverButton.iconSource = "qrc:/client/theme/black/folder.svg"
+            wait(0)
+
+            const iconTint = findChild(wizardHoverButton, "wizardButtonLeadingIconTint")
+            verify(iconTint !== null)
+            compare(iconTint.visible, true)
+            compare(iconTint.colorization, 1.0)
+            compare(iconTint.colorizationColor.toString(), Style.wizardPrimaryText.toString())
+        }
+
+        function test_trailingIconCannotOverlapLongText() {
+            wizardHoverButton.iconBeforeText = false
+            wizardHoverButton.iconSource = ""
+            wizardHoverButton.trailingIconSource = "qrc:/client/theme/black/caret-down.svg"
+            wizardHoverButton.text = "An intentionally long translated button label"
+            wait(0)
+
+            const textItem = findChild(wizardHoverButton, "wizardButtonText")
+            const trailingIcon = findChild(wizardHoverButton, "wizardButtonTrailingIcon")
+            verify(textItem !== null)
+            verify(trailingIcon !== null)
+            tryVerify(() => {
+                const textRight = textItem.mapToItem(wizardHoverButton, textItem.width, 0).x
+                const iconLeft = trailingIcon.mapToItem(wizardHoverButton, 0, 0).x
+                return textRight < iconLeft
+            })
+        }
+    }
+
+    TestCase {
+        name: "WizardMenuItem"
+        when: windowShown
+
+        function test_hoverUsesSharedWizardMenuSurface() {
+            mouseMove(input, 1, 1)
+            wait(0)
+            const restingColor = wizardMenuHoverItem.background.color.toString()
+
+            mouseMove(wizardMenuHoverItem, 2, 2)
+            tryCompare(wizardMenuHoverItem, "hovered", true)
+            verify(wizardMenuHoverItem.background.color.toString() !== restingColor)
+        }
+
+        function test_tintedIconUsesRequestedColor() {
+            const iconTint = findChild(wizardMenuHoverItem, "wizardMenuItemIconTint")
+            verify(iconTint !== null)
+            compare(iconTint.visible, true)
+            compare(iconTint.colorization, 1.0)
+            compare(iconTint.colorizationColor.toString(), Style.wizardPrimaryText.toString())
+        }
+    }
+
+    TestCase {
+        name: "UnifiedSearchResultDelegate"
+        when: windowShown
+
+        function init() {
+            resultDelegate.resultType = UnifiedSearchResultsListModel.ProviderHeader
+            resultDelegate.hasOverflow = true
+            resultDelegate.isSelected = false
+            fakeSearchModel.openedProviderDetails = 0
+            fakeSearchModel.activatedResults = 0
+            fakeSearchModel.loadedPages = 0
+            fakeSearchModel.retriedPages = 0
+            wait(0)
+        }
+
+        function test_providerHeaderReceivesDelegateDataAndGeometry() {
+            verify(resultDelegate.loadedItem !== null)
+            compare(resultDelegate.loadedItem.objectName, "providerHeaderRow")
+            compare(resultDelegate.loadedItem.width, resultDelegate.width)
+            compare(resultDelegate.height, 44)
+            compare(resultDelegate.loadedItem.text, "More from Files  →")
+            compare(resultDelegate.loadedItem.font.bold, false)
+            compare(resultDelegate.loadedItem.font.pixelSize, Style.unifiedSearchResultTitleFontSize)
+            compare(resultDelegate.loadedItem.leftPadding, 0)
+            compare(resultDelegate.loadedItem.hoverEnabled, true)
+            compare(findChild(resultDelegate.loadedItem, "providerHeaderIconTint"), null)
+
+            mouseMove(input, 1, 1)
+            mouseMove(input, 2, 2)
+            tryCompare(resultDelegate.loadedItem, "hovered", false)
+            compare(resultDelegate.loadedItem.background.color.toString(), "#00000000")
+            mouseMove(resultDelegate.loadedItem, 1, 1)
+            mouseMove(resultDelegate.loadedItem, 2, 2)
+            tryCompare(resultDelegate.loadedItem, "hovered", true)
+            compare(resultDelegate.loadedItem.background.color.toString(), Style.listItemHoverBackground.toString())
+
+            mousePress(resultDelegate.loadedItem)
+            compare(fakeSearchModel.openedProviderDetails, 1)
+            mouseRelease(resultDelegate.loadedItem)
+            compare(fakeSearchModel.openedProviderDetails, 1)
+        }
+
+        function test_plainProviderHeaderStaysRegularAndNonInteractive() {
+            resultDelegate.hasOverflow = false
+            wait(0)
+
+            compare(resultDelegate.loadedItem.text, "Files")
+            compare(resultDelegate.loadedItem.font.bold, false)
+            compare(resultDelegate.loadedItem.font.pixelSize, Style.unifiedSearchResultTitleFontSize)
+            compare(resultDelegate.loadedItem.leftPadding, 0)
+            compare(resultDelegate.loadedItem.hoverEnabled, false)
+        }
+
+        function test_resultRowReceivesDelegateDataAndGeometry() {
+            resultDelegate.resultType = UnifiedSearchResultsListModel.Default
+            wait(0)
+
+            verify(resultDelegate.loadedItem !== null)
+            compare(resultDelegate.loadedItem.objectName, "searchResultRow")
+            compare(resultDelegate.loadedItem.width, resultDelegate.width)
+            compare(resultDelegate.height, Style.unifiedSearchItemHeight)
+            verify(resultDelegate.height <= 44)
+            compare(resultDelegate.loadedItem.leftPadding, 0)
+            compare(resultDelegate.loadedItem.rightPadding, 0)
+            compare(resultDelegate.loadedItem.topPadding, 0)
+            compare(resultDelegate.loadedItem.bottomPadding, 0)
+            compare(resultDelegate.loadedItem.contentItem.height, resultDelegate.loadedItem.height)
+            compare(resultDelegate.loadedItem.background.height, resultDelegate.loadedItem.height)
+            compare(resultDelegate.loadedItem.contentItem.Accessible.ignored, true)
+
+            const title = findChild(resultDelegate.loadedItem, "searchResultTitle")
+            const subline = findChild(resultDelegate.loadedItem, "searchResultSubline")
+            const textContainer = findChild(resultDelegate.loadedItem, "searchResultTextContainer")
+            verify(title !== null)
+            verify(subline !== null)
+            verify(textContainer !== null)
+            compare(title.font.pixelSize, Style.unifiedSearchResultTitleFontSize)
+            compare(subline.font.pixelSize, title.font.pixelSize)
+            compare(textContainer.spacing, Style.unifiedSearchResultTextSpacing)
+
+            resultDelegate.isSelected = true
+            tryCompare(resultDelegate.loadedItem.background, "color", Style.wizardSecondaryButtonPressed)
+            resultDelegate.isSelected = false
+            mouseMove(resultDelegate.loadedItem, 2, 2)
+            tryCompare(resultDelegate.loadedItem, "hovered", true)
+            compare(resultDelegate.loadedItem.background.color.toString(), Style.listItemHoverBackground.toString())
+
+            mouseClick(resultDelegate.loadedItem)
+            compare(fakeSearchModel.activatedResults, 1)
+        }
+
+        function test_loadMoreUsesAFlatItemRow() {
+            resultDelegate.resultType = UnifiedSearchResultsListModel.FetchMoreTrigger
+            wait(0)
+
+            verify(resultDelegate.loadedItem !== null)
+            compare(resultDelegate.loadedItem.objectName, "searchPagingRow")
+            compare(resultDelegate.loadedItem.text, qsTr("Load more results"))
+            const pagingLabel = findChild(resultDelegate.loadedItem, "searchPagingLabel")
+            verify(pagingLabel !== null)
+            compare(pagingLabel.font.bold, false)
+            verify(resultDelegate.loadedItem.icon.source.toString().includes("more.svg"))
+            verify(!resultDelegate.loadedItem.hasOwnProperty("primary"))
+            compare(resultDelegate.loadedItem.height, 44)
+            mouseMove(input, 1, 1)
+            wait(0)
+            compare(resultDelegate.loadedItem.background.color.toString(), "#00000000")
+
+            mouseMove(resultDelegate.loadedItem, 2, 2)
+            tryCompare(resultDelegate.loadedItem, "hovered", true)
+            compare(resultDelegate.loadedItem.background.color.toString(), Style.listItemHoverBackground.toString())
+
+            mousePress(resultDelegate.loadedItem)
+            compare(fakeSearchModel.loadedPages, 1)
+            mouseRelease(resultDelegate.loadedItem)
+            compare(fakeSearchModel.loadedPages, 1)
+        }
+
+        function test_retryPagingUsesAFlatItemRow() {
+            resultDelegate.resultType = UnifiedSearchResultsListModel.RetryFetchMoreTrigger
+            wait(0)
+
+            verify(resultDelegate.loadedItem !== null)
+            compare(resultDelegate.loadedItem.objectName, "searchPagingRow")
+            compare(resultDelegate.loadedItem.text, qsTr("Retry loading more results"))
+            verify(!resultDelegate.loadedItem.hasOwnProperty("primary"))
+            compare(resultDelegate.loadedItem.height, 44)
+
+            mousePress(resultDelegate.loadedItem)
+            compare(fakeSearchModel.retriedPages, 1)
+            mouseRelease(resultDelegate.loadedItem)
+            compare(fakeSearchModel.retriedPages, 1)
+        }
+    }
+}

--- a/test/qml/search/testsearch.qml
+++ b/test/qml/search/testsearch.qml
@@ -70,7 +70,7 @@ Item {
                     darkImagePlaceholder: "",
                     lightImagePlaceholder: "",
                     isRounded: false,
-                    type: UnifiedSearchResultsListModel.Default,
+                    resultType: UnifiedSearchResultsListModel.Default,
                     isSelected: true,
                     isPartialMatch: false,
                     hasOverflow: false,
@@ -349,10 +349,16 @@ Item {
             const typeButton = findChild(searchWindow, "typeFilterButton")
             const dateButton = findChild(searchWindow, "dateFilterButton")
             const peopleButton = findChild(searchWindow, "peopleFilterButton")
+            const filterFlow = findChild(searchWindow, "categoryFilterFlow")
 
             verify(typeButton !== null)
             verify(dateButton !== null)
             verify(peopleButton !== null)
+            verify(filterFlow !== null)
+            compare(typeButton.width, dateButton.width)
+            compare(dateButton.width, peopleButton.width)
+            compare(typeButton.width, filterFlow.filterButtonWidth)
+            compare(filterFlow.filterButtonGapCount, filterFlow.filterButtonCount - 1)
             const todayMenuItem = findChild(searchWindow, "dateTodayMenuItem")
             verify(todayMenuItem !== null)
             compare(todayMenuItem.hoverEnabled, true)
@@ -550,9 +556,23 @@ Item {
             keyClick(Qt.Key_Down)
             keyClick(Qt.Key_End)
             keyClick(Qt.Key_Return)
-            compare(moveSpy.count, 2)
+            compare(moveSpy.count, 1)
             compare(activateSpy.count, 1)
             verify(input.activeFocus)
+        }
+
+        function test_homeAndEndEditTheQuery() {
+            input.text = "calendar"
+            input.cursorPosition = 4
+
+            keyClick(Qt.Key_Home)
+            compare(input.cursorPosition, 0)
+            compare(moveSpy.count, 0)
+
+            keyClick(Qt.Key_End, Qt.ShiftModifier)
+            compare(input.selectionStart, 0)
+            compare(input.selectionEnd, input.text.length)
+            compare(moveSpy.count, 0)
         }
 
         function test_activeFocusKeepsNeutralFrame() {
@@ -726,7 +746,7 @@ Item {
             compare(resultDelegate.loadedItem.background.color.toString(), Style.listItemHoverBackground.toString())
 
             mousePress(resultDelegate.loadedItem)
-            compare(fakeSearchModel.openedProviderDetails, 1)
+            compare(fakeSearchModel.openedProviderDetails, 0)
             mouseRelease(resultDelegate.loadedItem)
             compare(fakeSearchModel.openedProviderDetails, 1)
         }
@@ -802,7 +822,7 @@ Item {
             compare(resultDelegate.loadedItem.background.color.toString(), Style.listItemHoverBackground.toString())
 
             mousePress(resultDelegate.loadedItem)
-            compare(fakeSearchModel.loadedPages, 1)
+            compare(fakeSearchModel.loadedPages, 0)
             mouseRelease(resultDelegate.loadedItem)
             compare(fakeSearchModel.loadedPages, 1)
         }
@@ -818,7 +838,7 @@ Item {
             compare(resultDelegate.loadedItem.height, 44)
 
             mousePress(resultDelegate.loadedItem)
-            compare(fakeSearchModel.retriedPages, 1)
+            compare(fakeSearchModel.retriedPages, 0)
             mouseRelease(resultDelegate.loadedItem)
             compare(fakeSearchModel.retriedPages, 1)
         }

--- a/test/qml/search/testsearch.qml
+++ b/test/qml/search/testsearch.qml
@@ -308,6 +308,40 @@ Item {
             model.destroy()
         }
 
+        function test_peopleQueryIsRestoredWhenPopupReopens() {
+            const model = windowSearchModel.createObject(this, {
+                peopleFilterAvailable: true
+            })
+            const searchWindow = productionSearchWindow.createObject(null, {
+                searchModel: model,
+                visible: true
+            })
+            const peopleButton = findChild(searchWindow, "peopleFilterButton")
+            const popupLoader = findChild(searchWindow, "peoplePopupLoader")
+
+            verify(peopleButton !== null)
+            verify(popupLoader !== null)
+            mouseClick(peopleButton)
+            tryCompare(popupLoader, "status", Loader.Ready)
+            let peopleSearch = findChild(popupLoader.item, "peopleSearchField")
+            verify(peopleSearch !== null)
+            peopleSearch.forceActiveFocus()
+            keyClick(Qt.Key_A)
+            compare(peopleSearch.text, "a")
+
+            popupLoader.item.close()
+            tryCompare(popupLoader, "active", false)
+            mouseClick(peopleButton)
+            tryCompare(popupLoader, "status", Loader.Ready)
+            peopleSearch = findChild(popupLoader.item, "peopleSearchField")
+            verify(peopleSearch !== null)
+            compare(peopleSearch.text, "a")
+
+            popupLoader.item.close()
+            searchWindow.destroy()
+            model.destroy()
+        }
+
         function test_detailHeaderCentersProviderAndShowsBackArrow() {
             const model = windowSearchModel.createObject(this, {
                 viewMode: UnifiedSearchResultsListModel.ProviderDetail,
@@ -577,7 +611,7 @@ Item {
 
         function test_activeFocusKeepsNeutralFrame() {
             verify(input.activeFocus)
-            compare(input.background.border.width, 1)
+            compare(input.background.border.width, Style.normalBorderWidth)
             compare(input.background.border.color, Style.wizardFieldBorder)
         }
 

--- a/test/testiconutils.cpp
+++ b/test/testiconutils.cpp
@@ -43,6 +43,13 @@ private Q_SLOTS:
 
         QVERIFY(!OCC::Ui::IconUtils::drawSvgWithCustomFillColor(blackSvgDirPath + QStringLiteral("/") + blackImages.at(0), QColorConstants::Svg::green).isNull());
 
+        const auto imageFromZeroWidthRequest = OCC::Ui::IconUtils::drawSvgWithCustomFillColor(
+            blackSvgDirPath + QStringLiteral("/") + blackImages.at(0),
+            QColorConstants::Svg::green,
+            nullptr,
+            QSize(0, 24));
+        QVERIFY(!imageFromZeroWidthRequest.isNull());
+
         const QString whiteSvgDirPath{QString{OCC::Theme::themePrefix} + QStringLiteral("white")};
         const QDir whiteSvgDir(whiteSvgDirPath);
         const QStringList whiteImages = whiteSvgDir.entryList(QStringList("*.svg"));

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -12,6 +12,7 @@
 
 #include <QAbstractItemModelTester>
 #include <QDesktopServices>
+#include <QMetaMethod>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -135,7 +136,7 @@ public:
     }
 
     // initialize the JSON response containing the fake list of providers and their properties
-    void initProvidersResponse(const QString &excludedProviderId = {})
+    void initProvidersResponse(const QString &excludedProviderId = {}, const QString &providerWithoutPersonFilter = {})
     {
         QList<QVariant> providersList;
 
@@ -143,17 +144,21 @@ public:
             if (fakeProviderInitInfo._id == excludedProviderId) {
                 continue;
             }
+            auto filters = QVariantMap{
+                {QStringLiteral("term"), QVariantMap{}},
+                {QStringLiteral("since"), QVariantMap{}},
+                {QStringLiteral("until"), QVariantMap{}},
+                {QStringLiteral("person"), QVariantMap{}},
+            };
+            if (fakeProviderInitInfo._id == providerWithoutPersonFilter) {
+                filters.remove(QStringLiteral("person"));
+            }
             providersList.push_back(QVariantMap{
                 {QStringLiteral("id"), fakeProviderInitInfo._id},
                 {QStringLiteral("appId"), fakeProviderInitInfo._id},
                 {QStringLiteral("name"), fakeProviderInitInfo._name},
                 {QStringLiteral("order"), fakeProviderInitInfo._order},
-                {QStringLiteral("filters"), QVariantMap{
-                    {QStringLiteral("term"), QVariantMap{}},
-                    {QStringLiteral("since"), QVariantMap{}},
-                    {QStringLiteral("until"), QVariantMap{}},
-                    {QStringLiteral("person"), QVariantMap{}},
-                }},
+                {QStringLiteral("filters"), filters},
             });
         }
 
@@ -424,6 +429,44 @@ private Q_SLOTS:
 
         fakeDesktopServicesUrlHandler.reset(new FakeDesktopServicesUrlHandler);
     }
+
+    void testQmlVoidActionsAreSlots()
+    {
+        auto slotNames = QSet<QByteArray>{};
+        const auto &metaObject = OCC::UnifiedSearchResultsListModel::staticMetaObject;
+        for (auto methodIndex = metaObject.methodOffset(); methodIndex < metaObject.methodCount(); ++methodIndex) {
+            const auto method = metaObject.method(methodIndex);
+            if (method.methodType() == QMetaMethod::Slot) {
+                slotNames.insert(method.name());
+            }
+        }
+
+        const auto expectedSlots = QList<QByteArray>{
+            QByteArrayLiteral("setSearchTerm"),
+            QByteArrayLiteral("resultClicked"),
+            QByteArrayLiteral("fetchMoreTriggerClicked"),
+            QByteArrayLiteral("toggleProviderFilter"),
+            QByteArrayLiteral("clearTypeFilters"),
+            QByteArrayLiteral("setDatePreset"),
+            QByteArrayLiteral("clearDateFilter"),
+            QByteArrayLiteral("setPersonFilter"),
+            QByteArrayLiteral("clearPersonFilter"),
+            QByteArrayLiteral("removeFilter"),
+            QByteArrayLiteral("setExternalProvidersEnabled"),
+            QByteArrayLiteral("openProviderDetail"),
+            QByteArrayLiteral("closeProviderDetail"),
+            QByteArrayLiteral("loadMore"),
+            QByteArrayLiteral("retryLoadMore"),
+            QByteArrayLiteral("retryFailedProviders"),
+            QByteArrayLiteral("retry"),
+            QByteArrayLiteral("moveSelection"),
+            QByteArrayLiteral("activateSelected"),
+        };
+        for (const auto &slotName : expectedSlots) {
+            QVERIFY2(slotNames.contains(slotName), slotName.constData());
+        }
+    }
+
     void testSetSearchTermStartStopSearch()
     {
         // make sure the model is empty
@@ -931,6 +974,60 @@ private Q_SLOTS:
         QCOMPARE(model->searchState(), OCC::UnifiedSearchResultsListModel::SearchState::SearchError);
 
         model->setSearchTerm(QStringLiteral(""));
+    }
+
+    void testProviderDetailPreservesPartialMatchState()
+    {
+        model->setSearchTerm(QString());
+        model->closeProviderDetail();
+        model->clearTypeFilters();
+        model->clearDateFilter();
+        model->clearPersonFilter();
+
+        accountState->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        FakeSearchResultsStorage::instance()->initProvidersResponse({}, QStringLiteral("mail"));
+        accountState->setStateForTesting(OCC::AccountState::Connected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QTRY_VERIFY_WITH_TIMEOUT(model->providersReady(), 1000);
+        FakeSearchResultsStorage::instance()->initProvidersResponse();
+
+        model->setPersonFilter(QStringLiteral("ada"), QStringLiteral("Ada Lovelace"));
+        model->setSearchTerm(QStringLiteral("partial detail"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->isSearchInProgress() && !model->waitingForSearchTermEditEnd(), 2000);
+
+        model->openProviderDetail(QStringLiteral("mail"));
+        QCOMPARE(model->viewMode(), OCC::UnifiedSearchResultsListModel::ViewMode::ProviderDetail);
+        auto resultCount = 0;
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            if (model->data(index, OCC::UnifiedSearchResultsListModel::TypeRole).toInt() != OCC::UnifiedSearchResult::Type::Default) {
+                continue;
+            }
+            ++resultCount;
+            QVERIFY(model->data(index, OCC::UnifiedSearchResultsListModel::PartialMatchRole).toBool());
+        }
+        QVERIFY(resultCount > 0);
+
+        const auto rowsBeforePaging = model->rowCount();
+        model->loadMore(QStringLiteral("mail"));
+        QTRY_VERIFY_WITH_TIMEOUT(model->currentFetchMoreInProgressProviderId().isEmpty(), 1000);
+        QVERIFY(model->rowCount() > rowsBeforePaging);
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            if (model->data(index, OCC::UnifiedSearchResultsListModel::TypeRole).toInt() == OCC::UnifiedSearchResult::Type::Default) {
+                QVERIFY(model->data(index, OCC::UnifiedSearchResultsListModel::PartialMatchRole).toBool());
+            }
+        }
+
+        model->setSearchTerm(QString());
+        model->closeProviderDetail();
+        model->clearPersonFilter();
+        accountState->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        accountState->setStateForTesting(OCC::AccountState::Connected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QTRY_VERIFY_WITH_TIMEOUT(model->providersReady(), 1000);
     }
 
     void testDisconnectAndRediscoveryResetProviderState()

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -11,6 +11,7 @@
 #include "testhelper.h"
 
 #include <QAbstractItemModelTester>
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QMetaMethod>
 #include <QSignalSpy>
@@ -136,7 +137,7 @@ public:
     }
 
     // initialize the JSON response containing the fake list of providers and their properties
-    void initProvidersResponse(const QString &excludedProviderId = {}, const QString &providerWithoutPersonFilter = {})
+    void initProvidersResponse(const QString &excludedProviderId = {}, const QString &providerWithoutPersonFilter = {}, const QString &externalProviderId = {})
     {
         QList<QVariant> providersList;
 
@@ -159,6 +160,7 @@ public:
                 {QStringLiteral("name"), fakeProviderInitInfo._name},
                 {QStringLiteral("order"), fakeProviderInitInfo._order},
                 {QStringLiteral("filters"), filters},
+                {QStringLiteral("isExternalProvider"), fakeProviderInitInfo._id == externalProviderId},
             });
         }
 
@@ -496,6 +498,32 @@ private Q_SLOTS:
         QVERIFY(!model->isSearchInProgress());
     }
 
+    void testSearchTermNotifiesProgressDuringProviderDiscovery()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto slowAccount = OCC::Account::create();
+        slowAccount->setCredentials(new FakeCredentials(qnam.get()));
+        slowAccount->setUrl(QUrl(QStringLiteral("http://example.de")));
+        auto slowAccountState = std::make_unique<FakeAccountState>(slowAccount);
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            return static_cast<QNetworkReply *>(
+                new FakePayloadReply(operation, request, FakeSearchResultsStorage::instance()->fakeProvidersResponseJson(), 1000, qnam.get()));
+        });
+
+        OCC::UnifiedSearchResultsListModel slowModel(slowAccountState.get(), 0);
+        QCoreApplication::processEvents();
+        QVERIFY(!slowModel.providersReady());
+        QSignalSpy progressChanged(&slowModel, &OCC::UnifiedSearchResultsListModel::isSearchInProgressChanged);
+
+        slowModel.setSearchTerm(QStringLiteral("query"));
+        QVERIFY(slowModel.isSearchInProgress());
+        QCOMPARE(progressChanged.count(), 1);
+
+        slowModel.setSearchTerm(QString());
+        QVERIFY(!slowModel.isSearchInProgress());
+        QCOMPARE(progressChanged.count(), 2);
+    }
+
     void testSetSearchTermResultsFound()
     {
         // make sure the model is empty
@@ -788,6 +816,35 @@ private Q_SLOTS:
         model->clearTypeFilters();
         model->clearDateFilter();
         model->clearPersonFilter();
+    }
+
+    void testConnectedServicesActionIsHiddenWithProviderFilter()
+    {
+        model->setSearchTerm(QString());
+        model->clearTypeFilters();
+
+        accountState->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        FakeSearchResultsStorage::instance()->initProvidersResponse({}, {}, QStringLiteral("mail"));
+        accountState->setStateForTesting(OCC::AccountState::Connected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QTRY_VERIFY_WITH_TIMEOUT(model->providersReady(), 1000);
+
+        model->setSearchTerm(QStringLiteral("connected services"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->isSearchInProgress() && !model->waitingForSearchTermEditEnd(), 2000);
+        QVERIFY(model->showConnectedServicesAction());
+
+        model->toggleProviderFilter(QStringLiteral("files"));
+        QVERIFY(!model->showConnectedServicesAction());
+
+        model->setSearchTerm(QString());
+        model->clearTypeFilters();
+        accountState->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        FakeSearchResultsStorage::instance()->initProvidersResponse();
+        accountState->setStateForTesting(OCC::AccountState::Connected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QTRY_VERIFY_WITH_TIMEOUT(model->providersReady(), 1000);
     }
 
     void testSearchResultlicked()

--- a/test/testunifiedsearchlistmodel.cpp
+++ b/test/testunifiedsearchlistmodel.cpp
@@ -8,6 +8,7 @@
 #include "account.h"
 #include "accountstate.h"
 #include "syncenginetestutils.h"
+#include "testhelper.h"
 
 #include <QAbstractItemModelTester>
 #include <QDesktopServices>
@@ -134,15 +135,25 @@ public:
     }
 
     // initialize the JSON response containing the fake list of providers and their properties
-    void initProvidersResponse()
+    void initProvidersResponse(const QString &excludedProviderId = {})
     {
         QList<QVariant> providersList;
 
         for (const auto &fakeProviderInitInfo : fakeProvidersInitInfo) {
+            if (fakeProviderInitInfo._id == excludedProviderId) {
+                continue;
+            }
             providersList.push_back(QVariantMap{
                 {QStringLiteral("id"), fakeProviderInitInfo._id},
+                {QStringLiteral("appId"), fakeProviderInitInfo._id},
                 {QStringLiteral("name"), fakeProviderInitInfo._name},
                 {QStringLiteral("order"), fakeProviderInitInfo._order},
+                {QStringLiteral("filters"), QVariantMap{
+                    {QStringLiteral("term"), QVariantMap{}},
+                    {QStringLiteral("since"), QVariantMap{}},
+                    {QStringLiteral("until"), QVariantMap{}},
+                    {QStringLiteral("person"), QVariantMap{}},
+                }},
             });
         }
 
@@ -242,6 +253,65 @@ public:
                 .toJson(QJsonDocument::Compact);
         }
 
+        if (searchTerm == QStringLiteral("[app-icons]")) {
+            auto entries = QVariantList{};
+            if (providerId == QStringLiteral("settings_apps")) {
+                const auto titles = QStringList{
+                    QStringLiteral("Dashboard"),
+                    QStringLiteral("Talk"),
+                    QStringLiteral("Activity"),
+                    QStringLiteral("Unknown app"),
+                };
+                for (const auto &title : titles) {
+                    entries.push_back(QVariantMap{
+                        {QStringLiteral("thumbnailUrl"), QString()},
+                        {QStringLiteral("title"), title},
+                        {QStringLiteral("subline"), QString()},
+                        {QStringLiteral("resourceUrl"), QStringLiteral("http://example.de/index.php/apps/dashboard/")},
+                        {QStringLiteral("icon"), QStringLiteral("icon-arrow-right")},
+                        {QStringLiteral("rounded"), false},
+                    });
+                }
+            }
+            const auto dataMap = QVariantMap{
+                {QStringLiteral("name"), _searchResultsData[providerId]._name},
+                {QStringLiteral("isPaginated"), false},
+                {QStringLiteral("cursor"), QVariant()},
+                {QStringLiteral("entries"), entries},
+            };
+            const auto ocsMap = QVariantMap{{QStringLiteral("meta"), _metaSuccess}, {QStringLiteral("data"), dataMap}};
+            return QJsonDocument::fromVariant(QVariantMap{{QStringLiteral("ocs"), ocsMap}}).toJson(QJsonDocument::Compact);
+        }
+
+        if (searchTerm == QStringLiteral("[small-page]")) {
+            auto entries = resultsForProvider(providerId, 0);
+            while (entries.size() > 2) {
+                entries.removeLast();
+            }
+            const QVariantMap dataMap = {{QStringLiteral("name"), _searchResultsData[providerId]._name},
+                {QStringLiteral("isPaginated"), true}, {QStringLiteral("cursor"), cursor + entries.size()},
+                {QStringLiteral("entries"), entries}};
+            const QVariantMap ocsMap = {{QStringLiteral("meta"), _metaSuccess}, {QStringLiteral("data"), dataMap}};
+            return QJsonDocument::fromVariant(QVariantMap{{QStringLiteral("ocs"), ocsMap}})
+                .toJson(QJsonDocument::Compact);
+        }
+
+        if (searchTerm == QStringLiteral("[oversized-page]")) {
+            auto entries = QList<QVariant>();
+            const auto availableEntries = resultsForProvider(providerId, 0);
+            if (!availableEntries.isEmpty()) {
+                for (auto index = 0; index < 25; ++index) {
+                    entries.push_back(availableEntries.constFirst());
+                }
+            }
+            const QVariantMap dataMap = {{QStringLiteral("name"), _searchResultsData[providerId]._name},
+                {QStringLiteral("isPaginated"), false}, {QStringLiteral("cursor"), QVariant()},
+                {QStringLiteral("entries"), entries}};
+            const QVariantMap ocsMap = {{QStringLiteral("meta"), _metaSuccess}, {QStringLiteral("data"), dataMap}};
+            return QJsonDocument::fromVariant(QVariantMap{{QStringLiteral("ocs"), ocsMap}})
+                .toJson(QJsonDocument::Compact);
+        }
+
         const auto provider = _searchResultsData.value(providerId, Provider());
 
         const auto nextCursor = cursor + pageSize;
@@ -283,9 +353,10 @@ public:
 
     QScopedPointer<FakeQNAM> fakeQnam;
     OCC::AccountPtr account;
-    QScopedPointer<OCC::AccountState> accountState;
+    QScopedPointer<FakeAccountState> accountState;
     QScopedPointer<OCC::UnifiedSearchResultsListModel> model;
     QScopedPointer<QAbstractItemModelTester> modelTester;
+    QList<QUrl> requestedUrls;
 
     QScopedPointer<FakeDesktopServicesUrlHandler> fakeDesktopServicesUrlHandler;
 
@@ -304,10 +375,11 @@ private Q_SLOTS:
         account->setCredentials(new FakeCredentials{fakeQnam.data()});
         account->setUrl(QUrl(("http://example.de")));
 
-        accountState.reset(new OCC::AccountState(account));
+        accountState.reset(new FakeAccountState(account));
 
         fakeQnam->setOverride([this](QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *device) {
             Q_UNUSED(device);
+            requestedUrls.push_back(req.url());
             QNetworkReply *reply = nullptr;
 
             const auto urlQuery = QUrlQuery(req.url());
@@ -370,15 +442,10 @@ private Q_SLOTS:
         QCOMPARE(model->searchTerm(), QStringLiteral("discuss"));
         QCOMPARE(searhTermChanged.count(), 1);
 
-        // #3 test that model has not started search yet
         QVERIFY(!model->isSearchInProgress());
 
-        
-        // #4 test that model has started the search after specific delay
         QSignalSpy searchInProgressChanged(model.data(), &OCC::UnifiedSearchResultsListModel::isSearchInProgressChanged);
-        // allow search jobs to get created within the model
         QVERIFY(searchInProgressChanged.wait());
-        QCOMPARE(searchInProgressChanged.count(), 1);
         QVERIFY(model->isSearchInProgress());
 
         // #5 test that model has stopped the search after setting empty search term
@@ -395,21 +462,8 @@ private Q_SLOTS:
         // test that search term gets set, search gets started and enough results get returned
         model->setSearchTerm(model->searchTerm() + QStringLiteral("discuss"));
 
-        QSignalSpy searchInProgressChanged(
-            model.data(), &OCC::UnifiedSearchResultsListModel::isSearchInProgressChanged);
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has started
-        QCOMPARE(searchInProgressChanged.count(), 1);
-        QVERIFY(model->isSearchInProgress());
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has finished
-        QVERIFY(!model->isSearchInProgress());
-
-        QVERIFY(model->rowCount() > 0);
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
     }
 
     void testSetSearchTermResultsNotFound()
@@ -421,21 +475,9 @@ private Q_SLOTS:
         // test that search term gets set, search gets started and enough results get returned
         model->setSearchTerm(model->searchTerm() + QStringLiteral("[empty]"));
 
-        QSignalSpy searchInProgressChanged(
-            model.data(), &OCC::UnifiedSearchResultsListModel::isSearchInProgressChanged);
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has started
-        QCOMPARE(searchInProgressChanged.count(), 1);
-        QVERIFY(model->isSearchInProgress());
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has finished
-        QVERIFY(!model->isSearchInProgress());
-
-        QVERIFY(model->rowCount() == 0);
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress(), 2000);
+        QCOMPARE(model->rowCount(), 0);
     }
 
     void testFetchMoreClicked()
@@ -460,12 +502,30 @@ private Q_SLOTS:
         // make sure search has finished
         QVERIFY(!model->isSearchInProgress());
 
+        QString providerIdFetchMoreTriggered;
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            if (model->data(model->index(row), OCC::UnifiedSearchResultsListModel::TypeRole)
+                    == OCC::UnifiedSearchResult::Type::ProviderHeader
+                && model->data(model->index(row), OCC::UnifiedSearchResultsListModel::HasOverflowRole).toBool()) {
+                providerIdFetchMoreTriggered = model->data(model->index(row), OCC::UnifiedSearchResultsListModel::ProviderIdRole).toString();
+                break;
+            }
+        }
+        QVERIFY(!providerIdFetchMoreTriggered.isEmpty());
+        model->openProviderDetail(providerIdFetchMoreTriggered);
+        QCOMPARE(model->viewMode(), OCC::UnifiedSearchResultsListModel::ViewMode::ProviderDetail);
         const auto numRowsInModelPrev = model->rowCount();
+        QStringList stableKeysBeforePaging;
+        for (auto row = 0; row < numRowsInModelPrev - 1; ++row) {
+            stableKeysBeforePaging.push_back(model->data(model->index(row),
+                OCC::UnifiedSearchResultsListModel::StableKeyRole).toString());
+        }
+        QSignalSpy modelReset(model.data(), &QAbstractItemModel::modelReset);
+        QSignalSpy rowsInserted(model.data(), &QAbstractItemModel::rowsInserted);
+        QSignalSpy rowsRemoved(model.data(), &QAbstractItemModel::rowsRemoved);
 
-        // test fetch more results
         QSignalSpy currentFetchMoreInProgressProviderIdChanged(
             model.data(), &OCC::UnifiedSearchResultsListModel::currentFetchMoreInProgressProviderIdChanged);
-        QSignalSpy rowsInserted(model.data(), &OCC::UnifiedSearchResultsListModel::rowsInserted);
         for (int i = 0; i < model->rowCount(); ++i) {
             const auto type = model->data(model->index(i), OCC::UnifiedSearchResultsListModel::DataRole::TypeRole);
 
@@ -479,47 +539,24 @@ private Q_SLOTS:
         }
 
         // make sure the currentFetchMoreInProgressProviderId was set back and forth and correct number fows has been inserted
-        QCOMPARE(currentFetchMoreInProgressProviderIdChanged.count(), 1);
-
-        const auto providerIdFetchMoreTriggered = model->currentFetchMoreInProgressProviderId();
-
-        QVERIFY(!providerIdFetchMoreTriggered.isEmpty());
-
-        QVERIFY(currentFetchMoreInProgressProviderIdChanged.wait());
-
-        QVERIFY(model->currentFetchMoreInProgressProviderId().isEmpty());
-
-        QCOMPARE(rowsInserted.count(), 1);
-
-        const auto arguments = rowsInserted.takeFirst();
-
-        QVERIFY(arguments.size() > 0);
-
-        const auto first = arguments.at(0).toInt();
-        const auto last = arguments.at(1).toInt();
-
-        const int numInsertedExpected = last - first;
-
-        QCOMPARE(model->rowCount() - numRowsInModelPrev, numInsertedExpected);
+        QVERIFY(currentFetchMoreInProgressProviderIdChanged.count() > 0);
+        QTRY_VERIFY_WITH_TIMEOUT(model->currentFetchMoreInProgressProviderId().isEmpty(), 1000);
+        QVERIFY(model->rowCount() > numRowsInModelPrev);
+        QCOMPARE(modelReset.count(), 0);
+        QVERIFY(rowsInserted.count() > 0);
+        QCOMPARE(rowsRemoved.count(), 0);
+        for (auto row = 0; row < stableKeysBeforePaging.size(); ++row) {
+            QCOMPARE(model->data(model->index(row), OCC::UnifiedSearchResultsListModel::StableKeyRole).toString(),
+                stableKeysBeforePaging[row]);
+        }
 
         // make sure the FetchMoreTrigger gets removed when no more results available
         if (!providerIdFetchMoreTriggered.isEmpty()) {
             currentFetchMoreInProgressProviderIdChanged.clear();
-            rowsInserted.clear();
-
-            QSignalSpy rowsRemoved(model.data(), &OCC::UnifiedSearchResultsListModel::rowsRemoved);
-
             for (int i = 0; i < 10; ++i) {
                 model->fetchMoreTriggerClicked(providerIdFetchMoreTriggered);
-
-                QVERIFY(currentFetchMoreInProgressProviderIdChanged.wait());
-
-                if (rowsRemoved.count() > 0) {
-                    break;
-                }
+                QTRY_VERIFY_WITH_TIMEOUT(model->currentFetchMoreInProgressProviderId().isEmpty(), 1000);
             }
-            
-            QCOMPARE(rowsRemoved.count(), 1);
 
             bool isFetchMoreTriggerFound = false;
 
@@ -538,6 +575,178 @@ private Q_SLOTS:
         }
     }
 
+    void testSmallPaginatedFirstPageCanOpenAndLoadMore()
+    {
+        model->setSearchTerm(QStringLiteral("[small-page]"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
+
+        auto providerId = QString();
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            if (model->data(index, OCC::UnifiedSearchResultsListModel::TypeRole).toInt()
+                    == OCC::UnifiedSearchResult::Type::ProviderHeader
+                && model->data(index, OCC::UnifiedSearchResultsListModel::HasOverflowRole).toBool()) {
+                providerId = model->data(index, OCC::UnifiedSearchResultsListModel::ProviderIdRole).toString();
+                break;
+            }
+        }
+        QVERIFY(!providerId.isEmpty());
+
+        model->openProviderDetail(providerId);
+        QCOMPARE(model->viewMode(), OCC::UnifiedSearchResultsListModel::ViewMode::ProviderDetail);
+        const auto rowsBeforeLoading = model->rowCount();
+        QVERIFY(rowsBeforeLoading <= 3);
+        model->loadMore(providerId);
+        QTRY_VERIFY_WITH_TIMEOUT(model->currentFetchMoreInProgressProviderId().isEmpty(), 1000);
+        QVERIFY(model->rowCount() > rowsBeforeLoading);
+    }
+
+    void testNonConformingProviderPageIsCapped()
+    {
+        model->setSearchTerm(QStringLiteral("[oversized-page]"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
+
+        auto providerId = QString();
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            if (model->data(index, OCC::UnifiedSearchResultsListModel::TypeRole).toInt()
+                == OCC::UnifiedSearchResult::Type::ProviderHeader) {
+                providerId = model->data(index, OCC::UnifiedSearchResultsListModel::ProviderIdRole).toString();
+                break;
+            }
+        }
+        QVERIFY(!providerId.isEmpty());
+        model->openProviderDetail(providerId);
+        QCOMPARE(model->viewMode(), OCC::UnifiedSearchResultsListModel::ViewMode::ProviderDetail);
+        QCOMPARE(model->rowCount(), 10);
+    }
+
+    void testAggregateProjectionAndKeyboardSelection()
+    {
+        model->setSearchTerm(QStringLiteral("projection"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
+
+        QHash<QString, int> resultsByProvider;
+        auto loadMoreFound = false;
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            const auto type = model->data(index, OCC::UnifiedSearchResultsListModel::TypeRole).toInt();
+            if (type == OCC::UnifiedSearchResult::Type::Default) {
+                ++resultsByProvider[model->data(index, OCC::UnifiedSearchResultsListModel::ProviderIdRole).toString()];
+            } else if (type == OCC::UnifiedSearchResult::Type::FetchMoreTrigger) {
+                loadMoreFound = true;
+            }
+        }
+        for (const auto count : std::as_const(resultsByProvider)) QVERIFY(count <= 3);
+        QVERIFY(!loadMoreFound);
+        QVERIFY(model->selectedRow() >= 0);
+        const auto firstSelected = model->selectedRow();
+        model->moveSelection(OCC::UnifiedSearchResultsListModel::SelectionDirection::Next);
+        QVERIFY(model->selectedRow() >= firstSelected);
+        model->moveSelection(OCC::UnifiedSearchResultsListModel::SelectionDirection::Last);
+        const auto lastSelected = model->selectedRow();
+        model->moveSelection(OCC::UnifiedSearchResultsListModel::SelectionDirection::Next);
+        QCOMPARE(model->selectedRow(), lastSelected);
+    }
+
+    void testAppsProviderUsesNavigationAppIcons()
+    {
+        const auto navigationApps = QVariantList{
+            QVariantMap{{QStringLiteral("name"), QStringLiteral("Dashboard")},
+                        {QStringLiteral("href"), QStringLiteral("http://example.de/index.php/apps/dashboard/")},
+                        {QStringLiteral("id"), QStringLiteral("dashboard")},
+                        {QStringLiteral("icon"), QStringLiteral("http://example.de/apps/dashboard/img/app.svg")}},
+            QVariantMap{{QStringLiteral("name"), QStringLiteral("Talk")},
+                        {QStringLiteral("href"), QStringLiteral("http://example.de/call/")},
+                        {QStringLiteral("id"), QStringLiteral("spreed")},
+                        {QStringLiteral("icon"), QStringLiteral("http://example.de/apps/spreed/img/app.svg")}},
+            QVariantMap{{QStringLiteral("name"), QStringLiteral("Activity")},
+                        {QStringLiteral("href"), QStringLiteral("http://example.de/index.php/apps/activity/")},
+                        {QStringLiteral("id"), QStringLiteral("activity")},
+                        {QStringLiteral("icon"), QStringLiteral("http://example.de/apps/activity/img/app.svg")}},
+        };
+        const auto navigationResponse = QJsonDocument::fromVariant(QVariantMap{
+            {QStringLiteral("ocs"), QVariantMap{{QStringLiteral("data"), navigationApps}}},
+        });
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(),
+                                          "slotNavigationAppsFetched",
+                                          Qt::DirectConnection,
+                                          Q_ARG(QJsonDocument, navigationResponse),
+                                          Q_ARG(int, 200)));
+
+        model->setSearchTerm(QString());
+        model->closeProviderDetail();
+        model->clearTypeFilters();
+        model->clearDateFilter();
+        model->clearPersonFilter();
+        model->setSearchTerm(QStringLiteral("[app-icons]"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
+
+        model->openProviderDetail(QStringLiteral("settings_apps"));
+        QCOMPARE(model->rowCount(), 4);
+
+        const auto expectedIconUrls = QHash<QString, QString>{
+            {QStringLiteral("Dashboard"), QStringLiteral("http://example.de/apps/dashboard/img/app.svg")},
+            {QStringLiteral("Talk"), QStringLiteral("http://example.de/apps/spreed/img/app.svg")},
+            {QStringLiteral("Activity"), QStringLiteral("http://example.de/apps/activity/img/app.svg")},
+        };
+        for (auto row = 0; row < model->rowCount(); ++row) {
+            const auto index = model->index(row);
+            const auto title = model->data(index, OCC::UnifiedSearchResultsListModel::TitleRole).toString();
+            if (expectedIconUrls.contains(title)) {
+                QCOMPARE(model->data(index, OCC::UnifiedSearchResultsListModel::DarkIconsRole).toString(),
+                         expectedIconUrls.value(title) + QStringLiteral("/white"));
+                QCOMPARE(model->data(index, OCC::UnifiedSearchResultsListModel::LightIconsRole).toString(),
+                         expectedIconUrls.value(title) + QStringLiteral("/black"));
+            } else if (title == QStringLiteral("Unknown app")) {
+                QVERIFY(model->data(index, OCC::UnifiedSearchResultsListModel::DarkIconsRole)
+                            .toString()
+                            .endsWith(QStringLiteral("change.svg")));
+                QVERIFY(model->data(index, OCC::UnifiedSearchResultsListModel::LightIconsRole)
+                            .toString()
+                            .endsWith(QStringLiteral("change.svg")));
+            }
+        }
+    }
+
+    void testFiltersAndRequestParameters()
+    {
+        model->setSearchTerm(QString());
+        model->clearTypeFilters();
+        model->clearDateFilter();
+        model->clearPersonFilter();
+        requestedUrls.clear();
+
+        model->toggleProviderFilter(QStringLiteral("files"));
+        model->setDatePreset(QStringLiteral("last7days"));
+        model->setPersonFilter(QStringLiteral("ada"), QStringLiteral("Ada Lovelace"));
+        model->setSearchTerm(QStringLiteral("filtered"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model->isSearchInProgress() && !model->waitingForSearchTermEditEnd(), 2000);
+
+        QList<QUrl> searchRequests;
+        for (const auto &url : std::as_const(requestedUrls)) {
+            if (url.path().endsWith(QStringLiteral("/search"))) searchRequests.push_back(url);
+        }
+        QCOMPARE(searchRequests.size(), 1);
+        QVERIFY(searchRequests.constFirst().path().contains(QStringLiteral("/files/search")));
+        const QUrlQuery query(searchRequests.constFirst());
+        QCOMPARE(query.queryItemValue(QStringLiteral("term")), QStringLiteral("filtered"));
+        QCOMPARE(query.queryItemValue(QStringLiteral("limit")), QStringLiteral("10"));
+        QCOMPARE(query.queryItemValue(QStringLiteral("person")), QStringLiteral("ada"));
+        QVERIFY(!query.queryItemValue(QStringLiteral("since")).isEmpty());
+        QVERIFY(!query.queryItemValue(QStringLiteral("until")).isEmpty());
+        QVERIFY(!query.hasQueryItem(QStringLiteral("from")));
+
+        model->setSearchTerm(QString());
+        model->clearTypeFilters();
+        model->clearDateFilter();
+        model->clearPersonFilter();
+    }
+
     void testSearchResultlicked()
     {
         // make sure the model is empty
@@ -547,21 +756,8 @@ private Q_SLOTS:
         // test that search term gets set, search gets started and enough results get returned
         model->setSearchTerm(model->searchTerm() + QStringLiteral("discuss"));
 
-        QSignalSpy searchInProgressChanged(
-            model.data(), &OCC::UnifiedSearchResultsListModel::isSearchInProgressChanged);
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has started
-        QCOMPARE(searchInProgressChanged.count(), 1);
-        QVERIFY(model->isSearchInProgress());
-
-        QVERIFY(searchInProgressChanged.wait());
-
-        // make sure search has finished and some results has been received
-        QVERIFY(!model->isSearchInProgress());
-
-        QVERIFY(model->rowCount() != 0);
+        QTRY_VERIFY_WITH_TIMEOUT(!model->waitingForSearchTermEditEnd()
+            && !model->isSearchInProgress() && model->rowCount() > 0, 2000);
 
         QDesktopServices::setUrlHandler("http", fakeDesktopServicesUrlHandler.data(), "resultClicked");
         QDesktopServices::setUrlHandler("https", fakeDesktopServicesUrlHandler.data(), "resultClicked");
@@ -735,6 +931,32 @@ private Q_SLOTS:
         QCOMPARE(model->searchState(), OCC::UnifiedSearchResultsListModel::SearchState::SearchError);
 
         model->setSearchTerm(QStringLiteral(""));
+    }
+
+    void testDisconnectAndRediscoveryResetProviderState()
+    {
+        model->setSearchTerm(QString());
+        model->clearTypeFilters();
+        QVERIFY(model->providersReady());
+        model->toggleProviderFilter(QStringLiteral("files"));
+        QCOMPARE(model->activeFilters().size(), 1);
+        QSignalSpy providersReadyChanged(model.data(), &OCC::UnifiedSearchResultsListModel::providersReadyChanged);
+
+        accountState->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QCOMPARE(model->providersReady(), false);
+        QVERIFY(providersReadyChanged.count() > 0);
+
+        FakeSearchResultsStorage::instance()->initProvidersResponse(QStringLiteral("files"));
+        accountState->setStateForTesting(OCC::AccountState::Connected);
+        QVERIFY(QMetaObject::invokeMethod(accountState.data(), "isConnectedChanged", Qt::DirectConnection));
+        QTRY_VERIFY_WITH_TIMEOUT(model->providersReady(), 1000);
+        QCOMPARE(model->activeFilters().size(), 0);
+        for (const auto &providerValue : model->providers()) {
+            QVERIFY(providerValue.toMap().value(QStringLiteral("id")).toString() != QStringLiteral("files"));
+        }
+
+        FakeSearchResultsStorage::instance()->initProvidersResponse();
     }
 
     void cleanupTestCase()

--- a/test/testunifiedsearchpeoplemodel.cpp
+++ b/test/testunifiedsearchpeoplemodel.cpp
@@ -1,0 +1,202 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "gui/search/unifiedsearchpeoplemodel.h"
+
+#include "account.h"
+#include "accountstate.h"
+#include "syncenginetestutils.h"
+#include "testhelper.h"
+
+#include <QAbstractItemModelTester>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSignalSpy>
+#include <QTest>
+#include <QUrlQuery>
+
+#include <memory>
+
+namespace {
+const auto response = QByteArrayLiteral(R"({"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"exact":{"users":[{"label":"Ada Lovelace","value":{"shareWith":"ada","shareType":0}}]},"users":[{"label":"Ada duplicate","value":{"shareWith":"ada","shareType":0}},{"label":"Alan Turing","value":{"shareWith":"alan","shareType":0}}]}}})");
+const auto errorResponse = QByteArrayLiteral(R"({"ocs":{"meta":{"status":"failure","statuscode":500,"message":"Failure"},"data":{}}})");
+}
+
+class TestUnifiedSearchPeopleModel : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void retryIsExposedAsSlot()
+    {
+        const auto methodIndex = OCC::UnifiedSearchPeopleModel::staticMetaObject.indexOfSlot("retry()");
+        QVERIFY(methodIndex >= 0);
+    }
+
+    void emptyQueryShowsSignedInUserWithoutRequest()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setDavUser(QStringLiteral("current-user"));
+        auto state = std::make_unique<FakeAccountState>(account);
+        auto requestCount = 0;
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            ++requestCount;
+            return static_cast<QNetworkReply *>(new FakePayloadReply(operation, request, response, qnam.get()));
+        });
+
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        QAbstractItemModelTester tester(&model);
+        model.setAccountState(state.get());
+
+        QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 1, 1000);
+        QCOMPARE(requestCount, 0);
+        QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("current-user"));
+        QVERIFY(model.errorString().isEmpty());
+    }
+
+    void parsesUsersAndUsesDocumentedParameters()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setDavUser(QStringLiteral("me"));
+        auto state = std::make_unique<FakeAccountState>(account);
+        QUrl requestedUrl;
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            requestedUrl = request.url();
+            return static_cast<QNetworkReply *>(new FakePayloadReply(operation, request, response, qnam.get()));
+        });
+
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        QAbstractItemModelTester tester(&model);
+        model.setAccountState(state.get());
+        model.setSearchTerm(QStringLiteral("a"));
+        QTRY_VERIFY_WITH_TIMEOUT(!model.busy() && model.rowCount() == 2, 1000);
+
+        QCOMPARE(requestedUrl.path(), QStringLiteral("/ocs/v2.php/apps/files_sharing/api/v1/sharees"));
+        const QUrlQuery query(requestedUrl);
+        QCOMPARE(query.queryItemValue(QStringLiteral("shareType")), QStringLiteral("0"));
+        QCOMPARE(query.queryItemValue(QStringLiteral("lookup")), QStringLiteral("false"));
+        QCOMPARE(query.queryItemValue(QStringLiteral("page")), QStringLiteral("1"));
+        QCOMPARE(query.queryItemValue(QStringLiteral("perPage")), QStringLiteral("50"));
+        QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("ada"));
+        QCOMPARE(model.data(model.index(1), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("alan"));
+        QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::AvatarUrlRole).toString(),
+            QStringLiteral("https://cloud.example.test/index.php/avatar/ada/64"));
+    }
+
+    void injectsMatchingSignedInUser()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setDavUser(QStringLiteral("current-user"));
+        auto state = std::make_unique<FakeAccountState>(account);
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            return static_cast<QNetworkReply *>(new FakePayloadReply(operation, request, QByteArrayLiteral(R"({"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":{"exact":{"users":[]},"users":[]}}})"), qnam.get()));
+        });
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        model.setAccountState(state.get());
+        model.setSearchTerm(QStringLiteral("current"));
+        QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 1, 1000);
+        QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("current-user"));
+    }
+
+    void queryReplacementAndFailureClearOldPeople()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setDavUser(QStringLiteral("me"));
+        auto state = std::make_unique<FakeAccountState>(account);
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            const auto query = QUrlQuery(request.url()).queryItemValue(QStringLiteral("search"));
+            if (query == QStringLiteral("broken")) {
+                return static_cast<QNetworkReply *>(new FakeErrorReply(operation, request, qnam.get(), 500, errorResponse));
+            }
+            return static_cast<QNetworkReply *>(new FakePayloadReply(operation, request, response, qnam.get()));
+        });
+
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        QAbstractItemModelTester tester(&model);
+        model.setAccountState(state.get());
+        model.setSearchTerm(QStringLiteral("a"));
+        QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 2, 1000);
+
+        model.setSearchTerm(QStringLiteral("broken"));
+        QCOMPARE(model.rowCount(), 0);
+        QTRY_VERIFY_WITH_TIMEOUT(!model.busy() && !model.errorString().isEmpty(), 1000);
+        QCOMPARE(model.rowCount(), 0);
+    }
+
+    void accountDestructionClearsPeopleAndPointer()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setDavUser(QStringLiteral("current-user"));
+        auto state = std::make_unique<FakeAccountState>(account);
+
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        QAbstractItemModelTester tester(&model);
+        model.setAccountState(state.get());
+        QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 1, 1000);
+
+        state->setStateForTesting(OCC::AccountState::Disconnected);
+        QVERIFY(QMetaObject::invokeMethod(state.get(), "isConnectedChanged", Qt::DirectConnection));
+        QCOMPARE(model.rowCount(), 0);
+        QVERIFY(!model.errorString().isEmpty());
+
+        state.reset();
+        QCOMPARE(model.accountState(), nullptr);
+        QCOMPARE(model.rowCount(), 0);
+        QVERIFY(!model.errorString().isEmpty());
+    }
+
+    void capsNonConformingResponses()
+    {
+        auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
+        auto account = OCC::Account::create();
+        account->setCredentials(new FakeCredentials(qnam.get()));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        auto state = std::make_unique<FakeAccountState>(account);
+
+        auto users = QJsonArray();
+        for (auto index = 0; index < 75; ++index) {
+            users.push_back(QJsonObject{
+                {QStringLiteral("label"), QStringLiteral("User %1").arg(index)},
+                {QStringLiteral("value"), QJsonObject{{QStringLiteral("shareWith"), QStringLiteral("user-%1").arg(index)}}},
+            });
+        }
+        const auto oversizedResponse = QJsonDocument(QJsonObject{
+            {QStringLiteral("ocs"), QJsonObject{
+                {QStringLiteral("meta"), QJsonObject{{QStringLiteral("statuscode"), 200}}},
+                {QStringLiteral("data"), QJsonObject{
+                    {QStringLiteral("exact"), QJsonObject{{QStringLiteral("users"), QJsonArray()}}},
+                    {QStringLiteral("users"), users},
+                }},
+            }},
+        }).toJson(QJsonDocument::Compact);
+        qnam->setOverride([&](QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *) {
+            return static_cast<QNetworkReply *>(new FakePayloadReply(operation, request, oversizedResponse, qnam.get()));
+        });
+
+        OCC::UnifiedSearchPeopleModel model(nullptr, 0);
+        model.setAccountState(state.get());
+        model.setSearchTerm(QStringLiteral("user"));
+        QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 50, 1000);
+    }
+};
+
+QTEST_MAIN(TestUnifiedSearchPeopleModel)
+#include "testunifiedsearchpeoplemodel.moc"

--- a/test/testunifiedsearchpeoplemodel.cpp
+++ b/test/testunifiedsearchpeoplemodel.cpp
@@ -41,7 +41,7 @@ private Q_SLOTS:
         auto qnam = std::unique_ptr<FakeQNAM>(new FakeQNAM({}));
         auto account = OCC::Account::create();
         account->setCredentials(new FakeCredentials(qnam.get()));
-        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/")));
+        account->setUrl(QUrl(QStringLiteral("https://cloud.example.test/nextcloud")));
         account->setDavUser(QStringLiteral("current-user"));
         auto state = std::make_unique<FakeAccountState>(account);
         auto requestCount = 0;
@@ -57,6 +57,8 @@ private Q_SLOTS:
         QTRY_COMPARE_WITH_TIMEOUT(model.rowCount(), 1, 1000);
         QCOMPARE(requestCount, 0);
         QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("current-user"));
+        QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::AvatarUrlRole).toString(),
+                 QStringLiteral("https://cloud.example.test/nextcloud/index.php/avatar/current-user/64"));
         QVERIFY(model.errorString().isEmpty());
     }
 

--- a/test/testunifiedsearchpeoplemodel.cpp
+++ b/test/testunifiedsearchpeoplemodel.cpp
@@ -84,6 +84,7 @@ private Q_SLOTS:
 
         QCOMPARE(requestedUrl.path(), QStringLiteral("/ocs/v2.php/apps/files_sharing/api/v1/sharees"));
         const QUrlQuery query(requestedUrl);
+        QCOMPARE(query.queryItemValue(QStringLiteral("itemType")), QStringLiteral("file"));
         QCOMPARE(query.queryItemValue(QStringLiteral("shareType")), QStringLiteral("0"));
         QCOMPARE(query.queryItemValue(QStringLiteral("lookup")), QStringLiteral("false"));
         QCOMPARE(query.queryItemValue(QStringLiteral("page")), QStringLiteral("1"));
@@ -91,7 +92,7 @@ private Q_SLOTS:
         QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("ada"));
         QCOMPARE(model.data(model.index(1), OCC::UnifiedSearchPeopleModel::UserIdRole).toString(), QStringLiteral("alan"));
         QCOMPARE(model.data(model.index(0), OCC::UnifiedSearchPeopleModel::AvatarUrlRole).toString(),
-            QStringLiteral("https://cloud.example.test/index.php/avatar/ada/64"));
+                 QStringLiteral("https://cloud.example.test/index.php/avatar/ada/64"));
     }
 
     void injectsMatchingSignedInUser()

--- a/theme.qrc.in
+++ b/theme.qrc.in
@@ -192,6 +192,7 @@
 		<file>theme/black/caret-down.svg</file>
 		<file>theme/black/change.svg</file>
 		<file>theme/black/clear.svg</file>
+		<file>theme/black/filter.svg</file>
 		<file>theme/black/close.svg</file>
 		<file>theme/black/comment.svg</file>
 		<file>theme/black/confirm.svg</file>
@@ -269,6 +270,8 @@
   		<file>theme/white/error.svg</file>
 	
 		<!-- generic (not themed) -->
+		<file>theme/arrow-left.svg</file>
+		<file>theme/arrow-right.svg</file>
 		<file>theme/sync-arrow.svg</file>
 		<file>theme/close.svg</file>
 		<file>theme/files.svg</file>

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -49,6 +49,7 @@ QtObject {
     readonly property color wizardErrorText: darkMode ? "#ff7b86" : "#b00020"
     readonly property color wizardAvatarPlaceholder: darkMode ? "#3b464d" : "#dfe8ee"
     readonly property color wizardSelectedText: "#ffffff"
+    readonly property color listItemHoverBackground: darkMode ? "#3a3a3a" : "#f2f2f2"
 
     // ErrorBox colors
     readonly property color errorBoxBackgroundColor: Qt.rgba(0.89, 0.18, 0.18, 1)
@@ -126,6 +127,11 @@ QtObject {
     readonly property int wizardWindowMargin: 24
     readonly property int wizardWindowTopMargin: standardSpacing
     readonly property int wizardFooterButtonHeight: iconButtonWidth
+    readonly property int wizardButtonHorizontalPadding: 18
+    readonly property int wizardButtonContentSpacing: 6
+    readonly property int wizardButtonFontPixelSize: pixelSize + 3
+    readonly property int wizardChipButtonHeight: variableSize(26)
+    readonly property int wizardMenuItemHorizontalPadding: wizardSectionSpacing
     readonly property int wizardFooterSpacing: trayAccountPopupActionVerticalPadding
     readonly property int wizardSectionSpacing: trayAccountPopupRowPadding
     readonly property int wizardDialogMaximumWidth: 420
@@ -149,7 +155,7 @@ QtObject {
     readonly property int assistantWindowWidth: 640
     readonly property int assistantWindowHeight: 620
     readonly property int searchWindowWidth: 640
-    readonly property int searchWindowHeight: 620
+    readonly property int searchWindowHeight: 670
     readonly property int userStatusWindowWidth: 560
     readonly property int userStatusWindowHeight: 700
     readonly property int userStatusWindowMinimumHeight: 560
@@ -221,14 +227,31 @@ QtObject {
     property bool hoverEffectsEnabled: true
 
     // unified search constants
-    readonly property int unifiedSearchItemHeight: trayWindowHeaderHeight
+    readonly property int unifiedSearchDetailHeaderHeight: standardPrimaryButtonHeight
+    readonly property int unifiedSearchFilterButtonMinimumWidth: 140
+    readonly property real unifiedSearchFilterMenuWidthFactor: 1.5
+    readonly property int unifiedSearchProviderMenuMaximumVisibleRows: 8
+    readonly property int unifiedSearchPeoplePopupHorizontalMargin: standardPrimaryButtonHeight
+    readonly property int unifiedSearchPeoplePopupHeight: 340
+    readonly property int unifiedSearchPeoplePopupTopMargin: 150
+    readonly property int unifiedSearchProviderHeaderHeight: 44
+    readonly property int unifiedSearchPartialMatchesHeaderHeight: standardPrimaryButtonHeight
+    readonly property int unifiedSearchPagingRowHeight: unifiedSearchProviderHeaderHeight
+    readonly property int unifiedSearchLoadingPlaceholderCount: 3
+    readonly property real unifiedSearchLoadingPlaceholderInitialWidthRatio: 0.72
+    readonly property real unifiedSearchLoadingPlaceholderWidthStep: 0.07
+    readonly property real unifiedSearchLoadingPlaceholderOpacity: 0.55
+    readonly property real unifiedSearchPartialMatchOpacity: 0.72
+    readonly property int unifiedSearchItemHeight: Math.max(44,
+        unifiedSearchResultTitleFontSize * 2 + unifiedSearchResultTextSpacing + 8)
     readonly property int unifiedSearchResultTextLeftMargin: 18
     readonly property int unifiedSearchResultTextRightMargin: 16
     readonly property int unifiedSearchResultIconWidth: trayListItemIconSize * (1 - thumbnailImageSizeReduction)
     readonly property int unifiedSearchResultSmallIconWidth: trayListItemIconSize * (1 - thumbnailImageSizeReduction * 2)
     readonly property int unifiedSearchResultIconLeftMargin: 12
-    readonly property int unifiedSearchResultTitleFontSize: topLinePixelSize
-    readonly property int unifiedSearchResultSublineFontSize: subLinePixelSize
+    readonly property int unifiedSearchResultTitleFontSize: pixelSize + extraSmallSpacing
+    readonly property int unifiedSearchResultSublineFontSize: unifiedSearchResultTitleFontSize
+    readonly property int unifiedSearchResultTextSpacing: extraSmallSpacing
     readonly property int unifiedSearchResultSectionItemLeftPadding: 16
     readonly property int unifiedSearchResultSectionItemVerticalPadding: 8
     readonly property int unifiedSearchResultNothingFoundHorizontalMargin: 10

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -256,6 +256,9 @@ QtObject {
     readonly property int unifiedSearchResultSectionItemVerticalPadding: 8
     readonly property int unifiedSearchResultNothingFoundHorizontalMargin: 10
     readonly property int unifiedSearchInputContainerHeight: 40
+    readonly property int unifiedSearchInputIconSize: 24
+    readonly property int unifiedSearchInputHorizontalPadding: 8
+    readonly property int unifiedSearchInputControlInset: 4
     readonly property int unifiedSearchPlaceholderViewTitleFontPixelSize: pixelSize * 1.25
     readonly property int unifiedSearchPlaceholderViewSublineFontPixelSize: subLinePixelSize * 1.25
 

--- a/theme/arrow-left.svg
+++ b/theme/arrow-left.svg
@@ -1,0 +1,7 @@
+<!--
+  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  SPDX-License-Identifier: GPL-2.0-or-later
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M7.25 3 2.25 8l5 5 1.06-1.06L5.12 8.75H14v-1.5H5.12l3.19-3.19L7.25 3Z"/>
+</svg>

--- a/theme/arrow-right.svg
+++ b/theme/arrow-right.svg
@@ -1,0 +1,7 @@
+<!--
+  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  SPDX-License-Identifier: GPL-2.0-or-later
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="m8.75 3 5 5-5 5-1.06-1.06 3.19-3.19H2v-1.5h8.88L7.69 4.06 8.75 3Z"/>
+</svg>

--- a/theme/black/filter.svg
+++ b/theme/black/filter.svg
@@ -1,0 +1,3 @@
+<!-- SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors -->
+<!-- SPDX-License-Identifier: GPL-2.0-or-later -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 5a1 1 0 0 1 1-1h16a1 1 0 0 1 .8 1.6L14 14.67V20a1 1 0 0 1-.55.89l-4 2A1 1 0 0 1 8 22v-7.33L3.2 6.4A1 1 0 0 1 3 5Zm3 1 4 7v6.38l2-1v-4.05L18 6H6Z"/></svg>


### PR DESCRIPTION
- Modernize the account-scoped search window with provider, date, and people filters, connected-service results, and aggregate and provider detail views.
- Introduce cancellable per-provider search state, stable reveal ordering, stale-response protection, pagination, scoped retries, and persistent keyboard selection.
- Align the search UI with shared wizard styling and add coverage for the search models, QML behavior, people lookup, and image handling.

Server Reference: https://github.com/nextcloud/server/issues/60241

Assisted-by: Codex:GPT-5

<img width="658" height="684" alt="Bildschirmfoto 2026-08-21 um 11 21 09" src="https://github.com/user-attachments/assets/61c10784-7893-4212-aed5-374e1168381d" />

https://github.com/user-attachments/assets/4bb288f0-70f7-411c-b779-e123c3bca1a5

