### PR TITLE
fix(db): avoid printing misleading warning logs

### DIFF
--- a/src/common/syncjournaldb.cpp
+++ b/src/common/syncjournaldb.cpp
@@ -1282,7 +1282,10 @@ qint64 SyncJournalDb::keyValueStoreGetInt(const QString &key, qint64 defaultValu
     auto result = query->next();
 
     if (!result.ok || !result.hasData) {
-        qCWarning(lcDb) << "database error:" << query->error();
+        if (!result.ok) {
+            qCWarning(lcDb) << "database error:" << query->error();
+        }
+
         return defaultValue;
     }
 


### PR DESCRIPTION
would have printed this very useless and misleading warning in the logs: syncjournaldb.cpp:1285 ]:	database error: ""

this is in fact not an error but a lack of data

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
