### PR TITLE
fix(updater): remove leftover installer during config version migration

### DIFF
--- a/src/gui/updater/ocupdater.cpp
+++ b/src/gui/updater/ocupdater.cpp
@@ -26,7 +26,6 @@ const auto updateAvailableC = QStringLiteral("Updater/updateAvailable");
 const auto updateTargetVersionC = QStringLiteral("Updater/updateTargetVersion");
 const auto updateTargetVersionStringC = QStringLiteral("Updater/updateTargetVersionString");
 const auto autoUpdateAttemptedC = QStringLiteral("Updater/autoUpdateAttempted");
-const auto msiLogFileNameC = QStringLiteral("msi.log");
 }
 
 UpdaterScheduler::UpdaterScheduler(QObject *parent)
@@ -223,7 +222,7 @@ void OCUpdater::slotStartInstaller()
             return QDir::toNativeSeparators(path);
         };
 
-        QString msiLogFile = cfg.configPath() + msiLogFileNameC;
+        const auto msiLogFile = cfg.msiLogFilePath();
         QString command = QStringLiteral("&{msiexec /i '%1' /L*V '%2'| Out-Null ; &'%3'}")
              .arg(preparePathForPowershell(updateFile))
              .arg(preparePathForPowershell(msiLogFile))
@@ -305,30 +304,11 @@ void NSISUpdater::slotWriteFile()
 
 void NSISUpdater::wipeUpdateData()
 {
-    ConfigFile cfg;
-    QSettings settings(cfg.configFile(), QSettings::IniFormat);
-    QString updateFileName = settings.value(updateAvailableC).toString();
-    if (!updateFileName.isEmpty()) {
-        if (QFile::remove(updateFileName)) {
-            qCInfo(lcUpdater) << "Removed updater file:" << updateFileName;
-        } else {
-            qCWarning(lcUpdater) << "Failed to remove updater file:" << updateFileName;
-        }
-    }
-    // Also try to remove the msi log file (created when running msiexec)
-    const auto msiLogFileName = QString{cfg.configPath() + msiLogFileNameC};
-    if (QFile::exists(msiLogFileName)) {
-        if (QFile::remove(msiLogFileName)) {
-            qCInfo(lcUpdater) << "Removed msi log file:" << msiLogFileName;
-        } else {
-            qCWarning(lcUpdater) << "Failed to remove msi log file:" << msiLogFileName;
-        }
-    }
-
-    settings.remove(updateAvailableC);
-    settings.remove(updateTargetVersionC);
-    settings.remove(updateTargetVersionStringC);
-    settings.remove(autoUpdateAttemptedC);
+    // Deliberately delegated: ConfigFile::cleanUpdaterConfiguration() is also
+    // reached from Application::configVersionMigration() on the first start of
+    // a newly installed version, and both paths must remove the installer, not
+    // just the keys that point at it.
+    ConfigFile().cleanUpdaterConfiguration();
 }
 
 void NSISUpdater::slotDownloadFinished()

--- a/src/libsync/configfile.cpp
+++ b/src/libsync/configfile.cpp
@@ -434,10 +434,38 @@ QString ConfigFile::excludeFileFromSystem()
     return fi.absoluteFilePath();
 }
 
