### PR TITLE
fix(propagator): clean up logs related to item completed

### DIFF
--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -1629,7 +1629,6 @@ void User::slotItemCompleted(const QString &folder, const SyncFileItemPtr &item)
         return;
     }
 
-    qCWarning(lcActivity) << "Item " << item->_file << " retrieved resulted in " << item->_errorString;
     processCompletedSyncItem(folderInstance, item);
 }
 

--- a/src/libsync/bulkpropagatordownloadjob.cpp
+++ b/src/libsync/bulkpropagatordownloadjob.cpp
@@ -59,7 +59,7 @@ PropagatorJob::JobParallelism BulkPropagatorDownloadJob::parallelism() const
 
 void BulkPropagatorDownloadJob::finalizeOneFile(const SyncFileItemPtr &file)
 {
-    Q_EMIT propagator()->itemCompleted(file, ErrorCategory::GenericError);
+    propagator()->emitItemCompleted(file, ErrorCategory::GenericError);
 }
 
 void BulkPropagatorDownloadJob::start()
@@ -159,7 +159,7 @@ void BulkPropagatorDownloadJob::abortWithError(SyncFileItemPtr item, SyncFileIte
     if (item) {
         item->_errorString = error;
         item->_status = status;
-        Q_EMIT propagator()->itemCompleted(item, ErrorCategory::GenericError);
+        propagator()->emitItemCompleted(item, ErrorCategory::GenericError);
     }
     done(status);
 }

--- a/src/libsync/bulkpropagatorjob.cpp
+++ b/src/libsync/bulkpropagatorjob.cpp
@@ -628,7 +628,7 @@ void BulkPropagatorJob::done(SyncFileItemPtr item,
 
     handleJobDoneErrors(item, status);
 
-    Q_EMIT propagator()->itemCompleted(item, category);
+    propagator()->emitItemCompleted(item, category);
 }
 
 QMap<QByteArray, QByteArray> BulkPropagatorJob::headers(SyncFileItemPtr item) const

--- a/src/libsync/owncloudpropagator.cpp
+++ b/src/libsync/owncloudpropagator.cpp
@@ -276,12 +276,7 @@ void PropagateItemJob::done(const SyncFileItem::Status statusArg, const QString 
         break;
     }
 
-    if (_item->hasErrorStatus()) {
-        qCWarning(lcPropagator) << "Could not complete propagation of" << _item->destination() << "by" << this << "with status" << _item->_status << "and error:" << _item->_errorString;
-    } else {
-        qCInfo(lcPropagator) << "Completed propagation of" << _item->destination() << "by" << this << "with status" << _item->_status;
-    }
-    Q_EMIT propagator()->itemCompleted(_item, category);
+    propagator()->emitItemCompleted(_item, category);
     Q_EMIT finished(_item->_status);
 
     if (_item->_status == SyncFileItem::FatalError) {
@@ -926,6 +921,16 @@ void OwncloudPropagator::scheduleNextJobImpl()
             }
         }
     }
+}
+
+void OwncloudPropagator::emitItemCompleted(const SyncFileItemPtr &item, ErrorCategory category)
+{
+    if (item->hasErrorStatus()) {
+        qCWarning(lcPropagator) << "Could not complete propagation of" << item->destination() << "by" << this << "with status" << item->_status << "and error:" << item->_errorString;
+    } else {
+        qCInfo(lcPropagator) << "Completed propagation of" << item->destination() << "by" << this << "with status" << item->_status;
+    }
+    Q_EMIT itemCompleted(item, category);
 }
 
 void OwncloudPropagator::reportProgress(const SyncFileItem &item, qint64 bytes)

--- a/src/libsync/owncloudpropagator.h
+++ b/src/libsync/owncloudpropagator.h
@@ -641,8 +641,9 @@ public:
 
     [[nodiscard]] bool isInBulkUploadBlackList(const QString &file) const;
 
-private Q_SLOTS:
+    void emitItemCompleted(const OCC::SyncFileItemPtr &item, OCC::ErrorCategory category);
 
+private Q_SLOTS:
     void abortTimeout()
     {
         // Abort synchronously and finish


### PR DESCRIPTION
each time an item is completed and the info is forwarded to activities model, we print an useless warning

makes it more clear by improving a previous log with teh same info but better log level and make all our code to use teh same way to log completed items

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
