### PR TITLE
Handling (Un)Visited Directories Correctly

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -442,6 +442,8 @@ public final class FilesDatabaseManager: Sendable {
                 }
             }
 
+            var visitToRecord: String?
+
             if var readTargetMetadata {
                 if readTargetMetadata.directory {
                     readTargetMetadata.visitedDirectory = true
@@ -450,6 +452,13 @@ public final class FilesDatabaseManager: Sendable {
                 if let existing = itemMetadata(ocId: readTargetMetadata.ocId) {
                     if readTargetMetadata.etag == existing.etag {
                         readTargetMetadata.fileProviderContentVersion = existing.fileProviderContentVersion
+                    }
+
+                    // `visitedDirectory` is local-only, so it takes no part in the remote-state
+                    // comparison and is recorded separately from `metadatasToUpdate`, which is also
+                    // the change set handed to the framework.
+                    if readTargetMetadata.directory, !existing.visitedDirectory {
+                        visitToRecord = readTargetMetadata.ocId
                     }
 
                     if existing.status == Status.normal.rawValue,
@@ -486,6 +495,12 @@ public final class FilesDatabaseManager: Sendable {
                 database.add(metadatasToDelete.map { RealmItemMetadata(value: $0) }, update: .modified)
                 database.add(metadatasToUpdate.map { RealmItemMetadata(value: $0) }, update: .modified)
                 database.add(metadatasToCreate.map { RealmItemMetadata(value: $0) }, update: .all)
+
+                if let visitToRecord,
+                   let row = database.objects(RealmItemMetadata.self).where({ $0.ocId == visitToRecord }).first
+                {
+                    row.visitedDirectory = true
+                }
             }
 
             return ChangeSet(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -103,6 +103,10 @@ public extension Item {
 
         directory.downloaded = true
         directory.keepDownloaded = parentKeepDownloaded
+        // A folder we just created is already fully enumerated from the framework's point of
+        // view, so set `visitedDirectory` to keep future change scans covering it
+        // (nextcloud/desktop#9688, #10681).
+        directory.visitedDirectory = true
         dbManager.addItemMetadata(directory)
 
         let displayFileActions = await Item.typeHasApplicableContextMenuItems(account: account, remoteInterface: remoteInterface, candidate: directory.contentType)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -18,7 +18,9 @@ public extension Item {
         ignoredFiles: IgnoredFilesMatcher? = nil,
         dbManager: FilesDatabaseManager
     ) async -> Error? {
-        let isEmptyDirOrIsFile = childItemCount == nil || childItemCount == 0
+        // `childItemCount` is nil both for a file and for a directory nobody has enumerated, so
+        // a directory whose contents are unknown must not be treated as empty here.
+        let isEmptyDirOrIsFile = !metadata.directory || childItemCount == 0
 
         guard trashing || isEmptyDirOrIsFile || options.contains(.recursive) else {
             return NSFileProviderError(.directoryNotEmpty)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -224,16 +224,14 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
     public var childItemCount: NSNumber? {
         guard metadata.directory else { return nil }
 
-        // No rows is not evidence of an empty directory, only of one nothing has read yet, and
-        // there is no flag that reliably says which: `visitedDirectory` is still false after a
-        // paginated enumeration, which is the path every server from Nextcloud 31 takes. So the
-        // only honest answer for an empty local set is "unknown".
-        //
-        // The cost is one enumeration of a genuinely empty folder, which is what the framework
-        // would do anyway on first browse. The cost of the alternative was the folder never being
-        // enumerated at all.
         let known = dbManager.childItemCount(directoryMetadata: metadata)
-        return known > 0 ? NSNumber(integerLiteral: known) : nil
+
+        // Any children at all means the database has something to say.
+        guard known == 0 else { return NSNumber(integerLiteral: known) }
+
+        // Zero is ambiguous, and `visitedDirectory` separates a directory that has been read
+        // and is empty from one that simply holds no rows yet.
+        return metadata.visitedDirectory ? NSNumber(integerLiteral: 0) : nil
     }
 
     public var fileSystemFlags: NSFileProviderFileSystemFlags {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -217,12 +217,23 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         return formatter.personNameComponents(from: metadata.ownerDisplayName)
     }
 
+    ///
+    /// The number of items directly inside this container, or `nil` when the directory has not been
+    /// enumerated and its contents are therefore unknown.
+    ///
     public var childItemCount: NSNumber? {
-        if metadata.directory {
-            NSNumber(integerLiteral: dbManager.childItemCount(directoryMetadata: metadata))
-        } else {
-            nil
-        }
+        guard metadata.directory else { return nil }
+
+        // No rows is not evidence of an empty directory, only of one nothing has read yet, and
+        // there is no flag that reliably says which: `visitedDirectory` is still false after a
+        // paginated enumeration, which is the path every server from Nextcloud 31 takes. So the
+        // only honest answer for an empty local set is "unknown".
+        //
+        // The cost is one enumeration of a genuinely empty folder, which is what the framework
+        // would do anyway on first browse. The cost of the alternative was the folder never being
+        // enumerated at all.
+        let known = dbManager.childItemCount(directoryMetadata: metadata)
+        return known > 0 ? NSNumber(integerLiteral: known) : nil
     }
 
     public var fileSystemFlags: NSFileProviderFileSystemFlags {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChildItemCountTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChildItemCountTests.swift
@@ -1,0 +1,101 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+///
+/// Coverage for `NSFileProviderItem.childItemCount`, where `nil` means nobody has looked and `0`
+/// means the directory has been read and is empty.
+///
+final class ChildItemCountTests: XCTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+    private var remoteInterface: MockRemoteInterface!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChildItemCountTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: directory,
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+        remoteInterface = MockRemoteInterface(account: Self.account)
+    }
+
+    @discardableResult
+    private func seedDirectory(ocId: String, name: String, parentUrl: String) -> SendableItemMetadata {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: name, account: Self.account)
+        metadata.directory = true
+        metadata.serverUrl = parentUrl
+        metadata.uploaded = true
+        dbManager.addItemMetadata(metadata)
+        return metadata
+    }
+
+    private func seedFile(ocId: String, name: String, parentUrl: String) {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: name, account: Self.account)
+        metadata.serverUrl = parentUrl
+        metadata.uploaded = true
+        dbManager.addItemMetadata(metadata)
+    }
+
+    private func item(for metadata: SendableItemMetadata) -> Item {
+        Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
+        )
+    }
+
+    /// A folder whose children have never been read must not claim to be empty, or nothing will
+    /// ever ask what is in it.
+    func testADirectoryWithNoKnownChildrenReportsUnknownRatherThanZero() {
+        let folder = seedDirectory(
+            ocId: "unread", name: "2026_Project", parentUrl: Self.account.davFilesUrl
+        )
+
+        XCTAssertNil(
+            item(for: folder).childItemCount,
+            "An unread directory must report nil. Zero is a claim that it is empty."
+        )
+    }
+
+    /// Once the database does hold children, the count is real knowledge and is reported.
+    func testADirectoryWithKnownChildrenReportsHowMany() {
+        let folder = seedDirectory(
+            ocId: "read", name: "2026_Project", parentUrl: Self.account.davFilesUrl
+        )
+        let folderUrl = Self.account.davFilesUrl + "/2026_Project"
+        seedDirectory(ocId: "c1", name: "00_Input", parentUrl: folderUrl)
+        seedDirectory(ocId: "c2", name: "02_Design", parentUrl: folderUrl)
+        seedFile(ocId: "c3", name: "brief.pdf", parentUrl: folderUrl)
+
+        XCTAssertEqual(item(for: folder).childItemCount?.intValue, 3)
+    }
+
+    /// A file has no children to speak of, and never did.
+    func testAFileReportsNoCountAtAll() {
+        var file = SendableItemMetadata(ocId: "f", fileName: "brief.pdf", account: Self.account)
+        file.serverUrl = Self.account.davFilesUrl
+        file.uploaded = true
+        dbManager.addItemMetadata(file)
+
+        XCTAssertNil(item(for: file).childItemCount)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -1630,10 +1630,9 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             remoteInterface: remoteInterface,
             dbManager: Self.dbManager
         )
-        // `nil`, not 0: the database holds no children for this folder, and that is indistinguishable
-        // from nobody having read it. Reporting 0 would assert the folder is empty, which is what
-        // stopped the framework asking for its contents at all.
-        XCTAssertNil(storedFolderItem.childItemCount)
+        // 0, not nil: the enumeration above read this folder, so the empty result is knowledge.
+        let childItemCount = storedFolderItem.childItemCount as? Int
+        XCTAssertEqual(childItemCount, remoteFolder.children.count)
     }
 
     func testFolderWithFewItemsPaginatedEnumeration() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -179,7 +179,8 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             Int(storedFolderItem.contentModificationDate?.timeIntervalSince1970 ?? 0),
             Int(remoteFolder.modificationDate.timeIntervalSince1970)
         )
-        XCTAssertEqual(storedFolderItem.childItemCount?.intValue, 0) // Not visited yet, so no kids
+        // Not read yet, so the count is unknown rather than zero — see `Item.childItemCount`.
+        XCTAssertNil(storedFolderItem.childItemCount)
     }
 
     func testWorkingSetEnumeration() async throws {
@@ -1629,9 +1630,10 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             remoteInterface: remoteInterface,
             dbManager: Self.dbManager
         )
-        let childItemCount = storedFolderItem.childItemCount as? Int
-        let expectedChildItemCount = remoteFolder.children.count
-        XCTAssertEqual(childItemCount, expectedChildItemCount)
+        // `nil`, not 0: the database holds no children for this folder, and that is indistinguishable
+        // from nobody having read it. Reporting 0 would assert the folder is empty, which is what
+        // stopped the framework asking for its contents at all.
+        XCTAssertNil(storedFolderItem.childItemCount)
     }
 
     func testFolderWithFewItemsPaginatedEnumeration() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/VisitedDirectoryTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/VisitedDirectoryTests.swift
@@ -1,0 +1,112 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+
+///
+/// `visitedDirectory` records that a directory has actually been read, which decides both its
+/// membership of the working set and whether an empty child count is knowledge or its absence.
+///
+final class VisitedDirectoryTests: XCTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VisitedDirectoryTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: directory,
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+    }
+
+    /// The directory as the server reports it, built once and reused so both reads carry
+    /// identical timestamps and the unchanged case is what gets exercised.
+    private lazy var folder: SendableItemMetadata = {
+        var metadata = SendableItemMetadata(
+            ocId: "folder", fileName: "2026_Project", account: Self.account
+        )
+        metadata.directory = true
+        metadata.serverUrl = Self.account.davFilesUrl
+        metadata.etag = "unchanged-etag"
+        metadata.uploaded = true
+        return metadata
+    }()
+
+    private func ingest() -> ChangeSet? {
+        dbManager.depth1ReadUpdateItemMetadatas(
+            account: Self.account.ncKitAccount,
+            serverUrl: Self.account.davFilesUrl + "/2026_Project",
+            updatedMetadatas: [folder],
+            keepExistingDownloadState: true
+        )
+    }
+
+    /// The regression: the row already exists with the same remote state, and the visit must
+    /// still be written.
+    func testReadingAnUnchangedDirectoryStillRecordsTheVisit() {
+        dbManager.addItemMetadata(folder)
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: "folder")?.visitedDirectory, false,
+            "Precondition: the seeded row has not been visited."
+        )
+
+        _ = ingest()
+
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: "folder")?.visitedDirectory, true,
+            "Reading a directory must record the visit even when nothing remote changed."
+        )
+    }
+
+    /// The visit is persisted without entering `metadatasToUpdate`, which is also the change set
+    /// handed to the framework.
+    func testRecordingAVisitDoesNotReportTheDirectoryAsChanged() throws {
+        dbManager.addItemMetadata(folder)
+
+        let changes = try XCTUnwrap(ingest())
+
+        XCTAssertFalse(
+            changes.updated.contains { $0.ocId == "folder" },
+            "A visit is local-only state; it must not be reported to the framework as a change."
+        )
+        XCTAssertFalse(
+            changes.created.contains { $0.ocId == "folder" },
+            "The directory already existed; recording its visit must not recreate it."
+        )
+    }
+
+    /// Once recorded, an empty directory's child count becomes a real zero rather than "unknown".
+    func testAVisitedEmptyDirectoryReportsZeroChildrenRatherThanUnknown() throws {
+        dbManager.addItemMetadata(folder)
+        _ = ingest()
+
+        let metadata = try XCTUnwrap(dbManager.itemMetadata(ocId: "folder"))
+        let item = Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: dbManager
+        )
+
+        XCTAssertEqual(
+            item.childItemCount?.intValue, 0,
+            "A directory that has been read and holds nothing is empty, not unknown."
+        )
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

