### PR TITLE
Trash Exclusion from Working Set Updates

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Database/FilesDatabaseManager.swift
@@ -442,6 +442,10 @@ public final class FilesDatabaseManager: Sendable {
                 }
             }
 
+            // Set inside the branch below when the read recorded a visit that nothing else
+            // will persist.
+            var visitToRecord: String?
+
             if var readTargetMetadata {
                 if readTargetMetadata.directory {
                     readTargetMetadata.visitedDirectory = true
@@ -450,6 +454,13 @@ public final class FilesDatabaseManager: Sendable {
                 if let existing = itemMetadata(ocId: readTargetMetadata.ocId) {
                     if readTargetMetadata.etag == existing.etag {
                         readTargetMetadata.fileProviderContentVersion = existing.fileProviderContentVersion
+                    }
+
+                    // `visitedDirectory` is local-only, so it takes no part in the remote-state
+                    // comparison and is recorded separately from `metadatasToUpdate`, which is also
+                    // the change set handed to the framework.
+                    if readTargetMetadata.directory, !existing.visitedDirectory {
+                        visitToRecord = readTargetMetadata.ocId
                     }
 
                     if existing.status == Status.normal.rawValue,
@@ -486,6 +497,12 @@ public final class FilesDatabaseManager: Sendable {
                 database.add(metadatasToDelete.map { RealmItemMetadata(value: $0) }, update: .modified)
                 database.add(metadatasToUpdate.map { RealmItemMetadata(value: $0) }, update: .modified)
                 database.add(metadatasToCreate.map { RealmItemMetadata(value: $0) }, update: .all)
+
+                if let visitToRecord,
+                   let row = database.objects(RealmItemMetadata.self).where({ $0.ocId == visitToRecord }).first
+                {
+                    row.visitedDirectory = true
+                }
             }
 
             return ChangeSet(

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Enumeration/Enumerator+WorkingSetScan.swift
@@ -101,13 +101,16 @@ extension Enumerator {
             logger.debug("Completed checking materialised items for changes on the server.")
         }
 
+        // Trashed rows are excluded because trashing moves `serverUrl` to the trashbin without
+        // setting `deleted`, and the ordinary DAV path 404s there — which the scan reads as a
+        // deletion of the row trash reconciliation needs.
         // Unlike when enumerating items we can't progressively enumerate items as we need to
         // wait to see which items are truly deleted and which have just been moved elsewhere.
         // Visited folders and downloaded files. Sort in terms of their remote URLs.
         // This way we ensure we visit parent folders before their children.
         let materialisedItems = dbManager
             .materialisedItemMetadatas(account: account.ncKitAccount)
-            .filter { !$0.deleted }
+            .filter { !$0.deleted && !$0.isTrashed }
             .sorted { $0.remotePath().count < $1.remotePath().count }
 
         var accumulatedCreations = [SendableItemMetadata]()

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Create.swift
@@ -103,6 +103,10 @@ public extension Item {
 
         directory.downloaded = true
         directory.keepDownloaded = parentKeepDownloaded
+        // A folder we just created is already fully enumerated from the framework's point of
+        // view, so set `visitedDirectory` to keep future change scans covering it
+        // (nextcloud/desktop#9688, #10681).
+        directory.visitedDirectory = true
         dbManager.addItemMetadata(directory)
 
         let displayFileActions = await Item.typeHasApplicableContextMenuItems(account: account, remoteInterface: remoteInterface, candidate: directory.contentType)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+Delete.swift
@@ -18,7 +18,9 @@ public extension Item {
         ignoredFiles: IgnoredFilesMatcher? = nil,
         dbManager: FilesDatabaseManager
     ) async -> Error? {
-        let isEmptyDirOrIsFile = childItemCount == nil || childItemCount == 0
+        // `childItemCount` is nil both for a file and for a directory nobody has enumerated, so
+        // a directory whose contents are unknown must not be treated as empty here.
+        let isEmptyDirOrIsFile = !metadata.directory || childItemCount == 0
 
         guard trashing || isEmptyDirOrIsFile || options.contains(.recursive) else {
             return NSFileProviderError(.directoryNotEmpty)

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -224,16 +224,14 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
     public var childItemCount: NSNumber? {
         guard metadata.directory else { return nil }
 
-        // No rows is not evidence of an empty directory, only of one nothing has read yet, and
-        // there is no flag that reliably says which: `visitedDirectory` is still false after a
-        // paginated enumeration, which is the path every server from Nextcloud 31 takes. So the
-        // only honest answer for an empty local set is "unknown".
-        //
-        // The cost is one enumeration of a genuinely empty folder, which is what the framework
-        // would do anyway on first browse. The cost of the alternative was the folder never being
-        // enumerated at all.
         let known = dbManager.childItemCount(directoryMetadata: metadata)
-        return known > 0 ? NSNumber(integerLiteral: known) : nil
+
+        // Any children at all means the database has something to say.
+        guard known == 0 else { return NSNumber(integerLiteral: known) }
+
+        // Zero is ambiguous, and `visitedDirectory` separates a directory that has been read
+        // and is empty from one that simply holds no rows yet.
+        return metadata.visitedDirectory ? NSNumber(integerLiteral: 0) : nil
     }
 
     public var fileSystemFlags: NSFileProviderFileSystemFlags {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item.swift
@@ -217,12 +217,23 @@ public final class Item: NSObject, NSFileProviderItem, Sendable {
         return formatter.personNameComponents(from: metadata.ownerDisplayName)
     }
 
+    ///
+    /// The number of items directly inside this container, or `nil` when the directory has not been
+    /// enumerated and its contents are therefore unknown.
+    ///
     public var childItemCount: NSNumber? {
-        if metadata.directory {
-            NSNumber(integerLiteral: dbManager.childItemCount(directoryMetadata: metadata))
-        } else {
-            nil
-        }
+        guard metadata.directory else { return nil }
+
+        // No rows is not evidence of an empty directory, only of one nothing has read yet, and
+        // there is no flag that reliably says which: `visitedDirectory` is still false after a
+        // paginated enumeration, which is the path every server from Nextcloud 31 takes. So the
+        // only honest answer for an empty local set is "unknown".
+        //
+        // The cost is one enumeration of a genuinely empty folder, which is what the framework
+        // would do anyway on first browse. The cost of the alternative was the folder never being
+        // enumerated at all.
+        let known = dbManager.childItemCount(directoryMetadata: metadata)
+        return known > 0 ? NSNumber(integerLiteral: known) : nil
     }
 
     public var fileSystemFlags: NSFileProviderFileSystemFlags {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChildItemCountTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ChildItemCountTests.swift
@@ -1,0 +1,101 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+@testable import NextcloudFileProviderKit
+
+///
+/// Coverage for `NSFileProviderItem.childItemCount`, where `nil` means nobody has looked and `0`
+/// means the directory has been read and is empty.
+///
+final class ChildItemCountTests: XCTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+    private var remoteInterface: MockRemoteInterface!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChildItemCountTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: directory,
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+        remoteInterface = MockRemoteInterface(account: Self.account)
+    }
+
+    @discardableResult
+    private func seedDirectory(ocId: String, name: String, parentUrl: String) -> SendableItemMetadata {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: name, account: Self.account)
+        metadata.directory = true
+        metadata.serverUrl = parentUrl
+        metadata.uploaded = true
+        dbManager.addItemMetadata(metadata)
+        return metadata
+    }
+
+    private func seedFile(ocId: String, name: String, parentUrl: String) {
+        var metadata = SendableItemMetadata(ocId: ocId, fileName: name, account: Self.account)
+        metadata.serverUrl = parentUrl
+        metadata.uploaded = true
+        dbManager.addItemMetadata(metadata)
+    }
+
+    private func item(for metadata: SendableItemMetadata) -> Item {
+        Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: dbManager
+        )
+    }
+
+    /// A folder whose children have never been read must not claim to be empty, or nothing will
+    /// ever ask what is in it.
+    func testADirectoryWithNoKnownChildrenReportsUnknownRatherThanZero() {
+        let folder = seedDirectory(
+            ocId: "unread", name: "2026_Project", parentUrl: Self.account.davFilesUrl
+        )
+
+        XCTAssertNil(
+            item(for: folder).childItemCount,
+            "An unread directory must report nil. Zero is a claim that it is empty."
+        )
+    }
+
+    /// Once the database does hold children, the count is real knowledge and is reported.
+    func testADirectoryWithKnownChildrenReportsHowMany() {
+        let folder = seedDirectory(
+            ocId: "read", name: "2026_Project", parentUrl: Self.account.davFilesUrl
+        )
+        let folderUrl = Self.account.davFilesUrl + "/2026_Project"
+        seedDirectory(ocId: "c1", name: "00_Input", parentUrl: folderUrl)
+        seedDirectory(ocId: "c2", name: "02_Design", parentUrl: folderUrl)
+        seedFile(ocId: "c3", name: "brief.pdf", parentUrl: folderUrl)
+
+        XCTAssertEqual(item(for: folder).childItemCount?.intValue, 3)
+    }
+
+    /// A file has no children to speak of, and never did.
+    func testAFileReportsNoCountAtAll() {
+        var file = SendableItemMetadata(ocId: "f", fileName: "brief.pdf", account: Self.account)
+        file.serverUrl = Self.account.davFilesUrl
+        file.uploaded = true
+        dbManager.addItemMetadata(file)
+
+        XCTAssertNil(item(for: file).childItemCount)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -1630,10 +1630,9 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             remoteInterface: remoteInterface,
             dbManager: Self.dbManager
         )
-        // `nil`, not 0: the database holds no children for this folder, and that is indistinguishable
-        // from nobody having read it. Reporting 0 would assert the folder is empty, which is what
-        // stopped the framework asking for its contents at all.
-        XCTAssertNil(storedFolderItem.childItemCount)
+        // 0, not nil: the enumeration above read this folder, so the empty result is knowledge.
+        let childItemCount = storedFolderItem.childItemCount as? Int
+        XCTAssertEqual(childItemCount, remoteFolder.children.count)
     }
 
     func testFolderWithFewItemsPaginatedEnumeration() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/EnumeratorTests.swift
@@ -179,7 +179,8 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             Int(storedFolderItem.contentModificationDate?.timeIntervalSince1970 ?? 0),
             Int(remoteFolder.modificationDate.timeIntervalSince1970)
         )
-        XCTAssertEqual(storedFolderItem.childItemCount?.intValue, 0) // Not visited yet, so no kids
+        // Not read yet, so the count is unknown rather than zero — see `Item.childItemCount`.
+        XCTAssertNil(storedFolderItem.childItemCount)
     }
 
     func testWorkingSetEnumeration() async throws {
@@ -1629,9 +1630,10 @@ final class EnumeratorTests: NextcloudFileProviderKitTestCase {
             remoteInterface: remoteInterface,
             dbManager: Self.dbManager
         )
-        let childItemCount = storedFolderItem.childItemCount as? Int
-        let expectedChildItemCount = remoteFolder.children.count
-        XCTAssertEqual(childItemCount, expectedChildItemCount)
+        // `nil`, not 0: the database holds no children for this folder, and that is indistinguishable
+        // from nobody having read it. Reporting 0 would assert the folder is empty, which is what
+        // stopped the framework asking for its contents at all.
+        XCTAssertNil(storedFolderItem.childItemCount)
     }
 
     func testFolderWithFewItemsPaginatedEnumeration() async throws {

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -537,4 +537,88 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "A push with no locally known ids is correctly ignored."
         )
     }
+
+    /// Headline regression for nextcloud/desktop#9688 and #10681: a folder the user creates on the Mac,
+    /// then an item created inside it on the server, which stays invisible unless creation marks the
+    /// folder visited.
+    func testItemCreatedOnServerInLocallyCreatedFolderIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+
+        // Create the folder the way Finder does, through the extension's create path.
+        var folderMetadata = SendableItemMetadata(
+            ocId: "folder-id", fileName: "folder", account: Self.account
+        )
+        folderMetadata.directory = true
+        folderMetadata.classFile = NKTypeClassFile.directory.rawValue
+        folderMetadata.serverUrl = Self.account.davFilesUrl
+
+        let (createdFolderMaybe, createError) = await Item.create(
+            basedOn: Item(
+                metadata: folderMetadata,
+                parentItemIdentifier: .rootContainer,
+                account: Self.account,
+                remoteInterface: remoteInterface,
+                dbManager: Self.dbManager
+            ),
+            contents: nil,
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            progress: Progress(),
+            dbManager: Self.dbManager,
+            log: FileProviderLogMock()
+        )
+        XCTAssertNil(createError)
+        let createdFolder = try XCTUnwrap(createdFolderMaybe)
+
+        // The server-side creation inside that folder, with nothing in the subtree materialised.
+        let remoteFolder = try XCTUnwrap(rootItem.children.first { $0.name == "folder" })
+        let newFile = makeFile(name: "createdOnServer.txt", parent: remoteFolder, etag: "new-v1")
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        // Assert the user-visible outcome first, so a regression fails on the symptom rather than on
+        // the flag that causes it.
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a locally created folder must be reported. Reported: \(reportedIds(observer).sorted())"
+        )
+
+        // Then the mechanism: creation must record the folder as visited, or the working-set scan has
+        // no reason to read it.
+        let storedFolder = try XCTUnwrap(
+            Self.dbManager.itemMetadata(ocId: createdFolder.itemIdentifier.rawValue)
+        )
+        XCTAssertTrue(
+            storedFolder.visitedDirectory,
+            "A locally created folder must be recorded as visited; macOS will not enumerate it again."
+        )
+    }
+
+    /// The eviction-shaped variant of the same hole: a folder Finder has enumerated whose contents are
+    /// all dataless, where a new server-side child must still surface through the depth-1 read.
+    func testItemCreatedOnServerInVisitedFolderWithNoMaterialisedContentIsReported() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let folder = makeFolder(name: "folder", parent: rootItem, etag: "folder-v1")
+        let existingFile = makeFile(name: "itemA", parent: folder, etag: "itemA-v1")
+
+        seed(folder, visitedDirectory: true) // enumerated once by Finder
+        seed(existingFile, downloaded: false) // evicted / never downloaded
+
+        // A new item appears on the server; the parent ETag is deliberately left alone, so discovery
+        // cannot lean on the parent looking changed.
+        let newFile = makeFile(name: "createdOnServer.txt", parent: folder, etag: "new-v1")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let observer = try await runWorkingSetChanges(remoteInterface)
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            reportedIds(observer).contains(newFile.identifier),
+            "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
+        )
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/RemoteChangePropagationTests.swift
@@ -621,4 +621,50 @@ final class RemoteChangePropagationTests: NextcloudFileProviderKitTestCase {
             "An item created on the server inside a visited folder must be reported even when nothing in that folder is materialised."
         )
     }
