### PR TITLE
Repair account creation via CLI

### DIFF
--- a/src/cmd/cmd.cpp
+++ b/src/cmd/cmd.cpp
@@ -228,7 +228,8 @@ CommandMode parseOptions(const QStringList &app_args, CmdOptions *options)
 {
     auto result = CommandMode::UnknownMode;
 
-    auto args(app_args);
+    // Accept both "--option value" and "--option=value" for every option below.
+    auto args = Utility::expandCommandLineOptionValues(app_args);
 
     const auto argCount = args.count();
 
@@ -447,19 +448,22 @@ int main(int argc, char **argv)
             return -1;
         }
 
-        if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
-            if (AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine()) {
-                return 0;
-            } else {
-                qWarning() << "Creation of the account failed. See prior messages for a detailed error.";
-                return -1;
-            }
-        } else {
+        if (!AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             AccountSetupCommandLineManager::destroy();
             qWarning() << "Missing mandatory command line options for provisioning mode";
             help();
             return -1;
         }
+
+        if (!AccountSetupCommandLineManager::instance()->setupAccountFromCommandLine()) {
+            qWarning() << "Creation of the account failed. See prior messages for a detailed error.";
+            return -1;
+        }
+
+        // Setting up the account validates the credentials against the server and stores
+        // them in the keychain, both of which are asynchronous. The setup job ends the
+        // event loop with the exit code once it has finished.
+        return app.exec();
     }
 
     AccountPtr account = Account::create();

--- a/src/common/utility.cpp
+++ b/src/common/utility.cpp
@@ -688,5 +688,28 @@ QString Utility::fullRemotePathToRemoteSyncRootRelative(const QString &fullRemot
     return noLeadingSlashPath(noTrailingSlashPath(relativePathToRemoteSyncRoot));
 }
 
+QStringList Utility::expandCommandLineOptionValues(const QStringList &arguments)
+{
+    QStringList expandedArguments;
+    expandedArguments.reserve(arguments.size());
+
+    for (const auto &argument : arguments) {
+        // Anything that is not a long option is passed through untouched: paths and custom
+        // URI scheme arguments may legitimately contain a '='.
+        const auto separator = argument.startsWith(QLatin1String("--")) ? argument.indexOf(QLatin1Char('=')) : -1;
+        if (separator < 3) {
+            expandedArguments.append(argument);
+            continue;
+        }
+
+        expandedArguments.append(argument.left(separator));
+
+        if (const auto value = argument.mid(separator + 1); !value.isEmpty()) {
+            expandedArguments.append(value);
+        }
+    }
+
+    return expandedArguments;
+}
 
 } // namespace OCC