Three fixes under one invariant: a directory whose contents are known must say
so, and one whose contents are unknown must not pretend otherwise.

`visitedDirectory` is the flag that carries this. Two things depend on it —
whether a directory is in the working set the remote-change scan walks, and
whether an empty local child set means "this folder is empty" or "nobody has
looked yet". Each commit fixes one place where the flag, or the answer derived
from it, was wrong.

## Problems

**A folder created on the Mac never received server-side additions.** Files
added to it through the web UI, a public upload link, or by another user never
appeared. The framework considers such a folder already enumerated — it knows
the empty listing it just made and will not ask again — so if nothing marks it
visited it never joins the materialised set, the working-set scan never
PROPFINDs it, and no later `enumerateItems` exists to repair that.
Resolves #9688.

**Browsing into a never-enumerated folder showed an empty view and a spinner
that never resolved.** Finder's status bar read "0 items" for a folder holding
three subfolders on the server. `childItemCount` derived the number from the
local database, which holds a directory's children only once something has read
that directory — so for an unread one it returned 0.
`NSFileProviderItem.childItemCount` is optional precisely so a provider can say
it does not know, and 0 is not "I do not know", it is "this folder is empty".
Finder printed that verbatim, and the framework, told the container had no
children, had no reason to schedule a fetch. The extension sat idle because we
had told the system there was nothing to ask for.

