### PR TITLE
fix(tray): GNOME + AppIndicator compatibility

### DIFF
--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -701,8 +701,10 @@ void addRecentActivities(QMenu *menu, const int userId, const QVariantList &rece
 
 void populateAccountMenu(QMenu *menu, const int userId, const bool fetchActivityPreview = true)
 {
-    setFixedMenuWidth(menu);
-    clearDynamicMenu(menu);
+    if (!fetchActivityPreview) {
+        setFixedMenuWidth(menu);
+        clearDynamicMenu(menu);
+    }
 
     const auto userModel = UserModel::instance();
     if (!userModel || userId < 0 || userId >= userModel->rowCount()) {
@@ -716,6 +718,7 @@ void populateAccountMenu(QMenu *menu, const int userId, const bool fetchActivity
     };
     if (fetchActivityPreview && policy.fetchActivityPreview()) {
         userModel->fetchActivityPreview(userId);
+        return;
     }
 
     const auto menuIconPalette = nativeMenuIconPalette(menu);
@@ -807,9 +810,6 @@ void populateAccountMenu(QMenu *menu, const int userId, const bool fetchActivity
         QCoreApplication::translate("TrayWindowHeader", "Apps"));
     setFixedMenuWidth(appsMenu);
     appsMenu->menuAction()->setEnabled(populateAppsMenu(appsMenu, userId));
-    QObject::connect(appsMenu, &QMenu::aboutToShow, appsMenu, [appsMenu, userId] {
-        appsMenu->menuAction()->setEnabled(populateAppsMenu(appsMenu, userId));
-    });
 
     menu->addSeparator();
 
@@ -842,8 +842,9 @@ void populateTrayMenu(QMenu *menu, Systray *systray)
 
             const auto accountMenu = addSubMenu(menu, accountIcon, accountText);
             setFixedMenuWidth(accountMenu);
+            populateAccountMenu(accountMenu, userId, false);
             QObject::connect(accountMenu, &QMenu::aboutToShow, accountMenu, [accountMenu, userId] {
-                populateAccountMenu(accountMenu, userId);
+                populateAccountMenu(accountMenu, userId, true);
             });
             QObject::connect(userModel,
                 &QAbstractItemModel::dataChanged,


### PR DESCRIPTION
The account submenu does not work in a standard (Ubuntu) GNOME environment, for the following reasons:

* If the submenu is empty, no `aboutToShow` event is sent. This patch pre-populates the submenu.
* If the submenu is updated when handling `aboutToShow`, it will be closed immediately. This patch causes the event handler to only fetch the activities in this case. It will still enable dynamic updates for KDE, i.e. `dataChanged` will be called. In case of GNOME, however, the menu is not marked visible, thus the `dataChanged` handler will not update (and thus close) the menu. However, since the tray menu is built when opening, the contents will be relatively recent even there, though not updating.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#10076 
## Summary

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [ ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