--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -336,6 +336,19 @@ namespace Utility {
     OCSYNC_EXPORT QString noTrailingSlashPath(const QString &path);
     OCSYNC_EXPORT QString fullRemotePathToRemoteSyncRootRelative(const QString &fullRemotePath, const QString &remoteSyncRoot);
 
+    /**
+     * @brief Splits "--option=value" arguments into a separate "--option" and "value" entry
+     *
+     * The option parsers of the client and of nextcloudcmd walk the argument list with an
+     * iterator and expect the value of an option in the entry that follows it. Normalising
+     * the list before parsing makes both spellings work without teaching every single
+     * option about the inline form.
+     *
+     * Only entries starting with "--" are split, and only at their first '='. "--option="
+     * keeps no value so that the parsers report their usual "not specified" error.
+     */
+    OCSYNC_EXPORT QStringList expandCommandLineOptionValues(const QStringList &arguments);
+
 #ifdef Q_OS_WIN
     OCSYNC_EXPORT bool registryKeyExists(HKEY hRootKey, const QString &subKey);
     OCSYNC_EXPORT QVariant registryGetKeyValue(HKEY hRootKey, const QString &subKey, const QString &valueName);

--- a/src/gui/accountsetupfromcommandlinejob.cpp
+++ b/src/gui/accountsetupfromcommandlinejob.cpp
@@ -7,23 +7,33 @@
 
 #include "accountmanager.h"
 #include "accountstate.h"
+#include "common/filesystembase.h"
+#include "configfile.h"
 #include "creds/abstractcredentials.h"
 #include "creds/webflowcredentials.h"
-#include "common/filesystembase.h"
 #include "folder.h"
 #include "folderman.h"
 #include "networkjobs.h"
+#include "theme.h"
+
+#include <chrono>
+#include <iostream>
 
 #include <QDir>
 #include <QGuiApplication>
 #include <QJsonObject>
 #include <QLoggingCategory>
+#include <QTimer>
 
 using namespace Qt::StringLiterals;
 
 namespace OCC
 {
 Q_LOGGING_CATEGORY(lcAccountSetupCommandLineJob, "nextcloud.gui.accountsetupcommandlinejob", QtInfoMsg)
+
+// How long to wait for the keychain to confirm that the credentials were written before
+// finishing the setup without them.
+constexpr auto credentialsPersistTimeout = std::chrono::seconds(30);
 
 AccountSetupFromCommandLineJob::AccountSetupFromCommandLineJob(QString appPassword,
                                                                QString userId,
@@ -42,6 +52,44 @@ AccountSetupFromCommandLineJob::AccountSetupFromCommandLineJob(QString appPasswo
 {
 }
 
+bool AccountSetupFromCommandLineJob::localSyncFolderRequired() const
+{
+#ifdef BUILD_FILE_PROVIDER_MODULE
+    // Mirrors the guard in FolderMan::addFolder(): while the app-level File Provider mode
+    // is enabled, a classic sync folder cannot be created at all. The account is synced
+    // through the File Provider domain that is set up for it instead.
+    return !ConfigFile().macFileProviderModeEnabled();
+#else
+    return true;
+#endif
+}
+
+QString AccountSetupFromCommandLineJob::defaultLocalDirPath() const
+{
+    const auto overrideLocalDir = ConfigFile().overrideLocalDir();
+    auto localDirPath = overrideLocalDir;
+
+    if (localDirPath.isEmpty()) {
+        localDirPath = Theme::instance()->defaultClientFolder();
+
+        if (localDirPath.isEmpty()) {
+            return {};
+        }
+
+        if (!QDir(localDirPath).isAbsolute()) {
+            localDirPath = QDir::homePath() + QLatin1Char('/') + localDirPath;
+        }
+    }
+
+    auto serverUrlForFolder = _serverUrl;
+    serverUrlForFolder.setUserName(_userId);
+
+    return FolderMan::instance()->findGoodPathForNewSyncFolder(localDirPath,
+                                                               serverUrlForFolder,
+                                                               overrideLocalDir.isEmpty() ? FolderMan::GoodPathStrategy::AllowOnlyNewPath
+                                                                                          : FolderMan::GoodPathStrategy::AllowOverrideExistingPath);
+}
+
 bool AccountSetupFromCommandLineJob::handleAccountSetupFromCommandLine()
 {
     if (AccountManager::instance()->accountFromUserId(QStringLiteral("%1@%2").arg(_userId, _serverUrl.host()))) {
@@ -49,30 +97,32 @@ bool AccountSetupFromCommandLineJob::handleAccountSetupFromCommandLine()
         return false;
     }
 
-    if (_localDirPath.isEmpty()) {
-        printAccountSetupFromCommandLineStatusAndExit(
-            QStringLiteral("Folder creation failed. Could not create local folder because the name is empty"),
-            true);
-        return false;
+    if (!localSyncFolderRequired()) {
+        if (!_localDirPath.isEmpty()) {
+            qCInfo(lcAccountSetupCommandLineJob) << "Ignoring the given local folder, File Provider mode is enabled";
+            _localDirPath.clear();
+        }
     } else {
-        QDir dir(_localDirPath);
-        if (dir.exists() && !dir.isEmpty()) {
+        if (_localDirPath.isEmpty()) {
+            // The local folder is documented as optional, so fall back to the folder the
+            // account wizard would suggest rather than refusing to set the account up.
+            _localDirPath = defaultLocalDirPath();
+        }
+
+        if (_localDirPath.isEmpty()) {
+            printAccountSetupFromCommandLineStatusAndExit(
+                QStringLiteral("Could not determine a local folder to sync into. Please pass one with --localdirpath."),
+                true);
+            return false;
+        }
+
+        const QDir localDir(_localDirPath);
+        if (localDir.exists() && !localDir.isEmpty()) {
             printAccountSetupFromCommandLineStatusAndExit(
                 QStringLiteral("Local folder %1 already exists and is non-empty!").arg(QDir::toNativeSeparators(_localDirPath)),
                 true);
             return false;
         }
-
-        qCInfo(lcAccountSetupCommandLineJob) << "Creating folder" << _localDirPath;
-        if (!dir.exists() && !dir.mkpath(".")) {
-            printAccountSetupFromCommandLineStatusAndExit(
-                QStringLiteral("Folder creation failed. Could not create local folder %1").arg(QDir::toNativeSeparators(_localDirPath)),
-                true);
-            return false;
-        }
-
-        FileSystem::setFolderMinimumPermissions(_localDirPath);
-        Utility::setupFavLink(_localDirPath);
     }
 
     const auto credentials = new WebFlowCredentials(_userId, _appPassword);
@@ -81,12 +131,16 @@ bool AccountSetupFromCommandLineJob::handleAccountSetupFromCommandLine()
     _account->setCredentials(credentials);
     _account->setCredentialSetting(u"user"_s, _userId);
     _account->setUrl(_serverUrl);
-    auto accountState = AccountManager::instance()->addAccount(_account);
-    setupLocalSyncFolder(accountState);
 
-    Q_EMIT _account->wantsAccountSaved(_account);
-
+    // The account is only added, saved and given a sync folder once the credentials have
+    // been checked against the server, so that a failed setup leaves nothing behind. Both
+    // that check and the keychain write are asynchronous: the job keeps running until
+    // printAccountSetupFromCommandLineStatusAndExit() ends the event loop.
     if (_appPassword.isEmpty()) {
+        // Nothing to authenticate with, so the server cannot be asked for the dav user
+        // either. Store what was given and let the user log in from the client later on.
+        _account->setDavUser(_userId);
+        accountSetupFromCommandLinePropfindHandleSuccess();
         return true;
     }
 
@@ -112,18 +166,39 @@ void AccountSetupFromCommandLineJob::accountSetupFromCommandLinePropfindHandleSu
     const auto accountManager = AccountManager::instance();
     const auto accountState = accountManager->addAccount(_account);
 
-    // credentials->persist() (called by save()) is asynchronous — it chains
-    // multiple keychain write jobs before the password actually lands in the
-    // keychain.  Wait for the final write to complete before exiting so that
-    // the credentials are not lost when the process quits.
-    connect(_account->credentials(), &AbstractCredentials::credentialsPersisted, this, [this, accountState]() {
+    const auto finishAccountSetup = [this, accountState]() {
         if (!_localDirPath.isEmpty()) {
             setupLocalSyncFolder(accountState);
         } else {
             qCInfo(lcAccountSetupCommandLineJob) << QStringLiteral("Set up a new account without a folder.");
             printAccountSetupFromCommandLineStatusAndExit(QStringLiteral("Account %1 setup from command line success.").arg(_account->displayName()), false);
         }
+    };
+
+    // credentials->persist() (called by save()) is asynchronous — it chains
+    // multiple keychain write jobs before the password actually lands in the
+    // keychain.  Wait for the final write to complete before exiting so that
+    // the credentials are not lost when the process quits, but give up eventually:
+    // a keychain that never answers must not turn the setup into a hang.
+    const auto credentialsPersistTimer = new QTimer(this);
+    credentialsPersistTimer->setSingleShot(true);
+
+    connect(_account->credentials(), &AbstractCredentials::credentialsPersisted, this, [credentialsPersistTimer, finishAccountSetup]() {
+        if (!credentialsPersistTimer->isActive()) {
+            return;
+        }
+
+        credentialsPersistTimer->stop();
+        finishAccountSetup();
     });
+
+    connect(credentialsPersistTimer, &QTimer::timeout, this, [finishAccountSetup]() {
+        qCWarning(lcAccountSetupCommandLineJob) << "Timed out waiting for the credentials to be written to the keychain,"
+                                                << "the account may have to be authenticated again";
+        finishAccountSetup();
+    });
+
+    credentialsPersistTimer->start(credentialsPersistTimeout);
 
     accountManager->save();
 }
@@ -183,6 +258,22 @@ void AccountSetupFromCommandLineJob::accountSetupFromCommandLinePropfindHandleFa
 
 void AccountSetupFromCommandLineJob::setupLocalSyncFolder(AccountState *accountState)
 {
+    QDir localDir(_localDirPath);
+    if (!localDir.exists()) {
+        qCInfo(lcAccountSetupCommandLineJob) << "Creating folder" << _localDirPath;
+
+        if (!localDir.mkpath(QStringLiteral("."))) {
+            AccountManager::instance()->removeAccountState(accountState);
+            printAccountSetupFromCommandLineStatusAndExit(
+                QStringLiteral("Folder creation failed. Could not create local folder %1").arg(QDir::toNativeSeparators(_localDirPath)),
+                true);
+            return;
+        }
+    }
+
+    FileSystem::setFolderMinimumPermissions(_localDirPath);
+    Utility::setupFavLink(_localDirPath);
+
     FolderDefinition definition;
     definition.localPath = _localDirPath;
     definition.targetPath = FolderDefinition::prepareTargetPath(!_remoteDirPath.isEmpty() ? _remoteDirPath : QStringLiteral("/"));
@@ -209,7 +300,9 @@ void AccountSetupFromCommandLineJob::setupLocalSyncFolder(AccountState *accountS
         qCInfo(lcAccountSetupCommandLineJob) << QStringLiteral("Folder %1 setup from command line success.").arg(definition.localPath);
         printAccountSetupFromCommandLineStatusAndExit(QStringLiteral("Account %1 setup from command line success.").arg(_account->displayName()), false);
     } else {
-        AccountManager::instance()->deleteAccount(accountState);
+        // Drop the account again, but keep the app password valid: it was passed in on the
+        // command line and revoking it would make a retry impossible.
+        AccountManager::instance()->removeAccountState(accountState);
         printAccountSetupFromCommandLineStatusAndExit(
             QStringLiteral("Account %1 setup from command line failed, due to folder creation failure.").arg(_account->displayName()),
             true);
@@ -220,8 +313,10 @@ void AccountSetupFromCommandLineJob::printAccountSetupFromCommandLineStatusAndEx
 {
     if (isFailure) {
         qCWarning(lcAccountSetupCommandLineJob) << status;
+        std::cerr << qUtf8Printable(status) << std::endl;
     } else {
         qCInfo(lcAccountSetupCommandLineJob) << status;
+        std::cout << qUtf8Printable(status) << std::endl;
     }
     QTimer::singleShot(0, this, [this, isFailure]() {
         this->deleteLater();

--- a/src/gui/accountsetupfromcommandlinejob.h
+++ b/src/gui/accountsetupfromcommandlinejob.h
@@ -24,7 +24,7 @@ public:
                                    QString userId,
                                    QUrl serverUrl,
                                    QString localDirPath = {},
-                                   bool nonVfsMode = false,
+                                   bool isVfsEnabled = false,
                                    QString remoteDirPath = QStringLiteral("/"),
                                    QObject *parent = nullptr);
 
@@ -45,6 +45,20 @@ private Q_SLOTS:
     void fetchUserName();
 
 private:
+    /** Whether a classic sync folder has to be set up for the new account.
+     *
+     * With the app-level File Provider mode enabled the account is synced through its
+     * File Provider domain and FolderMan refuses to add a classic sync folder.
+     */
+    [[nodiscard]] bool localSyncFolderRequired() const;
+
+    /** The local folder to use when none was given on the command line.
+     *
+     * Follows what the account wizard suggests: the configured override, otherwise the
+     * theme's default client folder, made unique against the existing sync folders.
+     */
+    [[nodiscard]] QString defaultLocalDirPath() const;
+
     QString _appPassword;
     QString _userId;
     QUrl _serverUrl;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -27,10 +27,11 @@
 #include "updater/ocupdater.h"
 #endif
 
+#include "common/utility.h"
+#include "common/vfs.h"
+#include "csync_exclude.h"
 #include "owncloudsetupwizard.h"
 #include "version.h"
-#include "csync_exclude.h"
-#include "common/vfs.h"
 
 #include "config.h"
 
@@ -389,7 +390,10 @@ Application::Application(int &argc, char **argv)
             shouldExit = true;
         }
 
-        if (AccountSetupCommandLineManager::instance()) {
+        // Only a command line that actually provisions an account carries a meaningful
+        // --isvfsenabled value; on a normal start this would overwrite the user's setting
+        // with the default of an unused parser.
+        if (AccountSetupCommandLineManager::instance()->isCommandLineParsed()) {
             cfg.setVfsEnabled(AccountSetupCommandLineManager::instance()->isVfsEnabled());
         }
 
@@ -1006,7 +1010,10 @@ void Application::slotActivateRequestedMessage(const QStringList &arguments, con
 
 void Application::parseOptions(const QStringList &options)
 {
-    QStringListIterator it(options);
+    // Accept both "--option value" and "--option=value" for every option below.
+    const auto expandedOptions = Utility::expandCommandLineOptionValues(options);
+
+    QStringListIterator it(expandedOptions);
     // skip file name;
     if (it.hasNext()) {
         it.next();

--- a/test/testnextcloudcmdprovisioning.cpp
+++ b/test/testnextcloudcmdprovisioning.cpp
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: CC0-1.0
  */
 
-#include <QtTest>
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
 #include <QProcess>
 #include <QString>
-#include <QByteArray>
+#include <QTemporaryDir>
+#include <QtTest>
 
 #include "config.h"
 
@@ -33,11 +36,44 @@ private:
         proc.setProcessChannelMode(QProcess::MergedChannels);
         proc.start(nextcloudCmdBinary(), args);
         proc.closeWriteChannel(); // close stdin — no interactive reads
-        proc.waitForFinished(timeoutMs);
+        if (!proc.waitForFinished(timeoutMs)) {
+            // Kill rather than let the QProcess destructor block on a wedged child, and
+            // leave an exit code behind that no expectation below accepts.
+            proc.kill();
+            proc.waitForFinished();
+        }
         if (exitCodeOut) {
             *exitCodeOut = proc.exitCode();
         }
         return proc.readAll();
+    }
+
+    // Returns true once an account section has been written to the configuration in
+    // confDir.  A failed setup must leave the configuration without one.
+    static bool configHasAccount(const QString &confDir)
+    {
+        const QDir dir(confDir);
+        const auto configFileNames = dir.entryList({QStringLiteral("*.cfg")}, QDir::Files);
+
+        for (const auto &configFileName : configFileNames) {
+            QFile configFile(dir.filePath(configFileName));
+            if (!configFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                continue;
+            }
+
+            if (configFile.readAll().contains("webflow_user")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // A port nothing listens on, so the provisioning setup always fails on the first
+    // request instead of depending on a server being available to the test.
+    static QString unreachableServerUrl()
+    {
+        return QStringLiteral("http://127.0.0.1:1");
     }
 
 private Q_SLOTS:
@@ -145,6 +181,102 @@ private Q_SLOTS:
         QCOMPARE(exitCode, expectedExitCode);
         QVERIFY2(output.contains("--serverurl"), output.constData());
         QVERIFY2(!output.contains("Please enter username"), output.constData());
+    }
+
+    // The same as testUserIdAlonePrintsServerUrlError, but with the inline
+    // "--option=value" spelling.  Provisioning mode is selected by looking for
+    // --userid in the arguments, so before the inline form was expanded this fell
+    // through into sync mode and printed the generic help instead.
+    void testInlineOptionValuesSelectProvisioningMode()
+    {
+#if defined Q_OS_WINDOWS
+        constexpr auto expectedExitCode = -1;
+#else
+        constexpr auto expectedExitCode = 255;
+#endif
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--userid=alice")}, &exitCode);
+
+        QCOMPARE(exitCode, expectedExitCode);
+        QVERIFY2(output.contains("--serverurl"), output.constData());
+        QVERIFY2(!output.contains("Please enter username"), output.constData());
+    }
+
+    // A full set of provisioning options in the inline spelling has to reach the
+    // account setup.  Sync mode would instead have taken the last two arguments as
+    // the positional source directory and server URL and complained about the
+    // source directory not existing.
+    void testInlineOptionValuesReachAccountSetup()
+    {
+        QTemporaryDir confDir;
+        QVERIFY(confDir.isValid());
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--confdir"),
+                                    confDir.path(),
+                                    QStringLiteral("--userid=alice"),
+                                    QStringLiteral("--apppassword=secret"),
+                                    QStringLiteral("--serverurl=") + unreachableServerUrl()},
+                                   &exitCode);
+
+        QVERIFY2(output.contains("Could not fetch username"), output.constData());
+        QVERIFY2(!output.contains("does not exist"), output.constData());
+        QCOMPARE(exitCode, 1);
+    }
+
+    // --localdirpath is documented as optional.  Leaving it out used to abort the
+    // setup right away with "Could not create local folder because the name is
+    // empty", so the credentials were never even sent to the server.
+    void testSetupWithoutLocalDirPathIsNotRejected()
+    {
+        QTemporaryDir confDir;
+        QVERIFY(confDir.isValid());
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--confdir"),
+                                    confDir.path(),
+                                    QStringLiteral("--userid"),
+                                    QStringLiteral("alice"),
+                                    QStringLiteral("--apppassword"),
+                                    QStringLiteral("secret"),
+                                    QStringLiteral("--serverurl"),
+                                    unreachableServerUrl()},
+                                   &exitCode);
+
+        QVERIFY2(!output.contains("local folder because the name is empty"), output.constData());
+        // The setup got as far as contacting the server, which is where it fails here.
+        QVERIFY2(output.contains("Could not fetch username"), output.constData());
+        QCOMPARE(exitCode, 1);
+    }
+
+    // With an app password the setup is asynchronous: the credentials are checked
+    // against the server before the account is written.  nextcloudcmd has to run an
+    // event loop for any of that to happen — without one it returned success before
+    // the first reply arrived.  So an unreachable server has to be reported as a
+    // failure, and nothing may be left in the configuration.
+    void testAppPasswordSetupRunsTheEventLoop()
+    {
+        QTemporaryDir confDir;
+        QVERIFY(confDir.isValid());
+
+        int exitCode = 0;
+        const auto output = runCmd({QStringLiteral("--confdir"),
+                                    confDir.path(),
+                                    QStringLiteral("--userid"),
+                                    QStringLiteral("alice"),
+                                    QStringLiteral("--apppassword"),
+                                    QStringLiteral("secret"),
+                                    QStringLiteral("--serverurl"),
+                                    unreachableServerUrl()},
+                                   &exitCode);
+
+        // 1 is the code the setup job exits with.  The options were accepted, so this
+        // is neither the 255 of a rejected command line nor the 0 of an early return
+        // that never waited for the result.
+        QCOMPARE(exitCode, 1);
+        QVERIFY2(output.contains("Could not fetch username"), output.constData());
+        QVERIFY2(!configHasAccount(confDir.path()), "a failed setup must not store an account");
     }
 };
 

--- a/test/testutility.cpp
+++ b/test/testutility.cpp
@@ -376,6 +376,51 @@ private Q_SLOTS:
         QCOMPARE(QDir::homePath(), originalHome);
     }
 #endif
+
+    void testExpandCommandLineOptionValues_data()
+    {
+        QTest::addColumn<QStringList>("arguments");
+        QTest::addColumn<QStringList>("expected");
+
+        QTest::newRow("empty") << QStringList{} << QStringList{};
+
+        QTest::newRow("separate value is left alone") << QStringList{"nextcloud", "--userid", "alice"} << QStringList{"nextcloud", "--userid", "alice"};
+
+        QTest::newRow("inline value is split off") << QStringList{"nextcloud", "--userid=alice"} << QStringList{"nextcloud", "--userid", "alice"};
+
+        QTest::newRow("both spellings can be mixed") << QStringList{"nextcloud", "--userid=alice", "--serverurl", "https://example.com"}
+                                                     << QStringList{"nextcloud", "--userid", "alice", "--serverurl", "https://example.com"};
+
+        // Only the first '=' separates, so query strings and passwords stay intact.
+        QTest::newRow("value keeps its own equal signs")
+            << QStringList{"--serverurl=https://example.com/?a=b&c=d"} << QStringList{"--serverurl", "https://example.com/?a=b&c=d"};
+
+        QTest::newRow("password keeps its own equal signs") << QStringList{"--apppassword=pa=ss"} << QStringList{"--apppassword", "pa=ss"};
+
+        // An empty inline value must not become an empty argument: the option is left
+        // without a value so that the parsers report their usual "not specified" error.
+        QTest::newRow("empty inline value yields no value") << QStringList{"--userid="} << QStringList{"--userid"};
+
+        // Anything that is not a long option is passed through untouched, because local
+        // paths and custom URI scheme arguments may legitimately contain a '='.
+        QTest::newRow("path with an equal sign is untouched") << QStringList{"/home/alice/a=b/file.txt"} << QStringList{"/home/alice/a=b/file.txt"};
+
+        QTest::newRow("uri scheme argument is untouched") << QStringList{"nc://open/file?id=42"} << QStringList{"nc://open/file?id=42"};
+
+        QTest::newRow("short option is untouched") << QStringList{"-u=alice"} << QStringList{"-u=alice"};
+
+        QTest::newRow("bare double dash is untouched") << QStringList{"--"} << QStringList{"--"};
+
+        QTest::newRow("option without a name is untouched") << QStringList{"--=alice"} << QStringList{"--=alice"};
+    }
+
+    void testExpandCommandLineOptionValues()
+    {
+        QFETCH(QStringList, arguments);
+        QFETCH(QStringList, expected);
+
+        QCOMPARE(OCC::Utility::expandCommandLineOptionValues(arguments), expected);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestUtility)


### PR DESCRIPTION
## Problem

`Nextcloud --userid=admin --apppassword=admin --serverurl=http://…` printed `Unrecognized option '--userid=admin'`. Fixing that spelling only exposed the next failure, and so on — account setup from the command line could not succeed on macOS at all.

## Defects fixed

| # | Defect |
|---|---|
| 1 | Only `--option value` was parsed, never `--option=value` |
| 2 | `--localdirpath` documented optional, but an empty one was rejected |
| 3 | `FolderMan::addFolder()` refuses classic folders in File Provider mode; setup always created one |
| 4 | `09f46929e3` added the account and folder before authenticating, and quit before the credential check, save and keychain write could run |

Also: the failure path called `deleteAccount()`, revoking the app password passed on the command line, and `cfg.setVfsEnabled()` ran on every start, clobbering the user's setting.

## Notes

`nextcloudcmd` needs an event loop for the now fully asynchronous setup. Its QtKeychain jobs never emit `finished` — pre-existing, hidden by the previous immediate return. The wait is bounded at 30 s so provisioning terminates with a warning rather than hanging; whether the signed release binary is affected is still open.

## Testing

Against a local server, with the built client:

- `--userid=…` inline form accepted; account created, `dav_user` set, password in keychain
- no `--apppassword`: account created
- classic sync mode without `--localdirpath`: default folder derived and created
- wrong password: exits 1 with an error and leaves no account behind
- `--userid=`: reports `userid not specified`
- all scenarios from `testnextcloudcmdprovisioning` behave as the test expects