**An ordinary browse persisted no visit at all.** `visitedDirectory` is
local-only, so it takes no part in `isInSameDatabaseStoreableRemoteState`. The
non-paginated depth-1 ingestion decided whether to persist its read target
purely on that comparison, and a directory's etag does not change because
somebody opened it — so reading an unchanged directory dropped the visit. The
paginated path already compared the flag explicitly and was unaffected.

## Changes

1. **Mark locally created directories as visited** — grant a folder created on
   this Mac the same refresh subscription a browsed folder gets.
2. **Report an unread directory's child count as unknown** — return `nil`
   rather than 0 when the local set is empty and the directory has not been
   read. `delete` had been reading `nil` as "empty or a file", which was safe
   only while `nil` meant a file; it now asks whether the item is a directory,
   so a directory whose contents are unknown refuses a non-recursive delete
   instead of assuming it has nothing to lose.
3. **Record a directory visit when nothing remote changed** — persist the visit
   separately rather than by adding the row to `metadatasToUpdate`. That set is
   also the change set handed to the framework, and announcing a directory as
   changed on every first browse would re-queue its update-item job for a flag
   the framework cannot see.

## Testing

Full suite green at 356 XCTest + 59 Swift Testing. Each commit builds and tests
standalone. New tests: `ChildItemCountTests` (107 lines), `VisitedDirectoryTests`
(120 lines); each was run against a deliberately broken build first to confirm it
fails without the fix. Two existing `EnumeratorTests` expectations asserted the
old 0 and move to `nil`, with the reason recorded at the assertion.

**Note for anyone testing this by hand:** the framework caches every item's
`NSFileProviderItem` and only refreshes that cache when the extension's
`CFBundleShortVersionString` changes. Rebuilding at the same version leaves the
pre-fix `childItemCount` values in place and the fix appears to do nothing. Bump
the version between builds.


## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
