### PR TITLE
fix(activity): use window text color for scroll button

### DIFF
--- a/src/gui/activity/qml/ActivityList.qml
+++ b/src/gui/activity/qml/ActivityList.qml
@@ -143,7 +143,7 @@ ScrollView {
             Accessible.name: qsTr("Scroll to top")
             Accessible.onPressAction: scrollToTopButton.clicked()
 
-            icon.source: "image://svgimage-custom-color/chevron-double-up.svg/" + palette.buttonText
+            icon.source: "image://svgimage-custom-color/chevron-double-up.svg/" + palette.windowText
             icon.width: Style.activityListButtonIconSize
             icon.height: Style.activityListButtonIconSize
 


### PR DESCRIPTION
Use the client’s dark-mode-aware foreground

fixes #10740 

Assisted-by: Codex:GPT-5
