### PR TITLE
Fix file provider issues with directory handling and performance

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+ChangeDelivery.swift
@@ -56,6 +56,96 @@ extension FilesDatabaseManager {
         }
     }
 
+    ///
+    /// Append more changes to an open session, after everything already queued.
+    ///
+    /// Streaming delivery primes a session from a scan's first wave and appends the rest as they are
+    /// discovered, so a change found early is reported without waiting for the whole walk. Sequences
+    /// continue past the highest one stored — consumed items are deleted as the drain advances, so
+    /// the session's `nextSequence` is the floor to build on rather than the stored count.
+    ///
+    func appendChangeDeliveryItems(
+        sessionId: String,
+        updated: [SendableItemMetadata],
+        deleted: [SendableItemMetadata]
+    ) -> Bool {
+        let encoder = JSONEncoder()
+        let allChanges: [(metadata: SendableItemMetadata, deleted: Bool)] =
+            updated.map { (metadata: $0, deleted: false) } + deleted.map { (metadata: $0, deleted: true) }
+
+        guard !allChanges.isEmpty else { return true }
+
+        let encodedChanges: [(data: Data, deleted: Bool)] = allChanges.compactMap { change in
+            guard let metadataData = try? encoder.encode(change.metadata) else { return nil }
+            return (data: metadataData, deleted: change.deleted)
+        }
+
+        guard encodedChanges.count == allChanges.count else {
+            logger.error("Could not encode all metadata appended to a change-delivery session.")
+            return false
+        }
+
+        let database = ncDatabase()
+
+        guard let session = database.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId),
+              !session.completed
+        else {
+            logger.error("Cannot append to a change-delivery session that is not open.")
+            return false
+        }
+
+        let highestStored = database
+            .objects(RealmChangeDeliveryItem.self)
+            .filter("sessionId == %@", sessionId)
+            .max(ofProperty: "sequence") as Int? ?? (session.nextSequence - 1)
+        let firstSequence = max(highestStored + 1, session.nextSequence)
+
+        do {
+            try database.write {
+                let items = encodedChanges.enumerated().map { offset, change in
+                    RealmChangeDeliveryItem(
+                        sessionId: sessionId,
+                        sequence: firstSequence + offset,
+                        metadataData: change.data,
+                        deleted: change.deleted
+                    )
+                }
+                database.add(items, update: .modified)
+            }
+            return true
+        } catch {
+            logger.error("Could not append to a change-delivery session.")
+            return false
+        }
+    }
+
+    ///
+    /// Record a streaming session's outcome once its producer has finished.
+    ///
+    /// A streaming session is primed `incomplete` because the scan's success is not yet known. A
+    /// clean finish stamps the real sync anchor and clears the flag, which is what lets the
+    /// working-set sync point advance. Left as primed, the session keeps its incoming anchor and the
+    /// next signal re-derives — the safe outcome when a scan fails or is abandoned.
+    ///
+    func finalizeChangeDeliverySession(
+        sessionId: String,
+        finalAnchorRawValue: Data,
+        incomplete: Bool
+    ) {
+        let database = ncDatabase()
+
+        guard let session = database.object(ofType: RealmChangeDeliverySession.self, forPrimaryKey: sessionId),
+              !session.completed
+        else {
+            return
+        }
+
+        try? database.write {
+            session.finalAnchorRawValue = finalAnchorRawValue
+            session.incomplete = incomplete
+        }
+    }
+
     /// Return the active delivery session whose current continuation anchor matches `anchorKey`.
     func changeDeliverySession(forAnchorKey anchorKey: String) -> (
         sessionId: String,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Directories.swift
@@ -38,11 +38,34 @@ public extension FilesDatabaseManager {
             .toUnmanagedResults()
     }
 
+    ///
+    /// The number of **direct** children of a directory, as vended by `Item.childItemCount`.
+    ///
+    /// `NSFileProviderItem.childItemCount` is defined as the number of items directly contained
+    /// in the container, and Finder displays it verbatim. This previously matched descendants
+    /// too (`includingDescendants: true`), so every folder holding subfolders reported its whole
+    /// subtree — a root with 14 direct children reported 17372 — and the framework diffed that
+    /// against its own count on every read, feeding the container `update-item` retry loop.
+    ///
+    /// Soft-deleted tombstones and rows belonging to another account are excluded: neither is a
+    /// child the user can see.
+    ///
+    /// The container's own row is excluded too. ``fullServerPathUrl(for:)`` resolves the root to
+    /// its bare `serverUrl`, and the persisted root row carries that same value as *its*
+    /// `serverUrl` (see `NKFile.toItemMetadata()`, which keeps the root's server URL rather than
+    /// its parent's), so the root would otherwise match its own children predicate and count
+    /// itself.
+    ///
     func childItemCount(directoryMetadata: SendableItemMetadata) -> Int {
         let directoryServerUrl = fullServerPathUrl(for: directoryMetadata)
+        let account = directoryMetadata.account
+        let ocId = directoryMetadata.ocId
         return itemMetadatas
             .where { item in
-                RealmItemMetadata.hasServerUrl(item, equalTo: directoryServerUrl, includingDescendants: true)
+                item.account == account &&
+                    item.deleted == false &&
+                    item.ocId != ocId &&
+                    RealmItemMetadata.hasServerUrl(item, equalTo: directoryServerUrl, includingDescendants: false)
             }
             .count
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -693,6 +693,26 @@ public final class FilesDatabaseManager: Sendable {
             }
 
             toWrite.lockToken = existing.lockToken
+
+            // Nothing to persist when the row already holds this remote state. Without this the
+            // paginated ingestion path rewrote every row it read — one write transaction and one
+            // `evictLogicalDuplicates` query per item — even on a listing where nothing had
+            // changed. Measured on one working-set scan: 1,998 rows rewritten to surface 7 actual
+            // changes, against 5,858 evaluations that found no difference.
+            //
+            // This is the same guard the non-paginated ingestion path already applies in
+            // ``depth1ReadUpdateItemMetadatas``, including its `status == .normal` condition, which
+            // keeps an in-transit row from being judged against a server payload that cannot yet
+            // reflect it. `visitedDirectory` is compared explicitly because it is local-only and so
+            // absent from `isInSameDatabaseStoreableRemoteState`: a caller passing
+            // `preserveVisitedDirectory: false` is recording a visit and must always be written.
+            if existing.status == Status.normal.rawValue,
+               existing.isInSameDatabaseStoreableRemoteState(toWrite),
+               existing.visitedDirectory == toWrite.visitedDirectory
+            {
+                logger.debug("Skipping item metadata write; database already holds this remote state.", [.item: toWrite.ocId, .name: toWrite.fileName])
+                return toWrite
+            }
         } else {
             // The ocId lookup missed. Before falling back to defaults from the
             // server payload, look for a single non-deleted, non-local-lock row

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -153,6 +153,32 @@ public final class FilesDatabaseManager: Sendable {
     }
 
     ///
+    /// The containers to re-read for a set of numeric WebDAV file IDs received from notify-push.
+    ///
+    /// A push names what changed; this turns that into where to look. A changed directory is
+    /// returned as itself, a changed file as its parent — in both cases a depth-1 read of the
+    /// returned container shows the new state, including a child that was created or removed.
+    ///
+    /// Ids the database does not know are skipped rather than guessed at. That loses nothing in
+    /// practice: the server propagates a change's etag up every ancestor, so a push for a brand-new
+    /// item also carries its parent's id, and the parent is a container we already track. Unknown
+    /// ids on their own mean the change was outside the enumerated tree.
+    ///
+    public func containersForPushedFileIds(_ fileIds: Set<String>) -> Set<NSFileProviderItemIdentifier> {
+        var containers = Set<NSFileProviderItemIdentifier>()
+
+        for metadata in itemMetadatas.where({ $0.fileId.in(fileIds) && $0.deleted == false }) {
+            if metadata.directory {
+                containers.insert(NSFileProviderItemIdentifier(metadata.ocId))
+            } else if let parent = parentItemIdentifierFromMetadata(SendableItemMetadata(value: metadata)) {
+                containers.insert(parent)
+            }
+        }
+
+        return containers
+    }
+
+    ///
     /// Look up the item metadata by its account identifier and remote address.
     ///
     /// - Parameters:

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -543,6 +543,58 @@ public final class FilesDatabaseManager: Sendable {
         }
     }
 
+    ///
+    /// Persist several metadata rows in a **single** write transaction.
+    ///
+    /// Semantically identical to calling ``addItemMetadata(_:)`` per element, but the callers
+    /// that reconcile whole sets at once — materialized-set reconciliation, delivered-deletion
+    /// cleanup — were opening one transaction per row. On a large synced set that dominated the
+    /// callback and, because some of those loops run on the main actor or on the framework's
+    /// callback thread, stalled unrelated extension work behind them.
+    ///
+    public func addItemMetadatas(_ metadatas: [SendableItemMetadata]) {
+        guard !metadatas.isEmpty else { return }
+
+        let database = ncDatabase()
+
+        do {
+            try database.write {
+                for metadata in metadatas {
+                    evictLogicalDuplicates(of: metadata, in: database)
+                    database.add(RealmItemMetadata(value: metadata), update: .all)
+                }
+            }
+
+            logger.debug("Added \(metadatas.count) item metadata records in one transaction.")
+        } catch {
+            logger.error("Failed to add \(metadatas.count) item metadata records in one transaction.", [.error: error])
+        }
+    }
+
+    ///
+    /// Hard delete several items in a **single** write transaction.
+    ///
+    /// The batched counterpart of ``removeItemMetadata(ocId:)``; see ``addItemMetadatas(_:)`` for
+    /// why the per-row transaction was a problem.
+    ///
+    public func removeItemMetadatas(ocIds: [String]) {
+        guard !ocIds.isEmpty else { return }
+
+        let database = ncDatabase()
+
+        do {
+            let results = itemMetadatas.where { $0.ocId.in(ocIds) }
+
+            try database.write {
+                database.delete(results)
+            }
+
+            logger.debug("Removed \(ocIds.count) item metadata records in one transaction.")
+        } catch {
+            logger.error("Could not remove \(ocIds.count) item metadata records in one transaction.", [.error: error])
+        }
+    }
+
     /**
      * @brief Records that the provider returned `.excludedFromSync` for an item.
      *

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -53,3 +53,4 @@ It is designed specifically for the implementation of this file provider extensi
 - <doc:ExcludedFromSyncDeletion>
 - <doc:ChunkedUploads>
 - <doc:UnicodePathNormalization>
+- <doc:PerformanceBenchmarks>

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/PerformanceBenchmarks.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/PerformanceBenchmarks.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Performance benchmarks
+
+How to reproduce the scan, ingestion and enumeration measurements, and what each
+one actually measures.
+
+## Overview
+
+Two kinds of measurement appear in this package's history, and they are not
+interchangeable.
+
+**Counts** are reproducible from a checkout. How many PROPFINDs one scan issues,
+how many database rows one enumeration rewrites, and how many reads overlap are
+all properties of the code, not of the machine or the account it runs against.
+`PerformanceBenchmarkTests` asserts them exactly, so a regression fails the
+suite rather than merely reading slower.
+
+**Durations** are not. The figures quoted in commit messages and pull requests
+were taken on one live account with roughly 17,000 items over a real network,
+and nothing reproduces them but that account. What does carry over is the ratio
+between two revisions measured the same way on the same machine, which is what
+the timing benchmark below is for.
+
+Prefer the counts. A duration that improves without its count improving usually
+means the machine was quieter, not that the code got better.
+
+## Running them
+
+From the package root:
+
+```bash
+swift test --filter PerformanceBenchmarkTests
+```
+
+The timing benchmark prints its numbers with a `[benchmark]` prefix:
+
+```
+[benchmark] full working-set walk over 30 directories (6 files each, 50ms per read)
+[benchmark]   best of 3: 0.312381 seconds
+[benchmark]   sequential floor: 1.5 seconds
+[benchmark]   peak read overlap: 6
+```
+
+To compare two revisions, run the same suite on both. The benchmarks depend on
+one test-only addition to `MockRemoteInterface` — `enumerateLatency` and
+`maxConcurrentEnumerations` — so on a revision that predates them, copy
+`Tests/Interface/MockRemoteInterface.swift` and
+`Tests/NextcloudFileProviderKitTests/PerformanceBenchmarkTests.swift` across
+before running. Benchmarks that cover a feature the older revision does not have
+will not compile there; drop those and keep the rest.
+
+## What each benchmark measures
+
+### Read volume
+
+`testFullWalkReadsEachMaterialisedDirectoryOnce` asserts that a full working-set
+walk issues exactly one read per materialised directory and none for the
+materialised files inside them, whose state their parent's depth-1 read already
+carries. It is the baseline the targeted figure below is a ratio against, and
+the guard against the walk regaining per-file reads.
+
+`testPushTargetedWalkReadsOnlyTheNamedContainers` asserts that a walk answering a
+push reads only the containers the push named — one, against the thirty a full
+walk reads — and still reports the change. This is the mechanism behind the
+largest improvement measured on the live account: a push identifies a changed
+file within a second or so, and the extension used to answer it by walking the
+entire materialised set.
+
+### Write volume
+
+`testUnchangedPaginatedEnumerationWritesNoRows` and
+`testChangedPaginatedEnumerationWritesOnlyTheChangedRow` page through a
+200-file directory and count the rows whose persisted `syncTime` moved. A
+skipped write leaves the seeded timestamp untouched, so the count is exact.
+
+Pagination matters here: servers from Nextcloud 31 answer every enumeration with
+a paginated listing, and that is the ingestion path that used to write every row
+it read. The mock advertises server major version 28, so the benchmarks drive
+``Enumerator/readServerUrl(_:pageSettings:account:remoteInterface:dbManager:domain:enumeratedItemIdentifier:depth:log:)``
+with explicit page settings rather than going through
+``Enumerator/enumerateItems(for:startingAt:)``, whose pagination is gated on that
+version.
+
+The second test is the control. "Writes no rows" is also satisfied by a guard
+that suppresses genuine changes, which is the failure mode that matters — a
+suppressed write is a change the user never sees.
+
+### Read overlap
+
+`testWalkReadsOverlap` gives each mocked read a fixed duration and records how
+many were in flight at once. A sequential scan reads 1 no matter how large the
+tree is.
+
+`testFullWalkWallClock` times the same walk and asserts only that it beats the
+sequential floor — the duration issuing every read one after another would take.
+That is a ceiling a sequential scan cannot meet by construction, not a tuned
+threshold, so it does not turn into a flaky test on a loaded machine. The
+absolute numbers it prints are for comparing revisions, not for asserting.
+
+## Measured on this package
+
+Run on an Apple silicon Mac against `stable-34.0` (34.0.3) and against the
+branch, same machine, same invocation.
+
+| Benchmark | 34.0.3 | Branch |
+| --- | --- | --- |
+| Reads per full walk (30 materialised directories, 180 files) | 30 | 30 |
+| Rows rewritten by an unchanged 200-file paginated enumeration | 201 | 0 |
+| Rows rewritten when one of those 200 files changed | 201 | 1 |
+| Peak overlapping reads during a full walk | 1 | 6 |
+| Full walk wall clock, 30 reads × 50 ms | 1.80 s | 0.31 s |
+| Reads to answer a push naming one container | not implemented | 1 |
+
+The read-volume row is unchanged deliberately: the walk already read one
+directory at a time, and the benchmark exists to keep it that way.
+
+## Measuring on a live account
+
+The counts above are mechanisms. Their effect on a real domain depends on how
+much is materialised, how deep the tree is and how the server responds, so the
+figures in the commit messages were taken from the extension's own logs.
+
+The extension writes JSON Lines to its domain log directory, and every line
+carries a category and level. To watch a running extension instead:
+
+```bash
+log stream --predicate 'subsystem CONTAINS "FileProviderExt"' --level debug
+```
+
+The specific things worth counting in a captured window:
+
+- **Dataless transitions** — `Updating item state to dataless.` Each one is an
+  item the extension told the system to drop. A steady stream of them while
+  nothing is being evicted is the materialisation flip-flop described in
+  ``MaterializedEnumerationObserver``.
+- **Redundant writes** — `Skipping item metadata write; database already holds
+  this remote state.` against the number of items enumerated. The ratio is the
+  ingestion guard's hit rate.
+- **Scan span** — the interval between `Checking materialised items for changes
+  on the server...` and its matching completion line is one full walk.
+- **Targeted scans** — `Scanning N push-targeted container(s) instead of M
+  materialised item(s).` gives the ratio the push path achieved on that domain.
+- **Discovery-to-report latency** — the interval between the log line naming a
+  new item during a scan and the line reporting it to the change observer. This
+  is what streaming delivery shortens; before it, a change found early in a walk
+  waited for the walk to end.
+
+Take the same capture before and after a change, on the same account, with the
+same set of folders materialised. Comparing across accounts is not meaningful:
+every figure here scales with the materialised set.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/ChangeDeliveryBuffer.swift
@@ -4,6 +4,69 @@
 import Foundation
 
 ///
+/// Which streaming sessions still have a producer behind them, shared across every ``Enumerator`` in
+/// the process.
+///
+/// This is the correction to the first streaming attempt, which kept "a producer is running" on the
+/// buffer instance. The framework routinely serves an intermediate batch from a **new** `Enumerator`
+/// — the reason the session is persisted at all — and that instance saw no producer, reported
+/// `moreComing: false`, and both ended the sequence and deleted the session out from under the live
+/// scan. Since `moreComing: false` tells the framework it is synced, nothing was ever reported
+/// again.
+///
+/// Process-wide is the right scope: the framework replaces enumerators, not the extension process.
+/// Deliberately not persisted either — a *new process* means any producer from the old one is gone,
+/// and a session with no entry here is treated as abandoned, drained, and finished on its incoming
+/// anchor so the next signal re-derives. The deadline covers the remaining case of a producer that
+/// hangs rather than exits; expiring one early costs a redundant re-derivation, never a lost change.
+///
+final class StreamingProducerRegistry: @unchecked Sendable {
+    static let shared = StreamingProducerRegistry()
+
+    /// How long a producer stays trusted after its last sign of life.
+    static let livenessTimeout: TimeInterval = 10 * 60
+
+    private let lock = NSLock()
+    private var deadlines = [String: Date]()
+
+    /// Mark a producer alive, or extend it. Called when a stream opens and on every append.
+    func refresh(token: String, now: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        deadlines[token] = now.addingTimeInterval(Self.livenessTimeout)
+    }
+
+    /// Whether a producer is still expected to append to this session.
+    func isLive(token: String, now: Date = Date()) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let deadline = deadlines[token] else { return false }
+
+        if now >= deadline {
+            deadlines.removeValue(forKey: token)
+            return false
+        }
+
+        return true
+    }
+
+    /// The producer has finished or been superseded.
+    func retire(token: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        deadlines.removeValue(forKey: token)
+    }
+
+    /// Test seam: pretend a producer stopped signalling long ago.
+    func expire(token: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        deadlines[token] = Date(timeIntervalSince1970: 0)
+    }
+}
+
+///
 /// Durable FIFO state for a multi-batch File Provider change enumeration.
 ///
 /// The framework can invalidate an enumerator after an intermediate batch and invoke the next batch on a
@@ -113,6 +176,96 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
     }
 
     ///
+    /// Open a session for a producer to append to, and register it as live.
+    ///
+    /// Primed `incomplete` on purpose: the producer's outcome is unknown, so until
+    /// ``finishStreaming(token:finalAnchorRawValue:incomplete:)`` says otherwise the session must not
+    /// advance the working-set sync point.
+    ///
+    /// - Returns: A token identifying the stream. Every later call carries it, so a producer whose
+    ///   session was replaced under it cannot write to, or finish, the session that replaced it.
+    ///
+    func primeStreaming(key: String, incomingAnchorRawValue: Data) -> String? {
+        prime(key: key, finalAnchorRawValue: incomingAnchorRawValue, updated: [], deleted: [], incomplete: true)
+
+        lock.lock()
+        let token = sessionId
+        lock.unlock()
+
+        if let token {
+            StreamingProducerRegistry.shared.refresh(token: token)
+        }
+
+        return token
+    }
+
+    /// Queue more changes behind everything stored, and renew the producer's liveness.
+    func append(token: String, updated: [SendableItemMetadata], deleted: [SendableItemMetadata]) {
+        guard StreamingProducerRegistry.shared.isLive(token: token) else { return }
+        guard dbManager.changeDeliverySession(sessionId: token) != nil else { return }
+
+        StreamingProducerRegistry.shared.refresh(token: token)
+        _ = dbManager.appendChangeDeliveryItems(sessionId: token, updated: updated, deleted: deleted)
+    }
+
+    ///
+    /// Retire the producer and record the scan's verdict.
+    ///
+    /// `incomplete: true` keeps the incoming anchor so the next signal re-derives what this pass
+    /// could not read.
+    ///
+    func finishStreaming(token: String, finalAnchorRawValue: Data, incomplete: Bool) {
+        guard StreamingProducerRegistry.shared.isLive(token: token) else { return }
+
+        StreamingProducerRegistry.shared.retire(token: token)
+
+        dbManager.finalizeChangeDeliverySession(
+            sessionId: token,
+            finalAnchorRawValue: finalAnchorRawValue,
+            incomplete: incomplete
+        )
+    }
+
+    ///
+    /// Suspend until this session holds a deliverable item, or its producer is gone.
+    ///
+    /// Without this a streaming drain would answer `moreComing: true` with an empty batch, and the
+    /// framework would call straight back — a spin. Waiting parks the call exactly as the
+    /// non-streaming path already parked it for the whole scan, released now at the first wave.
+    /// Polled rather than condition-signalled so the wait is a real `await`: blocking a cooperative
+    /// thread would starve the scan it is waiting on.
+    ///
+    func awaitDeliverableItems() async {
+        while true {
+            guard let token = activeSessionId(), StreamingProducerRegistry.shared.isLive(token: token) else { return }
+            guard let session = dbManager.changeDeliverySession(sessionId: token) else { return }
+
+            let hasItems = !dbManager.changeDeliveryItems(
+                sessionId: token, fromSequence: session.nextSequence, limit: 1
+            ).isEmpty
+
+            if hasItems {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    /// The active session identifier. Separate helper because `NSLock` may not be taken from an
+    /// async context.
+    private func activeSessionId() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessionId
+    }
+
+    /// Test seam: make this session's producer look abandoned.
+    func expireProducerLivenessForTesting(token: String) {
+        StreamingProducerRegistry.shared.expire(token: token)
+    }
+
+    ///
     /// Consume the next combined update/delete batch and persist the cursor before returning it.
     ///
     /// `moreComing` is false when this batch consumed the final stored item. Intermediate batches return a
@@ -144,7 +297,11 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
             limit: budget + 1
         )
         let batchItems = Array(storedItems.prefix(budget))
-        let moreComing = storedItems.count > budget
+        // A live producer means more is coming even when this batch emptied the store. Ending the
+        // sequence here would tell the framework it is synced and drop everything the scan has yet
+        // to find — and the durable session, which any enumerator may pick up, is what makes this
+        // answer the same regardless of which one is serving the batch.
+        let moreComing = storedItems.count > budget || StreamingProducerRegistry.shared.isLive(token: sessionId)
         let decoder = JSONDecoder()
         var updated = [SendableItemMetadata]()
         var deleted = [SendableItemMetadata]()
@@ -201,6 +358,7 @@ final class ChangeDeliveryBuffer: @unchecked Sendable {
         }
 
         dbManager.removeChangeDeliverySession(sessionId: sessionId)
+        StreamingProducerRegistry.shared.retire(token: sessionId)
         self.sessionId = nil
         logger.info("Reset change delivery session.")
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+ObserverReporting.swift
@@ -191,9 +191,11 @@ extension Enumerator {
                     // reported (didDeleteItems ran in completeChangesBatch), and doing the DB write before
                     // finishEnumeratingChanges keeps the database consistent with what the observer has
                     // been told by the time the batch is acknowledged.
-                    for metadata in deletedToRemove {
-                        dbManager.removeItemMetadata(ocId: metadata.ocId)
-                    }
+                    //
+                    // One transaction for the batch, not one per item: this block runs on the main
+                    // actor, so a per-item write transaction put the whole batch's Realm work in
+                    // front of everything else scheduled there.
+                    dbManager.removeItemMetadatas(ocIds: deletedToRemove.map(\.ocId))
 
                     observer.finishEnumeratingChanges(upTo: anchor, moreComing: moreComing)
                 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -14,6 +14,26 @@ import Foundation
 ///
 private let workingSetScanConcurrency = 6
 
+///
+/// Identifiers a streaming scan has already handed to the change buffer, so the tail append skips
+/// them. The wave callback is `@Sendable` and runs on the scan's task, hence the lock.
+///
+private final class StreamedIdentifiers: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = Set<String>()
+
+    func formUnion(_ ocIds: some Sequence<String>) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage.formUnion(ocIds)
+    }
+
+    func contains(_ ocId: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage.contains(ocId)
+    }
+}
 
 ///
 /// Working-set change derivation. Because a change notification only ever signals `.workingSet`,
@@ -56,38 +76,73 @@ extension Enumerator {
                 let targets = RemoteChangeTargets.shared.consumeTargets()
                 let runFullScan = targets == nil || RemoteChangeTargets.shared.shouldRunFullScan()
 
-                let serverChanges = await scanMaterialisedItemsForRemoteChanges(
-                    restrictedToContainers: runFullScan ? nil : targets
-                )
-
-                if runFullScan, !serverChanges.hadFailure {
-                    RemoteChangeTargets.shared.noteFullScanCompleted()
+                // Stream the walk's discoveries rather than holding them until it ends. A full walk
+                // grows with the materialised set — 305 seconds when last measured — and a change
+                // found in its first seconds used to wait for its last: one document was seen 15
+                // seconds in and reported 4m34s later.
+                //
+                // Only scan-discovered creations and updates stream. Deletions cannot: an item
+                // absent from one directory may have moved into another the walk has not reached,
+                // which is only decidable once it has. The database-derived half is read after the
+                // scan (the scan's own writes feed it), so it joins the tail too.
+                guard let token = changeBuffer.primeStreaming(
+                    key: anchorKey, incomingAnchorRawValue: anchor.rawValue
+                ) else {
+                    logger.error("Could not open a change delivery session; skipping this derivation.")
+                    return
                 }
 
-                let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
+                // Detached: awaiting the walk here would hold this call for its whole duration and
+                // streaming would buy nothing. The drain below waits only for the first wave, and
+                // the framework's continuation calls drain whatever has landed since — from this
+                // enumerator or any other, because the session and the producer's liveness are both
+                // visible to all of them.
+                Task { [changeBuffer] in
+                    let streamed = StreamedIdentifiers()
+                    let serverChanges = await scanMaterialisedItemsForRemoteChanges(
+                        restrictedToContainers: runFullScan ? nil : targets
+                    ) { discovered in
+                        streamed.formUnion(discovered.map(\.ocId))
+                        changeBuffer.append(token: token, updated: discovered, deleted: [])
+                    }
 
-                let changes = ChangeSet(
-                    mergingUpdated: [serverChanges.updated, pendingLocalChanges.updated],
-                    deleted: [serverChanges.deleted, pendingLocalChanges.deleted]
-                )
+                    if runFullScan, !serverChanges.hadFailure {
+                        RemoteChangeTargets.shared.noteFullScanCompleted()
+                    }
 
-                // Sort created+updated by remote-path length (ascending) so parent directories are
-                // reported before their children. Draining the single combined list front-to-back
-                // preserves this across batches; without it macOS may create a rename-destination folder
-                // to house a child before it processes the parent rename, briefly leaving both the old
-                // and new folder names on disk.
-                let sortedUpdated = changes.createdAndUpdated
-                    .sorted { $0.remotePath().count < $1.remotePath().count }
+                    let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
 
-                let finalAnchor = serverChanges.hadFailure ? anchor : currentAnchor
-                changeBuffer.prime(
-                    key: anchorKey,
-                    finalAnchorRawValue: finalAnchor.rawValue,
-                    updated: sortedUpdated,
-                    deleted: changes.deleted,
-                    incomplete: serverChanges.hadFailure
-                )
+                    let changes = ChangeSet(
+                        mergingUpdated: [serverChanges.updated, pendingLocalChanges.updated],
+                        deleted: [serverChanges.deleted, pendingLocalChanges.deleted]
+                    )
+
+                    // Sort created+updated by remote-path length (ascending) so parent directories
+                    // are reported before their children. Draining front-to-back preserves this
+                    // across batches; without it macOS may create a rename-destination folder to
+                    // house a child before it processes the parent rename, briefly leaving both the
+                    // old and new folder names on disk. The streamed portion already satisfies the
+                    // rule by construction — waves run shallowest-depth-first — so only the tail
+                    // needs sorting.
+                    let remainingUpdated = changes.createdAndUpdated
+                        .filter { !streamed.contains($0.ocId) }
+                        .sorted { $0.remotePath().count < $1.remotePath().count }
+
+                    changeBuffer.append(token: token, updated: remainingUpdated, deleted: changes.deleted)
+
+                    let finalAnchor = serverChanges.hadFailure ? anchor : currentAnchor
+                    changeBuffer.finishStreaming(
+                        token: token,
+                        finalAnchorRawValue: finalAnchor.rawValue,
+                        incomplete: serverChanges.hadFailure
+                    )
+                }
             }
+
+            // Park until the producer has something, so a streaming session never answers with an
+            // empty batch and `moreComing: true` — which the framework answers by calling straight
+            // back. Returns at once when no producer is running.
+            await changeBuffer.awaitDeliverableItems()
 
             // Intermediate batches use a durable continuation anchor. The final batch normally advances
             // the working-set sync point to
@@ -123,8 +178,14 @@ extension Enumerator {
     ///   discovery, coverage and deletion reconciliation are unchanged; they simply operate over
     ///   what was actually read, so an item under a container this pass did not look at is never
     ///   claimed as deleted. `nil` performs the full reconciliation.
+    /// - Parameter onDiscovered: Invoked as each depth wave completes, with the creations and updates
+    ///   that wave revealed and no earlier one had. Waves run shallowest-first, so successive calls
+    ///   are already ordered parents-before-children. Deletions are deliberately absent: an item
+    ///   missing from one directory may have moved into another the walk has not reached yet, so
+    ///   they are only decidable once it is complete (see `survivingOcIds` below).
     func scanMaterialisedItemsForRemoteChanges(
-        restrictedToContainers: Set<NSFileProviderItemIdentifier>? = nil
+        restrictedToContainers: Set<NSFileProviderItemIdentifier>? = nil,
+        onDiscovered: (@Sendable ([SendableItemMetadata]) -> Void)? = nil
     ) async -> (
         updated: [SendableItemMetadata], deleted: [SendableItemMetadata], hadFailure: Bool
     ) {
@@ -158,6 +219,8 @@ extension Enumerator {
         // advancing the working-set sync point past changes this pass could not discover.
         var hadReadFailure = false
         var failedItemIds = Set<String>()
+        // What `onDiscovered` has already been handed, so each wave emits only its own delta.
+        var emittedUpdateOcIds = Set<String>()
 
         // Work queue seeded with the materialised items. A changed child directory discovered while
         // scanning is appended ONLY when its subtree actually contains a materialised item, so its
@@ -322,6 +385,18 @@ extension Enumerator {
                     }
 
                     scannedItemIds.formUnion(childrenCoveredByThisRead)
+                }
+            }
+
+            // Hand this wave over before starting the next. Emitting the delta with a persistent
+            // seen-set keeps first-occurrence ordering identical to the single dedup below.
+            if let onDiscovered {
+                let waveDiscoveries = (accumulatedCreations + accumulatedUpdates).filter {
+                    emittedUpdateOcIds.insert($0.ocId).inserted
+                }
+
+                if !waveDiscoveries.isEmpty {
+                    onDiscovered(waveDiscoveries)
                 }
             }
         }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -5,6 +5,17 @@
 import Foundation
 
 ///
+/// How many working-set scan reads may be in flight at once.
+///
+/// The scan is pure network waiting — a measured pass spent 76 seconds on 669 sequential PROPFINDs
+/// of roughly 100ms each to surface zero changes. Six matches the concurrency the framework already
+/// drives for content fetches on this domain, so it adds no load pattern the server does not
+/// already see.
+///
+private let workingSetScanConcurrency = 6
+
+
+///
 /// Working-set change derivation. Because a change notification only ever signals `.workingSet`,
 /// this is the path that drives remote changes into the framework for items the system tracks
 /// (visited folders and downloaded files) and the subtrees they reach.
@@ -101,16 +112,16 @@ extension Enumerator {
             logger.debug("Completed checking materialised items for changes on the server.")
         }
 
+        // Unlike when enumerating items we can't progressively enumerate items as we need to
+        // wait to see which items are truly deleted and which have just been moved elsewhere.
+        // Visited folders and downloaded files. Sort in terms of their remote URLs.
+        // This way we ensure we visit parent folders before their children.
         // Trashed rows are excluded. Trashing rewrites an item's `serverUrl` to the trashbin but
         // does not set `deleted`, and a folder keeps `visitedDirectory`, so a trashed folder stayed
         // in the materialised set and this scan PROPFINDed it through the ordinary DAV path — which
         // 404s. That 404 is then read as "the item is gone", reporting the item deleted and hard-
         // removing the row the trash reconciliation derives permanent deletions from. Trash has its
         // own enumeration path (``enumerateTrashChanges(for:anchor:)``, via `listingTrashAsync`).
-        // Unlike when enumerating items we can't progressively enumerate items as we need to
-        // wait to see which items are truly deleted and which have just been moved elsewhere.
-        // Visited folders and downloaded files. Sort in terms of their remote URLs.
-        // This way we ensure we visit parent folders before their children.
         let materialisedItems = dbManager
             .materialisedItemMetadatas(account: account.ncKitAccount)
             .filter { !$0.deleted && !$0.isTrashed }
@@ -137,118 +148,152 @@ extension Enumerator {
         // leaves (every never-enumerated descendant looks "new"), hammering the server. Unchanged
         // subtrees are likewise never enqueued, so the "skip unchanged directories" optimisation holds.
         var scanQueue = materialisedItems
-        var enqueuedDirectoryIds = Set(materialisedItems.filter(\.directory).map(\.ocId))
-        var scanIndex = 0
+        var enqueuedDirectoryIds = Set(scanQueue.filter(\.directory).map(\.ocId))
 
-        while scanIndex < scanQueue.count {
-            let itemToScan = scanQueue[scanIndex]
-            scanIndex += 1
+        /// The reads are issued concurrently, in waves grouped by remote-path depth.
+        ///
+        /// Depth is what makes concurrency safe here. The only ordering this loop depends on is that
+        /// a directory is read before the items it covers: a depth-1 read records its unchanged
+        /// direct children in `scannedItemIds`, which is what stops them being read individually.
+        /// Those children are always exactly one level deeper, and a changed child directory
+        /// enqueued mid-scan is deeper still — so processing strictly shallowest-depth-first
+        /// preserves every coverage decision the sequential walk made, while items *within* one
+        /// depth can never cover one another and are therefore independent.
+        ///
+        /// Results are merged back in wave order, single-threaded, so the accumulators and
+        /// `scannedItemIds` evolve exactly as before; only the network waiting overlaps. That
+        /// waiting was the whole cost: one measured scan spent 76s on 669 sequential PROPFINDs of
+        /// ~100ms each to surface zero changes.
+        func remotePathDepth(_ metadata: SendableItemMetadata) -> Int {
+            metadata.remotePath().reduce(into: 0) { count, character in
+                if character == "/" {
+                    count += 1
+                }
+            }
+        }
 
-            guard !scannedItemIds.contains(itemToScan.ocId) else { continue }
-            guard isLockFileName(itemToScan.fileName) == false else {
-                // Skip server requests for locally created lock files.
-                // They are not synchronised to the server for real.
-                // Thus they can be expected not to be found there.
-                // That would also cause their local deletion due to synchronisation logic.
-                logger.debug("Skipping materialised item in working set check because the name hints a lock file.", [.item: itemToScan, .name: itemToScan.name])
-                continue
+        while !scanQueue.isEmpty {
+            guard let waveDepth = scanQueue.map(remotePathDepth).min() else { break }
+
+            let wave = scanQueue.filter { remotePathDepth($0) == waveDepth }
+            scanQueue.removeAll { remotePathDepth($0) == waveDepth }
+
+            let toRead = wave.filter { candidate in
+                guard !scannedItemIds.contains(candidate.ocId) else { return false }
+                guard isLockFileName(candidate.fileName) == false else {
+                    // Skip server requests for locally created lock files.
+                    // They are not synchronised to the server for real.
+                    // Thus they can be expected not to be found there.
+                    // That would also cause their local deletion due to synchronisation logic.
+                    logger.debug("Skipping materialised item in working set check because the name hints a lock file.", [.item: candidate, .name: candidate.name])
+                    return false
+                }
+                return true
             }
 
-            let itemRemoteUrl = itemToScan.remotePath()
+            guard !toRead.isEmpty else { continue }
 
-            let readResult = await Enumerator.readServerUrl(itemRemoteUrl, account: account, remoteInterface: remoteInterface, dbManager: dbManager, depth: itemToScan.directory ? .targetAndDirectChildren : .target, log: logger.log)
-            let changes = readResult.changes ?? ChangeSet()
+            let waveResults = await concurrentlyReadForWorkingSetScan(toRead)
 
-            if readResult.error?.errorCode == 404 {
-                accumulatedDeletions.append(itemToScan)
-                scannedItemIds.insert(itemToScan.ocId)
-                // Children are not marked deleted here — they may have moved with their parent.
-                logger.debug("Parent returned 404; children will be checked individually.", [.url: itemRemoteUrl])
-            } else if let readError = readResult.error, readError != .success {
-                // A single unreadable folder must NOT abort discovery for the rest of the working set.
-                // The queue is sorted parent-first, so the account root and top-level folders (e.g. a
-                // very large "Talk" whose depth-1 PROPFIND times out) are scanned first; a `break` here
-                // meant one early failure silently stalled ALL remote-change propagation for every other
-                // folder — the "files uploaded on the web never appear" bug. Skip only the failing item
-                // (it is retried on the next scan) and keep scanning the remainder.
-                // See nextcloud/desktop#10442.
-                logger.error(
-                    "Read of materialised item failed during working-set scan; skipping it and continuing with the rest of the working set.",
-                    [.error: readError, .url: itemRemoteUrl]
-                )
-                hadReadFailure = true
-                failedItemIds.insert(itemToScan.ocId)
-                scannedItemIds.insert(itemToScan.ocId)
-                continue
-            } else {
-                accumulatedDeletions += changes.deleted
-                accumulatedUpdates += changes.updated
-                accumulatedCreations += changes.created
+            for (itemToScan, readResult) in waveResults {
+                // A shallower item in this same wave cannot have covered this one, but a read
+                // enqueued before an earlier merge in this wave can have: re-check.
+                guard !scannedItemIds.contains(itemToScan.ocId) else { continue }
 
-                // Reading a directory's children does not by itself require scanning each child's own
-                // children. Track which children this read has already accounted for.
-                var childrenCoveredByThisRead = Set<String>()
+                let itemRemoteUrl = itemToScan.remotePath()
+                let changes = readResult.changes ?? ChangeSet()
 
-                if let readItems = readResult.metadatas, let readTarget = readItems.first {
-                    scannedItemIds.insert(readTarget.ocId)
+                if readResult.error?.errorCode == 404 {
+                    accumulatedDeletions.append(itemToScan)
+                    scannedItemIds.insert(itemToScan.ocId)
+                    // Children are not marked deleted here — they may have moved with their parent.
+                    logger.debug("Parent returned 404; children will be checked individually.", [.url: itemRemoteUrl])
+                } else if let readError = readResult.error, readError != .success {
+                    // A single unreadable folder must NOT abort discovery for the rest of the working set.
+                    // The queue is sorted parent-first, so the account root and top-level folders (e.g. a
+                    // very large "Talk" whose depth-1 PROPFIND times out) are scanned first; a `break` here
+                    // meant one early failure silently stalled ALL remote-change propagation for every other
+                    // folder — the "files uploaded on the web never appear" bug. Skip only the failing item
+                    // (it is retried on the next scan) and keep scanning the remainder.
+                    // See nextcloud/desktop#10442.
+                    logger.error(
+                        "Read of materialised item failed during working-set scan; skipping it and continuing with the rest of the working set.",
+                        [.error: readError, .url: itemRemoteUrl]
+                    )
+                    hadReadFailure = true
+                    failedItemIds.insert(itemToScan.ocId)
+                    scannedItemIds.insert(itemToScan.ocId)
+                    continue
+                } else {
+                    accumulatedDeletions += changes.deleted
+                    accumulatedUpdates += changes.updated
+                    accumulatedCreations += changes.created
 
-                    if readItems.count > 1 {
-                        childrenCoveredByThisRead.formUnion(readItems[1...].filter { !$0.directory }.map(\.ocId))
-                    }
+                    // Reading a directory's children does not by itself require scanning each child's own
+                    // children. Track which children this read has already accounted for.
+                    var childrenCoveredByThisRead = Set<String>()
 
-                    if readItems.count > 1 {
-                        let childDirectories = readItems[1...].filter(\.directory)
-                        let changedChildOcIds = Set(changes.updated.map(\.ocId))
-                            .union(changes.created.map(\.ocId))
+                    if let readItems = readResult.metadatas, let readTarget = readItems.first {
+                        scannedItemIds.insert(readTarget.ocId)
 
-                        for childDirectory in childDirectories {
-                            // A changed child directory is scanned so its changed descendants are
-                            // discovered, even when the directory itself is not materialised — but
-                            // only when the working set actually tracks something inside it, i.e. it
-                            // has a materialised descendant (a visited subfolder or a downloaded file).
-                            // A changed-but-unmaterialised subtree is never crawled here: nothing in
-                            // it is cached locally, so its contents are read lazily on navigation
-                            // rather than walked now (which on a sparse domain would recurse into
-                            // entire never-visited subtrees). Its own change is still reported above
-                            // via `accumulatedUpdates` / `accumulatedCreations`.
-                            if changedChildOcIds.contains(childDirectory.ocId) {
-                                let childPath = childDirectory.remotePath()
-                                let childHasMaterialisedDescendant = materialisedItems.contains {
-                                    $0.ocId != childDirectory.ocId
-                                        && ($0.hasSameRemotePath(as: childPath)
-                                            || $0.isDescendant(of: childPath))
+                        if readItems.count > 1 {
+                            childrenCoveredByThisRead.formUnion(readItems[1...].filter { !$0.directory }.map(\.ocId))
+                        }
+
+                        if readItems.count > 1 {
+                            let childDirectories = readItems[1...].filter(\.directory)
+                            let changedChildOcIds = Set(changes.updated.map(\.ocId))
+                                .union(changes.created.map(\.ocId))
+
+                            for childDirectory in childDirectories {
+                                // A changed child directory is scanned so its changed descendants are
+                                // discovered, even when the directory itself is not materialised — but
+                                // only when the working set actually tracks something inside it, i.e. it
+                                // has a materialised descendant (a visited subfolder or a downloaded file).
+                                // A changed-but-unmaterialised subtree is never crawled here: nothing in
+                                // it is cached locally, so its contents are read lazily on navigation
+                                // rather than walked now (which on a sparse domain would recurse into
+                                // entire never-visited subtrees). Its own change is still reported above
+                                // via `accumulatedUpdates` / `accumulatedCreations`.
+                                if changedChildOcIds.contains(childDirectory.ocId) {
+                                    let childPath = childDirectory.remotePath()
+                                    let childHasMaterialisedDescendant = materialisedItems.contains {
+                                        $0.ocId != childDirectory.ocId
+                                            && ($0.hasSameRemotePath(as: childPath)
+                                                || $0.isDescendant(of: childPath))
+                                    }
+                                    if childHasMaterialisedDescendant,
+                                       enqueuedDirectoryIds.insert(childDirectory.ocId).inserted
+                                    {
+                                        scanQueue.append(childDirectory)
+                                    }
+                                    continue
                                 }
-                                if childHasMaterialisedDescendant,
-                                   enqueuedDirectoryIds.insert(childDirectory.ocId).inserted
-                                {
-                                    scanQueue.append(childDirectory)
+
+                                // Only skip unchanged child directories with no materialised descendants.
+                                // Lock changes don't propagate etags, so dirs with visible children must be enumerated.
+                                guard let localItem = materialisedItems.first(
+                                    where: { $0.ocId == childDirectory.ocId }
+                                ), localItem.isInSameDatabaseStoreableRemoteState(childDirectory) else {
+                                    continue
                                 }
-                                continue
-                            }
 
-                            // Only skip unchanged child directories with no materialised descendants.
-                            // Lock changes don't propagate etags, so dirs with visible children must be enumerated.
-                            guard let localItem = materialisedItems.first(
-                                where: { $0.ocId == childDirectory.ocId }
-                            ), localItem.isInSameDatabaseStoreableRemoteState(childDirectory) else {
-                                continue
-                            }
+                                let hasMaterialisedDescendants = materialisedItems.contains {
+                                    $0.ocId != localItem.ocId
+                                        && $0.isDescendant(of: localItem.remotePath())
+                                }
 
-                            let hasMaterialisedDescendants = materialisedItems.contains {
-                                $0.ocId != localItem.ocId
-                                    && $0.isDescendant(of: localItem.remotePath())
-                            }
-
-                            if !hasMaterialisedDescendants {
-                                childrenCoveredByThisRead.insert(childDirectory.ocId)
+                                if !hasMaterialisedDescendants {
+                                    childrenCoveredByThisRead.insert(childDirectory.ocId)
+                                }
                             }
                         }
+
+                        childrenCoveredByThisRead.formUnion(changes.deleted.map(\.ocId))
                     }
 
-                    childrenCoveredByThisRead.formUnion(changes.deleted.map(\.ocId))
+                    scannedItemIds.formUnion(childrenCoveredByThisRead)
                 }
-
-                scannedItemIds.formUnion(childrenCoveredByThisRead)
             }
         }
 
@@ -290,5 +335,54 @@ extension Enumerator {
         }
 
         return (updated: discoveredUpdates, deleted: reportedDeletions, hadFailure: hadReadFailure)
+    }
+
+    ///
+    /// Read `items` from the server concurrently, at most ``workingSetScanConcurrency`` at a time,
+    /// returning each paired with its result **in the original order**.
+    ///
+    /// Restoring the order matters: the caller merges these results single-threaded, so it observes
+    /// exactly the sequence the old sequential walk produced. Only the network waiting overlaps.
+    ///
+    private func concurrentlyReadForWorkingSetScan(
+        _ items: [SendableItemMetadata]
+    ) async -> [(SendableItemMetadata, RemoteReadResult)] {
+        await withTaskGroup(of: (Int, RemoteReadResult).self) { group in
+            var results = [Int: RemoteReadResult]()
+            var next = 0
+
+            func addRead(_ index: Int) {
+                let item = items[index]
+                group.addTask {
+                    let result = await Enumerator.readServerUrl(
+                        item.remotePath(),
+                        account: self.account,
+                        remoteInterface: self.remoteInterface,
+                        dbManager: self.dbManager,
+                        depth: item.directory ? .targetAndDirectChildren : .target,
+                        log: self.logger.log
+                    )
+                    return (index, result)
+                }
+            }
+
+            while next < min(workingSetScanConcurrency, items.count) {
+                addRead(next)
+                next += 1
+            }
+
+            while let (index, result) = await group.next() {
+                results[index] = result
+
+                if next < items.count {
+                    addRead(next)
+                    next += 1
+                }
+            }
+
+            return items.indices.compactMap { index in
+                results[index].map { (items[index], $0) }
+            }
+        }
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -101,13 +101,19 @@ extension Enumerator {
             logger.debug("Completed checking materialised items for changes on the server.")
         }
 
+        // Trashed rows are excluded. Trashing rewrites an item's `serverUrl` to the trashbin but
+        // does not set `deleted`, and a folder keeps `visitedDirectory`, so a trashed folder stayed
+        // in the materialised set and this scan PROPFINDed it through the ordinary DAV path — which
+        // 404s. That 404 is then read as "the item is gone", reporting the item deleted and hard-
+        // removing the row the trash reconciliation derives permanent deletions from. Trash has its
+        // own enumeration path (``enumerateTrashChanges(for:anchor:)``, via `listingTrashAsync`).
         // Unlike when enumerating items we can't progressively enumerate items as we need to
         // wait to see which items are truly deleted and which have just been moved elsewhere.
         // Visited folders and downloaded files. Sort in terms of their remote URLs.
         // This way we ensure we visit parent folders before their children.
         let materialisedItems = dbManager
             .materialisedItemMetadatas(account: account.ncKitAccount)
-            .filter { !$0.deleted }
+            .filter { !$0.deleted && !$0.isTrashed }
             .sorted { $0.remotePath().count < $1.remotePath().count }
 
         var accumulatedCreations = [SendableItemMetadata]()

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -48,7 +48,22 @@ extension Enumerator {
                 changeBuffer.reset()
                 logger.debug("Working-set change buffer not primed for anchor \(anchorKey); deriving changes.", [.account: account])
 
-                let serverChanges = await scanMaterialisedItemsForRemoteChanges()
+                // Prefer the containers a push named. Push identifies a change within a second,
+                // whereas the full walk grows with the materialised set — 305 seconds when this was
+                // measured. The full walk still runs when nothing is targeted, and is forced every
+                // `fullScanInterval` regardless, because push can drop messages across reconnects
+                // and only ever tells us what *did* change. See ``RemoteChangeTargets``.
+                let targets = RemoteChangeTargets.shared.consumeTargets()
+                let runFullScan = targets == nil || RemoteChangeTargets.shared.shouldRunFullScan()
+
+                let serverChanges = await scanMaterialisedItemsForRemoteChanges(
+                    restrictedToContainers: runFullScan ? nil : targets
+                )
+
+                if runFullScan, !serverChanges.hadFailure {
+                    RemoteChangeTargets.shared.noteFullScanCompleted()
+                }
+
                 let pendingLocalChanges = dbManager.pendingWorkingSetChanges(since: date)
 
                 let changes = ChangeSet(
@@ -103,7 +118,14 @@ extension Enumerator {
     /// - Returns: The discovered creations and updates (combined into `updated`) and the items that
     ///   were marked deleted.
     ///
-    func scanMaterialisedItemsForRemoteChanges() async -> (
+    /// - Parameter restrictedToContainers: When set, seed the walk with only these containers
+    ///   instead of the whole materialised set — the containers a `notify_push` named. Subtree
+    ///   discovery, coverage and deletion reconciliation are unchanged; they simply operate over
+    ///   what was actually read, so an item under a container this pass did not look at is never
+    ///   claimed as deleted. `nil` performs the full reconciliation.
+    func scanMaterialisedItemsForRemoteChanges(
+        restrictedToContainers: Set<NSFileProviderItemIdentifier>? = nil
+    ) async -> (
         updated: [SendableItemMetadata], deleted: [SendableItemMetadata], hadFailure: Bool
     ) {
         logger.debug("Checking materialised items for changes on the server...")
@@ -147,7 +169,14 @@ extension Enumerator {
         // activated domain triggers a full recursive PROPFIND of every changed branch down to its
         // leaves (every never-enumerated descendant looks "new"), hammering the server. Unchanged
         // subtrees are likewise never enqueued, so the "skip unchanged directories" optimisation holds.
+        // `materialisedItems` stays the full set below — it is what the descendant checks consult.
+        // Only the seed of the walk narrows.
         var scanQueue = materialisedItems
+        if let restrictedToContainers {
+            let targetOcIds = Set(restrictedToContainers.map(\.rawValue))
+            scanQueue = materialisedItems.filter { targetOcIds.contains($0.ocId) }
+            logger.info("Scanning \(scanQueue.count) push-targeted container(s) instead of \(materialisedItems.count) materialised item(s).")
+        }
         var enqueuedDirectoryIds = Set(scanQueue.filter(\.directory).map(\.ocId))
 
         /// The reads are issued concurrently, in waves grouped by remote-path depth.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/MaterializedEnumerationObserver.swift
@@ -38,9 +38,18 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
         handleEnumeratedItems(enumeratedItems, account: account, dbManager: dbManager, completionHandler: completionHandler)
     }
 
+    ///
+    /// A failed enumeration must not be reconciled.
+    ///
+    /// ``handleEnumeratedItems(_:account:dbManager:completionHandler:)`` treats absence from the
+    /// enumeration as proof of eviction, so running it over a partial result marks every item the
+    /// system never got round to reporting as dataless — the framework then re-downloads them,
+    /// and each download triggers another materialized-set enumeration. Reporting nothing leaves
+    /// the database untouched and lets the next successful pass reconcile.
+    ///
     public func finishEnumeratingWithError(_ error: Error) {
-        logger.error("Finishing enumeration with error.", [.error: error])
-        handleEnumeratedItems(enumeratedItems, account: account, dbManager: dbManager, completionHandler: completionHandler)
+        logger.error("Finishing enumeration with error. Skipping materialized-set reconciliation.", [.error: error])
+        completionHandler([], [])
     }
 
     func handleEnumeratedItems(_ identifiers: Set<NSFileProviderItemIdentifier>, account: Account, dbManager: FilesDatabaseManager, completionHandler: @escaping (_ materialized: Set<NSFileProviderItemIdentifier>, _ evicted: Set<NSFileProviderItemIdentifier>) -> Void) {
@@ -48,6 +57,7 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
         var metadataForMaterializedItemsByIdentifier = [NSFileProviderItemIdentifier: SendableItemMetadata]()
         var evictedItems = Set<NSFileProviderItemIdentifier>()
         var stillMaterializedItems = Set<NSFileProviderItemIdentifier>()
+        var metadatasToPersist = [SendableItemMetadata]()
 
         for metadata in metadataForMaterializedItems {
             let identifier = NSFileProviderItemIdentifier(metadata.ocId)
@@ -56,6 +66,10 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
         }
 
         for enumeratedIdentifier in identifiers {
+            // The system now accounts for this item itself, so the download record that protected
+            // it from the reconciliation below has served its purpose.
+            PendingMaterializationRegistry.shared.confirmMaterialized(enumeratedIdentifier)
+
             if evictedItems.contains(enumeratedIdentifier) {
                 evictedItems.remove(enumeratedIdentifier) // The enumerated item cannot be assumed as evicted any longer.
             } else {
@@ -83,10 +97,44 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
                     metadata.downloaded = true
                 }
 
-                logger.info("Updating state for item to materialized.", [.item: enumeratedIdentifier, .name: metadata.fileName])
-                dbManager.addItemMetadata(metadata)
+                logger.debug("Updating state for item to materialized.", [.item: enumeratedIdentifier, .name: metadata.fileName])
+                metadatasToPersist.append(metadata)
             }
         }
+
+        // An item this process downloaded moments ago is legitimately absent from the system's
+        // materialized set until the system catches up with it. Without this the reconciliation
+        // flipped every fresh download back to dataless, the framework re-requested the content,
+        // and a bulk materialisation never converged. See ``PendingMaterializationRegistry``.
+        let unconfirmed = PendingMaterializationRegistry.shared.awaitingConfirmation(among: evictedItems)
+
+        if !unconfirmed.isEmpty {
+            logger.debug("Deferring \(unconfirmed.count) recently downloaded item(s) awaiting confirmation from the system.")
+            evictedItems.subtract(unconfirmed)
+        }
+
+        // Only a file can go dataless. A directory has no payload of its own: `Item.isDownloaded`
+        // reports `true` for every directory regardless of the flag, `displayEvict` is hardcoded
+        // `false` for directories, and `hasEvictableDescendantFile` counts only `directory == false`
+        // rows — so a directory's `downloaded` is never read.
+        //
+        // Marking one evicted was therefore not just useless but self-perpetuating. A directory
+        // qualifies as materialized through `visitedDirectory`, which this reconciliation
+        // deliberately preserves (see below), so clearing `downloaded` did nothing to remove it
+        // from `materialisedItemMetadatas`. Any visited directory the system does not report back —
+        // routine, since macOS lists materialized *content* — was re-evicted on every single pass,
+        // forever, each time costing a database write and a log line. Measured on a font library:
+        // 630 directories re-evicted across 80 passes, 30,117 transitions and 28,334 log lines in
+        // seven minutes, the per-pass count climbing monotonically (122 → 596) as browsing marked
+        // more directories visited.
+        let evictedFiles = evictedItems.filter { metadataForMaterializedItemsByIdentifier[$0]?.directory == false }
+        let skippedDirectories = evictedItems.count - evictedFiles.count
+
+        if skippedDirectories > 0 {
+            logger.debug("Ignoring \(skippedDirectories) directory/directories absent from the materialized set; only files carry materialized content.")
+        }
+
+        evictedItems = evictedFiles
 
         for evictedItemIdentifier in evictedItems {
             guard var metadata = metadataForMaterializedItemsByIdentifier[evictedItemIdentifier] else {
@@ -94,21 +142,25 @@ public class MaterializedEnumerationObserver: NSObject, NSFileProviderEnumeratio
                 continue
             }
 
-            logger.info("Updating item state to dataless.", [.name: metadata.fileName, .item: evictedItemIdentifier])
+            logger.debug("Updating item state to dataless.", [.name: metadata.fileName, .item: evictedItemIdentifier])
 
             metadata.downloaded = false
+            // Files only reach this loop, and a file's `visitedDirectory` is meaningless — clear it
+            // alongside `downloaded` as before. A directory's `visitedDirectory` is our refresh
+            // subscription (keep watching a folder Finder has browsed for remote child changes) and
+            // is left untouched: directories are filtered out above.
+            metadata.visitedDirectory = false
 
-            // Being absent from enumeratorForMaterializedItems only means the item has no
-            // local materialized content. For directories, visitedDirectory is our refresh
-            // subscription: if Finder has enumerated a folder before, keep watching it for
-            // remote child changes even when macOS reports it as dataless. This matters for
-            // shared mount roots, which may be omitted from materialized items after browsing.
-            if !metadata.directory {
-                metadata.visitedDirectory = false
-            }
-
-            dbManager.addItemMetadata(metadata)
+            metadatasToPersist.append(metadata)
         }
+
+        // One transaction for the whole reconciliation, and one log line for the whole pass.
+        // This runs synchronously on the framework's callback thread, and it previously opened a
+        // write transaction and emitted an `info` line — each of which fsyncs through the single
+        // logging actor — for every single item.
+        dbManager.addItemMetadatas(metadatasToPersist)
+
+        logger.info("Reconciled materialized set: \(stillMaterializedItems.count) newly materialized, \(evictedItems.count) evicted, \(unconfirmed.count) deferred.")
 
         completionHandler(stillMaterializedItems, evictedItems)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+ClientCommunicationProtocol.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+ClientCommunicationProtocol.swift
@@ -68,13 +68,21 @@ extension FileProviderExtension: ClientCommunicationProtocol {
 
         let changedFileIds = Set(fileIds.map(\.stringValue))
 
-        guard dbManager.containsAnyItemMetadata(fileIds: changedFileIds) else {
+        // Resolve the ids to the containers worth re-reading rather than only asking whether any of
+        // them matched. Signalling the working set without them made every push a full walk of the
+        // materialised set: one measured pass spent 305 seconds to surface a file the push had
+        // named 1.5 seconds after it was created. The working-set derivation consumes these and
+        // reads just these containers; see ``RemoteChangeTargets``.
+        let containers = dbManager.containersForPushedFileIds(changedFileIds)
+
+        guard !containers.isEmpty else {
             logger.debug("Ignoring file ID changes because no locally known metadata matched.")
             completionHandler(true)
             return
         }
 
-        logger.info("Received file ID changes for locally known metadata. Signalling enumerator.")
+        RemoteChangeTargets.shared.record(containers: containers)
+        logger.info("Received file ID changes naming \(containers.count) container(s) to re-read. Signalling enumerator.")
         notifyChange()
         completionHandler(true)
     }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -65,6 +65,10 @@ import OSLog
     private var pendingAccount: Account?
     private var setupChain: Task<Void, Never> = Task {}
 
+    // Waiters parked in `awaitAccount(…)` until `ncAccount` is published. See that method.
+    private let accountReadyLock = NSLock()
+    private var accountReadyWaiters = [UUID: CheckedContinuation<Void, Never>]()
+
     /// Whether or not we are going to recursively scan new folders when they are discovered.
     /// Apple's recommendation is that we should always scan the file hierarchy fully.
     /// This does lead to long load times when a file provider domain is initially configured.
@@ -146,21 +150,24 @@ import OSLog
     public func item(for identifier: NSFileProviderItemIdentifier, request _: NSFileProviderRequest, completionHandler: @Sendable @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
         logger.debug("Received request for item.", [.item: identifier])
 
-        guard let ncAccount else {
-            logger.debug("Not fetching item because account not set up yet.", [.item: identifier])
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
-        guard let dbManager else {
-            logger.debug("Not fetching item because database is unavailable.", [.item: identifier])
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
         let progress = Progress(totalUnitCount: 1)
 
         Task {
+            // Same startup race as `fetchContents`: wait for the account instead of rejecting the
+            // request. Answering `notAuthenticated` here makes the framework treat the item as
+            // unreachable rather than merely not-ready-yet.
+            guard let ncAccount = await awaitAccount() else {
+                logger.error("Not fetching item because account was never set up.", [.item: identifier])
+                completionHandler(nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
+            guard let dbManager else {
+                logger.debug("Not fetching item because database is unavailable.", [.item: identifier])
+                completionHandler(nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
             if let item = await Item.storedItem(identifier: identifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log), item.metadata.deleted == false {
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
@@ -189,22 +196,26 @@ import OSLog
             return Progress()
         }
 
-        guard let ncAccount else {
-            logger.debug("Not fetching contents for item because account not set up yet.", [.item: itemIdentifier])
-            insertErrorAction(actionId)
-            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
-        guard let dbManager else {
-            logger.debug("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
-            completionHandler(nil, nil, NSFileProviderError(.cannotSynchronize))
-            return Progress()
-        }
-
         let progress = Progress()
 
         Task {
+            // Wait for the account rather than failing outright: the system starts this process and
+            // begins requesting content before the main app has handed the account over, and a
+            // rejected fetch is a download the framework may never ask for again.
+            guard let ncAccount = await awaitAccount() else {
+                logger.error("Not fetching contents for item because account was never set up.", [.item: itemIdentifier])
+                insertErrorAction(actionId)
+                completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
+            guard let dbManager else {
+                logger.debug("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
+                insertErrorAction(actionId)
+                completionHandler(nil, nil, NSFileProviderError(.cannotSynchronize))
+                return
+            }
+
             guard let item = await Item.storedItem(identifier: itemIdentifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log) else {
                 logger.error("Not fetching contents for item because item was not found.", [.item: itemIdentifier])
                 completionHandler(nil, nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemIdentifier))
@@ -800,8 +811,82 @@ import OSLog
             dbManager = databaseManager
 
             ncKit.setup(groupIdentifier: Bundle.main.bundleIdentifier!)
+            signalAccountReady()
             completionHandler?(nil)
             signalEnumeratorAfterAccountSetup()
+        }
+    }
+
+    ///
+    /// The domain account, waiting up to `timeoutNanoseconds` for it to be set up if it is not
+    /// available yet.
+    ///
+    /// The extension process is started by the system, not by the main app, so the framework can —
+    /// and does — ask it for work before the app has pushed the account across. Observed on an
+    /// extension relaunch: 17 `fetchContents` calls arrived in the first 0.6 seconds, 1.7 seconds
+    /// before the account landed. Failing them outright meant the framework treated those downloads
+    /// as failed, and only some were retried; the rest were simply dropped.
+    ///
+    /// Waiting instead turns that into a short delay, because the account almost always arrives
+    /// moments later. A genuinely account-less domain still fails, just after the timeout — and the
+    /// framework should not be asking for content there in the first place.
+    ///
+    func awaitAccount(timeoutNanoseconds: UInt64 = 10_000_000_000) async -> Account? {
+        if let ncAccount {
+            return ncAccount
+        }
+
+        let token = UUID()
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            accountReadyLock.lock()
+            accountReadyWaiters[token] = continuation
+            accountReadyLock.unlock()
+
+            // The account may have been published between the check above and the enqueue.
+            if ncAccount != nil {
+                resumeAccountWaiter(token)
+                return
+            }
+
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                self?.resumeAccountWaiter(token)
+            }
+        }
+
+        return ncAccount
+    }
+
+    ///
+    /// Resume one parked waiter, if it has not been resumed already. Removal under the lock is what
+    /// guarantees a continuation is resumed exactly once when the account and the timeout race.
+    ///
+    private func resumeAccountWaiter(_ token: UUID) {
+        accountReadyLock.lock()
+        let continuation = accountReadyWaiters.removeValue(forKey: token)
+        accountReadyLock.unlock()
+        continuation?.resume()
+    }
+
+    ///
+    /// Release everything parked in ``awaitAccount(timeoutNanoseconds:)``. Called once setup has
+    /// published ``ncAccount``.
+    ///
+    /// Not `private` so tests can exercise the park-and-release path without a real domain setup.
+    ///
+    func signalAccountReady() {
+        accountReadyLock.lock()
+        let waiters = accountReadyWaiters
+        accountReadyWaiters.removeAll()
+        accountReadyLock.unlock()
+
+        if !waiters.isEmpty {
+            logger.debug("Account is set up; releasing \(waiters.count) waiting request(s).")
+        }
+
+        for continuation in waiters.values {
+            continuation.resume()
         }
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/PendingMaterializationRegistry.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/PendingMaterializationRegistry.swift
@@ -1,0 +1,100 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+import Foundation
+
+///
+/// The set of items this process has just downloaded and marked `downloaded = true` in the
+/// database, but which the system has not yet reported back through
+/// `NSFileProviderManager.enumeratorForMaterializedItems()`.
+///
+/// ## Why this exists
+///
+/// ``Item/fetchContents(domain:progress:dbManager:)`` writes `downloaded = true` and returns the
+/// content URL; the framework materialises the file and adds it to its materialized set only
+/// *afterwards*. ``MaterializedEnumerationObserver`` reconciles in the opposite direction — it
+/// assumes every materialized database row is evicted until the system's enumeration proves
+/// otherwise — so any item caught in that window was flipped straight back to
+/// `downloaded = false` and logged as `Updating item state to dataless.`. The framework then
+/// re-requested the content, which downloaded it again, which reopened the window. During a bulk
+/// materialisation of a "keep downloaded" tree this produced a self-sustaining loop (132,165
+/// dataless transitions in a single extension log).
+///
+/// Recording the download here closes the window: the reconciliation skips an item until the
+/// system has confirmed it, and confirmation removes the entry so ordinary evictions are still
+/// detected on the very next pass.
+///
+/// ## Lifetime
+///
+/// The race is process-local by construction — it is the gap between this process' database write
+/// and this process' next callback — so in-memory state is the right scope and no Realm migration
+/// is involved. ``expiryInterval`` is only a backstop for a download the system never confirms
+/// (for example because the extension is torn down mid-transfer); the normal exit is
+/// ``confirmMaterialized(_:)``.
+///
+/// Guarded by an `NSLock` rather than an `actor` because
+/// ``MaterializedEnumerationObserver/handleEnumeratedItems(_:account:dbManager:completionHandler:)``
+/// runs synchronously on the framework's callback thread. Same idiom as ``ChangeDeliveryBuffer``.
+///
+final class PendingMaterializationRegistry: @unchecked Sendable {
+    static let shared = PendingMaterializationRegistry()
+
+    ///
+    /// How long an unconfirmed download is protected from being reconciled as evicted.
+    ///
+    /// Generous on purpose: being too short reopens the flip-flop, whereas being too long only
+    /// delays the dataless marking of an item evicted immediately after download until the entry
+    /// lapses. Confirmation normally clears entries long before this.
+    ///
+    private static let expiryInterval: TimeInterval = 60
+
+    private let lock = NSLock()
+    private var pending = [NSFileProviderItemIdentifier: Date]()
+
+    ///
+    /// Record that this process just materialised `identifier` locally and wrote that to the
+    /// database, ahead of the system's own bookkeeping.
+    ///
+    func recordDownloaded(_ identifier: NSFileProviderItemIdentifier, at date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        pending[identifier] = date
+    }
+
+    ///
+    /// Note that the system has now enumerated `identifier` as materialized, so the entry has
+    /// served its purpose and later evictions of it must be honoured immediately.
+    ///
+    func confirmMaterialized(_ identifier: NSFileProviderItemIdentifier) {
+        lock.lock()
+        defer { lock.unlock() }
+        pending.removeValue(forKey: identifier)
+    }
+
+    ///
+    /// The subset of `identifiers` whose download is still awaiting confirmation and which must
+    /// therefore not be reconciled as evicted yet. Lapsed entries are pruned as a side effect.
+    ///
+    func awaitingConfirmation(
+        among identifiers: Set<NSFileProviderItemIdentifier>,
+        now: Date = Date()
+    ) -> Set<NSFileProviderItemIdentifier> {
+        lock.lock()
+        defer { lock.unlock() }
+
+        pending = pending.filter { now.timeIntervalSince($0.value) < Self.expiryInterval }
+
+        return identifiers.filter { pending[$0] != nil }
+    }
+
+    ///
+    /// Drop all state. Test seam — the registry is a process-wide singleton, so a test that
+    /// exercises the reconciliation must not inherit entries from an earlier one.
+    ///
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        pending.removeAll()
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/RemoteChangeTargets.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/RemoteChangeTargets.swift
@@ -1,0 +1,101 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+
+///
+/// Containers a `notify_push` message named as changed, waiting to be scanned.
+///
+/// ## Why
+///
+/// A push already tells us exactly what changed, within a second or so. The extension used to treat
+/// it as a bare doorbell — `processFileIdsChanged` checked whether *any* of the ids were locally
+/// known, threw the ids away, and signalled the whole working set. That turned a one-file change
+/// into a walk of every materialised item: one measured pass took 305 seconds to surface a single
+/// 31-byte file the push had identified 1.5 seconds after it was created.
+///
+/// Recording the ids instead lets the working-set derivation read just those containers. A depth-1
+/// read of the parent is what reveals a new child, a modified child and a removed child alike, so
+/// one narrow read covers every case the wide walk did — for the items the push actually named.
+///
+/// ## Why the full scan stays
+///
+/// Push is not a guarantee. Messages are lost across reconnects and the socket can be down entirely,
+/// and the server only propagates etags up the tree — a push tells us a subtree changed, not that
+/// nothing else did. Targeted scans are therefore an accelerator layered over the periodic full
+/// walk, never a replacement: ``shouldRunFullScan(now:)`` forces one whenever nothing is targeted or
+/// ``fullScanInterval`` has elapsed, so anything push missed is still reconciled.
+///
+/// Guarded by an `NSLock` and process-wide, matching ``PendingMaterializationRegistry``. One
+/// extension process serves one domain.
+///
+final class RemoteChangeTargets: @unchecked Sendable {
+    static let shared = RemoteChangeTargets()
+
+    /// How long a targeted-only run may go before a full reconciliation is forced anyway.
+    static let fullScanInterval: TimeInterval = 10 * 60
+
+    private let lock = NSLock()
+    private var pending = Set<NSFileProviderItemIdentifier>()
+    private var lastFullScan: Date?
+
+    ///
+    /// Note that a push named these containers as changed.
+    ///
+    /// Callers pass containers, not the changed items themselves: for a file that is its parent
+    /// directory, whose depth-1 read shows the file's new state or its absence.
+    ///
+    func record(containers: some Sequence<NSFileProviderItemIdentifier>) {
+        lock.lock()
+        defer { lock.unlock() }
+        pending.formUnion(containers)
+    }
+
+    ///
+    /// Take the containers accumulated since the last derivation, clearing them.
+    ///
+    /// Returns `nil` when nothing is pending, which the caller reads as "no targeting information —
+    /// fall back to the full walk".
+    ///
+    func consumeTargets() -> Set<NSFileProviderItemIdentifier>? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !pending.isEmpty else { return nil }
+
+        let targets = pending
+        pending.removeAll()
+        return targets
+    }
+
+    ///
+    /// Whether this derivation must be a full walk rather than a targeted one.
+    ///
+    /// True until the first full scan has run, and again once ``fullScanInterval`` has elapsed since
+    /// it — so a long stream of pushes can never postpone reconciliation indefinitely.
+    ///
+    func shouldRunFullScan(now: Date = Date()) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let lastFullScan else { return true }
+
+        return now.timeIntervalSince(lastFullScan) >= Self.fullScanInterval
+    }
+
+    /// Record that a full walk just completed, restarting the interval.
+    func noteFullScanCompleted(at date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+        lastFullScan = date
+    }
+
+    /// Drop all state. Test seam — the registry is a process-wide singleton.
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        pending.removeAll()
+        lastFullScan = nil
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/RemoveDownloadVisibility.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/RemoveDownloadVisibility.swift
@@ -2,6 +2,91 @@
 //  SPDX-License-Identifier: LGPL-3.0-or-later
 
 @preconcurrency import FileProvider
+import Foundation
+
+///
+/// Batches ancestor-container refresh nudges over a short window.
+///
+/// Nudging immediately, per downloaded file, does not scale with the work that produces the
+/// nudges. Every file shares its ancestors with its siblings, so materialising a "keep downloaded"
+/// tree issued one `requestModification` per file *per level* — all landing on the same handful of
+/// containers. The root's `update-item` job was re-queued before it could finish (observed: 13
+/// times in 93 seconds under a single scheduler ID), and the sheer call rate is what macOS
+/// flagged as a notification flood.
+///
+/// Collapsing a window's worth of downloads into one deduplicated ancestor set costs a few hundred
+/// milliseconds of latency on the "Remove download" menu item and removes the amplification.
+///
+/// Guarded by an `NSLock`, following ``ChangeDeliveryBuffer``. A process serves a single file
+/// provider domain, so one shared instance covers all callers.
+///
+private final class AncestorRefreshCoalescer: @unchecked Sendable {
+    static let shared = AncestorRefreshCoalescer()
+
+    ///
+    /// How long to accumulate before nudging. Short enough to stay imperceptible in the context
+    /// menu, long enough to collapse the sibling files of a folder into one pass.
+    ///
+    private static let windowNanoseconds: UInt64 = 400_000_000
+
+    private let lock = NSLock()
+    private var pendingOcIds = Set<String>()
+    private var drainScheduled = false
+
+    ///
+    /// Take the accumulated batch and reopen the window, so downloads finishing while the batch is
+    /// being nudged start a fresh one rather than being dropped.
+    ///
+    /// Separate from the drain `Task` because `NSLock` is unavailable from an async context.
+    ///
+    private func claimBatch() -> Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let claimed = pendingOcIds
+        pendingOcIds.removeAll()
+        drainScheduled = false
+
+        return claimed
+    }
+
+    func enqueue(
+        ocIds: Set<String>,
+        manager: NSFileProviderManager,
+        dbManager: FilesDatabaseManager,
+        logger: FileProviderLogger
+    ) {
+        lock.lock()
+        pendingOcIds.formUnion(ocIds)
+
+        guard !drainScheduled else {
+            lock.unlock()
+            return
+        }
+
+        drainScheduled = true
+        lock.unlock()
+
+        Task {
+            try? await Task.sleep(nanoseconds: Self.windowNanoseconds)
+
+            let ocIds = claimBatch()
+            let ancestors = dbManager.ancestorContainerIdentifiers(ofFileItemsWithOcIds: ocIds)
+
+            guard !ancestors.isEmpty else { return }
+
+            logger.debug("Refreshing \(ancestors.count) ancestor container(s) for \(ocIds.count) item(s) to update Remove download visibility.")
+
+            for ancestor in ancestors {
+                do {
+                    try await manager.requestModification(of: [.lastUsedDate], forItemWithIdentifier: ancestor)
+                } catch {
+                    logger.error("Could not nudge ancestor container to refresh Remove download visibility.", [.item: ancestor, .error: error.localizedDescription])
+                }
+            }
+        }
+    }
+}
 
 ///
 /// Refresh the framework's cached snapshot of every ancestor container of the
@@ -25,6 +110,11 @@
 /// - The observer covers eviction (a file going dataless) and out-of-band
 ///   materialization it discovers itself.
 ///
+/// Calls are coalesced over a short window — see ``AncestorRefreshCoalescer`` — so a bulk
+/// materialisation nudges each shared ancestor once per window rather than once per file.
+/// The ancestor walk (a synchronous Realm read) happens on the drain, so callers on
+/// latency-sensitive paths are never blocked.
+///
 func refreshRemoveDownloadVisibility(
     forAncestorsOfFileOcIds ocIds: Set<String>,
     manager: NSFileProviderManager,
@@ -33,22 +123,5 @@ func refreshRemoveDownloadVisibility(
 ) {
     guard !ocIds.isEmpty else { return }
 
-    // Everything — the ancestor walk (a synchronous Realm read) and the nudges —
-    // runs inside the Task so callers on latency-sensitive paths (the
-    // materialized-set completion handler, `fetchContents`) are never blocked.
-    Task {
-        let ancestors = dbManager.ancestorContainerIdentifiers(ofFileItemsWithOcIds: ocIds)
-
-        guard !ancestors.isEmpty else { return }
-
-        logger.debug("Refreshing \(ancestors.count) ancestor container(s) to update Remove download visibility after materialization change.")
-
-        for ancestor in ancestors {
-            do {
-                try await manager.requestModification(of: [.lastUsedDate], forItemWithIdentifier: ancestor)
-            } catch {
-                logger.error("Could not nudge ancestor container to refresh Remove download visibility.", [.item: ancestor, .error: error.localizedDescription])
-            }
-        }
-    }
+    AncestorRefreshCoalescer.shared.enqueue(ocIds: ocIds, manager: manager, dbManager: dbManager, logger: logger)
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -103,6 +103,15 @@ public extension Item {
 
         directory.downloaded = true
         directory.keepDownloaded = parentKeepDownloaded
+        // A folder we just created is, from the framework's point of view, already fully enumerated:
+        // it knows the (empty) listing it created and will not ask for the contents again. So the
+        // refresh subscription a browsed folder gets must be granted here too — `visitedDirectory` is
+        // what puts a directory in the materialised set the working-set scan reads (see
+        // `FilesDatabaseManager.managedMaterialisedItemMetadatas()`); `downloaded` is ignored for
+        // directories there. Without it, a folder created locally is never PROPFINDed by the scan, so
+        // items added to it on the server (web UI, public upload link, another user) never surface —
+        // and no later `enumerateItems` exists to repair that. See nextcloud/desktop#9688, #10681.
+        directory.visitedDirectory = true
         dbManager.addItemMetadata(directory)
 
         let displayFileActions = await Item.typeHasApplicableContextMenuItems(account: account, remoteInterface: remoteInterface, candidate: directory.contentType)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Fetch.swift
@@ -103,6 +103,10 @@ public extension Item {
 
                 if !metadata.directory {
                     downloadedFileOcIds.append(metadata.ocId)
+                    // See the matching call in `fetchContents`: this row is downloaded ahead of
+                    // the system's materialized set, and must not be reconciled as evicted in
+                    // the meantime.
+                    PendingMaterializationRegistry.shared.recordDownloaded(NSFileProviderItemIdentifier(metadata.ocId))
                 }
 
                 progress.completedUnitCount += 1
@@ -236,6 +240,12 @@ public extension Item {
         updatedMetadata.sessionError = ""
 
         dbManager.addItemMetadata(updatedMetadata)
+
+        // The same ordering the comment below relies on — our `downloaded = true` lands before
+        // the system adds the file to its materialized set — is what would otherwise make the
+        // observer reconcile this row straight back to dataless. Hold it until the system
+        // confirms the materialisation.
+        PendingMaterializationRegistry.shared.recordDownloaded(itemIdentifier)
 
         // A newly downloaded file changes the "Remove download" visibility of every
         // ancestor folder and the root. This must happen here, not via the

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
@@ -85,6 +85,21 @@ public extension Item {
                     isDownloaded: child.downloaded,
                     manager: manager
                 )
+            } catch let error as NSFileProviderError where error.code == .noSuchItem {
+                // Expected, and the common case on a large subtree. These calls address the
+                // framework's own item store, which only knows what it has been handed through
+                // enumeration — so every descendant the user has never browsed answers
+                // `noSuchItem`. Measured on one pinned tree: 15,229 of 15,849 descendants, i.e.
+                // 96%, each previously logged as an error.
+                //
+                // Nothing is lost by skipping them. The database flag was already written above,
+                // so `Item.contentPolicy` reports `.downloadEagerlyAndKeepDownloaded` for the item,
+                // and the framework acts on that the moment it first enumerates it. The signal here
+                // only brings that forward for descendants the framework is already tracking.
+                logger.debug(
+                    "Framework does not know this descendant yet; its pin applies when the item is first enumerated.",
+                    [.item: child.ocId, .name: child.fileName]
+                )
             } catch {
                 logger.error(
                     "Could not signal keep-downloaded change to framework for descendant.",

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -2,8 +2,34 @@
 //  SPDX-License-Identifier: LGPL-3.0-or-later
 
 @preconcurrency import FileProvider
+import Foundation
 import NextcloudKit
 import UniformTypeIdentifiers
+
+///
+/// Compute-once box for a flag an ``Item`` derives from a database query.
+///
+/// ``Item`` is `Sendable` with `let` storage throughout, so holding the memo behind an
+/// `NSLock`-guarded reference — the same idiom as ``ChangeDeliveryBuffer`` — keeps that
+/// conformance honest instead of pushing `@unchecked` onto the item itself.
+///
+private final class MemoizedDatabaseFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var memo: Bool?
+
+    func value(_ compute: () -> Bool) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let memo {
+            return memo
+        }
+
+        let computed = compute()
+        memo = computed
+        return computed
+    }
+}
 
 ///
 /// Data model implementation for file provider items as defined by the file provider framework and `NSFileProviderItemProtocol`.
@@ -22,6 +48,22 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
 
     private let displayFileActions: Bool
     private let remoteSupportsTrash: Bool
+    private let evictableDescendantFileMemo = MemoizedDatabaseFlag()
+
+    ///
+    /// Whether this directory holds at least one evictable descendant file.
+    ///
+    /// Read by both ``itemVersion`` and ``userInfo``; memoized because the framework reads several
+    /// properties off the same item and each call is an unindexed prefix query over the item's
+    /// descendants. Always `false` for a file, which has no descendants to evict.
+    ///
+    private var hasEvictableDescendantFile: Bool {
+        guard metadata.directory else { return false }
+
+        return evictableDescendantFileMemo.value {
+            dbManager.hasEvictableDescendantFile(directoryMetadata: metadata)
+        }
+    }
 
     public var itemIdentifier: NSFileProviderItemIdentifier {
         NSFileProviderItemIdentifier(metadata.ocId)
@@ -108,7 +150,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         // the folder action itself flips, so it does not over-invalidate on every
         // descendant change.
         if metadata.directory {
-            metadataVersionString += "|\(dbManager.hasEvictableDescendantFile(directoryMetadata: metadata))"
+            metadataVersionString += "|\(hasEvictableDescendantFile)"
         }
 
         return NSFileProviderItemVersion(contentVersion: metadata.etag.data(using: .utf8)!, metadataVersion: metadataVersionString.data(using: .utf8)!)
@@ -268,7 +310,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         let notPinned = !metadata.keepDownloaded
         if metadata.directory {
             userInfoDict["displayEvict"] = false
-            userInfoDict["displayEvictDescendants"] = dbManager.hasEvictableDescendantFile(directoryMetadata: metadata) && notPinned
+            userInfoDict["displayEvictDescendants"] = hasEvictableDescendantFile && notPinned
         } else {
             userInfoDict["displayEvict"] = metadata.downloaded && notPinned
             userInfoDict["displayEvictDescendants"] = false
@@ -339,7 +381,8 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             account: account.ncKitAccount,
             classFile: NKTypeClassFile.directory.rawValue,
             contentType: "", // Placeholder as not set in original code
-            creationDate: Date(), // Default as not set in original code
+            creationDate: syntheticContainerFallbackDate,
+            date: syntheticContainerFallbackDate,
             directory: true,
             e2eEncrypted: false, // Default as not set in original code
             etag: "", // Placeholder as not set in original code
@@ -367,10 +410,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         // even after the user has enabled it — `displayKeepDownloaded` /
         // `displayAllowAutoEvicting` and `contentPolicy` all derive from the
         // freshly-synthesised (and therefore stale) metadata.
-        if let existing = dbManager.itemMetadata(ocId: metadata.ocId) {
-            metadata.keepDownloaded = existing.keepDownloaded
-            metadata.downloaded = existing.downloaded
-        }
+        metadata.mergePersistedSyntheticContainerState(dbManager: dbManager)
 
         return Item(
             metadata: metadata,
@@ -396,7 +436,8 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
             account: account.ncKitAccount,
             classFile: NKTypeClassFile.directory.rawValue,
             contentType: "", // Placeholder as not set in original code
-            creationDate: Date(), // Default as not set in original code
+            creationDate: syntheticContainerFallbackDate,
+            date: syntheticContainerFallbackDate,
             directory: true,
             e2eEncrypted: false, // Default as not set in original code
             etag: "", // Placeholder as not set in original code
@@ -420,10 +461,7 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         // See the matching rationale in `rootContainer(...)`: merge persisted
         // per-item toggles from the database so the trash container does not
         // forget its state between factory invocations.
-        if let existing = dbManager.itemMetadata(ocId: metadata.ocId) {
-            metadata.keepDownloaded = existing.keepDownloaded
-            metadata.downloaded = existing.downloaded
-        }
+        metadata.mergePersistedSyntheticContainerState(dbManager: dbManager)
 
         return Item(
             metadata: metadata,

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Log/FileProviderLog.swift
@@ -62,6 +62,18 @@ public actor FileProviderLog: FileProviderLogging {
     var handle: FileHandle?
 
     ///
+    /// Bytes written through ``handle`` since it was opened, tracked so rotation can be decided
+    /// without a file system round trip.
+    ///
+    /// ``rotateLogFileIfNeeded()`` runs before every single line and used to `stat` the log file
+    /// each time. Under load — a bulk materialisation emits tens of thousands of lines — that put
+    /// one syscall per line in front of the actor's serialized queue, which every hot path in the
+    /// extension awaits. The counter is exact because this actor is the only writer and each file
+    /// is created empty.
+    ///
+    var bytesWrittenToCurrentFile: Int64 = 0
+
+    ///
     /// Unified logger used for self-diagnostics of this actor, tagged with the category `"FileProviderLog"`.
     ///
     /// Used for messages about this actor's own concerns — log file rotation, startup and KVO transitions of the debug-logging gate, and errors that prevent writing to the JSONL file.
@@ -226,28 +238,22 @@ public actor FileProviderLog: FileProviderLogging {
             return
         }
 
-        do {
-            if let currentFile = file {
-                let fileAttributes = try fileManager.attributesOfItem(atPath: currentFile.path)
+        if let currentFile = file, bytesWrittenToCurrentFile >= maxLogFileSize {
+            // Close current handle, flushing anything still buffered in it first.
+            try? handle?.synchronize()
+            handle?.closeFile()
+            logger.debug("Closed current log file at \"\(currentFile.path, privacy: .public)\" because it exceeds the size limit.")
 
-                if let fileSize = fileAttributes[.size] as? Int64, fileSize >= maxLogFileSize {
-                    // Close current handle
-                    handle?.closeFile()
-                    logger.debug("Closed current log file at \"\(currentFile.path, privacy: .public)\" because it exceeds the size limit.")
-
-                    file = nil
-                    handle = nil
-                }
-            }
-        } catch {
-            // swiftformat:disable:next redundantSelf
-            logger.error("Failed to close open log file at \"\(self.file?.path ?? "nil")\": \(error.localizedDescription, privacy: .public)")
+            file = nil
+            handle = nil
         }
 
         guard handle == nil else {
             // Already have an active handle which was not closed previously, stick with that file.
             return
         }
+
+        bytesWrittenToCurrentFile = 0
 
         let creationDate = Date()
         let formattedDate = fileDateFormatter.string(from: creationDate)
@@ -347,9 +353,18 @@ public actor FileProviderLog: FileProviderLogging {
 
         do {
             let object = try encoder.encode(entry)
+            let newline = Data("\n".utf8)
+
+            // No `synchronize()` here. `FileHandle.write(contentsOf:)` is an unbuffered `write(2)`,
+            // so the line is in the file and readable the moment this returns; the fsync only
+            // added durability against power loss, which a diagnostic log does not need. Paying
+            // it per line serialized every caller of this actor — and every hot path in the
+            // extension logs — behind one disk flush each, so a burst of tens of thousands of
+            // lines became tens of thousands of serialized fsyncs. Rotation still flushes before
+            // closing a file.
             try handle.write(contentsOf: object)
-            try handle.write(contentsOf: "\n".data(using: .utf8)!)
-            try handle.synchronize()
+            try handle.write(contentsOf: newline)
+            bytesWrittenToCurrentFile += Int64(object.count + newline.count)
         } catch {
             logger.error("Failed to encode and write message: \(message, privacy: .public)!")
             return

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata+SyntheticContainer.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Metadata/SendableItemMetadata+SyntheticContainer.swift
@@ -1,0 +1,53 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+
+///
+/// Stand-in timestamp for a synthetic container (the root and trash containers) that has no
+/// persisted row yet.
+///
+/// It must be a **constant**, not `Date()`. ``Item/rootContainer(account:remoteInterface:dbManager:remoteSupportsTrash:log:)``
+/// and ``Item/trashContainer(remoteInterface:account:dbManager:remoteSupportsTrash:log:)`` build
+/// their metadata from scratch on every call, so a wall-clock default made every read of the
+/// container return new `creationDate` / `contentModificationDate` / `lastUsedDate` values. The
+/// framework compared those against its cached snapshot, logged
+/// `diffs:lastUsedDate|btime|mtime why:item propagated`, and re-queued the container's
+/// `update-item` job — which could never converge because the next read moved the timestamps
+/// again. Observed as the root container being updated 13 times in 93 seconds under a single
+/// scheduler ID during a bulk materialisation.
+///
+let syntheticContainerFallbackDate = Date(timeIntervalSince1970: 0)
+
+extension SendableItemMetadata {
+    ///
+    /// Overlay the persisted database row for a synthetic container onto freshly synthesised
+    /// metadata.
+    ///
+    /// Two kinds of state have to survive the synthesis:
+    ///
+    /// - Per-item toggles (`keepDownloaded`, `downloaded`). Without them the container is always
+    ///   rebuilt with defaults and `userInfo` keeps offering "Always keep downloaded" even after
+    ///   the user enabled it, because `displayKeepDownloaded` / `displayAllowAutoEvicting` and
+    ///   `contentPolicy` all derive from the synthesised metadata.
+    /// - Identity that the framework diffs against its cached snapshot (`creationDate`, `date`,
+    ///   `etag`). The server's real values are already stored — `NKFile.toItemMetadata()` writes
+    ///   them and remaps the server root row's `ocId` to `NSFileProviderItemIdentifier.rootContainer`
+    ///   — so reading them back is what makes the container's item stable between calls. `date`
+    ///   backs both `contentModificationDate` and `lastUsedDate`.
+    ///
+    /// `etag` is included deliberately: a synthesised container carries `etag: ""`, which leaves
+    /// its `contentVersion` empty and its `metadataVersion` varying only with the bundle version.
+    /// Carrying the real etag lets the framework detect that the container actually converged.
+    /// Containers have no content to download, so a changing `contentVersion` costs nothing here.
+    ///
+    mutating func mergePersistedSyntheticContainerState(dbManager: FilesDatabaseManager) {
+        guard let existing = dbManager.itemMetadata(ocId: ocId) else { return }
+
+        keepDownloaded = existing.keepDownloaded
+        downloaded = existing.downloaded
+        creationDate = existing.creationDate
+        date = existing.date
+        etag = existing.etag
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -587,8 +587,76 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     public var expectedEnumerationPaginationTokens: [String: String] = [:]
     public var forceNextPageOnLastContentPage: Bool = false
 
+    /// Guards the counters below. `enumerate` now runs concurrently (the working-set scan issues
+    /// its reads in waves), so a plain `+= 1` on a shared `Int` would be a data race and would
+    /// under-count exactly in the tests that care about request volume.
+    private let counterLock = NSLock()
+
+    private var _readOperationCount = 0
+    private var _maxConcurrentEnumerations = 0
+    private var _inFlightEnumerations = 0
+
     /// Track the number of read operations performed
-    public var readOperationCount: Int = 0
+    public var readOperationCount: Int {
+        get {
+            counterLock.lock()
+            defer { counterLock.unlock() }
+            return _readOperationCount
+        }
+        set {
+            counterLock.lock()
+            defer { counterLock.unlock() }
+            _readOperationCount = newValue
+        }
+    }
+
+    ///
+    /// When set, ``enumerate(remotePath:depth:showHiddenFiles:includeHiddenFiles:requestBody:account:options:taskHandler:)``
+    /// waits this long before answering, standing in for a PROPFIND round trip.
+    ///
+    /// Reads against the mock tree are otherwise effectively instantaneous, which hides the cost the
+    /// working-set scan actually pays: network waiting. Giving each read a fixed duration makes both
+    /// the wall clock of a scan and its read concurrency measurable and comparable between revisions.
+    ///
+    public var enumerateLatency: TimeInterval?
+
+    ///
+    /// The highest number of `enumerate` calls that were in flight at the same time.
+    ///
+    /// With a sequential scan this stays at 1 no matter how many items are read; with the wave-based
+    /// concurrent scan it rises to the scan's concurrency limit. Only meaningful together with
+    /// ``enumerateLatency``, which is what makes the calls overlap in wall-clock time at all.
+    ///
+    public var maxConcurrentEnumerations: Int {
+        counterLock.lock()
+        defer { counterLock.unlock() }
+        return _maxConcurrentEnumerations
+    }
+
+    /// Reset the read counter, the concurrency high-water mark and the in-flight tally together.
+    public func resetOperationCounters() {
+        counterLock.lock()
+        defer { counterLock.unlock() }
+        _readOperationCount = 0
+        _maxConcurrentEnumerations = 0
+        _inFlightEnumerations = 0
+    }
+
+    /// Count one starting `enumerate` call and update the concurrency high-water mark.
+    private func beginEnumeration() {
+        counterLock.lock()
+        defer { counterLock.unlock() }
+        _readOperationCount += 1
+        _inFlightEnumerations += 1
+        _maxConcurrentEnumerations = max(_maxConcurrentEnumerations, _inFlightEnumerations)
+    }
+
+    /// Count one finishing `enumerate` call.
+    private func endEnumeration() {
+        counterLock.lock()
+        defer { counterLock.unlock() }
+        _inFlightEnumerations -= 1
+    }
 
     /// When non-nil, the upload mock truncates the modification date returned to
     /// the caller to this precision (in seconds) — simulating Nextcloud's
@@ -1160,8 +1228,13 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
         options: NKRequestOptions = .init(),
         taskHandler: @escaping (URLSessionTask) -> Void = { _ in }
     ) async -> (account: String, files: [NKFile], data: AFDataResponse<Data>?, error: NKError) {
-        // Increment read operation counter
-        readOperationCount += 1
+        // Increment read operation counter and track how many reads overlap.
+        beginEnumeration()
+        defer { endEnumeration() }
+
+        if let enumerateLatency {
+            try? await Task.sleep(nanoseconds: UInt64(enumerateLatency * 1_000_000_000))
+        }
 
         var remotePath = remotePath
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/AwaitAccountTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/AwaitAccountTests.swift
@@ -1,0 +1,86 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+@testable import NextcloudFileProviderKit
+import XCTest
+
+///
+/// The system launches the extension process and starts asking it for work before the main app has
+/// handed the account over. Rejecting those requests outright loses them: observed on one extension
+/// relaunch, 17 `fetchContents` calls arrived in the first 0.6 seconds — 1.7 seconds before the
+/// account landed — and the framework never re-requested most of them.
+///
+/// ``FileProviderExtension/awaitAccount(timeoutNanoseconds:)`` turns that into a short wait.
+///
+final class AwaitAccountTests: NextcloudFileProviderKitTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private func makeExtension() -> FileProviderExtension {
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("test-domain-await-account"),
+            displayName: "Test"
+        )
+        return FileProviderExtension(domain: domain)
+    }
+
+    /// An account already in place is returned without waiting at all.
+    func testReturnsImmediatelyWhenAccountIsAlreadySetUp() async {
+        let ext = makeExtension()
+        ext.ncAccount = Self.account
+
+        let started = ContinuousClock().now
+        let account = await ext.awaitAccount(timeoutNanoseconds: 5_000_000_000)
+
+        XCTAssertEqual(account, Self.account)
+        XCTAssertLessThan(ContinuousClock().now - started, .milliseconds(500))
+    }
+
+    /// The waiting case: a request arrives first, the account lands while it is parked, and the
+    /// request proceeds instead of failing.
+    func testWaitsForAnAccountThatArrivesLater() async {
+        let ext = makeExtension()
+
+        async let awaited = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+
+        // Let the caller park before the account is published.
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        ext.ncAccount = Self.account
+        ext.signalAccountReady()
+
+        let account = await awaited
+        XCTAssertEqual(account, Self.account, "A request parked before setup must proceed once the account lands.")
+    }
+
+    /// A domain that never gets an account still fails — just after the timeout rather than
+    /// instantly — so a genuinely unauthenticated domain cannot hang a request forever.
+    func testGivesUpAfterTheTimeoutWhenNoAccountArrives() async {
+        let ext = makeExtension()
+
+        let started = ContinuousClock().now
+        let account = await ext.awaitAccount(timeoutNanoseconds: 300_000_000)
+        let elapsed = ContinuousClock().now - started
+
+        XCTAssertNil(account)
+        XCTAssertGreaterThan(elapsed, .milliseconds(200))
+        XCTAssertLessThan(elapsed, .seconds(5))
+    }
+
+    /// Several parked requests are all released by the single setup completion.
+    func testReleasesEveryParkedWaiter() async {
+        let ext = makeExtension()
+
+        async let first = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+        async let second = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+        async let third = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        ext.ncAccount = Self.account
+        ext.signalAccountReady()
+
+        let results = await [first, second, third]
+        XCTAssertEqual(results, [Self.account, Self.account, Self.account])
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChangeDeliveryStreamingTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChangeDeliveryStreamingTests.swift
@@ -1,0 +1,248 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+///
+/// Streaming change delivery: a working-set scan hands its discoveries over wave by wave rather than
+/// holding them until the walk ends, so a change found in the scan's first second is not reported
+/// only when its last second completes.
+///
+/// ## The failure this suite exists for
+///
+/// A first attempt at streaming was reverted after it silently stopped delivering remote changes.
+/// The framework served an intermediate batch from a **second `Enumerator`** — which is the entire
+/// reason the session is persisted in Realm — and that instance had no in-memory record of the
+/// producer still running. It reported `moreComing: false`, which both ended the sequence and
+/// deleted the session out from under the live scan. Nothing was ever reported again, because
+/// `moreComing: false` is precisely the statement that the client is synced.
+///
+/// The original tests all drove a single buffer instance, the one topology where that bug cannot
+/// appear. ``testASecondEnumeratorDoesNotEndASequenceWhoseProducerIsStillRunning`` is written first
+/// here for that reason: producer liveness has to be durable, not in-memory.
+///
+final class ChangeDeliveryStreamingTests: NextcloudFileProviderKitTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+    }
+
+    /// A buffer as a *different* enumerator would see it: same database, no shared memory.
+    private func makeBuffer() -> ChangeDeliveryBuffer {
+        ChangeDeliveryBuffer(dbManager: dbManager, log: FileProviderLogMock())
+    }
+
+    private func metadata(_ ocId: String) -> SendableItemMetadata {
+        SendableItemMetadata(ocId: ocId, fileName: "\(ocId).txt", account: Self.account)
+    }
+
+    private func anchorData(_ value: String) -> Data {
+        Data(value.utf8)
+    }
+
+    // MARK: - The regression that reverted streaming the first time
+
+    ///
+    /// The framework may serve any batch from a fresh `Enumerator`, and therefore a fresh buffer.
+    /// That instance must still see that a producer is running and keep the sequence open.
+    ///
+    func testASecondEnumeratorDoesNotEndASequenceWhoseProducerIsStillRunning() throws {
+        let producing = makeBuffer()
+        let token = try XCTUnwrap(
+            producing.primeStreaming(key: "anchor-1", incomingAnchorRawValue: anchorData("incoming"))
+        )
+        producing.append(token: token, updated: [metadata("wave1")], deleted: [])
+
+        // First batch through the producing enumerator.
+        let first = producing.takeBatch(maxItems: 100)
+        XCTAssertEqual(first.updated.map(\.ocId), ["wave1"])
+        XCTAssertTrue(first.moreComing)
+
+        // The framework now invalidates that enumerator and continues on a new one, which shares
+        // only the database. The producer is still walking and has not appended its next wave yet.
+        let continuation = makeBuffer()
+        let continuationKey = try XCTUnwrap(
+            String(data: XCTUnwrap(first.continuationAnchorRawValue), encoding: .utf8)
+        )
+        XCTAssertTrue(
+            continuation.isPrimed(forKey: continuationKey),
+            "The fresh enumerator must adopt the durable session."
+        )
+
+        let second = continuation.takeBatch(maxItems: 100)
+        XCTAssertTrue(
+            second.moreComing,
+            "A fresh enumerator must not end a sequence whose producer is still running — doing so tells the framework we are synced and silently drops everything the scan has yet to find."
+        )
+
+        // And the session must survive for the producer to keep appending to.
+        producing.append(token: token, updated: [metadata("wave2")], deleted: [])
+        let third = continuation.takeBatch(maxItems: 100)
+        XCTAssertEqual(
+            third.updated.map(\.ocId), ["wave2"],
+            "The still-running producer's later waves must still reach the framework."
+        )
+    }
+
+    ///
+    /// The other half: a producer that died must not wedge the sequence open forever. Once its
+    /// liveness lapses, any enumerator may finish the sequence — on the incoming anchor, so the next
+    /// signal re-derives whatever the dead scan never reached.
+    ///
+    func testAnAbandonedProducerLetsTheSequenceFinishOnTheIncomingAnchor() throws {
+        let producing = makeBuffer()
+        let token = try XCTUnwrap(
+            producing.primeStreaming(key: "anchor-2", incomingAnchorRawValue: anchorData("incoming"))
+        )
+        producing.append(token: token, updated: [metadata("first"), metadata("second")], deleted: [])
+
+        // One batch, so the next enumerator has a continuation anchor to adopt the session by.
+        let first = producing.takeBatch(maxItems: 1)
+        XCTAssertEqual(first.updated.map(\.ocId), ["first"])
+        let continuationKey = try XCTUnwrap(
+            String(data: XCTUnwrap(first.continuationAnchorRawValue), encoding: .utf8)
+        )
+
+        // The producing process goes away mid-scan: its liveness is never refreshed again.
+        producing.expireProducerLivenessForTesting(token: token)
+
+        let continuation = makeBuffer()
+        XCTAssertTrue(continuation.isPrimed(forKey: continuationKey))
+
+        var batch = continuation.takeBatch(maxItems: 100)
+        XCTAssertEqual(batch.updated.map(\.ocId), ["second"], "Whatever was stored is still delivered.")
+
+        while batch.moreComing {
+            batch = continuation.takeBatch(maxItems: 100)
+        }
+
+        XCTAssertEqual(
+            batch.finalAnchorRawValue, anchorData("incoming"),
+            "An abandoned stream keeps its incoming anchor so the next signal re-derives."
+        )
+    }
+
+    // MARK: - Core streaming contract
+
+    /// While a producer is appending, the sequence must never be declared finished.
+    func testSequenceStaysOpenWhileTheProducerIsStillAppending() throws {
+        let buffer = makeBuffer()
+        let token = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-3", incomingAnchorRawValue: anchorData("incoming"))
+        )
+
+        buffer.append(token: token, updated: [metadata("wave1")], deleted: [])
+        XCTAssertTrue(buffer.takeBatch(maxItems: 100).moreComing)
+
+        buffer.append(token: token, updated: [metadata("wave2")], deleted: [])
+        XCTAssertTrue(buffer.takeBatch(maxItems: 100).moreComing)
+    }
+
+    /// Only once the producer reports done may the sequence end, on the anchor it supplied.
+    func testFinishingTheProducerClosesTheSequenceOnTheFinalAnchor() throws {
+        let buffer = makeBuffer()
+        let token = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-4", incomingAnchorRawValue: anchorData("incoming"))
+        )
+
+        buffer.append(token: token, updated: [metadata("a")], deleted: [])
+        buffer.finishStreaming(token: token, finalAnchorRawValue: anchorData("final"), incomplete: false)
+
+        let batch = buffer.takeBatch(maxItems: 100)
+        XCTAssertEqual(batch.updated.map(\.ocId), ["a"])
+        XCTAssertFalse(batch.moreComing)
+        XCTAssertEqual(batch.finalAnchorRawValue, anchorData("final"))
+    }
+
+    /// A scan that could not read part of the working set keeps the incoming anchor.
+    func testAnIncompleteScanRetainsTheIncomingAnchor() throws {
+        let buffer = makeBuffer()
+        let token = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-5", incomingAnchorRawValue: anchorData("incoming"))
+        )
+
+        buffer.append(token: token, updated: [metadata("a")], deleted: [])
+        buffer.finishStreaming(token: token, finalAnchorRawValue: anchorData("incoming"), incomplete: true)
+
+        XCTAssertTrue(buffer.isPrimedIncomplete())
+    }
+
+    /// A fresh anchor mid-scan replaces the session; the superseded producer must not touch it.
+    func testASupersededProducerCannotTouchTheNewSession() throws {
+        let buffer = makeBuffer()
+        let stale = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-6", incomingAnchorRawValue: anchorData("incoming"))
+        )
+        buffer.append(token: stale, updated: [metadata("stale")], deleted: [])
+
+        buffer.reset()
+        let current = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-7", incomingAnchorRawValue: anchorData("incoming-2"))
+        )
+        buffer.append(token: current, updated: [metadata("fresh")], deleted: [])
+
+        buffer.append(token: stale, updated: [metadata("stale-late")], deleted: [])
+        buffer.finishStreaming(token: stale, finalAnchorRawValue: anchorData("stale-final"), incomplete: false)
+
+        let batch = buffer.takeBatch(maxItems: 100)
+        XCTAssertEqual(batch.updated.map(\.ocId), ["fresh"], "Only the live session's items are delivered.")
+        XCTAssertTrue(batch.moreComing, "A stale producer must not end the live sequence.")
+    }
+
+    /// The drain waits for the first wave rather than answering empty with `moreComing`, which the
+    /// framework would answer by calling straight back — a spin.
+    func testAwaitingDeliverableItemsReturnsOnceAWaveLands() async throws {
+        let buffer = makeBuffer()
+        let token = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-8", incomingAnchorRawValue: anchorData("incoming"))
+        )
+
+        let late = metadata("late")
+        let appender = Task { @Sendable in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            buffer.append(token: token, updated: [late], deleted: [])
+        }
+
+        await buffer.awaitDeliverableItems()
+        _ = await appender.result
+
+        XCTAssertEqual(buffer.takeBatch(maxItems: 100).updated.map(\.ocId), ["late"])
+    }
+
+    /// And must not hang when the producer finishes having produced nothing.
+    func testAwaitingDeliverableItemsReturnsWhenTheProducerFinishesEmpty() async throws {
+        let buffer = makeBuffer()
+        let token = try XCTUnwrap(
+            buffer.primeStreaming(key: "anchor-9", incomingAnchorRawValue: anchorData("incoming"))
+        )
+
+        let finalAnchor = anchorData("final")
+        let finisher = Task { @Sendable in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            buffer.finishStreaming(token: token, finalAnchorRawValue: finalAnchor, incomplete: false)
+        }
+
+        await buffer.awaitDeliverableItems()
+        _ = await finisher.result
+
+        XCTAssertFalse(buffer.takeBatch(maxItems: 100).moreComing)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ContainerRetryLoopTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ContainerRetryLoopTests.swift
@@ -1,0 +1,268 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+///
+/// Regressions for the container `update-item` retry loop observed during bulk materialisation of
+/// a "keep downloaded" tree: containers whose reported identity changed on every read, containers
+/// reporting their whole subtree as their child count, and freshly downloaded files being
+/// reconciled straight back to dataless.
+///
+final class ContainerRetryLoopTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+    private var remoteInterface: MockRemoteInterface!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+        remoteInterface = MockRemoteInterface(account: Self.account)
+    }
+
+    private func makeRootContainer() -> Item {
+        Item.rootContainer(
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager,
+            remoteSupportsTrash: false,
+            log: FileProviderLogMock()
+        )
+    }
+
+    // MARK: - Synthesised container timestamps
+
+    ///
+    /// The root container is rebuilt from scratch on every `item(for:)`. When its dates came from
+    /// `Date()` the framework saw `diffs:lastUsedDate|btime|mtime` on every read and re-queued the
+    /// container's `update-item` job forever.
+    ///
+    func testRootContainerReportsStableDatesWithoutPersistedRow() {
+        let first = makeRootContainer()
+        let second = makeRootContainer()
+
+        XCTAssertEqual(first.creationDate, second.creationDate)
+        XCTAssertEqual(first.contentModificationDate, second.contentModificationDate)
+        XCTAssertEqual(first.lastUsedDate, second.lastUsedDate)
+    }
+
+    func testRootContainerReportsPersistedDates() {
+        let creationDate = Date(timeIntervalSince1970: 1_396_778_454)
+        let modificationDate = Date(timeIntervalSince1970: 1_423_500_279)
+
+        var stored = SendableItemMetadata(
+            ocId: NSFileProviderItemIdentifier.rootContainer.rawValue,
+            fileName: "/",
+            account: Self.account
+        )
+        stored.directory = true
+        stored.creationDate = creationDate
+        stored.date = modificationDate
+        stored.etag = "root-etag"
+        dbManager.addItemMetadata(stored)
+
+        let item = makeRootContainer()
+
+        XCTAssertEqual(item.creationDate, creationDate)
+        XCTAssertEqual(item.contentModificationDate, modificationDate)
+        XCTAssertEqual(item.lastUsedDate, modificationDate)
+        XCTAssertEqual(item.metadata.etag, "root-etag")
+
+        // Still stable across reads now that a row exists.
+        XCTAssertEqual(makeRootContainer().contentModificationDate, modificationDate)
+    }
+
+    // MARK: - Child item count
+
+    ///
+    /// `childItemCount` must be the number of items *directly* in the container. Counting
+    /// descendants made every folder holding subfolders disagree with the framework's own count on
+    /// every read, and gave Finder wrong numbers.
+    ///
+    func testChildItemCountCountsDirectChildrenOnly() throws {
+        let directory = RealmItemMetadata()
+        directory.ocId = "dir"
+        directory.account = Self.account.ncKitAccount
+        directory.updateLocation(serverUrl: "https://cloud.example.com/files", fileName: "docs")
+        directory.directory = true
+
+        let directChild = RealmItemMetadata()
+        directChild.ocId = "direct-child"
+        directChild.account = Self.account.ncKitAccount
+        directChild.updateLocation(serverUrl: "https://cloud.example.com/files/docs", fileName: "report.pdf")
+
+        let subdirectory = RealmItemMetadata()
+        subdirectory.ocId = "subdirectory"
+        subdirectory.account = Self.account.ncKitAccount
+        subdirectory.updateLocation(serverUrl: "https://cloud.example.com/files/docs", fileName: "nested")
+        subdirectory.directory = true
+
+        let grandchild = RealmItemMetadata()
+        grandchild.ocId = "grandchild"
+        grandchild.account = Self.account.ncKitAccount
+        grandchild.updateLocation(serverUrl: "https://cloud.example.com/files/docs/nested", fileName: "deep.txt")
+
+        let tombstone = RealmItemMetadata()
+        tombstone.ocId = "tombstone"
+        tombstone.account = Self.account.ncKitAccount
+        tombstone.updateLocation(serverUrl: "https://cloud.example.com/files/docs", fileName: "gone.txt")
+        tombstone.deleted = true
+
+        let otherAccountChild = RealmItemMetadata()
+        otherAccountChild.ocId = "other-account-child"
+        otherAccountChild.account = "someoneElse"
+        otherAccountChild.updateLocation(serverUrl: "https://cloud.example.com/files/docs", fileName: "theirs.txt")
+
+        let realm = dbManager.ncDatabase()
+        try realm.write {
+            realm.add([directory, directChild, subdirectory, grandchild, tombstone, otherAccountChild])
+        }
+
+        let count = dbManager.childItemCount(directoryMetadata: SendableItemMetadata(value: directory))
+
+        XCTAssertEqual(count, 2, "Only the direct child and the subdirectory count; not the grandchild, the tombstone, or the other account's row.")
+    }
+
+    // MARK: - Materialized set reconciliation
+
+    ///
+    /// `fetchContents` persists `downloaded = true` before the system adds the file to its
+    /// materialized set. Reconciling in that window flipped the row back to dataless, the
+    /// framework re-requested the content, and the cycle repeated — 132,165 dataless transitions
+    /// in one observed extension log.
+    ///
+    func testRecentlyDownloadedItemIsNotReconciledAsEvicted() async {
+        var downloaded = SendableItemMetadata(ocId: "fresh", fileName: "fresh.otf", account: Self.account)
+        downloaded.downloaded = true
+        dbManager.addItemMetadata(downloaded)
+
+        PendingMaterializationRegistry.shared.recordDownloaded(NSFileProviderItemIdentifier("fresh"))
+
+        let expectation = XCTestExpectation(description: "Reconciliation finished")
+        let observer = MaterializedEnumerationObserver(
+            account: Self.account, dbManager: dbManager, log: FileProviderLogMock()
+        ) { _, evicted in
+            XCTAssertFalse(
+                evicted.contains(NSFileProviderItemIdentifier("fresh")),
+                "A download the system has not confirmed yet must not count as evicted."
+            )
+            expectation.fulfill()
+        }
+
+        // The system reports nothing: it has not caught up with the download.
+        observer.finishEnumerating(upTo: nil)
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(dbManager.itemMetadata(ocId: "fresh")?.downloaded, true)
+    }
+
+    ///
+    /// A visited directory absent from the system's materialized set must not be reconciled as
+    /// evicted. Only files carry materialized content; a directory qualifies as materialized
+    /// through `visitedDirectory`, which the reconciliation preserves, so marking it dataless never
+    /// removed it from the candidate set and it was re-evicted on every pass forever (630
+    /// directories × 80 passes = 30,117 transitions in one seven-minute run).
+    ///
+    func testVisitedDirectoryIsNotReconciledAsEvicted() async {
+        var directory = SendableItemMetadata(ocId: "folder", fileName: "glyphs", account: Self.account)
+        directory.directory = true
+        directory.visitedDirectory = true
+        dbManager.addItemMetadata(directory)
+
+        for pass in 1 ... 3 {
+            let expectation = XCTestExpectation(description: "Reconciliation pass \(pass) finished")
+            let observer = MaterializedEnumerationObserver(
+                account: Self.account, dbManager: dbManager, log: FileProviderLogMock()
+            ) { _, evicted in
+                XCTAssertFalse(
+                    evicted.contains(NSFileProviderItemIdentifier("folder")),
+                    "A directory must never be reported as evicted (pass \(pass))."
+                )
+                expectation.fulfill()
+            }
+
+            observer.finishEnumerating(upTo: nil)
+            await fulfillment(of: [expectation], timeout: 1)
+        }
+
+        let stored = dbManager.itemMetadata(ocId: "folder")
+        XCTAssertEqual(stored?.visitedDirectory, true, "The refresh subscription must survive.")
+    }
+
+    ///
+    /// The control for the test above: once the system has confirmed the item, an ordinary
+    /// eviction must still be detected on the very next pass.
+    ///
+    func testConfirmedItemIsReconciledAsEvictedOnTheNextPass() async {
+        var downloaded = SendableItemMetadata(ocId: "settled", fileName: "settled.otf", account: Self.account)
+        downloaded.downloaded = true
+        dbManager.addItemMetadata(downloaded)
+
+        PendingMaterializationRegistry.shared.recordDownloaded(NSFileProviderItemIdentifier("settled"))
+
+        // Pass one: the system reports the item, which clears the pending record.
+        let confirmation = XCTestExpectation(description: "Confirmation pass finished")
+        let confirmingObserver = MaterializedEnumerationObserver(
+            account: Self.account, dbManager: dbManager, log: FileProviderLogMock()
+        ) { _, _ in confirmation.fulfill() }
+        confirmingObserver.didEnumerate([MockFileProviderItem(identifier: NSFileProviderItemIdentifier("settled"), filename: "settled.otf", isUploaded: true)])
+        confirmingObserver.finishEnumerating(upTo: nil)
+        await fulfillment(of: [confirmation], timeout: 1)
+
+        // Pass two: the item is gone from the system's materialized set, i.e. genuinely evicted.
+        let eviction = XCTestExpectation(description: "Eviction pass finished")
+        let evictingObserver = MaterializedEnumerationObserver(
+            account: Self.account, dbManager: dbManager, log: FileProviderLogMock()
+        ) { _, evicted in
+            XCTAssertTrue(evicted.contains(NSFileProviderItemIdentifier("settled")))
+            eviction.fulfill()
+        }
+        evictingObserver.finishEnumerating(upTo: nil)
+        await fulfillment(of: [eviction], timeout: 1)
+
+        XCTAssertEqual(dbManager.itemMetadata(ocId: "settled")?.downloaded, false)
+    }
+
+    ///
+    /// A failed enumeration is a partial result, not evidence of eviction. Reconciling it marked
+    /// everything the system had not yet reported as dataless.
+    ///
+    func testFailedEnumerationDoesNotTouchTheDatabase() async {
+        var downloaded = SendableItemMetadata(ocId: "untouched", fileName: "untouched.otf", account: Self.account)
+        downloaded.downloaded = true
+        dbManager.addItemMetadata(downloaded)
+
+        let expectation = XCTestExpectation(description: "Error handling finished")
+        let observer = MaterializedEnumerationObserver(
+            account: Self.account, dbManager: dbManager, log: FileProviderLogMock()
+        ) { materialized, evicted in
+            XCTAssertTrue(materialized.isEmpty)
+            XCTAssertTrue(evicted.isEmpty)
+            expectation.fulfill()
+        }
+
+        observer.finishEnumeratingWithError(NSFileProviderError(.serverUnreachable))
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: "untouched")?.downloaded,
+            true,
+            "A partial enumeration must not mark unreported items dataless."
+        )
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -1145,7 +1145,9 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             log: FileProviderLogMock()
         )
         print(storedRootItem.metadata.serverUrl)
-        XCTAssertEqual(storedRootItem.childItemCount?.intValue, 4) // All items
+        // Direct children of the root only: the folder and the item just moved out of it.
+        // `itemB` stays inside the folder and the root's own row does not count itself.
+        XCTAssertEqual(storedRootItem.childItemCount?.intValue, 2)
 
         let storedFolderMaybe = await Item.storedItem(
             identifier: .init(remoteFolder.identifier),

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -2248,4 +2248,75 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         let storedB = try XCTUnwrap(Self.dbManager.itemMetadata(ocId: "B"))
         XCTAssertFalse(storedB.deleted)
     }
+
+    // MARK: - Redundant-write suppression
+
+    ///
+    /// The paginated ingestion path calls this for every row of every listing. It used to write
+    /// unconditionally — one transaction and one duplicate-eviction query per item — so a scan that
+    /// found nothing still rewrote the whole set. Measured on one working-set scan: 1,998 rows
+    /// rewritten for 7 real changes.
+    ///
+    /// `syncTime` is the observable: it is carried from the incoming payload, so it advances if and
+    /// only if the row was actually written.
+    ///
+    private func seedRow(ocId: String, etag: String, syncTime: Date, visited: Bool = false) -> SendableItemMetadata {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: "doc.txt", account: Self.account)
+        metadata.etag = etag
+        metadata.syncTime = syncTime
+        metadata.visitedDirectory = visited
+        // The convenience initializer stamps `Date()`, and `date` is part of the remote-state
+        // comparison — pin it so successive rows differ only where the test intends.
+        metadata.date = Date(timeIntervalSince1970: 500_000)
+        metadata.creationDate = Date(timeIntervalSince1970: 500_000)
+        return metadata
+    }
+
+    func testUnchangedRemoteStateIsNotRewritten() {
+        let ocId = "unchanged-\(name)"
+        let firstSeen = Date(timeIntervalSince1970: 1_000_000)
+        Self.dbManager.addItemMetadata(seedRow(ocId: ocId, etag: "v1", syncTime: firstSeen))
+
+        // Same remote state arriving again on a later scan.
+        let rescanned = seedRow(ocId: ocId, etag: "v1", syncTime: Date(timeIntervalSince1970: 2_000_000))
+        let returned = Self.dbManager.addItemMetadataPreservingLocalState(rescanned)
+
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: ocId)?.syncTime, firstSeen,
+            "An unchanged row must not be rewritten."
+        )
+        XCTAssertEqual(returned.ocId, ocId, "The merged metadata must still be returned to the caller.")
+        XCTAssertEqual(returned.etag, "v1")
+    }
+
+    func testChangedRemoteStateIsStillWritten() {
+        let ocId = "changed-\(name)"
+        Self.dbManager.addItemMetadata(seedRow(ocId: ocId, etag: "v1", syncTime: Date(timeIntervalSince1970: 1_000_000)))
+
+        let later = Date(timeIntervalSince1970: 2_000_000)
+        Self.dbManager.addItemMetadataPreservingLocalState(seedRow(ocId: ocId, etag: "v2", syncTime: later))
+
+        let stored = Self.dbManager.itemMetadata(ocId: ocId)
+        XCTAssertEqual(stored?.etag, "v2", "A real remote change must still be persisted.")
+        XCTAssertEqual(stored?.syncTime, later)
+    }
+
+    /// A caller passing `preserveVisitedDirectory: false` is recording a visit. `visitedDirectory` is
+    /// local-only and therefore not part of `isInSameDatabaseStoreableRemoteState`, so the skip must
+    /// compare it explicitly or the visit would be silently dropped.
+    func testRecordingADirectoryVisitIsAlwaysWritten() {
+        let ocId = "visit-\(name)"
+        var directory = seedRow(ocId: ocId, etag: "v1", syncTime: Date(timeIntervalSince1970: 1_000_000))
+        directory.directory = true
+        Self.dbManager.addItemMetadata(directory)
+
+        var visited = seedRow(ocId: ocId, etag: "v1", syncTime: Date(timeIntervalSince1970: 2_000_000), visited: true)
+        visited.directory = true
+        Self.dbManager.addItemMetadataPreservingLocalState(visited, preserveVisitedDirectory: false)
+
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: ocId)?.visitedDirectory, true,
+            "Recording a directory visit must be written even when the remote state is unchanged."
+        )
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/MaterialisedEnumerationObserverTests.swift
@@ -102,12 +102,15 @@ final class MaterialisedEnumerationObserverTests: NextcloudFileProviderKitTestCa
         let enumeratorItemsToReturn = [itemB, itemC]
 
         let observer = MaterializedEnumerationObserver(account: Self.account, dbManager: dbManager, log: FileProviderLogMock()) { newlyMaterialisedIds, unmaterialisedIds in
-            // Unmaterialised: itemA and dirD were materialized but not in the latest enumeration.
+            // Unmaterialised: only itemA. dirD is a directory, and a directory carries no
+            // materialized content of its own — it stays materialized through `visitedDirectory`,
+            // which this reconciliation preserves, so reporting it evicted would repeat on every
+            // pass forever.
             XCTAssertEqual(
-                unmaterialisedIds.count, 2, "itemA and dirD should be reported as unmaterialised."
+                unmaterialisedIds.count, 1, "Only itemA should be reported as unmaterialised."
             )
             XCTAssertTrue(unmaterialisedIds.contains(NSFileProviderItemIdentifier("itemA")))
-            XCTAssertTrue(unmaterialisedIds.contains(NSFileProviderItemIdentifier("dirD")))
+            XCTAssertFalse(unmaterialisedIds.contains(NSFileProviderItemIdentifier("dirD")))
 
             // Newly Materialised: itemB was NOT materialized but WAS in the latest enumeration.
             XCTAssertEqual(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
@@ -14,6 +14,9 @@ class NextcloudFileProviderKitTestCase: XCTestCase {
         // `PendingMaterializationRegistry` is a process-wide singleton, so entries recorded by a
         // download in one test would otherwise suppress the eviction reconciliation in another.
         PendingMaterializationRegistry.shared.removeAll()
+        // Likewise process-wide: targets recorded by one test must not steer another's scan, and a
+        // stale "last full scan" timestamp would silently turn a full walk into a targeted one.
+        RemoteChangeTargets.shared.removeAll()
     }
 
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NextcloudFileProviderKitTestCase.swift
@@ -1,12 +1,21 @@
 //  SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 //  SPDX-License-Identifier: LGPL-3.0-or-later
 
+@testable import NextcloudFileProviderKit
 import XCTest
 
 ///
 /// Common base class for all tests in this target.
 ///
 class NextcloudFileProviderKitTestCase: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        // `PendingMaterializationRegistry` is a process-wide singleton, so entries recorded by a
+        // download in one test would otherwise suppress the eviction reconciliation in another.
+        PendingMaterializationRegistry.shared.removeAll()
+    }
+
     ///
     /// Create a unique and temporary directory for Realm database testing purposes.
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/PerformanceBenchmarkTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/PerformanceBenchmarkTests.swift
@@ -1,0 +1,490 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+//
+//  Reproducible measurements for the working-set scan changes.
+//
+//  The figures quoted in the pull request were gathered on a live account and are not reproducible
+//  from a checkout. What *is* reproducible is the mechanism underneath each of them, and that is
+//  what these tests pin:
+//
+//    - how many PROPFINDs one scan issues (the "full walk vs. push-targeted walk" figure),
+//    - how many database rows one scan rewrites (the "1,998 rows to surface 7 changes" figure),
+//    - how many of the scan's reads overlap in time (the "76 seconds of sequential PROPFINDs"
+//      figure).
+//
+//  Each is a count, not a duration, so they hold on any machine and in CI. The two timing-shaped
+//  benchmarks additionally report a wall clock via `measure`, which is only comparable between
+//  revisions on the same machine — run them on `stable-34.0` and on this branch to reproduce the
+//  ratio, not the absolute numbers. See `Documentation/WorkingSetScanBenchmarks.md`.
+//
+
+@preconcurrency import FileProvider
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import NextcloudKit
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+final class PerformanceBenchmarkTests: NextcloudFileProviderKitTestCase {
+    static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    /// Directories in the synthetic tree. Each is materialised, so each is one PROPFIND of a full
+    /// walk. Large enough that a concurrency limit of six is visibly exercised, small enough to keep
+    /// the suite fast.
+    static let directoryCount = 30
+
+    /// Files per directory. They are materialised too, but a depth-1 read of their parent covers
+    /// them, so they must not add reads to the scan — which is itself one of the things measured.
+    static let filesPerDirectory = 6
+
+    /// Files in the single wide directory the write-volume benchmarks enumerate. Wide enough to
+    /// span several pages at ``paginatedPageSize``, which is the path that used to rewrite every row
+    /// it read.
+    static let paginatedDirectoryFileCount = 200
+
+    /// Page size for those enumerations, so the listing really is delivered in pages.
+    static let paginatedPageSize = 50
+
+    /// Stand-in for a PROPFIND round trip, used by the benchmarks that measure overlap rather than
+    /// counts. Reads against the mock tree are otherwise instantaneous, which hides the only cost
+    /// the scan actually pays.
+    static let simulatedReadLatency: TimeInterval = 0.05
+
+    private var dbManager: FilesDatabaseManager!
+    private var rootItem: MockRemoteItem!
+    private var directories: [MockRemoteItem] = []
+
+    /// Seeded rows are stamped well before the anchor, so a row whose `syncTime` has moved past this
+    /// is a row the scan wrote.
+    private let seedSyncTime = Date(timeIntervalSinceNow: -600)
+    private let anchorDate = Date(timeIntervalSinceNow: -300)
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: makeDatabaseDirectory(),
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+        rootItem = MockRemoteItem.rootItem(account: Self.account)
+        directories = []
+    }
+
+    override func tearDown() {
+        directories = []
+        rootItem = nil
+        dbManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Fixture
+
+    ///
+    /// Build a materialised tree of ``directoryCount`` directories, each holding
+    /// ``filesPerDirectory`` files, and seed the database with its current state.
+    ///
+    /// Every row is seeded from the mock's own state, so the tree starts fully in sync: a scan of it
+    /// has nothing to report and nothing to write, which is the baseline both count benchmarks
+    /// measure against.
+    ///
+    private func buildMaterialisedTree() {
+        for directoryIndex in 0 ..< Self.directoryCount {
+            let directory = makeFolder(
+                name: "folder-\(directoryIndex)", parent: rootItem, etag: "folder-\(directoryIndex)-v1"
+            )
+            directories.append(directory)
+
+            for fileIndex in 0 ..< Self.filesPerDirectory {
+                let file = makeFile(
+                    name: "file-\(directoryIndex)-\(fileIndex).txt",
+                    parent: directory,
+                    etag: "file-\(directoryIndex)-\(fileIndex)-v1"
+                )
+                seed(file, downloaded: true)
+            }
+
+            seed(directory, visitedDirectory: true)
+        }
+    }
+
+    @discardableResult
+    private func seed(
+        _ item: MockRemoteItem, downloaded: Bool = false, visitedDirectory: Bool = false
+    ) -> SendableItemMetadata {
+        var metadata = item.toItemMetadata(account: Self.account)
+        metadata.downloaded = downloaded
+        metadata.visitedDirectory = visitedDirectory
+        metadata.syncTime = seedSyncTime
+        dbManager.addItemMetadata(metadata)
+        return metadata
+    }
+
+    ///
+    /// Build one directory of ``paginatedDirectoryFileCount`` files and seed the database with its
+    /// current state, so an enumeration of it has nothing to persist.
+    ///
+    /// Separate from ``buildMaterialisedTree()`` because write volume is a property of the
+    /// *enumeration* path, which paginates on servers from Nextcloud 31, whereas the working-set
+    /// scan reads without pagination. One wide directory is what that path actually pages through.
+    ///
+    private func buildPaginatedDirectory() -> MockRemoteItem {
+        let folder = makeFolder(name: "paginated", parent: rootItem, etag: "paginated-v1")
+
+        for fileIndex in 0 ..< Self.paginatedDirectoryFileCount {
+            let file = makeFile(
+                name: "file-\(fileIndex).txt", parent: folder, etag: "file-\(fileIndex)-v1"
+            )
+            seed(file)
+        }
+
+        seed(folder, visitedDirectory: true)
+        return folder
+    }
+
+    ///
+    /// Page through a directory exactly as ``Enumerator/enumerateItems(for:startingAt:)`` does on a
+    /// Nextcloud 31+ server, and return how many pages it took.
+    ///
+    /// The read is driven through ``Enumerator/readServerUrl(_:pageSettings:account:remoteInterface:dbManager:domain:enumeratedItemIdentifier:depth:log:)``
+    /// directly because the enumerator decides whether to paginate from the server's advertised
+    /// major version, and the mock advertises 28. Passing `pageSettings` is the same switch that
+    /// version check flips.
+    ///
+    @discardableResult
+    private func enumerateItemsPaginated(
+        of folder: MockRemoteItem, using remoteInterface: MockRemoteInterface
+    ) async throws -> Int {
+        var page: NSFileProviderPage?
+        var index = 0
+
+        while true {
+            let result = await Enumerator.readServerUrl(
+                folder.remotePath,
+                pageSettings: (page: page, index: index, size: Self.paginatedPageSize),
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: dbManager,
+                depth: .targetAndDirectChildren,
+                log: FileProviderLogMock()
+            )
+
+            if let error = result.error, error != .success {
+                XCTFail("Paginated read of page \(index) failed: \(error)")
+                break
+            }
+
+            index += 1
+
+            guard let token = result.nextPage?.token,
+                  let tokenData = token.data(using: .utf8)
+            else { break }
+
+            page = NSFileProviderPage(tokenData)
+        }
+
+        return index
+    }
+
+    private func makeFolder(name: String, parent: MockRemoteItem, etag: String) -> MockRemoteItem {
+        let folder = MockRemoteItem(
+            identifier: name,
+            versionIdentifier: etag,
+            name: name,
+            remotePath: parent.remotePath + "/" + name,
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        folder.parent = parent
+        parent.children.append(folder)
+        return folder
+    }
+
+    private func makeFile(
+        name: String, parent: MockRemoteItem, etag: String, data: Data = Data([1, 2, 3])
+    ) -> MockRemoteItem {
+        let file = MockRemoteItem(
+            identifier: name,
+            versionIdentifier: etag,
+            name: name,
+            remotePath: parent.remotePath + "/" + name,
+            data: data,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        file.parent = parent
+        parent.children.append(file)
+        return file
+    }
+
+    private func runWorkingSetChanges(
+        _ remoteInterface: MockRemoteInterface
+    ) async throws -> MockChangeObserver {
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager,
+            log: FileProviderLogMock()
+        )
+        let observer = MockChangeObserver(enumerator: enumerator)
+        try await observer.enumerateChanges(from: Enumerator.syncAnchor(at: anchorDate))
+        return observer
+    }
+
+    /// Rows whose persisted `syncTime` has moved past the seeded value, i.e. rows the scan wrote.
+    /// The skip guard in `addItemMetadataPreservingLocalState` returns before the write, so a
+    /// skipped row keeps its seeded timestamp exactly.
+    private func rewrittenRowCount() -> Int {
+        dbManager
+            .ncDatabase()
+            .objects(RealmItemMetadata.self)
+            .filter { $0.syncTime > self.seedSyncTime }
+            .count
+    }
+
+    private var totalSeededRows: Int {
+        Self.directoryCount * (Self.filesPerDirectory + 1)
+    }
+
+    // MARK: - Request volume
+
+    ///
+    /// A full walk reads every materialised *directory* once and no materialised file individually:
+    /// a depth-1 read of the parent already carries each child's state.
+    ///
+    /// This is the baseline the push-targeted figure is a ratio against, and it is also the guard
+    /// against the walk silently regaining per-file reads — the shape that made one measured pass
+    /// spend 76 seconds on 669 PROPFINDs to surface no changes at all.
+    ///
+    func testFullWalkReadsEachMaterialisedDirectoryOnce() async throws {
+        buildMaterialisedTree()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.resetOperationCounters()
+
+        _ = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertEqual(
+            remoteInterface.readOperationCount,
+            Self.directoryCount,
+            """
+            A full walk must issue exactly one read per materialised directory (\(Self.directoryCount)), \
+            and none for the \(Self.directoryCount * Self.filesPerDirectory) materialised files their \
+            depth-1 reads already cover.
+            """
+        )
+    }
+
+    ///
+    /// A walk restricted to the containers a push named reads only those containers, and still
+    /// reports the change inside one of them.
+    ///
+    /// This is the mechanism behind the largest figure in the pull request: a push identifies the
+    /// changed file within a second or so, but the extension used to answer it by walking the whole
+    /// materialised set. The ratio here is the same one measured on the live account — reads fall
+    /// from "every materialised directory" to "the directories that changed".
+    ///
+    func testPushTargetedWalkReadsOnlyTheNamedContainers() async throws {
+        buildMaterialisedTree()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // First pass: a full walk, which is also what arms the interval that lets the next pass be
+        // targeted at all (`RemoteChangeTargets.shouldRunFullScan()` forces a full walk until one
+        // has completed).
+        remoteInterface.resetOperationCounters()
+        _ = try await runWorkingSetChanges(remoteInterface)
+        let fullWalkReads = remoteInterface.readOperationCount
+
+        // A file changes on the server inside one directory, and the push names that directory.
+        let changedDirectory = try XCTUnwrap(directories.first)
+        let changedFile = try XCTUnwrap(changedDirectory.children.first)
+        changedFile.versionIdentifier = "changed-v2"
+        changedFile.modificationDate = Date()
+        changedDirectory.versionIdentifier = "folder-0-v2"
+        RemoteChangeTargets.shared.record(
+            containers: [NSFileProviderItemIdentifier(changedDirectory.identifier)]
+        )
+
+        remoteInterface.resetOperationCounters()
+        let observer = try await runWorkingSetChanges(remoteInterface)
+        let targetedReads = remoteInterface.readOperationCount
+
+        XCTAssertNil(observer.error)
+        XCTAssertEqual(
+            targetedReads,
+            1,
+            "A push naming one container must be answered with one read, not a walk of the whole materialised set."
+        )
+        XCTAssertEqual(
+            fullWalkReads,
+            Self.directoryCount,
+            "The full walk this is measured against must still read every materialised directory."
+        )
+        XCTAssertTrue(
+            observer.changedItems.contains { $0.itemIdentifier.rawValue == changedFile.identifier },
+            "The targeted walk must still report the change that prompted the push."
+        )
+    }
+
+    // MARK: - Write volume
+
+    ///
+    /// Enumerating a directory whose contents have not changed writes no rows.
+    ///
+    /// Servers from Nextcloud 31 answer every enumeration with a paginated listing, and that
+    /// ingestion path used to write every row it read — one write transaction and one
+    /// `evictLogicalDuplicates` query each — whether or not the server state differed from the row
+    /// already held. One measured working-set pass rewrote 1,998 rows to surface 7 real changes.
+    ///
+    /// The count here is exact rather than a ratio: an unchanged listing has nothing to persist, so
+    /// the correct number of writes is zero. On `stable-34.0` this is
+    /// ``paginatedDirectoryFileCount`` + 1 — every row, plus the directory itself.
+    ///
+    func testUnchangedPaginatedEnumerationWritesNoRows() async throws {
+        let folder = buildPaginatedDirectory()
+
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account, rootItem: rootItem, pagination: true
+        )
+        try await enumerateItemsPaginated(of: folder, using: remoteInterface)
+
+        XCTAssertEqual(
+            rewrittenRowCount(),
+            0,
+            """
+            An enumeration that finds nothing changed must not rewrite any of the \
+            \(Self.paginatedDirectoryFileCount + 1) rows it read.
+            """
+        )
+    }
+
+    ///
+    /// The control for the test above: one changed file is still persisted, and nothing else is.
+    ///
+    /// Without this, "writes no rows" would also be satisfied by a guard that suppressed genuine
+    /// changes — which is the failure mode that matters, because a suppressed write is a change the
+    /// user never sees.
+    ///
+    func testChangedPaginatedEnumerationWritesOnlyTheChangedRow() async throws {
+        let folder = buildPaginatedDirectory()
+
+        let changedFile = try XCTUnwrap(folder.children.first)
+        changedFile.versionIdentifier = "changed-v2"
+        changedFile.modificationDate = Date()
+
+        let remoteInterface = MockRemoteInterface(
+            account: Self.account, rootItem: rootItem, pagination: true
+        )
+        try await enumerateItemsPaginated(of: folder, using: remoteInterface)
+
+        let changedRow = try XCTUnwrap(dbManager.itemMetadata(ocId: changedFile.identifier))
+        XCTAssertEqual(
+            changedRow.etag,
+            "changed-v2",
+            "The changed file must still be persisted; the guard suppresses redundant writes, not real ones."
+        )
+        XCTAssertEqual(
+            rewrittenRowCount(),
+            1,
+            """
+            Only the changed file may be rewritten, out of \
+            \(Self.paginatedDirectoryFileCount + 1) rows read.
+            """
+        )
+    }
+
+    // MARK: - Read overlap
+
+    ///
+    /// The scan's reads overlap, up to its concurrency limit.
+    ///
+    /// The limit itself is deliberately not asserted as an exact value — it is a tuning constant.
+    /// What must hold is that reads at the same depth run together rather than one after another,
+    /// and that the overlap stays bounded rather than fanning out over the whole materialised set.
+    ///
+    /// On `stable-34.0` this reads 1: every PROPFIND waited for the one before it.
+    ///
+    func testWalkReadsOverlap() async throws {
+        buildMaterialisedTree()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.enumerateLatency = Self.simulatedReadLatency
+        remoteInterface.resetOperationCounters()
+
+        _ = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertGreaterThan(
+            remoteInterface.maxConcurrentEnumerations,
+            1,
+            "The scan's reads must overlap; a high-water mark of 1 means it went back to waiting for each read in turn."
+        )
+        XCTAssertLessThanOrEqual(
+            remoteInterface.maxConcurrentEnumerations,
+            Self.directoryCount,
+            "Overlap must stay bounded rather than issuing the whole materialised set at once."
+        )
+    }
+
+    ///
+    /// Wall clock of one full walk over ``directoryCount`` directories whose reads each take
+    /// ``simulatedReadLatency``.
+    ///
+    /// Reported rather than asserted: the absolute number depends on the machine. Run this on
+    /// `stable-34.0` and on this branch to reproduce the ratio. With a sequential scan the floor is
+    /// `directoryCount * simulatedReadLatency`; with overlapping reads it is that divided by the
+    /// concurrency the scan achieves.
+    ///
+    func testFullWalkWallClock() async throws {
+        buildMaterialisedTree()
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.enumerateLatency = Self.simulatedReadLatency
+
+        // The first pass brings the tree in sync; the passes after it issue the same reads and write
+        // nothing, so they time the walk itself rather than the ingestion behind it.
+        _ = try await runWorkingSetChanges(remoteInterface)
+
+        var durations = [Duration]()
+        let clock = ContinuousClock()
+
+        for _ in 0 ..< 3 {
+            remoteInterface.resetOperationCounters()
+            let elapsed = try await clock.measure {
+                _ = try await runWorkingSetChanges(remoteInterface)
+            }
+            durations.append(elapsed)
+        }
+
+        let best = durations.min() ?? .zero
+        let sequentialFloor = Duration.seconds(
+            Double(Self.directoryCount) * Self.simulatedReadLatency
+        )
+
+        print("""
+        [benchmark] full working-set walk over \(Self.directoryCount) directories         (\(Self.filesPerDirectory) files each, \(Int(Self.simulatedReadLatency * 1000))ms per read)
+        [benchmark]   best of \(durations.count): \(best)
+        [benchmark]   sequential floor: \(sequentialFloor)
+        [benchmark]   peak read overlap: \(remoteInterface.maxConcurrentEnumerations)
+        """)
+
+        XCTAssertLessThan(
+            best,
+            sequentialFloor,
+            """
+            The walk must finish faster than issuing its \(Self.directoryCount) reads one after             another would allow. This is the only timing assertion here, and it is a ceiling the             sequential scan cannot meet by construction rather than a tuned threshold.
+            """
+        )
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -729,4 +729,129 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
         )
     }
 
+    // MARK: - Push-targeted scanning
+
+    /// A push names what changed; the client must turn that into where to look. A changed file
+    /// resolves to its parent container, a changed directory to itself.
+    func testPushedFileIdsResolveToContainersToReRead() {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        folder.identifier = "1000"
+        let file = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+        file.identifier = "1001"
+        seed(folder, visitedDirectory: true)
+        seed(file, downloaded: true)
+
+        // The file resolves to its parent folder: a depth-1 read of the parent shows the file's new
+        // state, or its absence.
+        let forFile = Self.dbManager.containersForPushedFileIds(["1001"])
+        XCTAssertFalse(
+            forFile.contains(NSFileProviderItemIdentifier(file.identifier)),
+            "The file itself is not a container to read."
+        )
+        XCTAssertTrue(
+            forFile.contains(NSFileProviderItemIdentifier(folder.identifier)),
+            "A changed file must resolve to its parent container. Got: \(forFile)"
+        )
+
+        // A directory resolves to itself.
+        XCTAssertTrue(
+            Self.dbManager.containersForPushedFileIds(["1000"])
+                .contains(NSFileProviderItemIdentifier(folder.identifier))
+        )
+
+        // Ids outside the enumerated tree contribute nothing.
+        XCTAssertTrue(Self.dbManager.containersForPushedFileIds(["9001"]).isEmpty)
+    }
+
+    /// The point of the whole change: a push naming one folder must read that folder, not the entire
+    /// materialised set.
+    func testATargetedScanReadsOnlyTheTargetedContainer() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let targeted = makeFolder(name: "targeted", parent: rootItem, etag: "targeted-v1")
+        let untouched = makeFolder(name: "untouched", parent: rootItem, etag: "untouched-v1")
+        seed(targeted, visitedDirectory: true)
+        seed(untouched, visitedDirectory: true)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        _ = await enumerator.scanMaterialisedItemsForRemoteChanges(
+            restrictedToContainers: [NSFileProviderItemIdentifier(targeted.identifier)]
+        )
+
+        let paths = recorder.paths
+        XCTAssertTrue(paths.contains { $0.hasSuffix("/targeted") }, "The targeted container is read.")
+        XCTAssertFalse(
+            paths.contains { $0.hasSuffix("/untouched") },
+            "An untargeted container must not be read. Got: \(paths)"
+        )
+    }
+
+    /// Push is an accelerator, not a replacement: with nothing targeted the walk must still be full,
+    /// or anything push dropped would never reconcile.
+    func testWithNothingTargetedTheScanIsStillFull() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let a = makeFolder(name: "alpha", parent: rootItem, etag: "alpha-v1")
+        let b = makeFolder(name: "beta", parent: rootItem, etag: "beta-v1")
+        seed(a, visitedDirectory: true)
+        seed(b, visitedDirectory: true)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let enumerator = try Enumerator(
+            enumeratedItemIdentifier: .workingSet,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        _ = await enumerator.scanMaterialisedItemsForRemoteChanges(restrictedToContainers: nil)
+
+        let paths = recorder.paths
+        XCTAssertTrue(paths.contains { $0.hasSuffix("/alpha") })
+        XCTAssertTrue(paths.contains { $0.hasSuffix("/beta") }, "A full scan reads every materialised container.")
+    }
+
+    /// A steady stream of pushes must not postpone reconciliation forever.
+    func testAFullScanIsForcedOnceTheIntervalElapses() {
+        let targets = RemoteChangeTargets.shared
+
+        XCTAssertTrue(targets.shouldRunFullScan(), "Before any full scan has run, one is due.")
+
+        let completedAt = Date()
+        targets.noteFullScanCompleted(at: completedAt)
+        XCTAssertFalse(targets.shouldRunFullScan(now: completedAt.addingTimeInterval(60)))
+        XCTAssertTrue(
+            targets.shouldRunFullScan(now: completedAt.addingTimeInterval(RemoteChangeTargets.fullScanInterval + 1)),
+            "Once the interval has elapsed a full reconciliation is due again."
+        )
+    }
+
+    /// Consuming clears, so one push's containers are not re-scanned on every later derivation.
+    func testConsumingTargetsClearsThem() {
+        let targets = RemoteChangeTargets.shared
+        XCTAssertNil(targets.consumeTargets(), "Nothing recorded means no targeting information.")
+
+        targets.record(containers: [NSFileProviderItemIdentifier("a"), NSFileProviderItemIdentifier("b")])
+        XCTAssertEqual(targets.consumeTargets()?.count, 2)
+        XCTAssertNil(targets.consumeTargets(), "A second derivation must not reuse consumed targets.")
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -634,4 +634,55 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
         )
     }
+
+    ///
+    /// A trashed folder must not be scanned through the ordinary DAV path.
+    ///
+    /// Trashing rewrites `serverUrl` to the trashbin but leaves `deleted == false`, and a folder
+    /// keeps `visitedDirectory`, so the row stayed in the materialised set. The scan then PROPFINDed
+    /// `/remote.php/dav/trashbin/<user>/trash/<name>.dNNNN`, which 404s — and the scan reads a 404
+    /// as "the item is gone", reporting it deleted and hard-removing the very row the trash
+    /// reconciliation derives permanent deletions from.
+    ///
+    func testTrashedFolderIsNotScannedThroughTheRegularDavPath() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let liveFolder = makeFolder(name: "live", parent: rootItem, etag: "live-v1")
+        seed(liveFolder, visitedDirectory: true)
+
+        // A folder the user trashed: still visited, not soft-deleted, but living in the trashbin.
+        var trashed = makeFolder(name: "gone", parent: rootItem, etag: "gone-v1")
+            .toItemMetadata(account: Self.account)
+        trashed.ocId = "trashed-folder"
+        trashed.visitedDirectory = true
+        trashed.deleted = false
+        trashed.syncTime = oldSyncTime
+        trashed.serverUrl = Self.account.trashUrl
+        trashed.apply(fileName: "gone.d1788354069")
+        Self.dbManager.addItemMetadata(trashed)
+        XCTAssertTrue(trashed.isTrashed, "Precondition: the row must look trashed.")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+        let enumeratedPaths = recorder.paths
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            enumeratedPaths.contains { $0.hasSuffix("/live") },
+            "Sanity: the live materialised folder is still scanned."
+        )
+        XCTAssertFalse(
+            enumeratedPaths.contains { $0.contains("/trashbin/") },
+            "A trashed row must never be PROPFINDed through the regular DAV path. Got: \(enumeratedPaths)"
+        )
+        XCTAssertNotNil(
+            Self.dbManager.itemMetadata(ocId: "trashed-folder"),
+            "The trash row must survive the scan; trash reconciliation derives deletions from it."
+        )
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -685,4 +685,48 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "The trash row must survive the scan; trash reconciliation derives deletions from it."
         )
     }
+
+    ///
+    /// A directory's depth-1 read already returns its children's state, so unchanged children must
+    /// not be PROPFINDed individually.
+    ///
+    /// This is the coverage rule the scan's ordering exists to serve, and the one thing the
+    /// concurrent (depth-stratified) walk must not lose: a parent is always one level shallower than
+    /// the children it covers, so it is always read in an earlier wave. Batch the walk by anything
+    /// other than depth and a folder plus its files land in the same wave, every file is read
+    /// separately, and the read count multiplies.
+    ///
+    func testUnchangedChildrenAreCoveredByTheirParentsRead() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let fileA = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+        let fileB = makeFile(name: "itemB", parent: folder, etag: "itemB-v1")
+
+        // Folder visited, both files downloaded: all three are in the materialised set and so all
+        // three seed the scan. Nothing has changed on the server.
+        seed(folder, visitedDirectory: true)
+        seed(fileA, downloaded: true)
+        seed(fileB, downloaded: true)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+        let enumeratedPaths = recorder.paths
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            enumeratedPaths.contains { $0.hasSuffix("/folder") },
+            "The materialised folder is read at depth 1."
+        )
+        XCTAssertFalse(
+            enumeratedPaths.contains { $0.hasSuffix("/folder/itemA") || $0.hasSuffix("/folder/itemB") },
+            "Unchanged children are covered by the parent's depth-1 read and must not be read individually. Got: \(enumeratedPaths)"
+        )
+    }
+
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -537,4 +537,101 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "A push with no locally known ids is correctly ignored."
         )
     }
+
+    /// Headline regression for nextcloud/desktop#9688 and #10681: a folder the user creates on the Mac,
+    /// then an item created inside it on the server (web UI, public upload link, another user).
+    ///
+    /// The folder is created through the real `Item.create` path rather than `seed(...)`, because the bug
+    /// was in what creation writes to the database: it set `downloaded` but not `visitedDirectory`, and
+    /// only `visitedDirectory` puts a directory into the materialised set that
+    /// `scanMaterialisedItemsForRemoteChanges()` reads. The folder was therefore never PROPFINDed by the
+    /// working-set scan, and the parent's depth-1 read would not enqueue it either — a changed child
+    /// directory is only crawled when its subtree holds something materialised, and a brand-new remote
+    /// item is not downloaded. macOS never re-enumerates a container the extension created for it, so
+    /// nothing repaired the gap: the new item stayed invisible until the folder was forced offline
+    /// ("Keep offline"), which is exactly the workaround both issues report.
+    func testItemCreatedOnServerInLocallyCreatedFolderIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // Create the folder the way Finder does, through the extension's create path.
+        var folderMetadata = SendableItemMetadata(
+            ocId: "folder-id", fileName: "folder", account: Self.account
+        )
+        folderMetadata.directory = true
+        folderMetadata.classFile = NKTypeClassFile.directory.rawValue
+        folderMetadata.serverUrl = Self.account.davFilesUrl
+
+        let (createdFolderMaybe, createError) = await Item.create(
+            basedOn: Item(
+                metadata: folderMetadata,
+                parentItemIdentifier: .rootContainer,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager
+            ),
+            contents: nil,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        XCTAssertNil(createError)
+        let createdFolder = try XCTUnwrap(createdFolderMaybe)
+
+        // The server-side creation inside that folder. Nothing in the subtree is materialised.
+        let remoteFolder = try XCTUnwrap(rootItem.children.first { $0.name == "folder" })
+        let newFile = makeFile(name: "createdOnServer.txt", parent: remoteFolder, etag: "new-v1")
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        // Assert the user-visible outcome first, so a regression fails on the symptom rather than on
+        // the flag that causes it.
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a locally created folder must be reported. Reported: \(reportedIds(observer).sorted())"
+        )
+
+        // Then the mechanism: creation must record the folder as visited, or the working-set scan has
+        // no reason to read it.
+        let storedFolder = try XCTUnwrap(
+            Self.dbManager.itemMetadata(ocId: createdFolder.itemIdentifier.rawValue)
+        )
+        XCTAssertTrue(
+            storedFolder.visitedDirectory,
+            "A locally created folder must be recorded as visited; macOS will not enumerate it again."
+        )
+    }
+
+    /// The eviction-shaped variant of the same hole: a folder Finder has enumerated (so macOS will not
+    /// enumerate it again) whose contents are all dataless, and a NEW item appears inside it on the
+    /// server. `visitedDirectory` is deliberately kept for directories macOS reports as dataless (see
+    /// `MaterializedEnumerationObserver`), so such a folder stays in the materialised set and is read at
+    /// depth 1 — which is what must surface the new child. Guards that property against a future
+    /// narrowing of the materialised-set query or of the scan's seed set.
+    func testItemCreatedOnServerInVisitedFolderWithNoMaterialisedContentIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let existingFile = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true) // enumerated once by Finder
+        seed(existingFile, downloaded: false) // evicted / never downloaded
+
+        // A new item appears on the server; the parent ETag is deliberately left alone, so discovery
+        // cannot lean on the parent looking changed.
+        let newFile = makeFile(name: "createdOnServer.txt", parent: folder, etag: "new-v1")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
+        )
+    }
 }


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves

### Resolved
https://github.com/nextcloud/desktop/issues/9688

### Very likely resolved:
https://github.com/nextcloud/desktop/issues/10558
https://github.com/nextcloud/desktop/issues/9854

### Possibly resolved:
https://github.com/nextcloud/desktop/issues/10334
https://github.com/nextcloud/desktop/issues/10560

## Summary
_Note: my first pull request here, was frustrated with the performance and bugs of the File Provider implementation. Created with a lotn of help from Claude Opus 5. Tested on our production Nextcloud with over 6TB data (Hetzner Storage Share NC 34.0.8, single server, macOS only)._

Targeting stable-34.0 (created on tag 34.0.3).

Making the Virtual Files on MacOS (File Provider) workable. Upgrading performance/speed and fixing Nextcloud Push to start enumeration.

Streaming was implemented, shipped, found to drop remote changes, reverted, and redone with the test written.

### Performance stats

Metric | Before | After | Conditions
-- | -- | -- | --
Dataless transitions | 30,117 over 630 dirs | 0 | 7-min window, same account
Error lines in log | 15,229 | 2 (unrelated) | 7-min window
Notification-rate faults | 421 → 863 per second | none | flagged by macOS
Metadata rows written per full scan | 1,998 (for 7 real changes) | 11 | one full scan each
Full scan wall clock | 98 s | 51 s | ~2,000 materialised items
Full scan wall clock | 305 s | 160 s | 2,566 materialised items
Scan for a push-named change | 305 s (full walk) | 17 s (5 containers) | 2,566 materialised items
Discovery → report | 4 m 34 s | 1.3 s (first batch) | during a full scan
Web-UI file visible in Finder | ~5 min | ~6 s | end to end



## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [X] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
