### PR TITLE
Fix macOS File Provider Synchronization Drops

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -101,13 +101,16 @@ extension Enumerator {
             logger.debug("Completed checking materialised items for changes on the server.")
         }
 
+        // Trashed rows are excluded because trashing moves `serverUrl` to the trashbin without
+        // setting `deleted`, and the ordinary DAV path 404s there — which the scan reads as a
+        // deletion of the row trash reconciliation needs.
         // Unlike when enumerating items we can't progressively enumerate items as we need to
         // wait to see which items are truly deleted and which have just been moved elsewhere.
         // Visited folders and downloaded files. Sort in terms of their remote URLs.
         // This way we ensure we visit parent folders before their children.
         let materialisedItems = dbManager
             .materialisedItemMetadatas(account: account.ncKitAccount)
-            .filter { !$0.deleted }
+            .filter { !$0.deleted && !$0.isTrashed }
             .sorted { $0.remotePath().count < $1.remotePath().count }
 
         var accumulatedCreations = [SendableItemMetadata]()

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -65,6 +65,10 @@ import OSLog
     private var pendingAccount: Account?
     private var setupChain: Task<Void, Never> = Task {}
 
+    // Waiters parked in `awaitAccount(…)` until `ncAccount` is published.
+    private let accountReadyLock = NSLock()
+    private var accountReadyWaiters = [UUID: CheckedContinuation<Void, Never>]()
+
     /// Whether or not we are going to recursively scan new folders when they are discovered.
     /// Apple's recommendation is that we should always scan the file hierarchy fully.
     /// This does lead to long load times when a file provider domain is initially configured.
