### PR TITLE
fix(file-provider): Correctly enumerate large change batches

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
@@ -1,0 +1,154 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+extension FilesDatabaseManager {
+    /// Create a durable change-delivery session and store the complete ordered change snapshot.
+    func createChangeDeliverySession(
+        sessionId: String,
+        anchorKey: String,
+        finalAnchorRawValue: Data,
+        updated: [SendableItemMetadata],
+        deleted: [SendableItemMetadata],
+        incomplete: Bool
+    ) -> Bool {
+        let encoder = JSONEncoder()
+        let allChanges: [(metadata: SendableItemMetadata, deleted: Bool)] =
+            updated.map { (metadata: $0, deleted: false) } + deleted.map { (metadata: $0, deleted: true) }
+        let encodedChanges: [(data: Data, deleted: Bool)] = allChanges.compactMap { change in
+            guard let metadataData = try? encoder.encode(change.metadata) else {
+                return nil
+            }
+            return (data: metadataData, deleted: change.deleted)
+        }
+
+        guard encodedChanges.count == allChanges.count else {
+            logger.error("Could not encode all metadata for a change-delivery session.")
+            return false
+        }
+
+        let database = ncDatabase()
+        do {
+            try database.write {
+                let session = RealmChangeDeliverySession(
+                    sessionId: sessionId,
+                    currentAnchorKey: anchorKey,
+                    finalAnchorRawValue: finalAnchorRawValue,
+                    incomplete: incomplete
+                )
+                database.add(session, update: .modified)
+
+                let items = encodedChanges.enumerated().map { index, change in
+                    RealmChangeDeliveryItem(
+                        sessionId: sessionId,
+                        sequence: index,
+                        metadataData: change.data,
+                        deleted: change.deleted
+                    )
+                }
+                database.add(items, update: .modified)
+            }
+            return true
+        } catch {
+            logger.error("Could not persist a change-delivery session.")
+            return false
+        }
+    }
+
+    /// Return the active delivery session whose current continuation anchor matches `anchorKey`.
+    func changeDeliverySession(forAnchorKey anchorKey: String) -> (
+        sessionId: String,
+        currentAnchorKey: String,
+        nextSequence: Int,
+        finalAnchorRawValue: Data,
+        incomplete: Bool
+    )? {
+        let sessions = ncDatabase()
+            .objects(RealmChangeDeliverySession.self)
+            .filter("currentAnchorKey == %@ AND completed == false", anchorKey)
+        guard let session = sessions.first
+        else {
+            return nil
+        }
+
+        return changeDeliverySession(sessionId: session.sessionId)
+    }
+
+    /// Return an active delivery session by its durable identifier.
+    func changeDeliverySession(sessionId: String) -> (
+        sessionId: String,
+        currentAnchorKey: String,
+        nextSequence: Int,
+        finalAnchorRawValue: Data,
+        incomplete: Bool
+    )? {
+        guard let session = ncDatabase().object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId),
+              !session.completed
+        else {
+            return nil
+        }
+
+        return (
+            session.sessionId,
+            session.currentAnchorKey,
+            session.nextSequence,
+            session.finalAnchorRawValue,
+            session.incomplete
+        )
+    }
+
+    /// Return the next ordered range of an active change-delivery session.
+    func changeDeliveryItems(
+        sessionId: String,
+        fromSequence sequence: Int,
+        limit: Int
+    ) -> [(sequence: Int, metadataData: Data, deleted: Bool)] {
+        ncDatabase()
+            .objects(RealmChangeDeliveryItem.self)
+            .filter("sessionId == %@ AND sequence >= %@", sessionId, sequence)
+            .sorted(byKeyPath: "sequence")
+            .prefix(limit)
+            .map { ($0.sequence, $0.metadataData, $0.deleted) }
+    }
+
+    /// Advance an active session to its next continuation anchor, or mark it complete.
+    func advanceChangeDeliverySession(
+        sessionId: String,
+        nextSequence: Int,
+        nextAnchorKey: String?,
+        completed: Bool
+    ) {
+        let database = ncDatabase()
+        guard let session = database.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId) else {
+            return
+        }
+
+        try? database.write {
+            session.nextSequence = nextSequence
+            session.completed = completed
+            if let nextAnchorKey {
+                session.currentAnchorKey = nextAnchorKey
+            }
+
+            database.objects(RealmChangeDeliveryItem.self)
+                .filter("sessionId == %@ AND sequence < %@", sessionId, nextSequence)
+                .forEach { database.delete($0) }
+        }
+    }
+
+    /// Remove an abandoned change-delivery session and all of its queued items.
+    func removeChangeDeliverySession(sessionId: String) {
+        let database = ncDatabase()
+        guard let session = database.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId) else {
+            return
+        }
+
+        try? database.write {
+            database.objects(RealmChangeDeliveryItem.self)
+                .filter("sessionId == %@", sessionId)
+                .forEach { database.delete($0) }
+            database.delete(session)
+        }
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
@@ -112,7 +112,7 @@ extension FilesDatabaseManager {
             .map { ($0.sequence, $0.metadataData, $0.deleted) }
     }
 
-    /// Advance an active session to its next continuation anchor, or mark it complete.
+    /// Advance an active session to its next continuation anchor, or remove it after the final batch.
     func advanceChangeDeliverySession(
         sessionId: String,
         nextSequence: Int,
@@ -125,15 +125,22 @@ extension FilesDatabaseManager {
         }
 
         try? database.write {
-            session.nextSequence = nextSequence
-            session.completed = completed
-            if let nextAnchorKey {
-                session.currentAnchorKey = nextAnchorKey
-            }
+            if completed {
+                database.objects(RealmChangeDeliveryItem.self)
+                    .filter("sessionId == %@", sessionId)
+                    .forEach { database.delete($0) }
+                database.delete(session)
+            } else {
+                session.nextSequence = nextSequence
+                session.completed = false
+                if let nextAnchorKey {
+                    session.currentAnchorKey = nextAnchorKey
+                }
 
-            database.objects(RealmChangeDeliveryItem.self)
-                .filter("sessionId == %@ AND sequence < %@", sessionId, nextSequence)
-                .forEach { database.delete($0) }
+                database.objects(RealmChangeDeliveryItem.self)
+                    .filter("sessionId == %@ AND sequence < %@", sessionId, nextSequence)
+                    .forEach { database.delete($0) }
+            }
         }
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -31,7 +31,7 @@ public final class FilesDatabaseManager: Sendable {
         )
     }
 
