### PR TITLE
feat(6404,gui): clarify exclusion list scopes, add link to global exl…

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -39,27 +39,28 @@
 
 #include <cmath>
 
+#include <QAbstractScrollArea>
+#include <QAction>
 #include <QColor>
 #include <QDesktopServices>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QDir>
-#include <QListWidgetItem>
-#include <QMessageBox>
-#include <QAction>
-#include <QAbstractScrollArea>
-#include <QSizePolicy>
-#include <QVBoxLayout>
-#include <QTreeView>
-#include <QKeySequence>
-#include <QIcon>
-#include <QVariant>
-#include <QJsonDocument>
-#include <QToolTip>
-#include <QPushButton>
-#include <QStyle>
 #include <QFileDialog>
 #include <QFrame>
+#include <QIcon>
+#include <QJsonDocument>
+#include <QKeySequence>
+#include <QLabel>
+#include <QListWidgetItem>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSizePolicy>
+#include <QStyle>
+#include <QToolTip>
+#include <QTreeView>
+#include <QVBoxLayout>
+#include <QVariant>
 
 using namespace Qt::StringLiterals;
 
@@ -632,6 +633,27 @@ void AccountSettings::openIgnoredFilesDialog(const QString & absFolderPath)
 
     const QString ignoreFile{absFolderPath + ".sync-exclude.lst"};
     const auto layout = new QVBoxLayout();
+
+    const auto folderName = QFileInfo(QDir::cleanPath(absFolderPath)).fileName();
+
+    const auto descriptionLabel = new QLabel(tr("This is specific exclude list for folder \"%1\".<br/>"
+                                                "Global settings (found <a href=\"global-ignore-list\">here</a>) "
+                                                "are also applied.")
+                                                 .arg(folderName.toHtmlEscaped()));
+    descriptionLabel->setObjectName(QStringLiteral("specificIgnoreListDescription"));
+    descriptionLabel->setTextFormat(Qt::RichText);
+    descriptionLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
+    descriptionLabel->setOpenExternalLinks(false);
+    descriptionLabel->setWordWrap(true);
+
+    connect(descriptionLabel, &QLabel::linkActivated, this, [this](const QString &link) {
+        if (link == QStringLiteral("global-ignore-list")) {
+            Q_EMIT openGlobalIgnoreListEditorRequested();
+        }
+    });
+
+    layout->addWidget(descriptionLabel);
+
     const auto ignoreListWidget = new IgnoreListTableWidget(this);
     ignoreListWidget->readIgnoreFile(ignoreFile);
     layout->addWidget(ignoreListWidget);

--- a/src/gui/accountsettings.h
+++ b/src/gui/accountsettings.h
@@ -72,6 +72,7 @@ Q_SIGNALS:
     void requestMnemonic();
     void removeAccountFolders(OCC::AccountState *account);
     void styleChanged();
+    void openGlobalIgnoreListEditorRequested();
 
 public Q_SLOTS:
     void slotOpenOC();

--- a/src/gui/advancedsettings.h
+++ b/src/gui/advancedsettings.h
@@ -28,11 +28,11 @@ public:
 
 public Q_SLOTS:
     void slotStyleChanged();
+    void slotIgnoreFilesEditor();
 
 private Q_SLOTS:
     void saveMiscSettings();
     void slotShowInExplorerNavigationPane(bool checked);
-    void slotIgnoreFilesEditor();
     void slotCreateDebugArchive();
     void loadMiscSettings();
     void slotRemotePollIntervalChanged(int seconds);

--- a/src/gui/ignorelisteditor.ui
+++ b/src/gui/ignorelisteditor.ui
@@ -102,6 +102,13 @@
        <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
       </property>
       <item>
+       <widget class="QLabel" name="ignorePatternsDescription">
+        <property name="text">
+         <string>Global exclusion list for all accounts and synchronized folders</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="ignoredPatternsPanelTitle">
         <property name="font">
          <font>

--- a/src/gui/settingsdialog.cpp
+++ b/src/gui/settingsdialog.cpp
@@ -181,7 +181,10 @@ SettingsDialog::SettingsDialog(ownCloudGui *gui, QWidget *parent)
     _firstNonAccountAction = _toolBar->addWidget(accountSpacer);
 
     addSettingsPage(QLatin1String(":/client/theme/settings.svg"), tr("General"), new GeneralSettings(this));
-    addSettingsPage(QLatin1String(":/client/theme/advanced.svg"), tr("Advanced"), new AdvancedSettings(this));
+
+    _advancedSettings = new AdvancedSettings(this);
+    addSettingsPage(QLatin1String(":/client/theme/advanced.svg"), tr("Advanced"), _advancedSettings);
+
     addSettingsPage(QLatin1String(":/client/theme/info.svg"), tr("Info"), new InfoSettings(this), true);
 
     QTimer::singleShot(1, this, &SettingsDialog::showFirstPage);
@@ -326,6 +329,13 @@ void SettingsDialog::showIssuesList(AccountState *account)
     Systray::instance()->showActivitiesWindow(id);
 }
 