+
+    ///
+    /// A trashed folder must not be scanned through the ordinary DAV path, whose 404 the scan would
+    /// read as a deletion.
+    ///
+    func testTrashedFolderIsNotScannedThroughTheRegularDavPath() async throws {
+        let db = Self.dbManager.ncDatabase(); debugPrint(db)
+
+        let liveFolder = makeFolder(name: "live", parent: rootItem, etag: "live-v1")
+        seed(liveFolder, visitedDirectory: true)
+
+        // A folder the user trashed: still visited, not soft-deleted, but living in the trashbin.
+        var trashed = makeFolder(name: "gone", parent: rootItem, etag: "gone-v1")
+            .toItemMetadata(account: Self.account)
+        trashed.ocId = "trashed-folder"
+        trashed.visitedDirectory = true
+        trashed.deleted = false
+        trashed.syncTime = oldSyncTime
+        trashed.serverUrl = Self.account.trashUrl
+        trashed.apply(fileName: "gone.d1788354069")
+        Self.dbManager.addItemMetadata(trashed)
+        XCTAssertTrue(trashed.isTrashed, "Precondition: the row must look trashed.")
+
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        let recorder = EnumeratePathRecorder()
+        remoteInterface.enumerateCallHandler = { remotePath, _, _, _, _, _, _, _ in
+            recorder.add(remotePath)
+        }
+
+        let observer = try await runWorkingSetChanges(remoteInterface)
+        let enumeratedPaths = recorder.paths
+
+        XCTAssertNil(observer.error)
+        XCTAssertTrue(
+            enumeratedPaths.contains { $0.hasSuffix("/live") },
+            "Sanity: the live materialised folder is still scanned."
+        )
+        XCTAssertFalse(
+            enumeratedPaths.contains { $0.contains("/trashbin/") },
+            "A trashed row must never be PROPFINDed through the regular DAV path. Got: \(enumeratedPaths)"
+        )
+        XCTAssertNotNil(
+            Self.dbManager.itemMetadata(ocId: "trashed-folder"),
+            "The trash row must survive the scan; trash reconciliation derives deletions from it."
+        )
+    }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/VisitedDirectoryTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/VisitedDirectoryTests.swift
@@ -1,0 +1,112 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+@preconcurrency import FileProvider
+import Foundation
+import NextcloudFileProviderKitMocks
+import RealmSwift
+@testable import TestInterface
+import XCTest
+@testable import NextcloudFileProviderKit
+
+///
+/// `visitedDirectory` records that a directory has actually been read, which decides both its
+/// membership of the working set and whether an empty child count is knowledge or its absence.
+///
+final class VisitedDirectoryTests: XCTestCase {
+    private static let account = Account(
+        user: "testUser", id: "testUserId", serverUrl: "https://mock.nc.com", password: "abcd"
+    )
+
+    private var dbManager: FilesDatabaseManager!
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = name
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VisitedDirectoryTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        dbManager = FilesDatabaseManager(
+            account: Self.account,
+            databaseDirectory: directory,
+            fileProviderDomainIdentifier: NSFileProviderDomainIdentifier("test"),
+            log: FileProviderLogMock()
+        )
+    }
+
+    /// The directory as the server reports it, built once and reused so both reads carry
+    /// identical timestamps and the unchanged case is what gets exercised.
+    private lazy var folder: SendableItemMetadata = {
+        var metadata = SendableItemMetadata(
+            ocId: "folder", fileName: "2026_Project", account: Self.account
+        )
+        metadata.directory = true
+        metadata.serverUrl = Self.account.davFilesUrl
+        metadata.etag = "unchanged-etag"
+        metadata.uploaded = true
+        return metadata
+    }()
+
+    private func ingest() -> ChangeSet? {
+        dbManager.depth1ReadUpdateItemMetadatas(
+            account: Self.account.ncKitAccount,
+            serverUrl: Self.account.davFilesUrl + "/2026_Project",
+            updatedMetadatas: [folder],
+            keepExistingDownloadState: true
+        )
+    }
+
+    /// The regression: the row already exists with the same remote state, and the visit must
+    /// still be written.
+    func testReadingAnUnchangedDirectoryStillRecordsTheVisit() throws {
+        dbManager.addItemMetadata(folder)
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: "folder")?.visitedDirectory, false,
+            "Precondition: the seeded row has not been visited."
+        )
+
+        _ = ingest()
+
+        XCTAssertEqual(
+            dbManager.itemMetadata(ocId: "folder")?.visitedDirectory, true,
+            "Reading a directory must record the visit even when nothing remote changed."
+        )
+    }
+
+    /// The visit is persisted without entering `metadatasToUpdate`, which is also the change set
+    /// handed to the framework.
+    func testRecordingAVisitDoesNotReportTheDirectoryAsChanged() throws {
+        dbManager.addItemMetadata(folder)
+
+        let changes = try XCTUnwrap(ingest())
+
+        XCTAssertFalse(
+            changes.updated.contains { $0.ocId == "folder" },
+            "A visit is local-only state; it must not be reported to the framework as a change."
+        )
+        XCTAssertFalse(
+            changes.created.contains { $0.ocId == "folder" },
+            "The directory already existed; recording its visit must not recreate it."
+        )
+    }
+
+    /// Once recorded, an empty directory's child count becomes a real zero rather than "unknown".
+    func testAVisitedEmptyDirectoryReportsZeroChildrenRatherThanUnknown() throws {
+        dbManager.addItemMetadata(folder)
+        _ = ingest()
+
+        let metadata = try XCTUnwrap(dbManager.itemMetadata(ocId: "folder"))
+        let item = Item(
+            metadata: metadata,
+            parentItemIdentifier: .rootContainer,
+            account: Self.account,
+            remoteInterface: MockRemoteInterface(account: Self.account),
+            dbManager: dbManager
+        )
+
+        XCTAssertEqual(
+            item.childItemCount?.intValue, 0,
+            "A directory that has been read and holds nothing is empty, not unknown."
+        )
+    }
+}


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Summary