@@ -146,21 +150,27 @@ import OSLog
     public func item(for identifier: NSFileProviderItemIdentifier, request _: NSFileProviderRequest, completionHandler: @Sendable @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
         logger.debug("Received request for item.", [.item: identifier])
 
-        guard let ncAccount else {
-            logger.debug("Not fetching item because account not set up yet.", [.item: identifier])
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
-        guard let dbManager else {
-            logger.debug("Not fetching item because database is unavailable.", [.item: identifier])
-            completionHandler(nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
         let progress = Progress(totalUnitCount: 1)
 
         Task {
+            // Same startup race as `fetchContents`, where answering `notAuthenticated` would
+            // make the framework treat the item as unreachable rather than not-ready-yet.
+            let ncAccount: Account
+
+            do {
+                ncAccount = try await awaitAccount()
+            } catch {
+                logger.error("Not fetching item because account was never set up.", [.item: identifier])
+                completionHandler(nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
+            guard let dbManager else {
+                logger.debug("Not fetching item because database is unavailable.", [.item: identifier])
+                completionHandler(nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
             if let item = await Item.storedItem(identifier: identifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log), item.metadata.deleted == false {
                 progress.completedUnitCount = 1
                 completionHandler(item, nil)
@@ -189,22 +199,30 @@ import OSLog
             return Progress()
         }
 
-        guard let ncAccount else {
-            logger.debug("Not fetching contents for item because account not set up yet.", [.item: itemIdentifier])
-            insertErrorAction(actionId)
-            completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
-            return Progress()
-        }
-
-        guard let dbManager else {
-            logger.debug("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
-            completionHandler(nil, nil, NSFileProviderError(.cannotSynchronize))
-            return Progress()
-        }
-
         let progress = Progress()
 
         Task {
+            // Wait for the account rather than failing outright: the system starts this process and
+            // begins requesting content before the main app has handed the account over, and a
+            // rejected fetch is a download the framework may never ask for again.
+            let ncAccount: Account
+
+            do {
+                ncAccount = try await awaitAccount()
+            } catch {
+                logger.error("Not fetching contents for item because account was never set up.", [.item: itemIdentifier])
+                insertErrorAction(actionId)
+                completionHandler(nil, nil, NSFileProviderError(.notAuthenticated))
+                return
+            }
+
+            guard let dbManager else {
+                logger.debug("Not fetching contents for item because database is unavailable.", [.item: itemIdentifier])
+                insertErrorAction(actionId)
+                completionHandler(nil, nil, NSFileProviderError(.cannotSynchronize))
+                return
+            }
+
             guard let item = await Item.storedItem(identifier: itemIdentifier, account: ncAccount, remoteInterface: ncKit, dbManager: dbManager, log: log) else {
                 logger.error("Not fetching contents for item because item was not found.", [.item: itemIdentifier])
                 completionHandler(nil, nil, NSError.fileProviderErrorForNonExistentItem(withIdentifier: itemIdentifier))
@@ -800,8 +818,77 @@ import OSLog
             dbManager = databaseManager
 
             ncKit.setup(groupIdentifier: Bundle.main.bundleIdentifier!)
+            signalAccountReady()
             completionHandler?(nil)
             signalEnumeratorAfterAccountSetup()
+        }
+    }
+
+    ///
+    /// The domain account, waiting up to `timeoutNanoseconds` for setup to publish it.
+    ///
+    /// - Throws: `NSFileProviderError(.notAuthenticated)` when no account arrives within
+    ///   `timeoutNanoseconds`.
+    ///
+    func awaitAccount(timeoutNanoseconds: UInt64 = 10_000_000_000) async throws -> Account {
+        if let ncAccount {
+            return ncAccount
+        }
+
+        let token = UUID()
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            accountReadyLock.lock()
+            accountReadyWaiters[token] = continuation
+            accountReadyLock.unlock()
+
+            // The account may have been published between the check above and the enqueue.
+            if ncAccount != nil {
+                resumeAccountWaiter(token)
+                return
+            }
+
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                self?.resumeAccountWaiter(token)
+            }
+        }
+
+        // Read after the resume, not at the resume site: a timeout that races an account landing a
+        // moment later should still hand back the account rather than fail the request.
+        guard let account = ncAccount else {
+            throw NSFileProviderError(.notAuthenticated)
+        }
+
+        return account
+    }
+
+    ///
+    /// Resume one parked waiter, if it has not been resumed already.
+    ///
+    private func resumeAccountWaiter(_ token: UUID) {
+        accountReadyLock.lock()
+        let continuation = accountReadyWaiters.removeValue(forKey: token)
+        accountReadyLock.unlock()
+        continuation?.resume()
+    }
+
+    ///
+    /// Release everything parked in ``awaitAccount(timeoutNanoseconds:)`` once setup has published
+    /// ``ncAccount``.
+    ///
+    func signalAccountReady() {
+        accountReadyLock.lock()
+        let waiters = accountReadyWaiters
+        accountReadyWaiters.removeAll()
+        accountReadyLock.unlock()
+
+        if !waiters.isEmpty {
+            logger.debug("Account is set up; releasing \(waiters.count) waiting request(s).")
+        }
+
+        for continuation in waiters.values {
+            continuation.resume()
         }
     }
 

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -103,6 +103,10 @@ public extension Item {
 
         directory.downloaded = true
         directory.keepDownloaded = parentKeepDownloaded
+        // A folder we just created is already fully enumerated from the framework's point of
+        // view, so set `visitedDirectory` to keep future change scans covering it
+        // (nextcloud/desktop#9688, #10681).
+        directory.visitedDirectory = true
         dbManager.addItemMetadata(directory)
 
         let displayFileActions = await Item.typeHasApplicableContextMenuItems(account: account, remoteInterface: remoteInterface, candidate: directory.contentType)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+KeepDownloaded.swift
@@ -85,6 +85,13 @@ public extension Item {
                     isDownloaded: child.downloaded,
                     manager: manager
                 )
+            } catch let error as NSFileProviderError where error.code == .noSuchItem {
+                // Expected, because the framework's item store only knows what enumeration
+                // handed it and the flag written above applies when it first enumerates the item.
+                logger.debug(
+                    "Framework does not know this descendant yet; its pin applies when the item is first enumerated.",
+                    [.item: child.ocId, .name: child.fileName]
+                )
             } catch {
                 logger.error(
                     "Could not signal keep-downloaded change to framework for descendant.",

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/AwaitAccountTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/AwaitAccountTests.swift
@@ -1,0 +1,90 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import Testing
+
+///
+/// Coverage for `awaitAccount`, which waits for account setup instead of failing the requests the
+/// framework makes before the main app has handed the account over.
+///
+struct AwaitAccountTests {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private func makeExtension() -> FileProviderExtension {
+        let domain = NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier("test-domain-await-account"),
+            displayName: "Test"
+        )
+        return FileProviderExtension(domain: domain)
+    }
+
+    ///
+    /// An account already in place is returned without waiting at all.
+    ///
+    @Test func returnsImmediatelyWhenAccountIsAlreadySetUp() async throws {
+        let ext = makeExtension()
+        ext.ncAccount = Self.account
+
+        let account = try await ext.awaitAccount(timeoutNanoseconds: 0)
+
+        #expect(account == Self.account)
+    }
+
+    ///
+    /// The waiting case: a request arrives first, the account lands while it is parked, and the
+    /// request proceeds instead of failing.
+    ///
+    @Test func waitsForAnAccountThatArrivesLater() async throws {
+        let ext = makeExtension()
+
+        async let awaited = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+
+        try await Task.sleep(for: .milliseconds(200))
+        ext.ncAccount = Self.account
+        ext.signalAccountReady()
+
+        let account = try await awaited
+
+        #expect(account == Self.account, "A request parked before setup must proceed once the account lands.")
+    }
+
+    ///
+    /// A domain that never gets an account fails after the timeout rather than hanging forever.
+    ///
+    @Test func givesUpAfterTheTimeoutWhenNoAccountArrives() async {
+        let ext = makeExtension()
+        let timeout = Duration.milliseconds(300)
+
+        let started = ContinuousClock().now
+
+        await #expect(throws: NSFileProviderError(.notAuthenticated)) {
+            try await ext.awaitAccount(timeoutNanoseconds: 300_000_000)
+        }
+
+        #expect(ContinuousClock().now - started >= timeout)
+    }
+
+    ///
+    /// Several parked requests are all released by the single setup completion.
+    ///
+    @Test func releasesEveryParkedWaiter() async throws {
+        let ext = makeExtension()
+
+        async let first = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+        async let second = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+        async let third = ext.awaitAccount(timeoutNanoseconds: 10_000_000_000)
+
+        try await Task.sleep(for: .milliseconds(200))
+        ext.ncAccount = Self.account
+        ext.signalAccountReady()
+
+        let results = try await [first, second, third]
+
+        #expect(results == [Self.account, Self.account, Self.account])
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -537,4 +537,88 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "A push with no locally known ids is correctly ignored."
         )
     }
+
+    /// Headline regression for nextcloud/desktop#9688 and #10681: a folder the user creates on the Mac,
+    /// then an item created inside it on the server, which stays invisible unless creation marks the
+    /// folder visited.
+    func testItemCreatedOnServerInLocallyCreatedFolderIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // Create the folder the way Finder does, through the extension's create path.
+        var folderMetadata = SendableItemMetadata(
+            ocId: "folder-id", fileName: "folder", account: Self.account
+        )
+        folderMetadata.directory = true
+        folderMetadata.classFile = NKTypeClassFile.directory.rawValue
+        folderMetadata.serverUrl = Self.account.davFilesUrl
+
+        let (createdFolderMaybe, createError) = await Item.create(
+            basedOn: Item(
+                metadata: folderMetadata,
+                parentItemIdentifier: .rootContainer,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager
+            ),
+            contents: nil,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        XCTAssertNil(createError)
+        let createdFolder = try XCTUnwrap(createdFolderMaybe)
+
+        // The server-side creation inside that folder, with nothing in the subtree materialised.
+        let remoteFolder = try XCTUnwrap(rootItem.children.first { $0.name == "folder" })
+        let newFile = makeFile(name: "createdOnServer.txt", parent: remoteFolder, etag: "new-v1")
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        // Assert the user-visible outcome first, so a regression fails on the symptom rather than on
+        // the flag that causes it.
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a locally created folder must be reported. Reported: \(reportedIds(observer).sorted())"
+        )
+
+        // Then the mechanism: creation must record the folder as visited, or the working-set scan has
+        // no reason to read it.
+        let storedFolder = try XCTUnwrap(
+            Self.dbManager.itemMetadata(ocId: createdFolder.itemIdentifier.rawValue)
+        )
+        XCTAssertTrue(
+            storedFolder.visitedDirectory,
+            "A locally created folder must be recorded as visited; macOS will not enumerate it again."
+        )
+    }
+
+    /// The eviction-shaped variant of the same hole: a folder Finder has enumerated whose contents are
+    /// all dataless, where a new server-side child must still surface through the depth-1 read.
+    func testItemCreatedOnServerInVisitedFolderWithNoMaterialisedContentIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let existingFile = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true) // enumerated once by Finder
+        seed(existingFile, downloaded: false) // evicted / never downloaded
+
+        // A new item appears on the server; the parent ETag is deliberately left alone, so discovery
+        // cannot lean on the parent looking changed.
+        let newFile = makeFile(name: "createdOnServer.txt", parent: folder, etag: "new-v1")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
+        )
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -621,4 +621,50 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
         )
     }
+
+    ///
+    /// A trashed folder must not be scanned through the ordinary DAV path, whose 404 the scan would
+    /// read as a deletion.
+    ///
+    func testTrashedFolderIsNotScannedThroughTheRegularDavPath() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let liveFolder = makeFolder(name: "live", parent: rootItem, etag: "live-v1")
+        seed(liveFolder, visitedDirectory: true)
+
+        // A folder the user trashed: still visited, not soft-deleted, but living in the trashbin.
+        var trashed = makeFolder(name: "gone", parent: rootItem, etag: "gone-v1")
+            .toItemMetadata(account: Self.account)
+        trashed.ocId = "trashed-folder"
+        trashed.visitedDirectory = true
+        trashed.deleted = false
+        trashed.syncTime = oldSyncTime
+        trashed.serverUrl = Self.account.trashUrl
+        trashed.apply(fileName: "gone.d1788354069")
+        Self.dbManager.addItemMetadata(trashed)
+        XCTAssertTrue(trashed.isTrashed, "Precondition: the row must look trashed.")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+        let enumeratedPaths = recorder.paths
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            enumeratedPaths.contains { $0.hasSuffix("/live") },
+            "Sanity: the live materialised folder is still scanned."
+        )
+        XCTAssertFalse(
+            enumeratedPaths.contains { $0.contains("/trashbin/") },
+            "A trashed row must never be PROPFINDed through the regular DAV path. Got: \(enumeratedPaths)"
+        )
+        XCTAssertNotNil(
+            Self.dbManager.itemMetadata(ocId: "trashed-folder"),
+            "The trash row must survive the scan; trash reconciliation derives deletions from it."
+        )
+    }
 }