+void SettingsDialog::openGlobalIgnoreListEditor()
+{
+    if (_advancedSettings) {
+        _advancedSettings->slotIgnoreFilesEditor();
+    }
+}
+
 void SettingsDialog::accountAdded(AccountState *s)
 {
     auto height = _toolBar->sizeHint().height();
@@ -360,6 +370,8 @@ void SettingsDialog::accountAdded(AccountState *s)
     connect(accountSettings, &AccountSettings::openFolderAlias,
         _gui, &ownCloudGui::slotFolderOpenAction);
     connect(accountSettings, &AccountSettings::showIssuesList, this, &SettingsDialog::showIssuesList);
+    connect(accountSettings, &AccountSettings::openGlobalIgnoreListEditorRequested, this, &SettingsDialog::openGlobalIgnoreListEditor);
+
     connect(s->account().data(), &Account::accountChangedAvatar, this, &SettingsDialog::slotAccountAvatarChanged);
     connect(s->account().data(), &Account::accountChangedDisplayName, this, &SettingsDialog::slotAccountDisplayNameChanged);
 

--- a/src/gui/settingsdialog.h
+++ b/src/gui/settingsdialog.h
@@ -24,6 +24,7 @@ namespace OCC {
 
 class AccountState;
 class AccountSettings;
+class AdvancedSettings;
 class Application;
 class FolderMan;
 class ownCloudGui;
@@ -66,6 +67,7 @@ protected:
 private Q_SLOTS:
     void accountAdded(OCC::AccountState *);
     void accountRemoved(OCC::AccountState *);
+    void openGlobalIgnoreListEditor();
 
 private:
     void customizeStyle();
@@ -92,6 +94,8 @@ private:
     bool _styleUpdatePending = false;
     bool _updatingStyle = false;
     OCC::AccountState *_initialAccount = nullptr;
+
+    AdvancedSettings *_advancedSettings = nullptr;
 
     void setupUi();
 };

--- a/test/testaccountsettings.cpp
+++ b/test/testaccountsettings.cpp
@@ -9,12 +9,17 @@
 
 #include <QtTest>
 
+#include "QApplication"
+#include "QDialog"
+#include "QLabel"
+#include "QTemporaryDir"
 #include "account.h"
-#include "testhelper.h"
 #include "foldermantestutils.h"
 #include "logger.h"
+#include "testhelper.h"
 
 #include "accountsettings.h"
+#include "ignorelisteditor.h"
 
 using namespace OCC;
 
@@ -52,6 +57,57 @@ private Q_SLOTS:
         auto accountState = new FakeAccountState(account);
         QCOMPARE_EQ(accountState->state(), OCC::AccountState::Connected);
         AccountSettings a(accountState);
+    }
+
+    void test_globalIgnoreList_hasScopeDescription()
+    {
+        IgnoreListEditor editor;
+
+        const auto descriptionLabel = editor.findChild<QLabel *>(QStringLiteral("ignorePatternsDescription"));
+
+        QVERIFY(descriptionLabel);
+        QCOMPARE(descriptionLabel->text(), QStringLiteral("Global exclusion list for all accounts and synchronized folders"));
+    }
+
+    void test_specificIgnoreList_hasScopeDescriptionAndRequestsGlobalEditor()
+    {
+        auto account = Account::create();
+        auto accountState = new FakeAccountState(account);
+        AccountSettings settings(accountState);
+
+        QTemporaryDir temporaryFolder(QDir(QDir::tempPath()).filePath(QStringLiteral("Folder & Name-XXXXXX")));
+        QVERIFY(temporaryFolder.isValid());
+
+        const auto invoked = QMetaObject::invokeMethod(&settings, "openIgnoredFilesDialog", Qt::DirectConnection, Q_ARG(QString, temporaryFolder.path()));
+        QVERIFY(invoked);
+
+        QLabel *descriptionLabel = nullptr;
+
+        for (auto *widget : QApplication::topLevelWidgets()) {
+            descriptionLabel = widget->findChild<QLabel *>(QStringLiteral("specificIgnoreListDescription"));
+
+            if (descriptionLabel) {
+                break;
+            }
+        }
+
+        QVERIFY(descriptionLabel);
+        QVERIFY(descriptionLabel->text().contains(QFileInfo(temporaryFolder.path()).fileName().toHtmlEscaped()));
+        QVERIFY(descriptionLabel->text().contains(QStringLiteral("<a href=\"global-ignore-list\">here</a>")));
+
+        QCOMPARE(descriptionLabel->textFormat(), Qt::RichText);
+        QVERIFY(descriptionLabel->wordWrap());
+        QVERIFY(!descriptionLabel->openExternalLinks());
+
+        QSignalSpy requestSpy(&settings, &AccountSettings::openGlobalIgnoreListEditorRequested);
+
+        QVERIFY(QMetaObject::invokeMethod(descriptionLabel, "linkActivated", Q_ARG(QString, QStringLiteral("unknown-link"))));
+        QCOMPARE(requestSpy.count(), 0);
+
+        QVERIFY(QMetaObject::invokeMethod(descriptionLabel, "linkActivated", Q_ARG(QString, QStringLiteral("global-ignore-list"))));
+        QCOMPARE(requestSpy.count(), 1);
+
+        delete descriptionLabel->window();
     }
 };
 


### PR DESCRIPTION
## Resolves
Resolves #6404 

## Summary
Updated the exclusion-list descriptions for the global and folder-specific settings. The global dialog now clarifies that the exclusion list applies to all accounts and synced folders, while the folder-specific dialog explains that it only applies to the current folder. The folder-specific dialog also displays the current folder name and includes a link to the global exclusion-list. Added tests to verify both descriptions and the link behavior.

Successfully ran AccountSettingsTest and built the desktop client. Manually verified the global and folder-specific dialogs, including that the link opens the global exclusion settings. Formatted the modified C++ files with clang-format and ran clang-tidy-21 on the modified C++ files.

### Global and specific exclusion lists (Before/After)

<img width="1177" height="654" alt="old_global_and_filespecific_ignorelist" src="https://github.com/user-attachments/assets/24da5ac7-3562-48a1-81f1-947def4f4349" />


<img width="1184" height="668" alt="fixed_global_and_filespecific_ignorelist" src="https://github.com/user-attachments/assets/6e9f9367-4edc-4e97-b049-b264abc3ef4b" />


## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