-    private static let schemaVersion = SchemaVersion.addedPendingChunkUploadCleanup
+    private static let schemaVersion = SchemaVersion.addedChangeDeliverySessions
     let logger: FileProviderLogger
     let account: Account
 
@@ -104,7 +104,9 @@ public final class FilesDatabaseManager: Sendable {
                 RealmItemMetadata.self,
                 RealmExcludedFromSyncItem.self,
                 RemoteFileChunk.self,
-                RealmPendingChunkUploadCleanup.self
+                RealmPendingChunkUploadCleanup.self,
+                RealmChangeDeliverySession.self,
+                RealmChangeDeliveryItem.self
             ]
         )
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/SchemaVersion.swift
@@ -13,4 +13,5 @@ enum SchemaVersion: UInt64 {
     case addedNormalizedFileNameIndexToRealmItemMetadata = 204
     case addedExcludedFromSyncItems = 205
     case addedPendingChunkUploadCleanup = 206
+    case addedChangeDeliverySessions = 207
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ChangeEnumeration.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/ChangeEnumeration.md
@@ -1,0 +1,191 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Change enumeration
+
+Change enumeration reports items that changed after a sync anchor. It is
+different from item enumeration:
+
+- Item enumeration reports the current contents of a container through
+  `NSFileProviderEnumerationObserver`.
+- Change enumeration reports updates and deletions through
+  `NSFileProviderChangeObserver`.
+
+Server-side WebDAV pagination, where used by a remote read, is also separate
+from File Provider change batching. The remote read must finish before its
+changes can be delivered to the observer.
+
+The main entry point is
+``Enumerator/enumerateChanges(for:from:)``. It performs three steps:
+
+1. Recognises a continuation from an earlier batch.
+2. Validates a normal sync anchor when the request is not a continuation.
+3. Dispatches the request to the working set, trash, or a regular directory.
+
+## Containers
+
+The enumerator has a different change source for each container type.
+
+| Container | Change source | Final anchor |
+| --- | --- | --- |
+| Working set | Scans materialised items on the server and combines those results with pending local changes. | A new current anchor when the scan completes. If a remote read fails, the incoming anchor is retained. |
+| Regular directory | Reads the directory from WebDAV and compares it with local metadata. | The incoming anchor. |
+| Trash | Lists the server trash and finds local trash rows that no longer exist there. | The incoming anchor. |
+
+Only the working set is signalled by remote-change notifications. A working-set
+scan can read changed descendants of materialised directories, so it may find
+changes that are not represented by the local pending-change query alone.
+
+## Normal sync anchors
+
+Normal anchors use this format:
+
+```text
+<extension-version>|<ISO-8601-date>
+```
+
+`Enumerator.syncAnchor(at:)` creates them. The extension checks the format and
+the embedded version in `validatedSyncAnchorDate(_:reportingTo:)`.
+
+An invalid or old-version anchor is reported as
+`NSFileProviderError(.syncAnchorExpired)`. File Provider can then discard its
+cached state and request a fresh item enumeration.
+
+The final anchor is not necessarily the anchor passed to the request. A
+successful working-set scan advances to the enumerator's current anchor. A
+scan with skipped remote reads keeps the incoming anchor so the next working-set
+signal retries the missed work.
+
+## Deriving and storing changes
+
+The working-set and regular-directory scans update local metadata while they
+run. Repeating a scan for every batch could therefore hide changes that were
+already written to the database.
+
+Each scan first creates one ordered change list:
+
+1. Created and updated items are sorted by remote path length, so parents come
+   before children.
+2. Deleted items follow the updates.
+3. The complete list is stored in the change-delivery buffer.
+
+The buffer stores the list in the File Provider domain's Realm database. A
+`RealmChangeDeliverySession` records the current anchor, cursor, final anchor,
+and incomplete-scan state. Each `RealmChangeDeliveryItem` stores one metadata
+value, its sequence number, and whether it is a deletion.
+
+This state is separate from the live item metadata. It preserves the exact
+value that was derived, including metadata for an item that may be removed from
+the live database before the next batch is requested.
+
+## Batches
+
+File Provider supplies `suggestedBatchSize` on the change observer. The
+enumerator uses that value, falls back to 1,000 when it is absent or zero, and
+limits it to 4,000.
+
+`ChangeDeliveryBuffer.takeBatch(maxItems:)` then:
+
+1. Reads the next `maxItems + 1` stored changes.
+2. Reports at most `maxItems` changes.
+3. Uses the extra item to determine `moreComing`.
+4. Advances the stored cursor.
+
+Updates and deletions share the same limit. For a limit of three, two updates
+and one deletion consume the whole batch.
+
+One call to `enumerateChanges(for:from:)` reports one batch. The enumerator
+does not loop through all batches. It calls
+`finishEnumeratingChanges(upTo:moreComing:)`; when `moreComing` is true, File
+Provider requests the next batch in a later call.
+
+For example:
+
+```text
+Stored changes: 0 1 2 3 4 5 6 7 8 9
+Batch size:     3
+
+Request 1:      0 1 2, moreComing = true
+Request 2:      3 4 5, moreComing = true
+Request 3:      6 7 8, moreComing = true
+Request 4:      9,     moreComing = false
+```
+
+## Continuation anchors
+
+An intermediate batch returns an opaque continuation anchor. It is not a
+normal version-tagged sync anchor. The anchor identifies the saved pending
+change list and its next position.
+
+The next request must check for this continuation before normal sync-anchor
+validation. When the saved list is found, the enumerator reads the next batch
+without contacting the server again. The final batch returns the container's
+final sync anchor instead of a continuation anchor.
+
+The framework may invalidate the current `Enumerator` after an intermediate
+batch and create another one for the next request. The extension process may
+also be restarted. Pending changes must therefore be stored outside the
+enumerator instance or be exactly reconstructible from the anchor. This
+implementation uses the Realm-backed list for both cases.
+
+Do not assume that a process restart causes File Provider to provide the
+original anchor again. The last anchor returned for a batch may be the anchor
+used for the next request. See Apple's documentation for
+[`NSFileProviderChangeObserver`](https://developer.apple.com/documentation/fileprovider/nsfileproviderchangeobserver),
+[`finishEnumeratingChanges(upTo:moreComing:)`](https://developer.apple.com/documentation/fileprovider/nsfileproviderchangeobserver/finishenumeratingchanges%28upto%3Amorecoming%3A%29),
+and [`NSFileProviderSyncAnchor`](https://developer.apple.com/documentation/fileprovider/nsfileprovidersyncanchor).
+
+## Incomplete working-set scans
+
+The working-set scan continues after an individual remote read fails. It
+records that the scan was incomplete and skips that item for the current pass.
+The changes found from other items are still delivered.
+
+When the stored list is exhausted, an incomplete scan returns the incoming
+anchor. The next working-set notification can then retry the unreadable item.
+This prevents the extension from claiming that it has synchronised past a
+change it did not inspect.
+
+Regular-directory and trash enumeration use their own remote-read error paths.
+A missing regular directory is reported as a deletion, a no-change response
+finishes without changes, and other read errors finish with an error.
+
+## Diagnostics
+
+The following messages describe one multi-batch sequence:
+
+```text
+Reporting change batch. updated: 200, deleted: 0, moreComing: true
+Enumerator is being invalidated.
+System requested enumerator.
+Enumerating changes (anchor: ...).
+```
+
+The last request may be handled by a different `Enumerator` instance. That is
+expected. The important check is that the returned anchor is recognised and
+the next batch is delivered without re-running the remote change scan.
+
+If a remote read fails, look for the corresponding
+`Read of materialised item failed during working-set scan` message. An
+incomplete scan should also log that it retained the incoming sync anchor.
+
+## Tests
+
+The change-enumeration tests are in
+`Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift`:
+
+- `testWorkingSetChangesDeliveredInBatchesRespectingSuggestedBatchSize`
+  checks the combined batch limit, ordering, unique continuation anchors, and
+  that the server scan runs once.
+- `testWorkingSetChangesResumeAcrossNewEnumeratorInstances` creates a new
+  enumerator for every continuation request and checks that no changes are
+  lost or duplicated.
+- `testWorkingSetChangesBatchMixingUpdatesAndDeletions` checks the shared
+  update/deletion budget.
+- `testContainerChangesDeliveredInBatches` checks regular-directory changes.
+- `testTrashChangesDeliveredInBatches` checks batched trash deletions.
+
+These tests exercise the delivery logic in the package. A signed macOS build
+is still required to verify the interaction with the real `fileproviderd`.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -49,6 +49,7 @@ It is designed specifically for the implementation of this file provider extensi
 
 ### Design notes
 
+- <doc:ChangeEnumeration>
 - <doc:ExcludedFromSyncDeletion>
 - <doc:ChunkedUploads>
 - <doc:UnicodePathNormalization>

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
@@ -4,160 +4,204 @@
 import Foundation
 
 ///
-/// A thread-safe FIFO buffer of change metadata still to be delivered to an
-/// `NSFileProviderChangeObserver` across the successive `enumerateChanges(for:from:)` invocations the
-/// framework drives with `moreComing: true`.
+/// Durable FIFO state for a multi-batch File Provider change enumeration.
 ///
-/// The framework asserts (`__FILEPROVIDER_OBSERVER_TOO_MANY_ITEMS__`) when a single batch reports more
-/// than 100× its suggested batch size — ≈20000 items for the default suggestion. Large change sets
-/// (especially the working set, which aggregates the whole reachable tree) must therefore be split
-/// across several batches, and the SDK resumes a split enumeration by *re-invoking* `enumerateChanges`
-/// with the anchor that the previous batch returned — there is one `finishEnumeratingChanges` per call.
+/// The framework can invalidate an enumerator after an intermediate batch and invoke the next batch on a
+/// new enumerator. The pending changes and their position are therefore stored in Realm. An intermediate
+/// anchor identifies those pending changes and must be handled before ordinary sync-anchor validation.
 ///
-/// The change derivation that feeds this buffer is **destructive**: the working-set scan
-/// (``Enumerator/scanMaterialisedItemsForRemoteChanges()``) and the depth-1 container read both persist
-/// the discovered creations and updates (matching etags) to the local database as they run, so
-/// re-deriving on a continuation invocation would surface (almost) no created/updated items and that
-/// undelivered remainder would be silently dropped. The buffer therefore holds the full derived change
-/// set after a single derivation and hands it out one batch at a time; the derivation never runs again
-/// while the buffer stays primed for the same sync anchor.
+/// Updates are stored before deletions and are already sorted parents-before-children by the caller. Each
+/// batch consumes one combined item budget, so the framework never receives an oversized update/delete
+/// payload.
 ///
-/// Durability: the buffer is in memory. Within a normal `moreComing` chain the framework reuses the same
-/// ``Enumerator`` instance, so the remainder survives. If the extension process is recycled mid-drain (only
-/// reachable for change sets larger than ``Enumerator/maxBatchSize``), a fresh instance re-derives from the
-/// original anchor: undelivered **deletions** are recovered (their soft-deleted rows persist with a fresh
-/// `syncTime` until ``FilesDatabaseManager/removeItemMetadata(ocId:)`` runs after delivery, and the
-/// working-set re-derivation re-surfaces them via `pendingWorkingSetChanges(since:)`), but undelivered
-/// **created/updated** items can be lost — for a regular container entirely, and for the working set when
-/// the item is not materialised. This replaces a guaranteed crash with a rare, bounded partial loss.
-///
-/// ``Enumerator`` is `Sendable` with only immutable members, so the mutable delivery state lives behind
+/// ``Enumerator`` is `Sendable` with only immutable members, so the mutable session identifier lives behind
 /// this `@unchecked Sendable`, `NSLock`-guarded box — the established concurrency idiom in this target
 /// (see `FileProviderExtension.actionsLock`). `Synchronization.Mutex` is unavailable because the
 /// deployment target is macOS 13.
 ///
 final class ChangeDeliveryBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private let logger: FileProviderLogger
-    private var anchorKey: String?
-    private var remainingUpdated: [SendableItemMetadata] = []
-    private var remainingDeleted: [SendableItemMetadata] = []
-    /// Whether the derivation that primed this buffer was incomplete (at least one remote read failed
-    /// and was skipped). The caller uses this to avoid advancing the working-set sync point past changes
-    /// it could not discover this pass. Preserved across the whole `moreComing` drain sequence and cleared
-    /// alongside `anchorKey`.
-    private var primedIncomplete = false
+    private static let continuationPrefix = "fp-continuation|"
 
-    init(log: any FileProviderLogging) {
+    private let lock = NSLock()
+    private let dbManager: FilesDatabaseManager
+    private let logger: FileProviderLogger
+    private var sessionId: String?
+
+    init(dbManager: FilesDatabaseManager, log: any FileProviderLogging) {
+        self.dbManager = dbManager
         logger = FileProviderLogger(category: "ChangeDeliveryBuffer", log: log)
     }
 
-    ///
-    /// Whether a derivation has already filled the buffer for the given sync-anchor key and changes are
-    /// still waiting to be delivered. A continuation invocation that sees `true` must drain rather than
-    /// re-derive.
-    ///
+    /// Whether an active durable session is positioned at the given anchor.
     func isPrimed(forKey key: String) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return anchorKey == key
+
+        if let sessionId {
+            guard let session = dbManager.changeDeliverySession(sessionId: sessionId) else {
+                self.sessionId = nil
+                return false
+            }
+
+            return session.currentAnchorKey == key
+        }
+
+        guard key.hasPrefix(Self.continuationPrefix),
+              let session = dbManager.changeDeliverySession(forAnchorKey: key)
+        else {
+            return false
+        }
+
+        sessionId = session.sessionId
+        return true
     }
 
-    ///
-    /// Whether the currently-primed derivation was incomplete (a remote read failed and was skipped).
-    /// Returns `false` once the buffer has fully drained. See ``prime(key:updated:deleted:incomplete:)``.
-    ///
+    /// Whether `key` is an active durable continuation anchor.
+    func isContinuation(forKey key: String) -> Bool {
+        guard key.hasPrefix(Self.continuationPrefix) else {
+            return false
+        }
+
+        return isPrimed(forKey: key)
+    }
+
+    /// Whether the currently active derivation was incomplete and must retain its incoming sync anchor.
     func isPrimedIncomplete() -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return anchorKey != nil && primedIncomplete
+
+        guard let sessionId,
+              let session = dbManager.changeDeliverySession(sessionId: sessionId)
+        else {
+            return false
+        }
+
+        return session.incomplete
     }
 
-    ///
-    /// Store the full derived change set for a drain sequence, keyed by the originating sync anchor.
-    ///
-    /// `updated` must already be sorted parents-before-children (ascending remote-path length) so that
-    /// draining the single combined list front-to-back never reports a child in an earlier batch than
-    /// its parent.
-    ///
+    /// Persist the complete ordered change set for a new drain sequence.
     func prime(
         key: String,
+        finalAnchorRawValue: Data,
         updated: [SendableItemMetadata],
         deleted: [SendableItemMetadata],
         incomplete: Bool = false
     ) {
         lock.lock()
         defer { lock.unlock() }
-        anchorKey = key
-        remainingUpdated = updated
-        remainingDeleted = deleted
-        primedIncomplete = incomplete
-        logger.debug(
-            "Primed change delivery buffer. anchor: \(key), updated: \(updated.count), deleted: \(deleted.count), incomplete: \(incomplete)."
-        )
+
+        if let sessionId {
+            dbManager.removeChangeDeliverySession(sessionId: sessionId)
+        }
+
+        let newSessionId = UUID().uuidString
+        guard dbManager.createChangeDeliverySession(
+            sessionId: newSessionId,
+            anchorKey: key,
+            finalAnchorRawValue: finalAnchorRawValue,
+            updated: updated,
+            deleted: deleted,
+            incomplete: incomplete
+        ) else {
+            sessionId = nil
+            logger.error("Could not persist change delivery session.")
+            return
+        }
+
+        sessionId = newSessionId
+        logger.debug("Persisted change delivery session.")
     }
 
     ///
-    /// Pop the next batch, budgeting updates and deletions *together* against `maxItems` so the combined
-    /// `didUpdate` + `didDeleteItems` payload of a single `finishEnumeratingChanges` stays under the cap.
-    /// Updates are drained before deletions, preserving the parent-before-child ordering of the updates.
+    /// Consume the next combined update/delete batch and persist the cursor before returning it.
     ///
-    /// `moreComing` reflects whether anything is still buffered *after* this batch (so an exactly-full
-    /// final batch does not provoke a spurious empty follow-up). The key is cleared once both lists drain,
-    /// so a later signal starts a fresh derivation.
+    /// `moreComing` is false when this batch consumed the final stored item. Intermediate batches return a
+    /// durable continuation anchor; the final batch returns the sync anchor captured when the session was
+    /// primed.
     ///
     func takeBatch(
         maxItems: Int
-    ) -> (updated: [SendableItemMetadata], deleted: [SendableItemMetadata], moreComing: Bool) {
+    ) -> (
+        updated: [SendableItemMetadata],
+        deleted: [SendableItemMetadata],
+        moreComing: Bool,
+        continuationAnchorRawValue: Data?,
+        finalAnchorRawValue: Data?
+    ) {
         lock.lock()
         defer { lock.unlock() }
 
-        let key = anchorKey ?? "nil"
         let budget = max(1, maxItems)
-
-        let updatedCount = Swift.min(remainingUpdated.count, budget)
-        let batchUpdated = Array(remainingUpdated.prefix(updatedCount))
-        remainingUpdated.removeFirst(updatedCount)
-
-        let deletedCount = Swift.min(remainingDeleted.count, budget - updatedCount)
-        let batchDeleted = Array(remainingDeleted.prefix(deletedCount))
-        remainingDeleted.removeFirst(deletedCount)
-
-        let moreComing = !remainingUpdated.isEmpty || !remainingDeleted.isEmpty
-        if !moreComing {
-            anchorKey = nil
-            primedIncomplete = false
+        guard let sessionId,
+              let session = dbManager.changeDeliverySession(sessionId: sessionId)
+        else {
+            return ([], [], false, nil, nil)
         }
 
-        logger.debug(
-            "Drained change batch. anchor: \(key), maxItems: \(budget), tookUpdated: \(updatedCount), tookDeleted: \(deletedCount), remainingUpdated: \(remainingUpdated.count), remainingDeleted: \(remainingDeleted.count), moreComing: \(moreComing)"
+        let storedItems = dbManager.changeDeliveryItems(
+            sessionId: sessionId,
+            fromSequence: session.nextSequence,
+            limit: budget + 1
+        )
+        let batchItems = Array(storedItems.prefix(budget))
+        let moreComing = storedItems.count > budget
+        let decoder = JSONDecoder()
+        var updated = [SendableItemMetadata]()
+        var deleted = [SendableItemMetadata]()
+
+        for item in batchItems {
+            guard let metadata = try? decoder.decode(SendableItemMetadata.self, from: item.metadataData) else {
+                logger.error("Could not decode change delivery item.")
+                return ([], [], false, nil, session.finalAnchorRawValue)
+            }
+
+            if item.deleted {
+                deleted.append(metadata)
+            } else {
+                updated.append(metadata)
+            }
+        }
+
+        let nextSequence = batchItems.last.map { $0.sequence + 1 } ?? session.nextSequence
+        let continuationAnchor: Data?
+        let nextAnchorKey: String?
+        if moreComing {
+            let key = "\(Self.continuationPrefix)\(sessionId)|\(nextSequence)"
+            continuationAnchor = Data(key.utf8)
+            nextAnchorKey = key
+        } else {
+            continuationAnchor = nil
+            nextAnchorKey = nil
+        }
+
+        dbManager.advanceChangeDeliverySession(
+            sessionId: sessionId,
+            nextSequence: nextSequence,
+            nextAnchorKey: nextAnchorKey,
+            completed: !moreComing
         )
 
-        return (batchUpdated, batchDeleted, moreComing)
+        logger.debug("Consumed change delivery batch.")
+        return (
+            updated,
+            deleted,
+            moreComing,
+            continuationAnchor,
+            session.finalAnchorRawValue
+        )
     }
 
-    ///
-    /// Discard any buffered state. Used when a fresh enumeration arrives under a different anchor than
-    /// the one the buffer was primed for, so a stale remainder is never served against a new sync point.
-    ///
+    /// Discard the active durable session when a fresh enumeration replaces an abandoned drain.
     func reset() {
         lock.lock()
         defer { lock.unlock() }
-        let previousKey = anchorKey
-        let discardedUpdated = remainingUpdated.count
-        let discardedDeleted = remainingDeleted.count
 
-        anchorKey = nil
-        remainingUpdated = []
-        remainingDeleted = []
-        primedIncomplete = false
-
-        // A non-empty discard means an in-progress drain was abandoned (a fresh enumeration arrived under
-        // a different anchor). Log it loudly enough to spot potential change loss from a debug archive.
-        if discardedUpdated > 0 || discardedDeleted > 0 {
-            logger.info(
-                "Reset change delivery buffer, discarding undelivered remainder. anchor: \(previousKey ?? "nil"), discardedUpdated: \(discardedUpdated), discardedDeleted: \(discardedDeleted)"
-            )
+        guard let sessionId else {
+            return
         }
+
+        dbManager.removeChangeDeliverySession(sessionId: sessionId)
+        self.sessionId = nil
+        logger.info("Reset change delivery session.")
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ChangeEnumeration.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ChangeEnumeration.swift
@@ -34,12 +34,10 @@ extension Enumerator {
 
             // Continuation of an in-progress drain: serve the next buffered batch without re-reading
             // the container (the depth-1 read is destructive, so re-deriving would lose the remainder).
-            // A regular container preserves its incoming anchor, so startAnchor and finalAnchor match.
             if changeBuffer.isPrimed(forKey: anchorKey) {
                 logger.debug("Container change buffer primed for anchor \(anchorKey); draining next batch without re-reading.", [.url: serverUrl])
                 drainChangeBuffer(
                     for: observer,
-                    startAnchor: anchor,
                     finalAnchor: anchor,
                     suggested: observer.suggestedBatchSize
                 )
@@ -116,11 +114,15 @@ extension Enumerator {
             // re-invocations without exceeding the per-batch limit.
             let sortedUpdated = changes.createdAndUpdated
                 .sorted { $0.remotePath().count < $1.remotePath().count }
-            changeBuffer.prime(key: anchorKey, updated: sortedUpdated, deleted: changes.deleted)
+            changeBuffer.prime(
+                key: anchorKey,
+                finalAnchorRawValue: anchor.rawValue,
+                updated: sortedUpdated,
+                deleted: changes.deleted
+            )
 
             drainChangeBuffer(
                 for: observer,
-                startAnchor: anchor,
                 finalAnchor: anchor,
                 suggested: observer.suggestedBatchSize
             )

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
@@ -78,19 +78,23 @@ extension Enumerator {
     ///
     /// Pop the next batch from ``changeBuffer`` and report it.
     ///
-    /// Intermediate batches (`moreComing == true`) return `startAnchor` — the anchor the enumeration was
-    /// invoked with — so that if the drain is interrupted the framework resumes *behind* every
-    /// undelivered item rather than advancing the sync point past changes still sitting in the buffer.
-    /// Only the final batch returns `finalAnchor` (the working set advances to ``currentAnchor``; a
-    /// regular container preserves its incoming anchor).
+    /// Intermediate batches (`moreComing == true`) return a durable continuation anchor. Only the final
+    /// batch returns the buffered `finalAnchor` (the working set advances to ``currentAnchor``; a regular
+    /// container preserves its incoming anchor).
     ///
     func drainChangeBuffer(
         for observer: NSFileProviderChangeObserver,
-        startAnchor: NSFileProviderSyncAnchor,
         finalAnchor: NSFileProviderSyncAnchor,
         suggested: Int?
     ) {
         let batch = changeBuffer.takeBatch(maxItems: effectiveBatchSize(suggested: suggested))
+        let reportedAnchor = if let continuationAnchorRawValue = batch.continuationAnchorRawValue {
+            NSFileProviderSyncAnchor(rawValue: continuationAnchorRawValue)
+        } else if let finalAnchorRawValue = batch.finalAnchorRawValue {
+            NSFileProviderSyncAnchor(rawValue: finalAnchorRawValue)
+        } else {
+            finalAnchor
+        }
         logger.info(
             "Reporting change batch. updated: \(batch.updated.count), deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)",
             [.item: enumeratedItemIdentifier]
@@ -99,7 +103,7 @@ extension Enumerator {
             observer,
             updated: batch.updated,
             deleted: batch.deleted,
-            anchor: batch.moreComing ? startAnchor : finalAnchor,
+            anchor: reportedAnchor,
             moreComing: batch.moreComing,
             account: account,
             remoteInterface: remoteInterface,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+Trash.swift
@@ -11,8 +11,8 @@ extension Enumerator {
     /// `NKTrash` items have no ETag; the only trash change of interest is a *permanent* remote deletion,
     /// detected as a local trash row absent from the remote listing. Those orphans are derived once (see
     /// ``enumerateTrashChanges(for:anchor:)``) and drained here one capped batch per invocation so a large
-    /// permanent-purge cannot exceed the framework's per-batch limit. Trash preserves its incoming anchor
-    /// (like a regular container), so the same anchor is returned on every batch. Each delivered orphan is
+    /// permanent-purge cannot exceed the framework's per-batch limit. Intermediate batches use a durable
+    /// continuation anchor, while the final batch preserves the incoming anchor. Each delivered orphan is
     /// soft-deleted (`deleteItemMetadata`) only after its batch finishes, so an interrupted drain keeps its
     /// row — the reconciliation re-derives it (the row still carries a trash `serverUrl`) rather than
     /// dropping it.
@@ -34,7 +34,15 @@ extension Enumerator {
             dbManager.deleteItemMetadata(ocId: metadata.ocId)
         }
 
-        observer.finishEnumeratingChanges(upTo: anchor, moreComing: batch.moreComing)
+        let reportedAnchor = if let continuationAnchorRawValue = batch.continuationAnchorRawValue {
+            NSFileProviderSyncAnchor(rawValue: continuationAnchorRawValue)
+        } else if let finalAnchorRawValue = batch.finalAnchorRawValue {
+            NSFileProviderSyncAnchor(rawValue: finalAnchorRawValue)
+        } else {
+            anchor
+        }
+
+        observer.finishEnumeratingChanges(upTo: reportedAnchor, moreComing: batch.moreComing)
 
         logger.debug("Reported trash deletion batch. deleted: \(batch.deleted.count), moreComing: \(batch.moreComing)")
     }
@@ -151,7 +159,12 @@ extension Enumerator {
                 logger.info("Permanently deleting remote trash item which could not be matched with a local one.", [.item: orphan.ocId])
             }
 
-            changeBuffer.prime(key: anchorKey, updated: [], deleted: orphans)
+            changeBuffer.prime(
+                key: anchorKey,
+                finalAnchorRawValue: anchor.rawValue,
+                updated: [],
+                deleted: orphans
+            )
             drainTrashDeletions(for: observer, anchor: anchor, suggested: observer.suggestedBatchSize)
         }
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -53,16 +53,18 @@ extension Enumerator {
                 let sortedUpdated = changes.createdAndUpdated
                     .sorted { $0.remotePath().count < $1.remotePath().count }
 
+                let finalAnchor = serverChanges.hadFailure ? anchor : currentAnchor
                 changeBuffer.prime(
                     key: anchorKey,
+                    finalAnchorRawValue: finalAnchor.rawValue,
                     updated: sortedUpdated,
                     deleted: changes.deleted,
                     incomplete: serverChanges.hadFailure
                 )
             }
 
-            // Intermediate batches keep the original anchor so an interrupted drain resumes behind all
-            // undelivered items. The final batch normally advances the working-set sync point to
+            // Intermediate batches use a durable continuation anchor. The final batch normally advances
+            // the working-set sync point to
             // currentAnchor — but when the scan was incomplete (a remote read failed and was skipped) we
             // keep the incoming anchor instead, so we do not tell the framework we are synced up to "now"
             // past changes we could not discover this pass. The next working-set signal re-derives and
@@ -71,7 +73,6 @@ extension Enumerator {
             let finalAnchor = changeBuffer.isPrimedIncomplete() ? anchor : currentAnchor
             drainChangeBuffer(
                 for: observer,
-                startAnchor: anchor,
                 finalAnchor: finalAnchor,
                 suggested: observer.suggestedBatchSize
             )

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator.swift
@@ -51,16 +51,8 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
     let remoteInterface: RemoteInterface
     let serverUrl: String
 
-    /// Holds the undelivered remainder of a large change set so it can be reported one batch at a time
-    /// across the framework's `moreComing` re-invocations without re-running the destructive derivation.
-    /// See ``ChangeDeliveryBuffer`` and ``drainChangeBuffer(for:startAnchor:finalAnchor:suggested:)``.
-    ///
-    /// Load-bearing assumption: the framework continues a `moreComing` chain on the *same* enumerator
-    /// instance, re-invoking `enumerateChanges(for:from:)` with the anchor the previous batch returned
-    /// (see `NSFileProviderEnumerating.h`, `currentSyncAnchorWithCompletionHandler`). The in-memory
-    /// buffer therefore survives the chain. If the extension process is recycled mid-drain, a fresh
-    /// instance re-derives from the original anchor; see ``ChangeDeliveryBuffer`` for the bounded
-    /// created/updated loss this can cause for change sets larger than ``maxBatchSize``.
+    /// Stores pending changes between File Provider requests. The changes are stored in Realm so a new
+    /// enumerator can resume the next batch.
     let changeBuffer: ChangeDeliveryBuffer
 
     /// Default number of items reported per page/batch when the system does not suggest one. Mirrors the
@@ -94,7 +86,7 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
         self.domain = domain
         pageItemCount = pageSize
         logger = FileProviderLogger(category: "Enumerator", log: log)
-        changeBuffer = ChangeDeliveryBuffer(log: log)
+        changeBuffer = ChangeDeliveryBuffer(dbManager: dbManager, log: log)
 
         if Self.isSystemIdentifier(enumeratedItemIdentifier) {
             logger.info("Providing enumerator for a system defined container.", [.item: enumeratedItemIdentifier])
@@ -149,6 +141,23 @@ public final class Enumerator: NSObject, NSFileProviderEnumerator, Sendable {
 
     public func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
         logger.debug("Enumerating changes (anchor: \(String(data: anchor.rawValue, encoding: .utf8) ?? "")).", [.url: serverUrl])
+
+        let anchorKey = String(data: anchor.rawValue, encoding: .utf8) ?? ""
+
+        // An intermediate anchor means that File Provider is asking for the next part of the same change
+        // list. Check for that saved list before parsing the anchor as a normal sync anchor. If the list is
+        // found, deliver its next batch; otherwise continue with normal validation, which rejects an
+        // unknown or stale anchor.
+        if changeBuffer.isContinuation(forKey: anchorKey) {
+            if enumeratedItemIdentifier == .workingSet {
+                enumerateWorkingSetChanges(for: observer, since: Date(), anchor: anchor)
+            } else if enumeratedItemIdentifier == .trashContainer {
+                enumerateTrashChanges(for: observer, anchor: anchor)
+            } else {
+                enumerateContainerChanges(for: observer, anchor: anchor)
+            }
+            return
+        }
 
         // The version-tagged anchor check applies to every container. An anchor that does not parse,
         // or whose embedded extension version differs from the running build, is rejected as expired

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/RealmChangeDeliveryItem.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/RealmChangeDeliveryItem.swift
@@ -1,0 +1,28 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import RealmSwift
+
+/// One durably stored item in a multi-batch File Provider change enumeration.
+final class RealmChangeDeliveryItem: Object {
+    @Persisted(primaryKey: true) var primaryKey = ""
+    @Persisted(indexed: true) var sessionId = ""
+    @Persisted var sequence = 0
+    @Persisted var metadataData = Data()
+    @Persisted var deleted = false
+
+    convenience init(
+        sessionId: String,
+        sequence: Int,
+        metadataData: Data,
+        deleted: Bool
+    ) {
+        self.init()
+        primaryKey = "\(sessionId)|\(sequence)"
+        self.sessionId = sessionId
+        self.sequence = sequence
+        self.metadataData = metadataData
+        self.deleted = deleted
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/RealmChangeDeliverySession.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/RealmChangeDeliverySession.swift
@@ -1,0 +1,28 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import RealmSwift
+
+/// Durable state for one multi-batch File Provider change enumeration.
+final class RealmChangeDeliverySession: Object {
+    @Persisted(primaryKey: true) var sessionId = ""
+    @Persisted var currentAnchorKey = ""
+    @Persisted var nextSequence = 0
+    @Persisted var finalAnchorRawValue = Data()
+    @Persisted var incomplete = false
+    @Persisted var completed = false
+
+    convenience init(
+        sessionId: String,
+        currentAnchorKey: String,
+        finalAnchorRawValue: Data,
+        incomplete: Bool
+    ) {
+        self.init()
+        self.sessionId = sessionId
+        self.currentAnchorKey = currentAnchorKey
+        self.finalAnchorRawValue = finalAnchorRawValue
+        self.incomplete = incomplete
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata.swift
@@ -10,7 +10,7 @@ import Foundation
 /// **Do not hand them across the boundaries of different concurrency domains!**
 /// Ensure that this representation is the only one passed around and always completely abstract Realm to upper layer calling code.
 ///
-public struct SendableItemMetadata: ItemMetadata, Sendable {
+public struct SendableItemMetadata: ItemMetadata, Codable, Sendable {
     public var ocId: String
     public var account: String
     public var checksums: String

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -2187,11 +2187,13 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             previousTotal = total
         }
 
-        // Intermediate batches keep the original anchor; only the final batch advances the sync point.
+        // Intermediate batches use distinct continuation anchors; only the final batch advances the sync point.
+        let intermediateAnchors = observer.finishes.dropLast().map(\.anchor.rawValue)
         for finish in observer.finishes.dropLast() {
             XCTAssertTrue(finish.moreComing, "Non-final batches must report moreComing == true.")
-            XCTAssertEqual(finish.anchor.rawValue, anchor.rawValue, "Intermediate batches must return the original anchor.")
+            XCTAssertNotEqual(finish.anchor.rawValue, anchor.rawValue, "Intermediate batches must return a continuation anchor.")
         }
+        XCTAssertEqual(Set(intermediateAnchors).count, intermediateAnchors.count, "Continuation anchors must be unique.")
         let finalFinish = try XCTUnwrap(observer.finishes.last)
         XCTAssertFalse(finalFinish.moreComing, "The final batch must report moreComing == false.")
         XCTAssertNotEqual(finalFinish.anchor.rawValue, anchor.rawValue, "The final batch must advance the working-set sync anchor.")
@@ -2201,6 +2203,88 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             remoteInterface.readOperationCount,
             itemCount + 2,
             "Continuation batches must drain the buffer, not re-run the server scan."
+        )
+    }
+
+    func testWorkingSetChangesResumeAcrossNewEnumeratorInstances() async throws {
+        // fileproviderd may invalidate the enumerator after an intermediate batch. The continuation must
+        // therefore resume from durable state when the next request is handled by a new Enumerator.
+        let db = Self.dbManager.ncDatabase()
+        debugPrint(db)
+
+        let anchor = Enumerator.syncAnchor(at: Date().addingTimeInterval(-300))
+        let itemCount = 10
+        let batchSize = 3
+        let expectedOcIds = seedMaterialisedWorkingSetFiles(count: itemCount, syncTime: Date())
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        let firstEnumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        let firstObserver = MockChangeObserver(enumerator: firstEnumerator)
+        firstObserver.suggestedBatchSize = batchSize
+        firstEnumerator.enumerateChanges(for: firstObserver, from: anchor)
+
+        for _ in 0 ..< 5000 {
+            if !firstObserver.finishes.isEmpty || firstObserver.error != nil {
+                break
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        XCTAssertNil(firstObserver.error)
+        let firstFinish = try XCTUnwrap(firstObserver.finishes.first)
+        XCTAssertTrue(firstFinish.moreComing)
+
+        var reportedOcIds = firstObserver.changedItems.map(\.itemIdentifier.rawValue)
+        var currentAnchor = firstFinish.anchor
+        var continuationAnchors = Set<Data>([currentAnchor.rawValue])
+        var batchCount = 1
+        var moreComing = firstFinish.moreComing
+
+        while moreComing, batchCount < 10 {
+            let nextEnumerator = try Enumerator(
+                enumeratedItemIdentifier: .workingSet,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager,
+                log: FileProviderLogMock()
+            )
+            let nextObserver = MockChangeObserver(enumerator: nextEnumerator)
+            nextObserver.suggestedBatchSize = batchSize
+            nextEnumerator.enumerateChanges(for: nextObserver, from: currentAnchor)
+
+            for _ in 0 ..< 5000 {
+                if !nextObserver.finishes.isEmpty || nextObserver.error != nil {
+                    break
+                }
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+
+            XCTAssertNil(nextObserver.error)
+            let finish = try XCTUnwrap(nextObserver.finishes.first)
+            reportedOcIds += nextObserver.changedItems.map(\.itemIdentifier.rawValue)
+            XCTAssertTrue(
+                continuationAnchors.insert(finish.anchor.rawValue).inserted,
+                "Each intermediate continuation must identify a distinct durable cursor."
+            )
+            currentAnchor = finish.anchor
+            batchCount += 1
+            moreComing = finish.moreComing
+        }
+
+        XCTAssertEqual(batchCount, 4, "Ten items with a batch size of three require four batches.")
+        XCTAssertEqual(reportedOcIds.count, itemCount)
+        XCTAssertEqual(Set(reportedOcIds), expectedOcIds)
+        XCTAssertNotEqual(currentAnchor.rawValue, anchor.rawValue)
+        XCTAssertLessThanOrEqual(
+            remoteInterface.readOperationCount,
+            itemCount + 2,
+            "New enumerator instances must drain the persisted snapshot without re-reading the server."
         )
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -25,6 +25,50 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         XCTAssertNotNil(Self.dbManager, "FilesDatabaseManager should be initialized")
     }
 
+    func testCompletedChangeDeliverySessionRemovesPersistedState() {
+        let sessionId = "completed-change-delivery-\(name)"
+        let metadata = SendableItemMetadata(
+            ocId: "change-delivery-item-\(name)",
+            fileName: "item.txt",
+            account: Self.account
+        )
+
+        XCTAssertTrue(
+            Self.dbManager.createChangeDeliverySession(
+                sessionId: sessionId,
+                anchorKey: "initial-anchor-\(name)",
+                finalAnchorRawValue: Data("final-anchor".utf8),
+                updated: [metadata],
+                deleted: [],
+                incomplete: false
+            )
+        )
+
+        let database = Self.dbManager.ncDatabase()
+        XCTAssertNotNil(database.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId))
+        XCTAssertEqual(
+            database.objects(RealmChangeDeliveryItem.self)
+                .where { $0.sessionId == sessionId }
+                .count,
+            1
+        )
+
+        Self.dbManager.advanceChangeDeliverySession(
+            sessionId: sessionId,
+            nextSequence: 1,
+            nextAnchorKey: nil,
+            completed: true
+        )
+
+        let cleanedDatabase = Self.dbManager.ncDatabase()
+        XCTAssertNil(cleanedDatabase.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId))
+        XCTAssertTrue(
+            cleanedDatabase.objects(RealmChangeDeliveryItem.self)
+                .where { $0.sessionId == sessionId }
+                .isEmpty
+        )
+    }
+
     func testSchema203MigrationBackfillsCanonicalPathKeys() throws {
         let databaseDirectory = makeDatabaseDirectory()
         let domainIdentifier = NSFileProviderDomainIdentifier("migration-test")


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->


## Resolves

https://github.com/nextcloud/desktop/issues/10556

## Summary

We had issues with the batched change reporting in the enumerator.

1. We needed to change the anchor in between change batches in order for moreComing to be respected by the system (and for further changes to be requested by the system)
2. These intermediate anchors need to survive outside of the enumerator instance used for the initial change enumeration, as the system creates a new enumerator per batch

## Issue Reproduction

The unchanged-anchor bug reproduced successfully.

- Baseline folder was empty and visited.
- With client and extension stopped, 205 files were uploaded successfully.
- After restart, the extension derived 207 updates: 205 files plus the root and test folder.
- It reported 200 updates, retained seven, and returned moreComing: true.
- Subsequent scans restarted from the identical anchor instead of delivering the seven-item continuation.
- Finder’s File Provider mount contained only 198 of the 205 files. The missing files were item-122.txt through item-127.txt, plus item-191.txt.
- All seven missing files returned HTTP 200 from the server.
- No 502 occurred, and there were zero File Provider errors before cleanup.

The current macOS version did not retain the literal “token is unchanged” message, but the daemon’s anchor remained unchanged and no updated: 7, moreComing: false batch occurred. The behavior is therefore confirmed directly.


## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
