### PR TITLE
fix(gui): fix tray submenus not appearing by removing lazy loading on linux

### DIFF
--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -807,9 +807,6 @@ void populateAccountMenu(QMenu *menu, const int userId, const bool fetchActivity
         QCoreApplication::translate("TrayWindowHeader", "Apps"));
     setFixedMenuWidth(appsMenu);
     appsMenu->menuAction()->setEnabled(populateAppsMenu(appsMenu, userId));
-    QObject::connect(appsMenu, &QMenu::aboutToShow, appsMenu, [appsMenu, userId] {
-        appsMenu->menuAction()->setEnabled(populateAppsMenu(appsMenu, userId));
-    });
 
     menu->addSeparator();
 
@@ -842,9 +839,13 @@ void populateTrayMenu(QMenu *menu, Systray *systray)
 
             const auto accountMenu = addSubMenu(menu, accountIcon, accountText);
             setFixedMenuWidth(accountMenu);
+#ifdef Q_OS_LINUX
+            populateAccountMenu(accountMenu, userId);
+#else
             QObject::connect(accountMenu, &QMenu::aboutToShow, accountMenu, [accountMenu, userId] {
                 populateAccountMenu(accountMenu, userId);
             });
+#endif
             QObject::connect(userModel,
                 &QAbstractItemModel::dataChanged,
                 accountMenu,


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#10465

## Summary
This fixes a bug, which is to my understanding specific to the GNOME desktop environment on Linux: The account submenu in the tray menu did not open by clicking on the account name. This issue was caused by lazy loading the submenu triggered by `QMenu::aboutToShow`, which never triggered on GNOME. The same problem existed for the apps sub-submenu.
To fix the account submenu, I eager loaded the submenu on Linux to also prevent this issue on other, lesser known desktop environments. For the apps submenu, there was already an eager loading approach implemented, alongside a lazy loading approch. I removed the lazy loading approach because is redundant, as there is a `QObject::connect` on `&QAbstractItemModel::dataChanged` reloading the submenu if there is a change done to the account.
Many thanks to @maksimtech for his/her great hypothesis which really helped with debugging.

### Screenshots
#### Before:
<img width="298" height="209" alt="screenshot-before" src="https://github.com/user-attachments/assets/538bf243-c8a7-4244-b2b5-f35b3b09800d" />

#### After:
<img width="346" height="912" alt="screenshot-after" src="https://github.com/user-attachments/assets/e84807f6-60b5-44e1-bd13-539fa1a8a9fd" />


## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