+namespace {
+void removeUpdaterArtifact(const QString &path)
+{
+    if (path.isEmpty() || !QFile::exists(path)) {
+        return;
+    }
+
+    if (QFile::remove(path)) {
+        qCInfo(lcConfigFile) << "Removed leftover updater file:" << path;
+    } else {
+        qCWarning(lcConfigFile) << "Failed to remove leftover updater file:" << path;
+    }
+}
+}
+
+QString ConfigFile::msiLogFilePath() const
+{
+    return configPath() + QStringLiteral("msi.log");
+}
+
 void OCC::ConfigFile::cleanUpdaterConfiguration()
 {
     QSettings settings(configFile(), QSettings::IniFormat);
     settings.beginGroup("Updater");
+
+    // The config is the only record of where the downloaded installer lives.
+    // Delete it before dropping the keys, or every version change orphans
+    // another installer in the config folder with nothing left to find it by.
+    // See https://github.com/nextcloud/desktop/issues/7009
+    removeUpdaterArtifact(settings.value("updateAvailable").toString());
+    removeUpdaterArtifact(msiLogFilePath());
+
     settings.remove("autoUpdateAttempted");
     settings.remove("updateTargetVersion");
     settings.remove("updateTargetVersionString");

--- a/src/libsync/configfile.h
+++ b/src/libsync/configfile.h
@@ -42,6 +42,8 @@ public:
     static QString excludeFileFromSystem(); // doesn't access config dir
 
     void cleanUpdaterConfiguration();
+    /** Path of the log msiexec writes while installing an update (Windows). */
+    [[nodiscard]] QString msiLogFilePath() const;
     void cleanupGlobalNetworkConfiguration();
 
     /**

--- a/test/testupdater.cpp
+++ b/test/testupdater.cpp
@@ -51,6 +51,53 @@ private Q_SLOTS:
         QVERIFY(currVersion < highVersion);
     }
 
+    // Reproduces #7009: on the first start of a newly installed version the
+    // leftover installer must be gone. Application::configVersionMigration()
+    // (src/gui/application.cpp:161-164) drops the Updater/* keys before
+    // main() calls handleStartup() (src/gui/main.cpp:104 vs 142), so the
+    // cleanup in NSISUpdater::handleStartup() never sees the artifact.
+    void testLeftoverInstallerIsRemovedAfterVersionChange()
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+        QVERIFY(ConfigFile::setConfDir(tempDir.path()));
+
+        ConfigFile cfg;
+        const auto writeFile = [](const QString &path, const QByteArray &contents) {
+            QFile f(path);
+            return f.open(QIODevice::WriteOnly) && f.write(contents) == contents.size();
+        };
+
+        // a previous run downloaded an installer and msiexec left its log behind
+        const auto installer = FileSystem::joinPath(cfg.configPath(), "Nextcloud-1.0.0-x64.msi"_L1);
+        const auto msiLog = FileSystem::joinPath(cfg.configPath(), "msi.log"_L1);
+        QVERIFY(writeFile(installer, "this would be the installer"_ba));
+        QVERIFY(writeFile(msiLog, "this would be the msiexec log"_ba));
+
+        {
+            QSettings settings(cfg.configFile(), QSettings::IniFormat);
+            settings.setValue("Updater/updateAvailable"_L1, installer);
+            settings.setValue("Updater/updateTargetVersion"_L1, "1.0.0"_L1);
+            settings.setValue("Updater/updateTargetVersionString"_L1, "1.0.0"_L1);
+            settings.setValue("Updater/autoUpdateAttempted"_L1, true);
+            settings.sync();
+        }
+
+        // the update was installed: the running binary is newer than the target
+        QVERIFY(Updater::Helper::currentVersionToInt() > Updater::Helper::stringVersionToInt("1.0.0"_L1));
+
+        // what Application::configVersionMigration() does on that very first
+        // start, before the updater gets a chance to look at its own state
+        cfg.setClientVersionString("1.0.0"_L1);
+        cfg.cleanUpdaterConfiguration();
+
+        NSISUpdater updater(QUrl("http://localhost:1/updateinfo.xml"_L1));
+        updater.handleStartup();
+
+        QVERIFY(!QFileInfo::exists(installer));
+        QVERIFY(!QFileInfo::exists(msiLog));
+    }
+
 #ifdef HAVE_QHTTPSERVER
     void testUpdaterDownloadRedirect()
     {


### PR DESCRIPTION
## Resolves
#7009

## Summary

Every update leaves its installer (~200 MB) and `msi.log` behind in `%APPDATA%\Nextcloud`, one file per release.

#8980 did not take effect in practice. On the first start of a newly installed version, `Application::configVersionMigration()` calls `ConfigFile::cleanUpdaterConfiguration()` (`application.cpp:161-164`), which drops `Updater/updateAvailable` — the only record of where the installer is — before `main()` reaches `NSISUpdater::handleStartup()` (`main.cpp:104` vs `:142`). Both `wipeUpdateData()` call sites then sit behind a guard that can no longer be true, and the file is orphaned with nothing left to find it by.

The trigger is the version number in `nextcloud.cfg` versus the one compiled into the running binary. They differ on every real update, and are identical when the same version is reinstalled — which is why this passes local testing, and why CI cannot express the case at all (one binary, one `MIRALL_VERSION_STRING`). It regressed in v3.16.0 with b3886ed (#7807); before that the main flow cleaned up correctly and only unusual paths leaked.

`ConfigFile::cleanUpdaterConfiguration()` now deletes the installer and `msi.log` before dropping the keys, and `NSISUpdater::wipeUpdateData()` delegates to it instead of duplicating the same four key removals. Startup ordering is untouched, so #7807's intent is preserved.

Deliberately not included: installers that have already accumulated (no recorded path remains, so they need a directory sweep) and the download location itself.

### Tests

`testLeftoverInstallerIsRemovedAfterVersionChange` fails on master and passes with the fix. 

| | before | after |
|---|---|---|
| Windows, version change, real `nextcloud.exe` | `Version changed…` logged, no removal, both files survive | two `Removed leftover updater file:` lines, both files gone |
| Windows, pending update, no version change | untouched | untouched (must not regress) |
| Windows `ctest` | 78/78 | 78/78 |
| Linux `ctest` | 79/79 | 79/79 |

All seven paths the updater can take were driven against the real binary — the five dialog outcomes ("New update ready" → Cancel / OK; "Update Failed" → Ask again later / Restart and update / Update manually) plus the two non-interactive ones (version change, external install).

**Deletion happens only in the two cases where the update is genuinely finished, and in none of the five where a decision is still pending** — a pending installer is never removed. 

Built and verified on Windows (Craft/MSVC 2022) and Linux (Qt 6.10.2). Not tested: the locked-file case (`QFile::remove` failing under an antivirus or open handle), which logs a warning and leaves the file.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
- [ ] Uploaded screenshots from before and after for UI changes. — no UI change
- [x] Test(s) added to branch, with before/after results included in PR description.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable — stable-34.0, stable-33.0
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
