### PR TITLE
Indexed Logical Address Lookups

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
@@ -108,91 +108,59 @@ public extension FilesDatabaseManager {
     }
 
     ///
-    /// Rewrite the normalized location keys of any row whose keys have drifted from its raw
-    /// columns, at the cost of one full walk of the table per open, since a row keyed at the
-    /// wrong address is invisible to every location lookup.
+    /// One-shot startup pass that rewrites drifted normalized location keys and soft-deletes rows
+    /// that share a logical address, in a single walk of the table.
     ///
-    func repairDriftedNormalizedLocationKeys() {
-        let database = ncDatabase()
-        let drifted = database
-            .objects(RealmItemMetadata.self)
-            .filter {
-                $0.normalizedFileName != $0.fileName.precomposedStringWithCanonicalMapping
-                    || $0.normalizedServerUrl != $0.serverUrl.precomposedStringWithCanonicalMapping
-            }
-
-        guard !drifted.isEmpty else { return }
-
-        logger.error(
-            "Repairing \(drifted.count) row(s) whose normalized location keys do not match their raw columns."
-        )
-
-        do {
-            try database.write {
-                for item in drifted {
-                    item.updateLocation(serverUrl: item.serverUrl, fileName: item.fileName)
-                }
-            }
-        } catch {
-            logger.error("Failed to repair drifted normalized location keys.", [.error: error])
-        }
-    }
-
-    ///
-    /// One-shot startup pass that heals pre-existing logical duplicates
-    /// already persisted in the database.
-    ///
-    /// Buckets all non-deleted, non-lock-file rows (except the synthetic
-    /// root-container row) by `(serverUrl, fileName)`. Within each
-    /// bucket containing more than one row, picks a winner among the
-    /// settled (non-in-flight) rows by greatest ``ItemMetadata/syncTime``
-    /// — with the lexicographically greater `ocId` breaking ties — and
-    /// soft-deletes every other settled row. In-flight rows are never
-    /// touched (the still-running NSURLSession task references the
-    /// specific `ocId`) and an `error`-level log records each skip. If a
-    /// bucket is entirely in-flight, the whole bucket is left intact; the
-    /// next run-time eviction will heal it once the row settles.
-    ///
-    /// A write transaction is opened only when at least one bucket has
-    /// more than one row, so clean databases pay no transaction cost.
-    ///
-    func cleanupPreexistingLogicalDuplicates() {
+    func repairPersistedLogicalAddresses() {
         let database = ncDatabase()
         let rootContainerOcId = NSFileProviderItemIdentifier.rootContainer.rawValue
-
-        let candidates = database
-            .objects(RealmItemMetadata.self)
-            .where {
-                !$0.deleted
-                    && !$0.isLockFileOfLocalOrigin
-                    && $0.ocId != rootContainerOcId
-            }
 
         struct LogicalKey: Hashable {
             let serverUrl: String
             let fileName: String
         }
 
+        var drifted: [RealmItemMetadata] = []
         var buckets: [LogicalKey: [RealmItemMetadata]] = [:]
 
-        for candidate in candidates {
-            let key = LogicalKey(
-                serverUrl: candidate.normalizedServerUrl,
-                fileName: candidate.normalizedFileName
-            )
-            buckets[key, default: []].append(candidate)
+        // Bucketing on the keys computed here rather than on the stored ones is what lets a
+        // drifted row be repaired and deduplicated in the same walk.
+        for row in database.objects(RealmItemMetadata.self) {
+            let serverUrl = row.serverUrl.precomposedStringWithCanonicalMapping
+            let fileName = row.fileName.precomposedStringWithCanonicalMapping
+
+            if row.normalizedServerUrl != serverUrl || row.normalizedFileName != fileName {
+                drifted.append(row)
+            }
+
+            // The exclusions decide which rows may be soft-deleted, not which rows are repaired.
+            guard !row.deleted, !row.isLockFileOfLocalOrigin, row.ocId != rootContainerOcId else {
+                continue
+            }
+
+            buckets[LogicalKey(serverUrl: serverUrl, fileName: fileName), default: []].append(row)
         }
 
         let collisions = buckets.values.filter { $0.count > 1 }
 
-        guard !collisions.isEmpty else {
+        guard !drifted.isEmpty || !collisions.isEmpty else {
             return
+        }
+
+        if !drifted.isEmpty {
+            logger.error(
+                "Repairing \(drifted.count) row(s) whose normalized location keys do not match their raw columns."
+            )
         }
 
         let now = Date()
 
         do {
             try database.write {
+                for row in drifted {
+                    row.updateLocation(serverUrl: row.serverUrl, fileName: row.fileName)
+                }
+
                 for group in collisions {
                     let settled = group.filter { $0.status == Status.normal.rawValue }
 
@@ -243,7 +211,7 @@ public extension FilesDatabaseManager {
                 }
             }
         } catch {
-            logger.error("Startup deduplication: write transaction failed.", [.error: error])
+            logger.error("Startup repair: write transaction failed.", [.error: error])
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager+Deduplication.swift
@@ -108,6 +108,37 @@ public extension FilesDatabaseManager {
     }
 
     ///
+    /// Rewrite the normalized location keys of any row whose keys have drifted from its raw
+    /// columns, at the cost of one full walk of the table per open, since a row keyed at the
+    /// wrong address is invisible to every location lookup.
+    ///
+    func repairDriftedNormalizedLocationKeys() {
+        let database = ncDatabase()
+        let drifted = database
+            .objects(RealmItemMetadata.self)
+            .filter {
+                $0.normalizedFileName != $0.fileName.precomposedStringWithCanonicalMapping
+                    || $0.normalizedServerUrl != $0.serverUrl.precomposedStringWithCanonicalMapping
+            }
+
+        guard !drifted.isEmpty else { return }
+
+        logger.error(
+            "Repairing \(drifted.count) row(s) whose normalized location keys do not match their raw columns."
+        )
+
+        do {
+            try database.write {
+                for item in drifted {
+                    item.updateLocation(serverUrl: item.serverUrl, fileName: item.fileName)
+                }
+            }
+        } catch {
+            logger.error("Failed to repair drifted normalized location keys.", [.error: error])
+        }
+    }
+
+    ///
     /// One-shot startup pass that heals pre-existing logical duplicates
     /// already persisted in the database.
     ///

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -115,6 +115,7 @@ public final class FilesDatabaseManager: Sendable {
         do {
             _ = try Realm()
             logger.info("Successfully created Realm.")
+            repairDriftedNormalizedLocationKeys()
             cleanupPreexistingLogicalDuplicates()
         } catch {
             logger.fault("Error creating Realm: \(error)")

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -115,8 +115,7 @@ public final class FilesDatabaseManager: Sendable {
         do {
             _ = try Realm()
             logger.info("Successfully created Realm.")
-            repairDriftedNormalizedLocationKeys()
-            cleanupPreexistingLogicalDuplicates()
+            repairPersistedLogicalAddresses()
         } catch {
             logger.fault("Error creating Realm: \(error)")
         }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmItemMetadata+Queries.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/RealmItemMetadata+Queries.swift
@@ -4,36 +4,35 @@
 import RealmSwift
 
 extension RealmItemMetadata {
+    ///
+    /// Match the row occupying a logical address, comparing on the indexed normalized keys alone so
+    /// Realm can answer it without scanning the table.
+    ///
     static func hasLocation(
         _ item: Query<RealmItemMetadata>,
         serverUrl: String,
         fileName: String
     ) -> Query<Bool> {
-        let canonicalServerUrl = serverUrl.precomposedStringWithCanonicalMapping
-        let canonicalFileName = fileName.precomposedStringWithCanonicalMapping
-
-        return (item.normalizedServerUrl == canonicalServerUrl
-            || (item.normalizedServerUrl == "" && item.serverUrl == serverUrl))
-            && (item.normalizedFileName == canonicalFileName
-                || (item.normalizedFileName == "" && item.fileName == fileName))
+        // File name first, because both conjuncts cost the same and Realm breaks the tie by source
+        // order, so the query drives off the near-unique name rather than the whole sibling set.
+        item.normalizedFileName == fileName.precomposedStringWithCanonicalMapping
+            && item.normalizedServerUrl == serverUrl.precomposedStringWithCanonicalMapping
     }
 
+    /// Match rows in a directory, optionally including everything beneath it, comparing only the
+    /// normalized key as ``hasLocation`` does.
     static func hasServerUrl(
         _ item: Query<RealmItemMetadata>,
         equalTo serverUrl: String,
         includingDescendants: Bool
     ) -> Query<Bool> {
         let canonicalServerUrl = serverUrl.precomposedStringWithCanonicalMapping
-        let canonicalPrefix = canonicalServerUrl + "/"
 
         if includingDescendants {
             return item.normalizedServerUrl == canonicalServerUrl
-                || item.normalizedServerUrl.starts(with: canonicalPrefix)
-                || (item.normalizedServerUrl == ""
-                    && (item.serverUrl == serverUrl || item.serverUrl.starts(with: serverUrl + "/")))
+                || item.normalizedServerUrl.starts(with: canonicalServerUrl + "/")
         }
 
         return item.normalizedServerUrl == canonicalServerUrl
-            || (item.normalizedServerUrl == "" && item.serverUrl == serverUrl)
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/UnicodePathNormalization.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/UnicodePathNormalization.md
@@ -43,21 +43,22 @@ The normalized values are local identity keys only.
 
 New objects populate both forms. Realm schema migration version 203 backfills
 the normalized properties for rows created by earlier versions, and
-`FilesDatabaseManager.repairDriftedNormalizedLocationKeys()` runs at every
-open to repair any row whose keys have drifted from its raw columns.
+`FilesDatabaseManager.repairPersistedLogicalAddresses()` runs at every open to
+repair any row whose keys have drifted from its raw columns.
 
 Drift is a mismatch between a stored key and the normalization of the raw
 column it is derived from, so it cannot be expressed as a Realm query: an
 index can only be probed for a value, and the value a drifted key should hold
 is whatever `precomposedStringWithCanonicalMapping` returns for that row. The
 repair therefore walks the whole table once per open and normalizes both raw
-columns of every row. Rows are collected into an array rather than a lazy
+columns of every row. Rows are collected into arrays rather than left as lazy
 `Results`, which is also what makes the subsequent rewrite safe, because
-mutating the columns a live query reads would let it skip rows. Deleted rows,
-lock files of local origin, and the synthetic root container are repaired
-alongside everything else: the exclusions that `cleanupPreexistingLogicalDuplicates()`
-applies are about which rows may be soft-deleted, not about which rows have to
-be findable by location.
+mutating the columns a live query reads would let it skip rows.
+
+Deleted rows, lock files of local origin, and the synthetic root container are
+repaired alongside everything else. The exclusions applied further down decide
+which rows may be soft-deleted as duplicates, not which rows have to be
+findable by location: a lock file resolved by path is a row like any other.
 
 ## Where normalization is required
 
@@ -88,10 +89,9 @@ site.
 
 ## Duplicate cleanup
 
-The startup method
-`FilesDatabaseManager.cleanupPreexistingLogicalDuplicates()` scans existing
-rows and groups them by account, normalized parent URL, and normalized file
-name. This is important even after the migration:
+The same startup walk that repairs drifted keys also groups existing rows by
+account, normalized parent URL, and normalized file name. This is important
+even after the migration:
 
 1. Before the fix, two canonically equivalent paths could have been persisted
    as different raw strings.
@@ -99,7 +99,14 @@ name. This is important even after the migration:
 3. Grouping by normalized properties makes them one logical location.
 4. The newest settled row wins; other settled rows are soft-deleted.
 5. In-flight rows are not deleted because active transfers refer to their
-   specific `ocId`.
+   specific `ocId`, and a bucket that is entirely in-flight is left intact for
+   the next run-time eviction to heal.
+
+Grouping uses the keys the walk computes rather than the ones stored on the
+row, so a drifted row is deduplicated in the pass that repairs it instead of
+in the next one. Both halves share a single write transaction, which is opened
+only when there is something to change, so a clean database pays no transaction
+cost.
 
 The related `evictLogicalDuplicates(of:in:now:)` path applies the same
 normalized-location rule while processing newly received metadata. The raw

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/UnicodePathNormalization.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/UnicodePathNormalization.md
@@ -41,8 +41,23 @@ The original values must not be replaced globally. They are used for server
 requests, downloads, uploads, deletes, logging, and user-visible metadata.
 The normalized values are local identity keys only.
 
-New objects populate both forms. Realm schema migration version 203 also
-backfills the normalized properties for rows created by earlier versions.
+New objects populate both forms. Realm schema migration version 203 backfills
+the normalized properties for rows created by earlier versions, and
+`FilesDatabaseManager.repairDriftedNormalizedLocationKeys()` runs at every
+open to repair any row whose keys have drifted from its raw columns.
+
+Drift is a mismatch between a stored key and the normalization of the raw
+column it is derived from, so it cannot be expressed as a Realm query: an
+index can only be probed for a value, and the value a drifted key should hold
+is whatever `precomposedStringWithCanonicalMapping` returns for that row. The
+repair therefore walks the whole table once per open and normalizes both raw
+columns of every row. Rows are collected into an array rather than a lazy
+`Results`, which is also what makes the subsequent rewrite safe, because
+mutating the columns a live query reads would let it skip rows. Deleted rows,
+lock files of local origin, and the synthetic root container are repaired
+alongside everything else: the exclusions that `cleanupPreexistingLogicalDuplicates()`
+applies are about which rows may be soft-deleted, not about which rows have to
+be findable by location.
 
 ## Where normalization is required
 
@@ -63,8 +78,9 @@ translates them into database queries. The reusable query expressions in
 `RealmItemMetadata+Queries.swift` centralize the persisted-field predicates:
 `hasLocation` compares an account, normalized parent URL, and normalized file
 name; `hasServerUrl` compares an exact URL or a slash-delimited descendant
-path. Both helpers retain a raw-value fallback for rows whose normalized
-properties are empty during migration or recovery.
+path. Both helpers compare the normalized properties alone; the exact-match
+forms are answered from their indexes, while the descendant form stays a prefix
+disjunction that Realm cannot drive off an index.
 
 For ordinary in-memory values, `ItemMetadata.hasSameLocation(as:)` provides the
 corresponding comparison without exposing normalization details at each call

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/FilesDatabaseManagerTests.swift
@@ -560,9 +560,8 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
 
         let parent = RealmItemMetadata()
         parent.ocId = "parent"
-        parent.fileName = "Parent"
+        parent.updateLocation(serverUrl: "https://example.com", fileName: "Parent")
         parent.account = "TestAccount"
-        parent.serverUrl = "https://example.com"
         parent.directory = true
         parent.downloaded = true
         parent.uploaded = true
@@ -570,9 +569,8 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         // Simulate existing metadata in the database
         let existingMetadata = RealmItemMetadata()
         existingMetadata.ocId = "id-1"
-        existingMetadata.fileName = "File.pdf"
+        existingMetadata.updateLocation(serverUrl: "https://example.com/Parent", fileName: "File.pdf")
         existingMetadata.account = "TestAccount"
-        existingMetadata.serverUrl = "https://example.com/Parent"
         existingMetadata.downloaded = true
         existingMetadata.uploaded = true
 
@@ -619,18 +617,16 @@ final class FilesDatabaseManagerTests: NextcloudFileProviderKitTestCase {
         // 1. Item that exists locally and is marked as uploaded
         let uploadedItem = RealmItemMetadata()
         uploadedItem.ocId = "ocid-uploaded-123"
-        uploadedItem.fileName = "SyncedFile.txt"
+        uploadedItem.updateLocation(serverUrl: testServerUrl, fileName: "SyncedFile.txt")
         uploadedItem.account = testAccount
-        uploadedItem.serverUrl = testServerUrl
         uploadedItem.downloaded = true
         uploadedItem.uploaded = true // IMPORTANT: Marked as uploaded
 
         // 2. Item that exists locally but is NOT marked as uploaded (e.g., new local file)
         let unuploadedItem = RealmItemMetadata()
         unuploadedItem.ocId = "ocid-local-456" // May or may not have ocId yet
-        unuploadedItem.fileName = "NewLocalFile.txt"
+        unuploadedItem.updateLocation(serverUrl: testServerUrl, fileName: "NewLocalFile.txt")
         unuploadedItem.account = testAccount
-        unuploadedItem.serverUrl = testServerUrl
         unuploadedItem.downloaded = true
         unuploadedItem.uploaded = false // IMPORTANT: Not marked as uploaded
         unuploadedItem.status = Status.normal.rawValue // Ensure it's not in a transient state if relevant

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NormalizedLocationKeyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NormalizedLocationKeyTests.swift
@@ -63,8 +63,8 @@ final class NormalizedLocationKeyTests: XCTestCase {
         )
     }
 
-    /// The safety net for a row that lacks its keys anyway, repaired at open for the cost of one
-    /// indexed equality against an empty result set.
+    /// The safety net for a row that lacks its keys anyway, repaired the next time the database
+    /// is opened.
     func testOpeningTheDatabaseRepairsARowWithMissingNormalizedKeys() throws {
         let manager = makeManager()
         let serverUrl = Self.account.davFilesUrl + "/folder"
@@ -110,7 +110,7 @@ final class NormalizedLocationKeyTests: XCTestCase {
         }
 
         // The first pass legitimately fills in the key the empty name left behind.
-        manager.repairDriftedNormalizedLocationKeys()
+        manager.repairPersistedLogicalAddresses()
 
         let rewritten = expectation(description: "A later repair pass modified a row.")
         rewritten.isInverted = true
@@ -121,11 +121,75 @@ final class NormalizedLocationKeyTests: XCTestCase {
         }
         defer { token.invalidate() }
 
-        manager.repairDriftedNormalizedLocationKeys()
+        manager.repairPersistedLogicalAddresses()
 
         // A rewrite of the row would be notified on the first run-loop turn after the pass
         // returns, so waiting longer buys nothing but suite time.
         wait(for: [rewritten], timeout: 0.2)
+    }
+
+    /// A drifted row has to be deduplicated by the pass that repairs it, which holds only while
+    /// the walk buckets on the keys it computes rather than the ones already stored.
+    func testADriftedDuplicateIsRepairedAndEvictedInOnePass() throws {
+        let manager = makeManager()
+        let serverUrl = Self.account.davFilesUrl + "/folder"
+
+        try manager.ncDatabase().write {
+            let older = RealmItemMetadata()
+            older.ocId = "older"
+            older.account = Self.account.ncKitAccount
+            older.updateLocation(serverUrl: serverUrl, fileName: "dup.txt")
+            older.syncTime = Date(timeIntervalSince1970: 1000)
+            older.uploaded = true
+            // The row a client older than the migration left behind, raw columns only.
+            older.normalizedServerUrl = ""
+            older.normalizedFileName = ""
+            manager.ncDatabase().add(older, update: .all)
+
+            let newer = RealmItemMetadata()
+            newer.ocId = "newer"
+            newer.account = Self.account.ncKitAccount
+            newer.updateLocation(serverUrl: serverUrl, fileName: "dup.txt")
+            newer.syncTime = Date(timeIntervalSince1970: 2000)
+            newer.uploaded = true
+            manager.ncDatabase().add(newer, update: .all)
+        }
+
+        manager.repairPersistedLogicalAddresses()
+
+        let database = manager.ncDatabase()
+        let older = try XCTUnwrap(database.object(ofType: RealmItemMetadata.self, forPrimaryKey: "older"))
+        let newer = try XCTUnwrap(database.object(ofType: RealmItemMetadata.self, forPrimaryKey: "newer"))
+
+        XCTAssertEqual(older.normalizedFileName, "dup.txt", "The drifted row should have been repaired.")
+        XCTAssertTrue(older.deleted, "The older row at the address should have been evicted.")
+        XCTAssertFalse(newer.deleted, "The newest settled row at the address should survive.")
+    }
+
+    /// The repair covers the rows deduplication excludes, because a tombstone or a lock file is
+    /// still resolved by path.
+    func testARowExcludedFromDeduplicationIsStillRepaired() throws {
+        let manager = makeManager()
+
+        try manager.ncDatabase().write {
+            let tombstone = RealmItemMetadata()
+            tombstone.ocId = "tombstone"
+            tombstone.account = Self.account.ncKitAccount
+            tombstone.updateLocation(serverUrl: Self.account.davFilesUrl + "/folder", fileName: "gone.txt")
+            tombstone.deleted = true
+            tombstone.normalizedServerUrl = ""
+            tombstone.normalizedFileName = ""
+            manager.ncDatabase().add(tombstone, update: .all)
+        }
+
+        manager.repairPersistedLogicalAddresses()
+
+        let repaired = try XCTUnwrap(
+            manager.ncDatabase().object(ofType: RealmItemMetadata.self, forPrimaryKey: "tombstone")
+        )
+
+        XCTAssertEqual(repaired.normalizedFileName, "gone.txt")
+        XCTAssertEqual(repaired.normalizedServerUrl, Self.account.davFilesUrl + "/folder")
     }
 
     /// Normalization is why the comparison can be an equality at all, since a decomposed name

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NormalizedLocationKeyTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/NormalizedLocationKeyTests.swift
@@ -1,0 +1,172 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+import XCTest
+
+///
+/// Guards for the assumption that lets logical-address lookups be answered from an index: every row
+/// carries normalized keys, so `hasLocation` never falls back to the unindexed raw columns.
+///
+final class NormalizedLocationKeyTests: XCTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var databaseDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        databaseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("NormalizedLocationKeyTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: databaseDirectory, withIntermediateDirectories: true)
+    }
+
+    private func makeManager() -> FilesDatabaseManager {
+        FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: databaseDirectory,
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+    }
+
+    private func metadata(fileName: String, serverUrl: String, ocId: String) -> SendableItemMetadata {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: fileName, account: Self.account)
+        metadata.serverUrl = serverUrl
+        metadata.uploaded = true
+        return metadata
+    }
+
+    /// Every write of the raw location columns goes through `updateLocation`, and this asserts
+    /// the outcome rather than the route so it still holds for a new write path.
+    func testRowsWrittenThroughThePublicPathCarryTheirNormalizedKeys() {
+        let manager = makeManager()
+        let serverUrl = Self.account.davFilesUrl + "/folder"
+
+        for (ocId, name) in [("a", "one.txt"), ("b", "two.txt"), ("c", "three.txt")] {
+            manager.addItemMetadata(metadata(fileName: name, serverUrl: serverUrl, ocId: ocId))
+        }
+
+        let unnormalized = manager.itemMetadatas.filter {
+            !$0.fileName.isEmpty && ($0.normalizedFileName.isEmpty || $0.normalizedServerUrl.isEmpty)
+        }
+
+        XCTAssertTrue(
+            unnormalized.isEmpty,
+            "A row with empty normalized keys is invisible to every location lookup."
+        )
+    }
+
+    /// The safety net for a row that lacks its keys anyway, repaired at open for the cost of one
+    /// indexed equality against an empty result set.
+    func testOpeningTheDatabaseRepairsARowWithMissingNormalizedKeys() throws {
+        let manager = makeManager()
+        let serverUrl = Self.account.davFilesUrl + "/folder"
+        let database = manager.ncDatabase()
+
+        // Bypass `updateLocation` deliberately: this is the row shape the fallback used to carry.
+        try database.write {
+            let stranded = RealmItemMetadata()
+            stranded.ocId = "stranded"
+            stranded.account = Self.account.ncKitAccount
+            stranded.fileName = "stranded.txt"
+            stranded.serverUrl = serverUrl
+            stranded.uploaded = true
+            database.add(stranded, update: .all)
+        }
+
+        XCTAssertNil(
+            manager.itemMetadata(account: Self.account.ncKitAccount, locatedAtRemoteUrl: serverUrl + "/" + "stranded.txt"),
+            "Precondition: without its normalized keys the row cannot be found by location."
+        )
+
+        // Opening the database again runs the repair.
+        let reopened = makeManager()
+
+        let repaired = reopened.itemMetadata(account: Self.account.ncKitAccount, locatedAtRemoteUrl: serverUrl + "/" + "stranded.txt")
+        XCTAssertEqual(repaired?.ocId, "stranded", "The repair should make the row findable by location again.")
+    }
+
+    /// The repair has to be a fixed point, or a row it cannot actually change is rewritten on every
+    /// open.
+    func testTheRepairDoesNotRewriteARowItCannotChange() throws {
+        let manager = makeManager()
+        let database = manager.ncDatabase()
+
+        // An empty raw file name normalizes to itself, so an emptiness test selects this row forever.
+        try database.write {
+            let row = RealmItemMetadata()
+            row.ocId = "emptyName"
+            row.account = Self.account.ncKitAccount
+            row.serverUrl = Self.account.davFilesUrl + "/folder"
+            row.uploaded = true
+            database.add(row, update: .all)
+        }
+
+        // The first pass legitimately fills in the key the empty name left behind.
+        manager.repairDriftedNormalizedLocationKeys()
+
+        let rewritten = expectation(description: "A later repair pass modified a row.")
+        rewritten.isInverted = true
+        let token = database.objects(RealmItemMetadata.self).observe { change in
+            if case let .update(_, _, _, modifications) = change, !modifications.isEmpty {
+                rewritten.fulfill()
+            }
+        }
+        defer { token.invalidate() }
+
+        manager.repairDriftedNormalizedLocationKeys()
+
+        // A rewrite of the row would be notified on the first run-loop turn after the pass
+        // returns, so waiting longer buys nothing but suite time.
+        wait(for: [rewritten], timeout: 0.2)
+    }
+
+    /// Normalization is why the comparison can be an equality at all, since a decomposed name
+    /// has to match the precomposed row already stored.
+    func testADecomposedNameMatchesThePrecomposedRow() {
+        let manager = makeManager()
+        let serverUrl = Self.account.davFilesUrl + "/folder"
+        // Written as scalars so the file's own encoding cannot quietly normalize the literals.
+        let precomposed = "Gr\u{00FC}\u{00DF}e.txt"
+        let decomposed = "Gru\u{0308}\u{00DF}e.txt"
+
+        // Swift's own `==` normalizes and reports these as equal, which is why the normalized
+        // keys have to exist for Realm's byte comparison.
+        XCTAssertNotEqual(
+            Array(precomposed.utf8), Array(decomposed.utf8),
+            "Precondition: the two forms differ in the bytes Realm would compare."
+        )
+
+        manager.addItemMetadata(metadata(fileName: precomposed, serverUrl: serverUrl, ocId: "umlaut"))
+
+        let found = manager.itemMetadata(account: Self.account.ncKitAccount, locatedAtRemoteUrl: serverUrl + "/" + decomposed)
+
+        XCTAssertEqual(found?.ocId, "umlaut", "Lookup must match across Unicode normalization forms.")
+    }
+
+    /// A rename rewrites the location, so it has to rewrite the keys with it.
+    func testARenameMovesTheNormalizedKeysWithTheRow() {
+        let manager = makeManager()
+        let serverUrl = Self.account.davFilesUrl + "/folder"
+        manager.addItemMetadata(metadata(fileName: "before.txt", serverUrl: serverUrl, ocId: "renamed"))
+
+        manager.renameItemMetadata(ocId: "renamed", newServerUrl: serverUrl, newFileName: "after.txt")
+
+        XCTAssertNil(
+            manager.itemMetadata(account: Self.account.ncKitAccount, locatedAtRemoteUrl: serverUrl + "/" + "before.txt"),
+            "The old address should no longer resolve."
+        )
+        XCTAssertEqual(
+            manager.itemMetadata(account: Self.account.ncKitAccount, locatedAtRemoteUrl: serverUrl + "/" + "after.txt")?.ocId,
+            "renamed",
+            "The new address should resolve to the same row."
+        )
+    }
+}


### PR DESCRIPTION
`RealmItemMetadata.hasLocation` compared the two indexed normalized keys, but also accepted a row whose keys were empty by falling back to the raw serverUrl and fileName columns. Those columns are not indexed, and a disjunction that reaches them cannot be answered from an index, so Realm scanned the whole table instead -- once per row being ingested. The index that was added to remove that scan could never be used.

The fallback existed for rows written before the normalized keys, and there are none: the addedCanonicalPathKeys migration backfilled them, and updateLocation is the only way either raw column is written since. Compare on the normalized keys alone, and repair any row that lacks them when the database is opened, so the assumption is enforced rather than trusted. Enforcing it matters because the failure is silent -- a row with empty keys does not merely take longer to find, it stops matching, so its duplicates are never evicted and it is never found by path.

Ingesting 2000 rows into a 10000-row database: 1.61 s to 0.46 s. The per-directory cost also stops growing with the database, which is what made this worse the longer the client ran: across a 100x larger database it went from 1.78x to 1.12x, and at 20000 rows the ingest is 31.2 ms to 14.4 ms.

Two test fixtures built rows by assigning the raw columns directly, which no production path does; they now go through updateLocation like everything else.


Assisted-by: Claude Code:claude-opus-5

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
