### PR TITLE
fix(osx): refresh stale FinderSync pluginkit registration on install.

### DIFF
--- a/admin/osx/post_install.sh.cmake
+++ b/admin/osx/post_install.sh.cmake
@@ -30,6 +30,14 @@ elif [ ! -x "$(command -v pluginkit)" ]; then
 else
     echo "$LOG_PREFIX registering extension for user '$CONSOLE_USER' (uid $CONSOLE_UID)"
 
+    # Force remove any stale registration first (failure is expected on first install).
+    run_as_console_user pluginkit -r "$APPEX"; rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "$LOG_PREFIX pluginkit -r succeeded for $APPEX"
+    else
+        echo "$LOG_PREFIX pluginkit -r returned $rc for $APPEX (expected if nothing was registered yet)"
+    fi
+
     # Add it to the DB. This happens automatically too, but we push a bit harder (#3463).
     run_as_console_user pluginkit -a "$APPEX"; rc=$?
     if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
## Resolves
Broken Finder extension when installing a new client over a legacy client.

## Summary
Existing registration from a previous install is dropped and added again rather than left untouched. pluginkit -a doesn't work when the identifier is already registered, which can leave a stale UUID/path cached in the PlugInKit database after the appex on disk has been replaced by a newer build (e.g. installing over an existing client), causing the FinderSyncBroker to fail to spawn. So the result is a not working Finder extension.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- x ] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
