### PR TITLE
[stable-33.0] fix(macOS): Always use un-sandboxed path for sync folder location in wizard(s)

### DIFF
--- a/src/gui/owncloudsetupwizard.cpp
+++ b/src/gui/owncloudsetupwizard.cpp
@@ -9,6 +9,9 @@
 #include "accountmanager.h"
 #include "clientproxy.h"
 #include "common/utility.h"
+#ifdef Q_OS_MACOS
+#include "common/utility_mac_sandbox.h"
+#endif
 #include "configfile.h"
 #include "filesystem.h"
 #include "folderman.h"
@@ -118,7 +121,13 @@ void OwncloudSetupWizard::startWizard()
     // if its a relative path, prepend with users home dir, otherwise use as absolute path
 
     if (!QDir(localFolder).isAbsolute()) {
-        localFolder = QDir::homePath() + QLatin1Char('/') + localFolder;
+        const auto homeDirectory =
+#ifdef Q_OS_MACOS
+            Utility::getRealHomeDirectory();
+#else
+            QDir::homePath();
+#endif
+        localFolder = QDir(homeDirectory).filePath(localFolder);
     }
 
     _ocWizard->setProperty("localFolder", localFolder);

--- a/src/gui/wizard/owncloudadvancedsetuppage.cpp
+++ b/src/gui/wizard/owncloudadvancedsetuppage.cpp
@@ -18,6 +18,9 @@
 #include "wizard/owncloudwizardcommon.h"
 #include "wizard/owncloudadvancedsetuppage.h"
 #include "account.h"
+#ifdef Q_OS_MACOS
+#include "common/utility_mac_sandbox.h"
+#endif
 #include "theme.h"
 #include "configfile.h"
 #include "selectivesyncdialog.h"
@@ -487,7 +490,13 @@ void OwncloudAdvancedSetupPage::setRemoteFolder(const QString &remoteFolder)
 
 void OwncloudAdvancedSetupPage::slotSelectFolder()
 {
-    QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Local Sync Folder"), QDir::homePath());
+    const auto homeDirectory =
+#ifdef Q_OS_MACOS
+        Utility::getRealHomeDirectory();
+#else
+        QDir::homePath();
+#endif
+    QString dir = QFileDialog::getExistingDirectory(nullptr, tr("Local Sync Folder"), homeDirectory);
     if (!dir.isEmpty()) {
         // TODO: remove when UX decision is made
         refreshVirtualFilesAvailibility(dir);
@@ -588,8 +597,13 @@ void OwncloudAdvancedSetupPage::slotQuotaRetrievedWithError(QNetworkReply *reply
 qint64 OwncloudAdvancedSetupPage::availableLocalSpace() const
 {
     QString localDir = localFolder();
-    QString path = !QDir(localDir).exists() && localDir.contains(QDir::homePath()) ?
-                QDir::homePath() : localDir;
+    const auto homeDirectory =
+#ifdef Q_OS_MACOS
+        Utility::getRealHomeDirectory();
+#else
+        QDir::homePath();
+#endif
+    QString path = !QDir(localDir).exists() && localDir.contains(homeDirectory) ? homeDirectory : localDir;
     QStorageInfo storage(QDir::toNativeSeparators(path));
 
     return storage.bytesAvailable();


### PR DESCRIPTION


<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

In some cases (i.e. advanced setup wizard) we do not use the unsandboxed home location (in the old wizard for stable-33)

This fixes that

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [X] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
