### PR TITLE
fix(file-provider): Prevent concurrent write crash in XPC utils

### DIFF
--- a/src/gui/macOS/fileproviderxpc_mac_utils.mm
+++ b/src/gui/macOS/fileproviderxpc_mac_utils.mm
@@ -79,7 +79,9 @@ NSArray<NSDictionary<NSFileProviderServiceName, NSFileProviderService *> *> *get
             } else if (service.name == nil) {
                 qCWarning(lcFileProviderXPCUtils) << "Service has no name";
             } else {
+                @synchronized (fpServices) {
                 [fpServices addObject:@{service.name: service}];
+            }
             }
 
             dispatch_group_leave(group);
@@ -108,7 +110,11 @@ NSArray<NSURL *> *getDomainUrlsForManagers(NSArray<NSFileProviderManager *> *man
             }
 
             qCDebug(lcFileProviderXPCUtils) << "Got user visible url" << url;
+            if (url != nil) {
+                @synchronized (urls) {
             [urls addObject:url];
+                }
+            }
             dispatch_group_leave(group);
         }];
     }
@@ -142,7 +148,11 @@ NSArray<NSDictionary<NSFileProviderServiceName, NSFileProviderService *> *> *get
                                       << url.absoluteString
                                       << "has number of services:"
                                       << services.count;
+            if (services != nil) {
+                @synchronized (fpServices) {
             [fpServices addObject:services];
+                }
+            }
             dispatch_group_leave(group);
         }];
     }
@@ -189,7 +199,9 @@ NSArray<NSXPCConnection *> *connectToFileProviderServices(NSArray<NSDictionary<N
                     return;
                 }
 
+                @synchronized (connections) {
                 [connections addObject:connection];
+                }
                 dispatch_group_leave(group);
             }];
         }

--- a/src/gui/macOS/fileproviderxpc_mac_utils.mm
+++ b/src/gui/macOS/fileproviderxpc_mac_utils.mm
@@ -76,6 +76,8 @@ NSArray<NSDictionary<NSFileProviderServiceName, NSFileProviderService *> *> *get
                 qCWarning(lcFileProviderXPCUtils) << "Failed to resolve service for file provider domain: " << error;
             } else if (service == nil) {
                 qCWarning(lcFileProviderXPCUtils) << "Service is nil!";
+            } else if (service.name == nil) {
+                qCWarning(lcFileProviderXPCUtils) << "Service has no name";
             } else {
                 [fpServices addObject:@{service.name: service}];
             }

--- a/test/macOS/CMakeLists.txt
+++ b/test/macOS/CMakeLists.txt
@@ -7,3 +7,8 @@
 nextcloud_add_test(FinderSyncBrokerIdentity)
 nextcloud_add_test(SystraySyncControlMacOS)
 nextcloud_add_test(MacSandboxUtility)
+
+if(BUILD_FILE_PROVIDER_MODULE)
+    nextcloud_add_test(FileProviderXPCUtils)
+    set_source_files_properties(testfileproviderxpcutils.cpp PROPERTIES COMPILE_FLAGS "-x objective-c++")
+endif()

--- a/test/macOS/testfileproviderxpcutils.cpp
+++ b/test/macOS/testfileproviderxpcutils.cpp
@@ -37,7 +37,7 @@ class TestFileProviderXPCUtils : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void concurrentServiceLookupsCanBeCollected()
     {
         constexpr auto managerCount = 128;

--- a/test/macOS/testfileproviderxpcutils.cpp
+++ b/test/macOS/testfileproviderxpcutils.cpp
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QtTest>
+
+#include "macOS/fileproviderxpc_mac_utils.h"
+
+#import <FileProvider/FileProvider.h>
+
+@interface TestFileProviderService : NSObject
+@property (nonatomic, copy) NSString *name;
+@end
+
+@implementation TestFileProviderService
+@end
+
+@interface TestFileProviderManager : NSObject
+@property (nonatomic, retain) NSFileProviderService *service;
+@end
+
+@implementation TestFileProviderManager
+
+- (void)getServiceWithName:(NSFileProviderServiceName)serviceName
+             itemIdentifier:(NSFileProviderItemIdentifier)itemIdentifier
+          completionHandler:(void (^)(NSFileProviderService *service, NSError *error))completionHandler
+{
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        completionHandler(self.service, nil);
+    });
+}
+
+@end
+
+class TestFileProviderXPCUtils : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void concurrentServiceLookupsCanBeCollected()
+    {
+        constexpr auto managerCount = 128;
+        NSMutableArray<NSFileProviderManager *> * const managers = NSMutableArray.array;
+
+        for (auto index = 0; index < managerCount; ++index) {
+            const auto service = [TestFileProviderService new];
+            service.name = [NSString stringWithFormat:@"service-%d", index];
+
+            const auto manager = [TestFileProviderManager new];
+            manager.service = (NSFileProviderService *)service;
+            [managers addObject:(NSFileProviderManager *)manager];
+            [service release];
+            [manager release];
+        }
+
+        const auto services = OCC::Mac::FileProviderXPCUtils::getFileProviderServices(managers);
+        QCOMPARE(services.count, managerCount);
+    }
+
+    void serviceWithoutNameIsIgnored()
+    {
+        const auto service = [TestFileProviderService new];
+        const auto manager = [TestFileProviderManager new];
+        manager.service = (NSFileProviderService *)service;
+
+        const auto services = OCC::Mac::FileProviderXPCUtils::getFileProviderServices(@[(NSFileProviderManager *)manager]);
+        QCOMPARE(services.count, 0);
+
+        [service release];
+        [manager release];
+    }
+};
+
+QTEST_APPLESS_MAIN(TestFileProviderXPCUtils)
+#include "testfileproviderxpcutils.moc"


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

On launch, it is possible for concurrent accesses to be made to some of the internal members of `FileProviderXPCUtils`, triggering a crash:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000181f8abf0 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x0000000181a1691c objc_exception_throw + 88
	2   CoreFoundation                      0x0000000181ea2ec8 -[__NSPlaceholderArray initWithObjects:count:] + 640
	3   CoreFoundation                      0x0000000181ec6310 -[NSArray initWithArray:range:copyItems:] + 364
	4   Nextcloud                           0x0000000102c664e4 _ZN3OCC3Mac20FileProviderXPCUtils23getFileProviderServicesEP7NSArrayIP21NSFileProviderManagerE + 332
	5   Nextcloud                           0x0000000102c60e10 _ZN3OCC3Mac15FileProviderXPC28connectToFileProviderDomainsEv + 236
	6   Nextcloud                           0x0000000102c45a6c _ZN3OCC3Mac12FileProvider12configureXPCEv + 344
	7   Nextcloud                           0x0000000102c5b954 _ZNK3OCC3Mac30FileProviderSettingsController16operationMessageEv + 164
	8   Nextcloud                           0x0000000102c55f94 _ZN3OCC3Mac30FileProviderSettingsControllerC2EP7QObject + 92
	9   Nextcloud                           0x0000000102c55ef0 _ZN3OCC3Mac30FileProviderSettingsController8instanceEv + 80
	10  Nextcloud                           0x0000000102a0af24 _ZN3OCC11ApplicationC2ERiPPc + 7088
	11  Nextcloud                           0x0000000102979d44 main + 160
	12  dyld                                0x0000000181aa3da4 start + 6992
)
libc++abi: terminating due to uncaught exception of type NSException
```

This PR synchronises writes to these data structures

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
