### PR TITLE
fix: Normalisation of Windows paths during journal clean-up after recursive deletion

### DIFF
--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -25,6 +25,7 @@
 
 #include <filesystem>
 #include <ctime>
+#include <optional>
 
 
 namespace OCC {
@@ -32,6 +33,30 @@ namespace OCC {
 Q_LOGGING_CATEGORY(lcPropagateLocalRemove, "nextcloud.sync.propagator.localremove", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcPropagateLocalMkdir, "nextcloud.sync.propagator.localmkdir", QtInfoMsg)
 Q_LOGGING_CATEGORY(lcPropagateLocalRename, "nextcloud.sync.propagator.localrename", QtInfoMsg)
+
+namespace {
+
+std::optional<QString> journalRelativePath(const QString &syncRoot, const QString &filesystemPath)
+{
+    const auto normalizedRoot = QDir::cleanPath(QDir::fromNativeSeparators(syncRoot));
+    const auto normalizedPath = QDir::cleanPath(QDir::fromNativeSeparators(filesystemPath));
+    if (normalizedRoot.isEmpty() || normalizedPath.isEmpty()) {
+        return std::nullopt;
+    }
+
+    auto relativePath = QDir::fromNativeSeparators(QDir{normalizedRoot}.relativeFilePath(normalizedPath));
+    relativePath = QDir::cleanPath(relativePath);
+    if (relativePath == QLatin1Char('.')) {
+        relativePath.clear();
+    }
+    if (QDir::isAbsolutePath(relativePath) || relativePath == QStringLiteral("..")
+        || relativePath.startsWith(QStringLiteral("../"))) {
+        return std::nullopt;
+    }
+    return relativePath;
+}
+
+} // namespace
 
 QByteArray localFileIdFromFullId(const QByteArray &id)
 {

--- a/src/libsync/propagatorjobs.cpp
+++ b/src/libsync/propagatorjobs.cpp
@@ -75,6 +75,7 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
 {
     QString absolute = propagator()->fullLocalPath(_item->_file + path);
     QList<QPair<QString, bool>> deleted;
+    QString conversionError;
     const auto fileInfo = QFileInfo{absolute};
     const auto parentFolderPath = fileInfo.dir().absolutePath();
     const auto parentPermissionsHandler = FileSystem::FilePermissionsRestore{parentFolderPath, FileSystem::FolderPermissions::ReadWrite};
@@ -83,10 +84,18 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
 
     Q_EMIT propagator()->touchedFile(absolute);
 
+    // FileSystem::removeRecursively() reports deleted items as absolute filesystem paths using
+    // the host's native separators. Convert them before storing them for journal cleanup, which
+    // uses normalized paths relative to the sync folder.
     const auto success = FileSystem::removeRecursively(absolute,
-                                                       [&deleted](const QString &path, bool isDir) {
+                                                       [&deleted, &conversionError, root = propagator()->localPath()](const QString &path, bool isDir) {
                                                            // by prepending, a folder deletion may be followed by content deletions
-                                                           deleted.prepend(qMakePair(path, isDir));
+                                                           const auto relativePath = journalRelativePath(root, path);
+                                                           if (!relativePath) {
+                                                               conversionError = QStringLiteral("Filesystem path is outside the sync root");
+                                                               return;
+                                                           }
+                                                           deleted.prepend(qMakePair(*relativePath, isDir));
                                                        },
                                                        nullptr,
                                                        nullptr,
@@ -110,19 +119,21 @@ bool PropagateLocalRemove::removeRecursively(const QString &path)
         // Do it while avoiding redundant delete calls to the journal.
         QString deletedDir;
         for (const auto &it : deleted) {
-            if (!it.first.startsWith(propagator()->localPath())) {
-                continue;
-            }
             if (isPathInsideDeletedDir(it.first, deletedDir)) {
                 continue;
             }
-            if (it.second) {
-                deletedDir = it.first;
-            }
-            if (!propagator()->_journal->deleteFileRecord(it.first.mid(propagator()->localPath().size()), it.second)) {
-                qCWarning(lcPropagateLocalRemove) << "Failed to delete file record from local DB" << it.first.mid(propagator()->localPath().size());
+            if (propagator()->_journal->deleteFileRecord(it.first, it.second)) {
+                if (it.second) {
+                    deletedDir = it.first;
+                }
+            } else {
+                qCWarning(lcPropagateLocalRemove) << "Failed to delete file record from local DB" << it.first;
             }
         }
+    }
+    if (!conversionError.isEmpty()) {
+        qCWarning(lcPropagateLocalRemove) << "Failed to convert a deleted filesystem path to a journal path:" << conversionError;
+        return false;
     }
     return success;
 }

--- a/test/testlockedfiles.cpp
+++ b/test/testlockedfiles.cpp
@@ -338,6 +338,76 @@ private Q_SLOTS:
         QVERIFY(fakeFolder.syncOnce());
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
     }
+
+    void testPartialRecursiveRemoteRemovalNormalisesJournalPaths()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        const auto journalRoot = fakeFolder.localPath();
+        const auto deletedCallbackPath = QDir::toNativeSeparators(journalRoot + QStringLiteral("A/a2"));
+        QVERIFY(!deletedCallbackPath.startsWith(journalRoot));
+
+        fakeFolder.remoteModifier().remove(QStringLiteral("A"));
+        fakeFolder.scheduleSync();
+        fakeFolder.execUntilBeforePropagation();
+
+        // Lock the file after discovery so the folder removal fails during recursive cleanup.
+        const auto lockedFile = makeHandle(fakeFolder.localPath() + QStringLiteral("A/a1"), 0);
+        QVERIFY(lockedFile != INVALID_HANDLE_VALUE);
+
+        const auto syncResult = fakeFolder.execUntilFinished();
+        CloseHandle(lockedFile);
+
+        QVERIFY(!syncResult);
+        QVERIFY(QFile::exists(fakeFolder.localPath() + QStringLiteral("A/a1")));
+        QVERIFY(!QFile::exists(fakeFolder.localPath() + QStringLiteral("A/a2")));
+
+        SyncJournalFileRecord lockedRecord;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a1"), &lockedRecord));
+        QVERIFY(lockedRecord.isValid());
+
+        SyncJournalFileRecord deletedRecord;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a2"), &deletedRecord));
+        QVERIFY(!deletedRecord.isValid());
+    }
+
+    void testPartialRecursiveRemoteRemovalDoesNotDeleteRemoteFileOnNextSync()
+    {
+        FakeFolder fakeFolder{FileInfo::A12_B12_C12_S12()};
+        const auto journalRoot = fakeFolder.localPath();
+        const auto deletedCallbackPath = QDir::toNativeSeparators(journalRoot + QStringLiteral("A/a2"));
+        QVERIFY(!deletedCallbackPath.startsWith(journalRoot));
+
+        fakeFolder.remoteModifier().remove(QStringLiteral("A"));
+        fakeFolder.scheduleSync();
+        fakeFolder.execUntilBeforePropagation();
+
+        const auto lockedFile = makeHandle(fakeFolder.localPath() + QStringLiteral("A/a1"), 0);
+        QVERIFY(lockedFile != INVALID_HANDLE_VALUE);
+
+        const auto syncResult = fakeFolder.execUntilFinished();
+        CloseHandle(lockedFile);
+
+        QVERIFY(!syncResult);
+
+        // Recreate the remote folder before the next sync. A stale journal entry for a2
+        // would interpret the remote file as a local removal and delete it remotely.
+        fakeFolder.remoteModifier().mkdir(QStringLiteral("A"));
+        fakeFolder.remoteModifier().insert(QStringLiteral("A/a1"), 4);
+        fakeFolder.remoteModifier().insert(QStringLiteral("A/a2"), 4);
+
+        auto remoteA2Deleted = false;
+        fakeFolder.setServerOverride([&remoteA2Deleted](QNetworkAccessManager::Operation op, const QNetworkRequest &request, QIODevice *) {
+            if (op == QNetworkAccessManager::DeleteOperation && request.url().path().endsWith(QStringLiteral("/A/a2"))) {
+                remoteA2Deleted = true;
+            }
+            return static_cast<QNetworkReply *>(nullptr);
+        });
+
+        QVERIFY(fakeFolder.syncOnce());
+        QVERIFY(!remoteA2Deleted);
+        QVERIFY(fakeFolder.remoteModifier().find(QStringLiteral("A/a2")));
+        QVERIFY(QFile::exists(fakeFolder.localPath() + QStringLiteral("A/a2")));
+    }
 #endif
 };
 

--- a/test/testsyncdelete.cpp
+++ b/test/testsyncdelete.cpp
@@ -12,6 +12,10 @@
 #include "syncenginetestutils.h"
 #include <syncengine.h>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 using namespace OCC;
 
 class TestSyncDelete : public QObject
@@ -66,6 +70,37 @@ private Q_SLOTS:
         QVERIFY(fakeFolder.syncOnce());
         QVERIFY(fakeFolder.currentRemoteState().find("B/b1"));
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
+    }
+
+    void partiallyFailedRecursiveRemovalCleansJournal()
+    {
+#ifndef Q_OS_WIN
+        QSKIP("Requires Windows file-sharing semantics");
+#else
+        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
+        fakeFolder.remoteModifier().remove(QStringLiteral("A"));
+        fakeFolder.scheduleSync();
+        fakeFolder.execUntilBeforePropagation();
+
+        const auto lockedFilePath = FileSystem::longWinPath(
+            QDir::toNativeSeparators(fakeFolder.localPath() + QStringLiteral("A/a1")));
+        const auto lockedFile = CreateFileW(reinterpret_cast<const wchar_t *>(lockedFilePath.utf16()),
+            GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        QVERIFY(lockedFile != INVALID_HANDLE_VALUE);
+
+        const auto syncResult = fakeFolder.execUntilFinished();
+        CloseHandle(lockedFile);
+
+        QVERIFY(!syncResult);
+
+        SyncJournalFileRecord lockedRecord;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a1"), &lockedRecord));
+        QVERIFY(lockedRecord.isValid());
+
+        SyncJournalFileRecord deletedRecord;
+        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a2"), &deletedRecord));
+        QVERIFY(!deletedRecord.isValid());
+#endif
     }
 };
 

--- a/test/testsyncdelete.cpp
+++ b/test/testsyncdelete.cpp
@@ -12,10 +12,6 @@
 #include "syncenginetestutils.h"
 #include <syncengine.h>
 
-#ifdef Q_OS_WIN
-#include <windows.h>
-#endif
-
 using namespace OCC;
 
 class TestSyncDelete : public QObject
@@ -70,37 +66,6 @@ private Q_SLOTS:
         QVERIFY(fakeFolder.syncOnce());
         QVERIFY(fakeFolder.currentRemoteState().find("B/b1"));
         QCOMPARE(fakeFolder.currentLocalState(), fakeFolder.currentRemoteState());
-    }
-
-    void partiallyFailedRecursiveRemovalCleansJournal()
-    {
-#ifndef Q_OS_WIN
-        QSKIP("Requires Windows file-sharing semantics");
-#else
-        FakeFolder fakeFolder{ FileInfo::A12_B12_C12_S12() };
-        fakeFolder.remoteModifier().remove(QStringLiteral("A"));
-        fakeFolder.scheduleSync();
-        fakeFolder.execUntilBeforePropagation();
-
-        const auto lockedFilePath = FileSystem::longWinPath(
-            QDir::toNativeSeparators(fakeFolder.localPath() + QStringLiteral("A/a1")));
-        const auto lockedFile = CreateFileW(reinterpret_cast<const wchar_t *>(lockedFilePath.utf16()),
-            GENERIC_READ, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-        QVERIFY(lockedFile != INVALID_HANDLE_VALUE);
-
-        const auto syncResult = fakeFolder.execUntilFinished();
-        CloseHandle(lockedFile);
-
-        QVERIFY(!syncResult);
-
-        SyncJournalFileRecord lockedRecord;
-        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a1"), &lockedRecord));
-        QVERIFY(lockedRecord.isValid());
-
-        SyncJournalFileRecord deletedRecord;
-        QVERIFY(fakeFolder.syncJournal().getFileRecord(QStringLiteral("A/a2"), &deletedRecord));
-        QVERIFY(!deletedRecord.isValid());
-#endif
     }
 };
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

On Windows, recursive deletion callbacks used absolute `\`-separated paths, while journal entries use relative `/`-separated paths. The old prefix comparison therefore failed. Successfully deleted items could remain in the journal and later be misinterpreted as user deletions, causing unintended remote deletion.

This fix normalises callback paths with Qt, converts them to validated journal-relative paths before cleanup, and uses component-aware directory matching.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [X] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
