### PR TITLE
fix(file-provider): continue change batches across enumerators

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
@@ -20,16 +20,12 @@ import Foundation
 /// re-deriving on a continuation invocation would surface (almost) no created/updated items and that
 /// undelivered remainder would be silently dropped. The buffer therefore holds the full derived change
 /// set after a single derivation and hands it out one batch at a time; the derivation never runs again
-/// while the buffer stays primed for the same sync anchor.
+/// while the buffer stays primed for the incoming anchor or the latest continuation anchor it returned.
 ///
-/// Durability: the buffer is in memory. Within a normal `moreComing` chain the framework reuses the same
-/// ``Enumerator`` instance, so the remainder survives. If the extension process is recycled mid-drain (only
-/// reachable for change sets larger than ``Enumerator/maxBatchSize``), a fresh instance re-derives from the
-/// original anchor: undelivered **deletions** are recovered (their soft-deleted rows persist with a fresh
-/// `syncTime` until ``FilesDatabaseManager/removeItemMetadata(ocId:)`` runs after delivery, and the
-/// working-set re-derivation re-surfaces them via `pendingWorkingSetChanges(since:)`), but undelivered
-/// **created/updated** items can be lost — for a regular container entirely, and for the working set when
-/// the item is not materialised. This replaces a guaranteed crash with a rare, bounded partial loss.
+/// File Provider may request a continuation from a fresh ``Enumerator``. While `moreComing` is true,
+/// ``ChangeDeliveryBufferStore`` therefore keeps this in-memory buffer alive across those instances.
+/// Recycling the extension process still loses an undelivered created/updated remainder; continuation
+/// anchors retain the original date so a fresh process can re-derive from the earlier sync point.
 ///
 /// ``Enumerator`` is `Sendable` with only immutable members, so the mutable delivery state lives behind
 /// this `@unchecked Sendable`, `NSLock`-guarded box — the established concurrency idiom in this target
