### PR TITLE
fix(systray): don't open the tray popup while starting up

### DIFF
--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -20,6 +20,7 @@
 #include "logger.h"
 #include "pushnotifications.h"
 #include "socketapi/socketapi.h"
+#include "systray.h"
 #include "theme.h"
 #include "urischemehandler.h"
 
@@ -452,6 +453,13 @@ Application::Application(int &argc, char **argv)
     // setup that follows, like folder setup
     _gui = new ownCloudGui(this);
     connect(_theme, &Theme::systrayUseMonoIconsChanged, _gui, &ownCloudGui::slotComputeOverallSyncStatus);
+
+    // Startup is done, so a newly added account may open the tray popup again.
+    // Restoring the saved accounts above emits AccountManager::accountAdded too,
+    // and on X11 the popup takes a pointer and keyboard grab that is then held
+    // across the blocking disk I/O in FolderMan::setupFolders(), leaving the
+    // whole desktop unable to accept any input for as long as that takes.
+    Systray::instance()->setStartupFinished(true);
     if (_showLogWindow) {
         _gui->slotToggleLogBrowser(); // _showLogWindow is set in parseOptions.
     }

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -169,7 +169,17 @@ Systray::Systray()
     // is placed
 
     connect(AccountManager::instance(), &AccountManager::accountAdded,
-        this, [this]{ showTrayPopup(WindowPosition::Center); });
+        this, [this]{
+            // accountAdded is also emitted during startup, when
+            // AccountManager::restore() brings the saved accounts back. Showing the
+            // popup there takes an X11 pointer and keyboard grab while the GUI thread
+            // goes straight on into FolderMan::setupFolders() and blocks on disk,
+            // so input dies desktop-wide for as long as that takes.
+            if (!startupFinished()) {
+                return;
+            }
+            showTrayPopup(WindowPosition::Center);
+        });
 #endif
 
     if (FolderMan::instance()) {

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -74,6 +74,13 @@ public:
     static Systray *instance();
     ~Systray() override = default;
 
+    /** No tray popup while the client is still starting up: showing it takes an
+     *  X11 pointer and keyboard grab, and the GUI thread blocks right afterwards
+     *  in FolderMan::setupFolders() doing synchronous disk I/O. The grab is then
+     *  held for the whole of that, freezing input for the entire desktop. */
+    void setStartupFinished(bool finished) { _startupFinished = finished; }
+    [[nodiscard]] bool startupFinished() const { return _startupFinished; }
+
     enum class TaskBarPosition { Bottom, Left, Top, Right };
     Q_ENUM(TaskBarPosition);
 
@@ -230,6 +237,7 @@ private:
     bool _isTrayContextMenuVisible = false;
     bool _syncIsPaused = true;
     bool _anySyncFolders = false;
+    bool _startupFinished = false;
 
     std::unique_ptr<QQmlApplicationEngine> _trayEngine;
     QPointer<QMenu> _contextMenu;


### PR DESCRIPTION
## Resolves
#10610

## Summary

On Linux the tray popup opens during startup and takes an X11 pointer and keyboard grab.
The same thread then blocks in `FolderMan::setupFolders()`, so the grab is held across all
of it and the whole desktop stops accepting input — no application sees a click or a
keystroke until startup is done. Everything keeps rendering, which is what makes it look
like the machine has locked up rather than like a slow client.

`Systray::Systray()` wires the popup to `AccountManager::accountAdded`. That is meant for
the wizard, so an account added by hand opens the tray centered instead of wherever the
cursor happens to be. But `AccountManager::restore()` emits the same signal while restoring
the saved accounts at startup, so the popup opens on every single launch.

This adds a `startupFinished` flag to `Systray`. The lambda returns early while it is
false, and `Application` sets it once the GUI is up, right after `ownCloudGui` is
constructed. That point is past every account restore path, including the early return in
`setupAccountsAndFolders()` when no accounts are found, so the wizard still opens the popup
centered for accounts added at runtime.

This only removes the grab. `setupFolders()` still does blocking disk I/O on the GUI
thread, which is the real problem underneath, but that is a much larger change — the grab
is what turns it into a system-wide freeze.

### Measured

Sync folder on a 4-disk btrfs raid10 of spinning disks, 395 MB `.sync_*.db`, ~71k
directories, Arch Linux, KDE Plasma on X11. A cold start gives around 22 seconds of dead
input.

Polling `XGrabPointer`/`XGrabKeyboard` from a separate process every 250 ms across startup
reported `AlreadyGrabbed` for pointer *and* keyboard in 87 of 252 samples, covering exactly
the window between restoring the account and `AccountsRestoreSuccess`:

```
14:56:36.060  [info]    nextcloud.gui.account.manager  accountmanager.cpp:719  Restored: 0 unknown certs.
14:56:57.889  [warning] nextcloud.gui.application      application.cpp:722     Account(s) setup result: AccountsRestoreSuccess
```

`Xorg`, `kwin_x11` and `plasmashell` never left `S` state during that window, so nothing
was actually hung — input simply had nowhere to go.

A second reporter on #10610 sees the same thing on Arch/XFCE with about 6000 folders on a
mechanical disk, at around 100 seconds per start.

### After the fix

Same machine and the same sync folder, journal dropped from the page cache before the run
so the start is cold, polling every 250 ms again:

| | before | after |
|---|---|---|
| blocking phase (restore → `AccountsRestoreSuccess`) | 21.8 s | 23.9 s |
| samples with pointer **and** keyboard grabbed | 87 of 252 | **0 of 95** |
| longest uninterrupted grab | 21.8 s | **0 s** |

```
2026-08-26 12:00:55:028  Restored:  0  unknown certs.
2026-08-26 12:01:18:891  Account(s) setup result: AccountsRestoreSuccess
```

Input stays alive across the whole startup now. The blocking phase itself is unchanged, as
expected — this only drops the grab, it does not make `setupFolders()` any faster.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.
