### PR TITLE
fix(cmake): set cmake var APPLICATION_REV_DOMAIN_INSTALLER 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,8 @@ if(NOT DEFINED APPLICATION_VIRTUALFILE_SUFFIX)
 endif()
 
 # need this logic to not mess with re/uninstallations via macosx.pkgproj
-if(${APPLICATION_REV_DOMAIN} STREQUAL "com.owncloud.desktopclient")
-    set(APPLICATION_REV_DOMAIN_INSTALLER "com.ownCloud.client")
-else()
-    set(APPLICATION_REV_DOMAIN_INSTALLER ${APPLICATION_REV_DOMAIN})
+if(NOT DEFINED APPLICATION_REV_DOMAIN_INSTALLER)
+    set(APPLICATION_REV_DOMAIN_INSTALLER "${APPLICATION_REV_DOMAIN}")
 endif()
 
 option( APPLICATION_DISPLAY_LEGACY_IMPORT_DIALOG "Display legacy import dialog" ON )

--- a/admin/osx/macosx.pkgproj.cmake
+++ b/admin/osx/macosx.pkgproj.cmake
@@ -17,6 +17,8 @@
 							<key>CHILDREN</key>
 							<array>
 								<dict>
+									<key>BUNDLE_CAN_DOWNGRADE</key>
+									<true/>
 									<key>CHILDREN</key>
 									<array/>
 									<key>GID</key>


### PR DESCRIPTION
## Resolves
It allows the client to install over another legacy client on macOS.

Without this, installing a rebranded client over an existing install like a legacy client receipt being upgraded via APPLICATION_REV_DOMAIN_INSTALLER can leave stale files from the previous bundle mixed with the new payload, producing an invalid code signature ("a sealed resource is missing or invalid") that fails Gatekeeper/launchd validation on next boot.

## To do

- [ ] test it with the brander

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