@@ -39,6 +35,7 @@ import Foundation
 final class ChangeDeliveryBuffer: @unchecked Sendable {
     private let lock = NSLock()
     private let logger: FileProviderLogger
+    private let onBatchTaken: ((ChangeDeliveryBuffer, Bool) -> Void)?
     private var anchorKey: String?
     private var remainingUpdated: [SendableItemMetadata] = []
     private var remainingDeleted: [SendableItemMetadata] = []
@@ -48,14 +45,19 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     /// alongside `anchorKey`.
     private var primedIncomplete = false
 
-    init(log: any FileProviderLogging) {
+    init(
+        log: any FileProviderLogging,
+        onBatchTaken: ((ChangeDeliveryBuffer, Bool) -> Void)? = nil
+    ) {
         logger = FileProviderLogger(category: "ChangeDeliveryBuffer", log: log)
+        self.onBatchTaken = onBatchTaken
     }
 
     ///
     /// Whether a derivation has already filled the buffer for the given sync-anchor key and changes are
     /// still waiting to be delivered. A continuation invocation that sees `true` must drain rather than
-    /// re-derive.
+    /// re-derive. The key starts as the incoming anchor and advances to each intermediate continuation
+    /// anchor returned to File Provider.
     ///
     func isPrimed(forKey key: String) -> Bool {
         lock.lock()
@@ -74,7 +76,8 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     }
 
     ///
-    /// Store the full derived change set for a drain sequence, keyed by the originating sync anchor.
+    /// Store the full derived change set for a drain sequence, initially keyed by the originating sync
+    /// anchor.
     ///
     /// `updated` must already be sorted parents-before-children (ascending remote-path length) so that
     /// draining the single combined list front-to-back never reports a child in an earlier batch than
@@ -103,14 +106,15 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     /// Updates are drained before deletions, preserving the parent-before-child ordering of the updates.
     ///
     /// `moreComing` reflects whether anything is still buffered *after* this batch (so an exactly-full
-    /// final batch does not provoke a spurious empty follow-up). The key is cleared once both lists drain,
-    /// so a later signal starts a fresh derivation.
+    /// final batch does not provoke a spurious empty follow-up). When more changes remain, the buffer is
+    /// re-keyed to `continuationKey`, matching the progressing anchor returned to File Provider. The key
+    /// is cleared once both lists drain, so a later signal starts a fresh derivation.
     ///
     func takeBatch(
-        maxItems: Int
+        maxItems: Int,
+        continuationKey: String
     ) -> (updated: [SendableItemMetadata], deleted: [SendableItemMetadata], moreComing: Bool) {
         lock.lock()
-        defer { lock.unlock() }
 
         let key = anchorKey ?? "nil"
         let budget = max(1, maxItems)
@@ -124,14 +128,22 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
         remainingDeleted.removeFirst(deletedCount)
 
         let moreComing = !remainingUpdated.isEmpty || !remainingDeleted.isEmpty
-        if !moreComing {
+        if moreComing {
+            anchorKey = continuationKey
+        } else {
             anchorKey = nil
             primedIncomplete = false
         }
 
+        let remainingUpdatedCount = remainingUpdated.count
+        let remainingDeletedCount = remainingDeleted.count
+        lock.unlock()
+
         logger.debug(
-            "Drained change batch. anchor: \(key), maxItems: \(budget), tookUpdated: \(updatedCount), tookDeleted: \(deletedCount), remainingUpdated: \(remainingUpdated.count), remainingDeleted: \(remainingDeleted.count), moreComing: \(moreComing)"
+            "Drained change batch. anchor: \(key), maxItems: \(budget), tookUpdated: \(updatedCount), tookDeleted: \(deletedCount), remainingUpdated: \(remainingUpdatedCount), remainingDeleted: \(remainingDeletedCount), moreComing: \(moreComing)"
         )
+
+        onBatchTaken?(self, moreComing)
 
         return (batchUpdated, batchDeleted, moreComing)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBufferStore.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBufferStore.swift
@@ -1,0 +1,46 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+
+///
+/// Keeps active `moreComing` buffers alive across fresh ``Enumerator`` instances, isolated by container.
+///
+final class ChangeDeliveryBufferStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private let log: any FileProviderLogging
+    private var buffers: [String: ChangeDeliveryBuffer] = [:]
+
+    init(log: any FileProviderLogging) {
+        self.log = log
+    }
+
+    /// Return the active buffer for `key`, or an unretained buffer for a new enumeration.
+    func buffer(for key: String) -> ChangeDeliveryBuffer {
+        lock.lock()
+        if let buffer = buffers[key] {
+            lock.unlock()
+            return buffer
+        }
+        lock.unlock()
+
+        return ChangeDeliveryBuffer(log: log) { [weak self] buffer, moreComing in
+            self?.setActive(buffer, for: key, active: moreComing)
+        }
+    }
+
+    private func setActive(_ buffer: ChangeDeliveryBuffer, for key: String, active: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if active {
+            buffers[key] = buffer
+            return
+        }
+
+        guard buffers[key] === buffer else {
+            return
+        }
+        buffers.removeValue(forKey: key)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
@@ -78,11 +78,8 @@ extension Enumerator {
     ///
     /// Pop the next batch from ``changeBuffer`` and report it.
     ///
-    /// Intermediate batches (`moreComing == true`) return `startAnchor` — the anchor the enumeration was
-    /// invoked with — so that if the drain is interrupted the framework resumes *behind* every
-    /// undelivered item rather than advancing the sync point past changes still sitting in the buffer.
-    /// Only the final batch returns `finalAnchor` (the working set advances to ``currentAnchor``; a
-    /// regular container preserves its incoming anchor).
+    /// Intermediate batches return a unique continuation anchor with `startAnchor`'s date. The final
+    /// batch returns `finalAnchor`.
     ///
     func drainChangeBuffer(
         for observer: NSFileProviderChangeObserver,
@@ -90,7 +87,12 @@ extension Enumerator {
         finalAnchor: NSFileProviderSyncAnchor,
         suggested: Int?
     ) {
-        let batch = changeBuffer.takeBatch(maxItems: effectiveBatchSize(suggested: suggested))
+        let continuationAnchor = Self.continuationSyncAnchor(from: startAnchor)
+        let continuationKey = String(data: continuationAnchor.rawValue, encoding: .utf8) ?? ""
+        let batch = changeBuffer.takeBatch(
+            maxItems: effectiveBatchSize(suggested: suggested),
+            continuationKey: continuationKey
+        )
         logger.info(
             "Reporting change batch. updated: \(batch.updated.count), deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)",
             [.item: enumeratedItemIdentifier]
@@ -99,7 +101,7 @@ extension Enumerator {
             observer,
             updated: batch.updated,
             deleted: batch.deleted,
-            anchor: batch.moreComing ? startAnchor : finalAnchor,
+            anchor: batch.moreComing ? continuationAnchor : finalAnchor,
             moreComing: batch.moreComing,
             account: account,
             remoteInterface: remoteInterface,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncAnchor.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+SyncAnchor.swift
@@ -7,11 +7,8 @@ import Foundation
 ///
 /// The version-tagged sync anchor scheme.
 ///
-/// Every container the extension enumerates (working set, root, sub-directories, trash) hands the
-/// framework an anchor of the form `"<extension-version>|<ISO8601-date>"`. On the next
-/// `enumerateChanges(for:from:)` the embedded version is compared against the running extension; a
-/// mismatch is rejected with `NSFileProviderError(.syncAnchorExpired)` so the framework drops its
-/// cached `NSFileProviderItem` snapshots and re-enumerates the container. See nextcloud/desktop#10065.
+/// Anchors contain the extension version and ISO8601 date. Intermediate batch anchors add an opaque
+/// continuation component. A version mismatch expires the anchor; see nextcloud/desktop#10065.
 ///
 extension Enumerator {
     ///
@@ -28,18 +25,33 @@ extension Enumerator {
     }
 
     ///
+    /// Build a unique intermediate anchor for a split change enumeration.
+    ///
+    /// The UUID progresses each intermediate batch while the embedded sync date stays unchanged.
+    ///
+    static func continuationSyncAnchor(from anchor: NSFileProviderSyncAnchor) -> NSFileProviderSyncAnchor {
+        guard let parsed = parseSyncAnchor(anchor) else {
+            assertionFailure("Cannot build a continuation anchor from an invalid sync anchor.")
+            return anchor
+        }
+
+        let raw = "\(parsed.version)|\(ISO8601DateFormatter().string(from: parsed.date))|\(UUID().uuidString)"
+        return NSFileProviderSyncAnchor(raw.data(using: .utf8)!)
+    }
+
+    ///
     /// Parse a sync anchor produced by ``syncAnchor(at:)``.
     ///
-    /// Returns `nil` for anchors that are not in the expected `"<version>|<ISO8601-date>"` format — including anchors persisted by builds older than #10065 that carried only the ISO8601 date. The caller treats `nil` as an expired anchor.
+    /// Accepts an optional opaque continuation component; malformed and legacy unversioned anchors fail.
     ///
     static func parseSyncAnchor(_ anchor: NSFileProviderSyncAnchor) -> (version: String, date: Date)? {
         guard let raw = String(data: anchor.rawValue, encoding: .utf8) else {
             return nil
         }
 
-        let parts = raw.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+        let parts = raw.split(separator: "|", omittingEmptySubsequences: false)
 
-        guard parts.count == 2 else {
+        guard parts.count == 2 || (parts.count == 3 && !parts[2].isEmpty) else {
             return nil
         }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
@@ -8,19 +8,18 @@ extension Enumerator {
     ///
     /// Pop the next batch of trash deletions from ``changeBuffer`` and report it.
     ///
-    /// `NKTrash` items have no ETag; the only trash change of interest is a *permanent* remote deletion,
-    /// detected as a local trash row absent from the remote listing. Those orphans are derived once (see
-    /// ``enumerateTrashChanges(for:anchor:)``) and drained here one capped batch per invocation so a large
-    /// permanent-purge cannot exceed the framework's per-batch limit. Trash preserves its incoming anchor
-    /// (like a regular container), so the same anchor is returned on every batch. Each delivered orphan is
-    /// soft-deleted (`deleteItemMetadata`) only after its batch finishes, so an interrupted drain keeps its
-    /// row — the reconciliation re-derives it (the row still carries a trash `serverUrl`) rather than
-    /// dropping it.
+    /// Drain permanently deleted trash items in capped batches. Intermediate anchors progress without
+    /// changing the sync date; each delivered row is soft-deleted after its batch.
     ///
     private func drainTrashDeletions(
         for observer: NSFileProviderChangeObserver, anchor: NSFileProviderSyncAnchor, suggested: Int?
     ) {
-        let batch = changeBuffer.takeBatch(maxItems: effectiveBatchSize(suggested: suggested))
+        let continuationAnchor = Self.continuationSyncAnchor(from: anchor)
+        let continuationKey = String(data: continuationAnchor.rawValue, encoding: .utf8) ?? ""
+        let batch = changeBuffer.takeBatch(
+            maxItems: effectiveBatchSize(suggested: suggested),
+            continuationKey: continuationKey
+        )
         let orphanedIdentifiers = batch.deleted.map { NSFileProviderItemIdentifier($0.ocId) }
 
         if orphanedIdentifiers.isEmpty == false {
@@ -34,7 +33,10 @@ extension Enumerator {
             dbManager.deleteItemMetadata(ocId: metadata.ocId)
         }
 
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: batch.moreComing)
+        observer.finishEnumeratingChanges(
+            upTo: batch.moreComing ? continuationAnchor : anchor,
+            moreComing: batch.moreComing
+        )
 
         logger.debug("Reported trash deletion batch. deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)")
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -61,13 +61,8 @@ extension Enumerator {
                 )
             }
 
-            // Intermediate batches keep the original anchor so an interrupted drain resumes behind all
-            // undelivered items. The final batch normally advances the working-set sync point to
-            // currentAnchor — but when the scan was incomplete (a remote read failed and was skipped) we
-            // keep the incoming anchor instead, so we do not tell the framework we are synced up to "now"
-            // past changes we could not discover this pass. The next working-set signal re-derives and
-            // picks up the previously-unreadable folders once they succeed. (isPrimedIncomplete() is read
-            // before the final takeBatch clears the buffer, so it reflects this drain sequence.)
+            // Advance the durable sync date only after a complete scan drains. An incomplete scan keeps
+            // the incoming anchor, whose continuation component still carries the original date.
             let finalAnchor = changeBuffer.isPrimedIncomplete() ? anchor : currentAnchor
             drainChangeBuffer(
                 for: observer,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -51,16 +51,8 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     let remoteInterface: RemoteInterface
     let serverUrl: String
 
-    /// Holds the undelivered remainder of a large change set so it can be reported one batch at a time
-    /// across the framework's `moreComing` re-invocations without re-running the destructive derivation.
-    /// See ``ChangeDeliveryBuffer`` and ``drainChangeBuffer(for:startAnchor:finalAnchor:suggested:)``.
-    ///
-    /// Load-bearing assumption: the framework continues a `moreComing` chain on the *same* enumerator
-    /// instance, re-invoking `enumerateChanges(for:from:)` with the anchor the previous batch returned
-    /// (see `NSFileProviderEnumerating.h`, `currentSyncAnchorWithCompletionHandler`). The in-memory
-    /// buffer therefore survives the chain. If the extension process is recycled mid-drain, a fresh
-    /// instance re-derives from the original anchor; see ``ChangeDeliveryBuffer`` for the bounded
-    /// created/updated loss this can cause for change sets larger than ``maxBatchSize``.
+    /// Holds the remainder of a split change set. The extension reuses it across fresh continuation
+    /// enumerators while `moreComing` is true.
     let changeBuffer: ChangeDeliveryBuffer
 
     /// Default number of items reported per page/batch when the system does not suggest one. Mirrors the
@@ -78,13 +70,35 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         identifier == .rootContainer || identifier == .trashContainer || identifier == .workingSet
     }
 
-    public init(
+    public convenience init(
         enumeratedItemIdentifier: NSFileProviderItemIdentifier,
         account: Account,
         remoteInterface: RemoteInterface,
         dbManager: FilesDatabaseManager,
         domain: NSFileProviderDomain? = nil,
         pageSize: Int = 1000,
+        log: any FileProviderLogging
+    ) throws {
+        try self.init(
+            enumeratedItemIdentifier: enumeratedItemIdentifier,
+            account: account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager,
+            domain: domain,
+            pageSize: pageSize,
+            changeBuffer: ChangeDeliveryBuffer(log: log),
+            log: log
+        )
+    }
+
+    init(
+        enumeratedItemIdentifier: NSFileProviderItemIdentifier,
+        account: Account,
+        remoteInterface: RemoteInterface,
+        dbManager: FilesDatabaseManager,
+        domain: NSFileProviderDomain? = nil,
+        pageSize: Int = 1000,
+        changeBuffer: ChangeDeliveryBuffer,
         log: any FileProviderLogging
     ) throws {
         self.enumeratedItemIdentifier = enumeratedItemIdentifier
@@ -94,7 +108,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         self.domain = domain
         pageItemCount = pageSize
         logger = FileProviderLogger(category: "Enumerator", log: log)
-        changeBuffer = ChangeDeliveryBuffer(log: log)
+        self.changeBuffer = changeBuffer
 
         if Self.isSystemIdentifier(enumeratedItemIdentifier) {
             logger.info("Providing enumerator for a system defined container.", [.item: enumeratedItemIdentifier])

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -21,6 +21,7 @@ import OSLog
     let keychain: Keychain
     let log: any FileProviderLogging
     let logger: FileProviderLogger
+    private let changeBufferStore: ChangeDeliveryBufferStore
 
     ///
     /// The file provider manager for the domain managed by this extension implementation.
@@ -89,6 +90,7 @@ import OSLog
         // Set up logging.
         log = FileProviderLog(fileProviderDomainIdentifier: domain.identifier)
         logger = FileProviderLogger(category: "FileProviderExtension", log: log)
+        changeBufferStore = ChangeDeliveryBufferStore(log: log)
         logger.debug("Initializing with domain identifier.", [.domain: domain.identifier.rawValue])
 
         // Set up NextcloudKit.
@@ -468,6 +470,7 @@ import OSLog
             remoteInterface: ncKit,
             dbManager: dbManager,
             domain: domain,
+            changeBuffer: changeBufferStore.buffer(for: containerItemIdentifier.rawValue),
             log: log
         )
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockChangeObserver.swift
@@ -5,6 +5,10 @@
 import Foundation
 import NextcloudFileProviderKit
 
+public enum MockChangeObserverError: Error {
+    case unchangedContinuationAnchor
+}
+
 public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
     public var changedItems: [any NSFileProviderItemProtocol] = []
     public var deletedItemIdentifiers: [NSFileProviderItemIdentifier] = []
@@ -22,9 +26,14 @@ public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
     var isComplete = false
     private var batchComplete = false
     var enumerator: NSFileProviderEnumerator
+    private let continuationEnumeratorFactory: (() throws -> NSFileProviderEnumerator)?
 
-    public init(enumerator: NSFileProviderEnumerator) {
+    public init(
+        enumerator: NSFileProviderEnumerator,
+        continuationEnumeratorFactory: (() throws -> NSFileProviderEnumerator)? = nil
+    ) {
         self.enumerator = enumerator
+        self.continuationEnumeratorFactory = continuationEnumeratorFactory
     }
 
     public func didUpdate(_ changedItems: [any NSFileProviderItemProtocol]) {
@@ -55,8 +64,14 @@ public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
         isComplete = false
         var currentAnchor = anchor
         // Drive the batches the way the framework does: re-invoke enumerateChanges from the anchor the
-        // previous batch returned until one finishes with moreComing == false.
+        // previous batch returned until one finishes with moreComing == false. File Provider discards a
+        // moreComing response whose anchor did not progress, so fail the test at that same boundary.
+        var isFirstBatch = true
         repeat {
+            if !isFirstBatch, let continuationEnumeratorFactory {
+                enumerator = try continuationEnumeratorFactory()
+            }
+            isFirstBatch = false
             batchComplete = false
             enumerator.enumerateChanges?(for: self, from: currentAnchor)
             while !batchComplete {
@@ -65,8 +80,11 @@ public class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
             if let error {
                 throw error
             }
-            if let latestAnchor = finishes.last?.anchor {
-                currentAnchor = latestAnchor
+            if let latestFinish = finishes.last {
+                if latestFinish.moreComing && latestFinish.anchor.rawValue == currentAnchor.rawValue {
+                    throw MockChangeObserverError.unchangedContinuationAnchor
+                }
+                currentAnchor = latestFinish.anchor
             }
         } while !isComplete
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -2158,14 +2158,22 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
         let expectedOcIds = seedMaterialisedWorkingSetFiles(count: itemCount, syncTime: Date())
 
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
-        let enumerator = try Enumerator(
-            enumeratedItemIdentifier: .workingSet,
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            dbManager: Self.dbManager,
-            log: FileProviderLogMock()
+        let log = FileProviderLogMock()
+        let changeBufferStore = ChangeDeliveryBufferStore(log: log)
+        let makeEnumerator: () throws -> NSFileProviderEnumerator = {
+            try Enumerator(
+                enumeratedItemIdentifier: .workingSet,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager,
+                changeBuffer: changeBufferStore.buffer(for: NSFileProviderItemIdentifier.workingSet.rawValue),
+                log: log
+            )
+        }
+        let observer = MockChangeObserver(
+            enumerator: try makeEnumerator(),
+            continuationEnumeratorFactory: makeEnumerator
         )
-        let observer = MockChangeObserver(enumerator: enumerator)
         observer.suggestedBatchSize = batchSize
 
         try await observer.enumerateChanges(from: anchor)
@@ -2187,16 +2195,30 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             previousTotal = total
         }
 
-        // Intermediate batches keep the original anchor; only the final batch advances the sync point.
+        // Intermediate batches advance an opaque continuation token while preserving the original sync
+        // date. File Provider discards moreComing when the returned anchor is unchanged. The final batch
+        // advances the working-set sync date.
+        let parsedInputAnchor = try XCTUnwrap(Enumerator.parseSyncAnchor(anchor))
+        var previousAnchor = anchor
         for finish in observer.finishes.dropLast() {
             XCTAssertTrue(finish.moreComing, "Non-final batches must report moreComing == true.")
-            XCTAssertEqual(finish.anchor.rawValue, anchor.rawValue, "Intermediate batches must return the original anchor.")
+            XCTAssertNotEqual(finish.anchor.rawValue, previousAnchor.rawValue)
+            XCTAssertEqual(
+                try XCTUnwrap(Enumerator.parseSyncAnchor(finish.anchor)).date,
+                parsedInputAnchor.date
+            )
+            previousAnchor = finish.anchor
         }
         let finalFinish = try XCTUnwrap(observer.finishes.last)
         XCTAssertFalse(finalFinish.moreComing, "The final batch must report moreComing == false.")
-        XCTAssertNotEqual(finalFinish.anchor.rawValue, anchor.rawValue, "The final batch must advance the working-set sync anchor.")
+        XCTAssertNotEqual(finalFinish.anchor.rawValue, previousAnchor.rawValue)
+        XCTAssertGreaterThan(
+            try XCTUnwrap(Enumerator.parseSyncAnchor(finalFinish.anchor)).date,
+            parsedInputAnchor.date
+        )
 
-        // The destructive scan ran once: one server read per materialised item, not once per batch.
+        // The observer requests each continuation from a fresh Enumerator, matching the live framework.
+        // The destructive scan still ran once: one server read per materialised item, not once per batch.
         XCTAssertLessThanOrEqual(
             remoteInterface.readOperationCount,
             itemCount + 2,


### PR DESCRIPTION
## Resolves

#<issue-number>

## Summary

Large File Provider change sets are delivered across multiple calls using
`moreComing`. File Provider requires each continuation anchor to progress and
may create a fresh `Enumerator` for the next batch.

Previously, intermediate batches returned the incoming anchor while the
undelivered changes remained owned by that `Enumerator`. This could prevent
the continuation or lose the buffered remainder when File Provider created a
new enumerator.

This change:

- returns a unique intermediate anchor while preserving the original sync date;
- retains active `moreComing` buffers per container at extension scope;
- reuses the buffer when File Provider creates the continuation enumerator;
- removes the buffer after the final batch;
- avoids retaining buffers for item-only and single-batch enumerations;
- adds regression coverage that recreates the enumerator between batches and
  rejects unchanged continuation anchors.

## Issue Reproduction

The unchanged-anchor bug reproduced successfully.

- Baseline folder was empty and visited.
- With client and extension stopped, 205 files were uploaded successfully.
- After restart, the extension derived 207 updates: 205 files plus the root and test folder.
- It reported 200 updates, retained seven, and returned moreComing: true.
- Subsequent scans restarted from the identical anchor instead of delivering the seven-item continuation.
- Finder’s File Provider mount contained only 198 of the 205 files. The missing files were item-122.txt through item-127.txt, plus item-191.txt.
- All seven missing files returned HTTP 200 from the server.
- No 502 occurred, and there were zero File Provider errors before cleanup.

The current macOS version did not retain the literal “token is unchanged” message, but the daemon’s anchor remained unchanged and no updated: 7, moreComing: false batch occurred. The behavior is therefore confirmed directly.

## Validation

Prior runtime validation of the same batching behavior, before the final
active-buffer lifecycle cleanup:

- the extension derived 207 updates;
- it reported `200` updates with `moreComing: true`;
- macOS created a fresh enumerator;
- the second enumerator reported the remaining `7` updates with
  `moreComing: false`;
- Finder and the server both contained all 205 test files with identical names;
- the following scan reported zero pending changes;
- no 502 errors or incomplete scans were recorded.

Assisted-by: Codex:GPT-5