### PR DESCRIPTION
## Summary

First of eight PRs splitting #10728 into self-contained changes, as requested in review.
This one is correctness only — five fixes for cases where remote changes silently never
reach the Mac, plus the log noise that made those cases hard to diagnose.

**No performance claims here**, so there is nothing to benchmark. The figures quoted below
are observations from live runs that motivated each fix, not measurements of an improvement.
The benchmark harness the later PRs use is #<harness PR number>.

### What is fixed

**Locally created directories are never scanned** — a folder created on the Mac never got
`visitedDirectory`, which is what puts a directory into the materialised set the working-set
scan reads. Items added to it on the server (web UI, public upload link, another user) never
surfaced, and no later `enumerateItems` existed to repair it.
Resolves #9688.

**Trashed rows break the working-set scan** — trashing rewrites an item's `serverUrl` to the
trashbin but leaves `deleted` false, and a folder keeps `visitedDirectory`. The scan then
PROPFINDed the trashed folder through the ordinary DAV path, which 404s, and read that 404 as
"the item is gone" — reporting it deleted and hard-removing the row the trash reconciliation
derives permanent deletions from. Trash has its own path via `listingTrashAsync`.

**Requests arriving before the account does** — the system starts the extension and asks it
for work before the main app has handed the account across. `fetchContents` and `item(for:)`
answered `notAuthenticated` outright and the framework treated those downloads as failed. On
one relaunch, 17 fetches arrived in the first 0.6 s, 1.7 s before the account landed, and most
were never re-requested. Both now wait for the account, turning the race into a short delay.
`createItem` / `modifyItem` / `deleteItem` are deliberately left alone — they are
user-initiated — and `enumerator(for:)` already self-heals.

