### PR TITLE
fix(ci): cancel obsolete pull request workflows

### DIFF
--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -10,18 +10,18 @@ name: Block unconventional commits
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
 
 permissions:
   contents: read
 
 concurrency:
-  group: block-unconventional-commits-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   block-unconventional-commits:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Block unconventional commits
 
     runs-on: ubuntu-latest-low

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -4,14 +4,18 @@ name: Check translations
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Declare default permissions as read only.
 permissions: read-all
 
 jobs:
   checkGermanTranslations:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     
     steps:
@@ -21,7 +25,7 @@ jobs:
           [[ $(grep "Benötigt keine Übersetzung" translations/client_de.ts -c) -gt 0 ]] && exit 1 || exit 0
 
   checkTranslations:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container: ghcr.io/nextcloud/continuous-integration-translations-desktop:latest
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,10 +3,15 @@
 name: Clang Format Checker
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -10,18 +10,18 @@ name: Block fixup and squash commits
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
 
 permissions:
   contents: read
 
 concurrency:
-  group: fixup-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   commit-message-check:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
 
     permissions:
       pull-requests: write

--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -3,11 +3,15 @@
 name: Linux Appimage Package
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Linux Appimage Package
     runs-on: ubuntu-latest
     container: ghcr.io/nextcloud/continuous-integration-client-appimage-qt6:client-appimage-el8-6.10.2-4

--- a/.github/workflows/linux-clang-compile-tests.yml
+++ b/.github/workflows/linux-clang-compile-tests.yml
@@ -3,10 +3,15 @@
 name: Linux Clang compilation and tests
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Linux Clang compilation and tests
     runs-on: ubuntu-latest
     container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-4

--- a/.github/workflows/linux-gcc-compile-tests.yml
+++ b/.github/workflows/linux-gcc-compile-tests.yml
@@ -3,10 +3,15 @@
 name: Linux GCC compilation and tests
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Linux GCC compilation and tests
     runs-on: ubuntu-latest
     container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-4

--- a/.github/workflows/mac-crafter-ci.yml
+++ b/.github/workflows/mac-crafter-ci.yml
@@ -11,14 +11,18 @@ on:
       - ".github/workflows/mac-crafter-ci.yml"
   pull_request:
     branches: ["master"]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - "admin/osx/mac-crafter/**"
       - ".github/workflows/mac-crafter-ci.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: Test mac-crafter
     timeout-minutes: 15
     runs-on: macos-26

--- a/.github/workflows/macos-craft-ci.yml
+++ b/.github/workflows/macos-craft-ci.yml
@@ -5,11 +5,15 @@ name: macOS CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   setup_craft:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Set up Craft and install dependencies
     timeout-minutes: 60
     runs-on: macos-15
@@ -92,7 +96,7 @@ jobs:
 
 
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Build and test ${{ matrix.buildFileProviderModule == 'True' && 'File Provider' || 'classic' }} client
     needs: setup_craft
     strategy:

--- a/.github/workflows/nextcloudcmd-provisioning-tests.yml
+++ b/.github/workflows/nextcloudcmd-provisioning-tests.yml
@@ -3,15 +3,20 @@
 name: nextcloudcmd provisioning tests
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - 'src/cmd/**'
       - 'test/testnextcloudcmdprovisioning.cpp'
       - 'test/CMakeLists.txt'
       - '.github/workflows/nextcloudcmd-provisioning-tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: nextcloudcmd provisioning tests
     runs-on: ubuntu-latest
     container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2

--- a/.github/workflows/nextcloudfileproviderkit.yml
+++ b/.github/workflows/nextcloudfileproviderkit.yml
@@ -12,14 +12,18 @@ on:
       - ".github/workflows/nextcloudfileproviderkit.yml"
   pull_request:
     branches: [ "master" ]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
     paths:
       - "shell_integration/MacOSX/NextcloudFileProviderKit/**"
       - ".github/workflows/nextcloudfileproviderkit.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Lint:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: macos-26
 
     defaults:
@@ -33,7 +37,7 @@ jobs:
         run: swiftformat --lint . --reporter github-actions-log
 
   Tests:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     runs-on: macos-26
 
     defaults:

--- a/.github/workflows/qml-label-check.yml
+++ b/.github/workflows/qml-label-check.yml
@@ -3,10 +3,15 @@
 name: QML Label component check
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: QML Label component check
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -11,14 +11,18 @@ name: REUSE Compliance Check
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   reuse-compliance-check:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest-low
     steps:
       - name: Checkout

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,15 +11,15 @@ on:
       - "**/*.c"
       - "**/*.h"
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
 
 concurrency:
-  group: sonarcloud-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ github.event_name != 'pull_request' || (github.event.action != 'closed' && !github.event.pull_request.draft) }}
     name: SonarCloud analysis
     runs-on: [ubuntu-latest, self-hosted]
     container: ghcr.io/nextcloud/continuous-integration-client-qt6:client-sid-6.10.2-2

--- a/.github/workflows/windows-build-and-test.yml
+++ b/.github/workflows/windows-build-and-test.yml
@@ -3,10 +3,15 @@
 name: Windows Build and Test
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event.action != 'closed' && !github.event.pull_request.draft }}
     name: Windows Build and Test
     runs-on: windows-2022
     env:


### PR DESCRIPTION
- Adds PR-scoped concurrency to all 15 pull-request workflows.
- Uses `cancel-in-progress: true` to cancel obsolete runs after new commits.
- Adds the `closed` activity so closing or merging a PR cancels its active runs.
- Prevents cancellation-only runs from executing jobs.
- Preserves separate concurrency for `master` push workflows.

note on the if-condition. this is used to cancel existing runs when a PR is closed

- Another commit creates a new run in the same group. Because cancel-in-progress: true, GitHub cancels the older run.
- Closing or merging the PR emits the newly enabled closed event. That creates another run in the same group, causing GitHub to cancel the active run.
- The job condition prevents the new close-event run from doing any work

Assisted-by: Codex:GPT-5