A folder in the trash was still being scanned as if it were a live folder, and
the 404 that produced destroyed the database row that trash restore and
permanent-deletion reconciliation depend on.

Trashing rewrites an item's `serverUrl` to the trashbin path but leaves
`deleted` false, and a folder keeps its `visitedDirectory` flag. Both are what
put an item in the materialised set, so a trashed folder stayed in it and the
working-set scan PROPFINDed it through the ordinary DAV path. That path 404s for
something that now lives in the trashbin — and the scan reads a 404 as "the item
is gone". It reported the item deleted and hard-removed the row, which is the
same row the trash reconciliation derives permanent deletions from. Trash has
its own enumeration path via `listingTrashAsync` and does not need the scan to
visit it.

The fix excludes trashed rows from the scan's seed set.

## Changes

1. **Add remote-change propagation regression tests** — covers the path a
   notify_push or root-ETag signal actually drives:
   `enumerateChanges(.workingSet)` → `scanMaterialisedItemsForRemoteChanges()`
   → `pendingWorkingSetChanges(since:)` → the change observer. Each test mutates
   the mock server and asserts the change reaches `MockChangeObserver`. Three of
   them reproduce silent drops that were real: the scan relying on the lossy
   `syncTime` reconstruction instead of returning what it discovered, recursion
   into changed subdirectories, and `size` participating in the change-detection
   predicate.
2. **Keep trashed rows out of the working-set scan** — filter them from the
   materialised set the scan walks.

## Testing

Full suite green at 359 XCTest + 59 Swift Testing; the first commit is green
standalone at 358 + 59.

`testTrashedFolderIsNotScannedThroughTheRegularDavPath` fails on both counts
without the fix: it observes the PROPFIND going to
`/remote.php/dav/trashbin/…` and it observes the row being destroyed.

## Depends on #<B>

This branch is stacked on the directory-visits PR and its diff here includes
those three commits until that one merges.

The dependency is real, not just packaging.
`testItemCreatedOnServerInLocallyCreatedFolderIsReported` fails on `stable-34.0`
without "mark locally created directories as visited", and the trashed-rows
change does not apply to the test file without the tests commit that precedes
it. Happy to rebase and repush once the other one lands.


## Checklist
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [X] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [X] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [X] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [X] The content of this PR was partly or fully generated using AI
  - [X] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [X] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
