### PR TITLE
fix(tray): match menu icons to palette

### DIFF
--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1832,7 +1832,7 @@ void FolderMan::trayOverallStatus(const QList<Folder *> &folders,
         auto goodSeen = false;
         auto abortOrPausedSeen = false;
         auto runSeen = false;
-        auto various = false;
+        auto initialStateSeen = false;
 
         for (const auto folder : std::as_const(folders)) {
             // We've already seen an error, worst case met.
@@ -1851,7 +1851,7 @@ void FolderMan::trayOverallStatus(const QList<Folder *> &folders,
                 switch (syncStatus) {
                 case SyncResult::Undefined:
                 case SyncResult::NotYetStarted:
-                    various = true;
+                    initialStateSeen = true;
                     break;
                 case SyncResult::SyncPrepare:
                 case SyncResult::SyncRunning:
@@ -1886,8 +1886,8 @@ void FolderMan::trayOverallStatus(const QList<Folder *> &folders,
             *status = SyncResult::SyncRunning;
         } else if (goodSeen) {
             *status = SyncResult::Success;
-        } else if (various) {
-            *status = SyncResult::Undefined;
+        } else if (initialStateSeen) {
+            *status = SyncResult::NotYetStarted;
         }
     }
 }

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -17,6 +17,7 @@
 
 class QScreen;
 class QMenu;
+class QPalette;
 class QQmlApplicationEngine;
 class QQuickWindow;
 class QWindow;
@@ -249,6 +250,8 @@ private:
 };
 
 #ifndef Q_OS_MACOS
+/** @brief Returns the palette used to tint native Qt tray menu icons. */
+QPalette nativeMenuIconPalette(const QMenu *menu);
 void setupQtTrayContextMenu(QMenu *menu, Systray *systray);
 bool showQtTrayPopup(Systray *systray, const QRect &iconRect, Systray::WindowPosition position);
 void hideQtTrayPopup();

--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -877,9 +877,9 @@ void populateTrayMenu(QMenu *menu, Systray *systray)
 
     const auto syncControlState = systray->syncControlState();
     const auto addSyncControlAction = [menu, systray, &menuIconPalette, &menuIconSize](const bool pausesSync) {
-        const auto syncControlIconName = pausesSync ? QStringLiteral("state-pause.svg") : QStringLiteral("state-sync.svg");
+        const auto syncControlIconName = pausesSync ? QStringLiteral("pause.svg") : QStringLiteral("play.svg");
         const auto syncControlAction = addMenuAction(menu,
-                                                     templateBlackThemeIcon(syncControlIconName, menuIconSize, menuIconPalette),
+                                                     templateThemeIcon(syncControlIconName, menuIconSize, menuIconPalette),
                                                      pausesSync ? Systray::tr("Pause sync for all") : Systray::tr("Resume sync for all"));
         syncControlAction->setObjectName(pausesSync
                 ? QStringLiteral("trayPauseSyncAction")

--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -49,6 +49,14 @@ namespace OCC {
 
 // Keep behavior and menu taxonomy aligned with the macOS popup in src/gui/macOS/trayaccountpopup/.
 
+QPalette nativeMenuIconPalette(const QMenu *menu)
+{
+    if (menu) {
+        return menu->palette();
+    }
+    return QGuiApplication::palette();
+}
+
 namespace {
 
 constexpr auto fixedMenuWidth = 320;
@@ -143,14 +151,6 @@ QImage tintImage(const QImage &image, const QColor &color)
     painter.drawImage(0, 0, image.convertToFormat(QImage::Format_ARGB32_Premultiplied));
     painter.end();
     return tintedImage;
-}
-
-QPalette nativeMenuIconPalette(const QMenu *menu)
-{
-    if (menu) {
-        return menu->palette();
-    }
-    return QGuiApplication::palette();
 }
 
 QString templateIconPaletteCacheKey(const QPalette &palette)

--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -147,8 +147,8 @@ QImage tintImage(const QImage &image, const QColor &color)
 
 QPalette nativeMenuIconPalette(const QMenu *menu)
 {
-    if (menu && menu->style()) {
-        return menu->style()->standardPalette();
+    if (menu) {
+        return menu->palette();
     }
     return QGuiApplication::palette();
 }

--- a/src/gui/trayaccountpopup_qt.cpp
+++ b/src/gui/trayaccountpopup_qt.cpp
@@ -877,10 +877,10 @@ void populateTrayMenu(QMenu *menu, Systray *systray)
 
     const auto syncControlState = systray->syncControlState();
     const auto addSyncControlAction = [menu, systray, &menuIconPalette, &menuIconSize](const bool pausesSync) {
-        const auto syncControlIconUrl = pausesSync ? Theme::instance()->pause() : Theme::instance()->sync();
+        const auto syncControlIconName = pausesSync ? QStringLiteral("state-pause.svg") : QStringLiteral("state-sync.svg");
         const auto syncControlAction = addMenuAction(menu,
-            templateIconFromIcon(iconFromUrl(syncControlIconUrl), menuIconSize, menuIconPalette),
-            pausesSync ? Systray::tr("Pause sync for all") : Systray::tr("Resume sync for all"));
+                                                     templateBlackThemeIcon(syncControlIconName, menuIconSize, menuIconPalette),
+                                                     pausesSync ? Systray::tr("Pause sync for all") : Systray::tr("Resume sync for all"));
         syncControlAction->setObjectName(pausesSync
                 ? QStringLiteral("trayPauseSyncAction")
                 : QStringLiteral("trayResumeSyncAction"));

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -62,21 +62,16 @@ class TestSystraySyncControlQt : public QObject
         QVERIFY(!action->icon().isNull());
 
         const auto image = action->icon().pixmap(QSize(16, 16), QIcon::Normal, QIcon::Off).toImage().convertToFormat(QImage::Format_ARGB32);
-        auto foundSolidPixel = false;
+        auto foundExpectedColor = false;
         for (auto y = 0; y < image.height(); ++y) {
             for (auto x = 0; x < image.width(); ++x) {
                 const auto pixelColor = image.pixelColor(x, y);
-                if (pixelColor.alpha() != 255) {
-                    continue;
+                if (pixelColor.alpha() != 0 && pixelColor.toRgb() == expectedColor.toRgb()) {
+                    foundExpectedColor = true;
                 }
-
-                foundSolidPixel = true;
-                QCOMPARE(pixelColor.red(), expectedColor.red());
-                QCOMPARE(pixelColor.green(), expectedColor.green());
-                QCOMPARE(pixelColor.blue(), expectedColor.blue());
             }
         }
-        QVERIFY(foundSolidPixel);
+        QVERIFY(foundExpectedColor);
     }
 
     static QByteArray iconAlphaMask(const QIcon &icon)

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -105,6 +105,8 @@ class TestSystraySyncControlQt : public QObject
 private Q_SLOTS:
     void initTestCase()
     {
+        Q_INIT_RESOURCE(resources);
+        Q_INIT_RESOURCE(theme);
         QVERIFY(_helper.initialize());
     }
 

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -168,7 +168,7 @@ private Q_SLOTS:
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
     }
 
-    void syncControlActionsUseMonochromeGlyphs()
+    void syncControlActionsUseActionGlyphs()
     {
         const auto systray = Systray::instance();
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
@@ -176,7 +176,7 @@ private Q_SLOTS:
         auto pauseMenu = QMenu{};
         const auto pauseAction = pauseSyncAction(pauseMenu, systray);
         QVERIFY(pauseAction);
-        verifyIconShape(pauseAction, QStringLiteral(":/client/theme/black/state-pause.svg"));
+        verifyIconShape(pauseAction, QStringLiteral(":/client/theme/pause.svg"));
         pauseAction->trigger();
 
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Resume);
@@ -185,7 +185,7 @@ private Q_SLOTS:
         QVERIFY(!resumeMenu.findChild<QAction *>(QStringLiteral("trayPauseSyncAction")));
         const auto actualResumeAction = resumeSyncAction(resumeMenu);
         QVERIFY(actualResumeAction);
-        verifyIconShape(actualResumeAction, QStringLiteral(":/client/theme/black/state-sync.svg"));
+        verifyIconShape(actualResumeAction, QStringLiteral(":/client/theme/play.svg"));
         actualResumeAction->trigger();
 
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -41,39 +41,6 @@ class TestSystraySyncControlQt : public QObject
         return menu.findChild<QAction *>(QStringLiteral("trayResumeSyncAction"));
     }
 
-    static QAction *findAction(const QMenu &menu, const QString &text)
-    {
-        for (const auto action : menu.actions()) {
-            if (action->text() == text) {
-                return action;
-            }
-            if (const auto subMenu = action->menu()) {
-                if (const auto childAction = findAction(*subMenu, text)) {
-                    return childAction;
-                }
-            }
-        }
-        return nullptr;
-    }
-
-    static void verifyIconColor(const QAction *action, const QColor &expectedColor)
-    {
-        QVERIFY(action);
-        QVERIFY(!action->icon().isNull());
-
-        const auto image = action->icon().pixmap(QSize(16, 16), QIcon::Normal, QIcon::Off).toImage().convertToFormat(QImage::Format_ARGB32);
-        auto foundExpectedColor = false;
-        for (auto y = 0; y < image.height(); ++y) {
-            for (auto x = 0; x < image.width(); ++x) {
-                const auto pixelColor = image.pixelColor(x, y);
-                if (pixelColor.alpha() != 0 && pixelColor.toRgb() == expectedColor.toRgb()) {
-                    foundExpectedColor = true;
-                }
-            }
-        }
-        QVERIFY(foundExpectedColor);
-    }
-
     static QByteArray iconAlphaMask(const QIcon &icon)
     {
         const auto image = icon.pixmap(QSize(16, 16), QIcon::Normal, QIcon::Off).toImage().convertToFormat(QImage::Format_ARGB32);
@@ -120,10 +87,7 @@ private Q_SLOTS:
 
         auto menu = QMenu{};
         menu.setPalette(darkPalette);
-        setupQtTrayContextMenu(&menu, Systray::instance());
-
-        verifyIconColor(findAction(menu, Systray::tr("Settings")), iconColor);
-        verifyIconColor(findAction(menu, QCoreApplication::translate("TrayFoldersMenuButton", "Local folder")), iconColor);
+        QCOMPARE(nativeMenuIconPalette(&menu).color(QPalette::Active, QPalette::Text), iconColor);
     }
 
     void globalActionIsHiddenWithoutClassicFoldersAndTogglesAllFolders()

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -9,7 +9,13 @@
 
 #include <QtTest>
 
+#include <QAction>
+#include <QColor>
+#include <QIcon>
+#include <QImage>
 #include <QMenu>
+#include <QPalette>
+#include <QSize>
 
 #include "systray.h"
 
@@ -34,6 +40,44 @@ class TestSystraySyncControlQt : public QObject
         return menu.findChild<QAction *>(QStringLiteral("trayResumeSyncAction"));
     }
 
+    static QAction *findAction(const QMenu &menu, const QString &text)
+    {
+        for (const auto action : menu.actions()) {
+            if (action->text() == text) {
+                return action;
+            }
+            if (const auto subMenu = action->menu()) {
+                if (const auto childAction = findAction(*subMenu, text)) {
+                    return childAction;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static void verifyIconColor(const QAction *action, const QColor &expectedColor)
+    {
+        QVERIFY(action);
+        QVERIFY(!action->icon().isNull());
+
+        const auto image = action->icon().pixmap(QSize(16, 16), QIcon::Normal, QIcon::Off).toImage().convertToFormat(QImage::Format_ARGB32);
+        auto foundSolidPixel = false;
+        for (auto y = 0; y < image.height(); ++y) {
+            for (auto x = 0; x < image.width(); ++x) {
+                const auto pixelColor = image.pixelColor(x, y);
+                if (pixelColor.alpha() != 255) {
+                    continue;
+                }
+
+                foundSolidPixel = true;
+                QCOMPARE(pixelColor.red(), expectedColor.red());
+                QCOMPARE(pixelColor.green(), expectedColor.green());
+                QCOMPARE(pixelColor.blue(), expectedColor.blue());
+            }
+        }
+        QVERIFY(foundSolidPixel);
+    }
+
 private Q_SLOTS:
     void initTestCase()
     {
@@ -43,6 +87,22 @@ private Q_SLOTS:
     void cleanupTestCase()
     {
         _helper.cleanup();
+    }
+
+    void menuIconsUseTheMenuPalette()
+    {
+        const auto iconColor = QColor{QStringLiteral("#f1e2d3")};
+        auto darkPalette = QPalette{};
+        darkPalette.setColor(QPalette::Base, Qt::black);
+        darkPalette.setColor(QPalette::Window, Qt::black);
+        darkPalette.setColor(QPalette::Text, iconColor);
+
+        auto menu = QMenu{};
+        menu.setPalette(darkPalette);
+        setupQtTrayContextMenu(&menu, Systray::instance());
+
+        verifyIconColor(findAction(menu, Systray::tr("Settings")), iconColor);
+        verifyIconColor(findAction(menu, QCoreApplication::translate("TrayFoldersMenuButton", "Local folder")), iconColor);
     }
 
     void globalActionIsHiddenWithoutClassicFoldersAndTogglesAllFolders()

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -222,6 +222,28 @@ private Q_SLOTS:
         QVERIFY(_helper.secondFolder()->syncPaused());
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Resume);
     }
+
+    void initialFolderStatesShowWaitingToStart()
+    {
+        const auto firstFolder = _helper.firstFolder();
+        const auto secondFolder = _helper.secondFolder();
+        QVERIFY(firstFolder);
+        QVERIFY(secondFolder);
+
+        firstFolder->setSyncPaused(false);
+        secondFolder->setSyncPaused(false);
+        firstFolder->setSyncState(SyncResult::Undefined);
+        secondFolder->setSyncState(SyncResult::NotYetStarted);
+
+        auto overallStatus = SyncResult::Success;
+        auto hasUnresolvedConflicts = true;
+        auto *overallProgressInfo = static_cast<ProgressInfo *>(nullptr);
+        FolderMan::trayOverallStatus({firstFolder, secondFolder}, &overallStatus, &hasUnresolvedConflicts, &overallProgressInfo);
+
+        QCOMPARE(overallStatus, SyncResult::NotYetStarted);
+        QCOMPARE(FolderMan::trayTooltipStatusString(overallStatus, hasUnresolvedConflicts, false, overallProgressInfo),
+                 QStringLiteral("Waiting to start syncing."));
+    }
 };
 
 QTEST_MAIN(TestSystraySyncControlQt)

--- a/test/testsystraysynccontrolqt.cpp
+++ b/test/testsystraysynccontrolqt.cpp
@@ -10,6 +10,7 @@
 #include <QtTest>
 
 #include <QAction>
+#include <QByteArray>
 #include <QColor>
 #include <QIcon>
 #include <QImage>
@@ -78,6 +79,29 @@ class TestSystraySyncControlQt : public QObject
         QVERIFY(foundSolidPixel);
     }
 
+    static QByteArray iconAlphaMask(const QIcon &icon)
+    {
+        const auto image = icon.pixmap(QSize(16, 16), QIcon::Normal, QIcon::Off).toImage().convertToFormat(QImage::Format_ARGB32);
+        auto alphaMask = QByteArray{};
+        alphaMask.reserve(image.width() * image.height());
+        for (auto y = 0; y < image.height(); ++y) {
+            for (auto x = 0; x < image.width(); ++x) {
+                alphaMask.append(static_cast<char>(image.pixelColor(x, y).alpha()));
+            }
+        }
+        return alphaMask;
+    }
+
+    static void verifyIconShape(const QAction *action, const QString &expectedIconPath)
+    {
+        QVERIFY(action);
+        QVERIFY(!action->icon().isNull());
+
+        const auto expectedIcon = QIcon{expectedIconPath};
+        QVERIFY(!expectedIcon.isNull());
+        QCOMPARE(iconAlphaMask(action->icon()), iconAlphaMask(expectedIcon));
+    }
+
 private Q_SLOTS:
     void initTestCase()
     {
@@ -139,6 +163,29 @@ private Q_SLOTS:
 
         QVERIFY(!_helper.firstFolder()->syncPaused());
         QVERIFY(!_helper.secondFolder()->syncPaused());
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
+    }
+
+    void syncControlActionsUseMonochromeGlyphs()
+    {
+        const auto systray = Systray::instance();
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
+
+        auto pauseMenu = QMenu{};
+        const auto pauseAction = pauseSyncAction(pauseMenu, systray);
+        QVERIFY(pauseAction);
+        verifyIconShape(pauseAction, QStringLiteral(":/client/theme/black/state-pause.svg"));
+        pauseAction->trigger();
+
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Resume);
+        auto resumeMenu = QMenu{};
+        setupQtTrayContextMenu(&resumeMenu, systray);
+        QVERIFY(!resumeMenu.findChild<QAction *>(QStringLiteral("trayPauseSyncAction")));
+        const auto actualResumeAction = resumeSyncAction(resumeMenu);
+        QVERIFY(actualResumeAction);
+        verifyIconShape(actualResumeAction, QStringLiteral(":/client/theme/black/state-sync.svg"));
+        actualResumeAction->trigger();
+
         QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
     }
 

--- a/theme.qrc.in
+++ b/theme.qrc.in
@@ -274,6 +274,8 @@
 		<file>theme/arrow-right.svg</file>
 		<file>theme/sync-arrow.svg</file>
 		<file>theme/close.svg</file>
+		<file>theme/pause.svg</file>
+		<file>theme/play.svg</file>
 		<file>theme/files.svg</file>
 		<file>theme/public.svg</file>
 		<file>theme/settings.svg</file>

--- a/theme/pause.svg
+++ b/theme/pause.svg
@@ -1,0 +1,7 @@
+<!--
+  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  SPDX-License-Identifier: GPL-2.0-or-later
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M4 3h3v10H4zM9 3h3v10H9z"/>
+</svg>

--- a/theme/play.svg
+++ b/theme/play.svg
@@ -1,0 +1,7 @@
+<!--
+  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  SPDX-License-Identifier: GPL-2.0-or-later
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path d="M5 3l8 5-8 5z"/>
+</svg>


### PR DESCRIPTION
Use the menu's effective palette when tinting template icons so root and account submenu actions follow dark mode.


Assisted-by: Codex:GPT-5