**Expected `noSuchItem` logged as an error** — pinning a subtree asks the framework to download
every descendant, but that addresses the framework's own item store, which only knows what
enumeration has handed it. Every never-browsed descendant answers `noSuchItem`: 15,229 of
15,849 on one pinned tree, roughly half the log volume. Nothing is lost by skipping them, since
the database flag is written first and `contentPolicy` reports
`.downloadEagerlyAndKeepDownloaded` when the item is first enumerated. Genuine failures still
log as errors.

**Regression tests** for the path a `notify_push` or root-ETag signal actually drives:
`enumerateChanges(.workingSet)` → `scanMaterialisedItemsForRemoteChanges()` →
`pendingWorkingSetChanges(since:)` → the change observer. Three of them reproduced real silent
drops before the fixes and now guard them.

### Verification

- 357 tests pass, 7 of them new (350 on `stable-34.0`)
- Every commit builds and tests standalone, so the history bisects
- Each fix has a test that fails without it

### TODO
- [ ] Close #10728 once the split is agreed
- [ ] Rebase after the scan PRs land — `Enumerator+WorkingSetScan.swift` is touched by both
- [ ] Labels and milestone need a maintainer; I have no triage rights on this repo

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
- [x] Uploaded screenshots from before and after for UI changes. — n/a, no UI changes
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable. — tests added; no performance claims in this PR
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required. — not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes). — n/a, targets `stable-34.0`
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement). — needs maintainer
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version. — needs maintainer
