### PR TITLE
fix(gui): add application menu to Activities window

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -5,6 +5,7 @@
         <file>src/gui/UserStatusWindow.qml</file>
         <file>src/gui/WindowAccountHeader.qml</file>
         <file>src/gui/activity/qml/ActivitiesWindow.qml</file>
+        <file>src/gui/activity/qml/ActivitiesWindowMenu.qml</file>
         <file>src/gui/AssistantWindow.qml</file>
         <file>src/gui/search/SearchWindow.qml</file>
         <file>src/gui/UserStatusWindowStatusRow.qml</file>

--- a/src/gui/WindowAccountHeader.qml
+++ b/src/gui/WindowAccountHeader.qml
@@ -106,15 +106,18 @@ Item {
         }
 
         ColumnLayout {
+            // Round up so that a fractional implicit width does not elide text that fits.
             Layout.preferredWidth: Math.min(root.maximumAccountTextWidth,
-                                            Math.max(accountNameLabel.implicitWidth,
-                                                     accountServerLabel.implicitWidth))
+                                            Math.ceil(Math.max(accountNameLabel.implicitWidth,
+                                                               accountServerLabel.implicitWidth)))
             Layout.maximumWidth: root.maximumAccountTextWidth
             Layout.minimumWidth: 0
             spacing: Style.wizardHeaderLabelSpacing
 
             EnforcedPlainTextLabel {
                 id: accountNameLabel
+
+                objectName: "windowAccountHeaderNameLabel"
 
                 Layout.fillWidth: true
                 text: root.user ? root.user.name : ""
@@ -127,6 +130,8 @@ Item {
 
             EnforcedPlainTextLabel {
                 id: accountServerLabel
+
+                objectName: "windowAccountHeaderServerLabel"
 
                 Layout.fillWidth: true
                 text: root.user ? root.user.server : ""

--- a/src/gui/WindowAccountHeader.qml
+++ b/src/gui/WindowAccountHeader.qml
@@ -4,6 +4,7 @@
  */
 
 import QtQuick
+import QtQuick.Controls.Basic as BasicControls
 import QtQuick.Layouts
 
 import Style
@@ -14,14 +15,22 @@ Item {
 
     property string title: ""
     property var user: null
+    // Opt-in: turns the account area into a control that opens an application menu.
+    property bool accountMenuEnabled: false
+
+    signal accountMenuRequested()
 
     readonly property string avatarSource: user && user.avatar !== ""
         ? user.avatar
         : (Style.darkMode ? "image://avatars/fallbackWhite" : "image://avatars/fallbackBlack")
+    readonly property int accountMenuIndicatorWidth: accountMenuEnabled
+        ? Style.smallIconSize + Style.wizardHeaderRowSpacing
+        : 0
     readonly property int maximumAccountTextWidth: Math.max(0,
                                                             Math.round(width * 0.55)
                                                             - Style.wizardHeaderAvatarSize
-                                                            - Style.wizardHeaderRowSpacing)
+                                                            - Style.wizardHeaderRowSpacing
+                                                            - accountMenuIndicatorWidth)
 
     implicitHeight: Math.max(titleLabel.implicitHeight, accountRow.implicitHeight)
 
@@ -40,9 +49,42 @@ Item {
         elide: Text.ElideRight
     }
 
+    BasicControls.Button {
+        id: accountMenuButton
+
+        objectName: "windowAccountHeaderMenuButton"
+        anchors.fill: accountRow
+        anchors.margins: -Style.extraSmallSpacing
+        z: -1
+        visible: root.accountMenuEnabled && accountRow.visible
+        enabled: visible
+        focusPolicy: Qt.StrongFocus
+
+        Accessible.role: Accessible.ButtonMenu
+        Accessible.name: qsTr("Account switcher and settings menu")
+        Accessible.onPressAction: accountMenuButton.clicked()
+
+        onClicked: root.accountMenuRequested()
+
+        background: Rectangle {
+            radius: Style.mediumRoundedButtonRadius
+            color: {
+                if (accountMenuButton.down) {
+                    return Style.wizardSecondaryButtonPressed
+                }
+                return accountMenuButton.hovered ? Style.listItemHoverBackground : "transparent"
+            }
+        }
+
+        HoverHandler {
+            cursorShape: Qt.PointingHandCursor
+        }
+    }
+
     RowLayout {
         id: accountRow
 
+        objectName: "windowAccountHeaderAccountRow"
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         width: implicitWidth
@@ -93,6 +135,20 @@ Item {
                 horizontalAlignment: Text.AlignLeft
                 elide: Text.ElideRight
             }
+        }
+
+        Image {
+            objectName: "windowAccountHeaderCaret"
+            Layout.preferredWidth: visible ? Style.smallIconSize : 0
+            Layout.preferredHeight: Style.smallIconSize
+            visible: root.accountMenuEnabled
+            source: visible
+                ? "image://svgimage-custom-color/caret-down.svg/" + Style.wizardSecondaryText
+                : ""
+            sourceSize.width: Style.smallIconSize
+            sourceSize.height: Style.smallIconSize
+            fillMode: Image.PreserveAspectFit
+            Accessible.ignored: true
         }
     }
 }

--- a/src/gui/activity/qml/ActivitiesWindow.qml
+++ b/src/gui/activity/qml/ActivitiesWindow.qml
@@ -31,7 +31,16 @@ WizardStyledWindow {
 
     Shortcut {
         sequences: [StandardKey.Cancel]
+        // Let the application menu handle the key while it is open.
+        enabled: !applicationMenu.opened
         onActivated: root.close()
+    }
+
+    ActivitiesWindowMenu {
+        id: applicationMenu
+
+        anchorItem: accountHeader
+        onCloseWindowRequested: root.close()
     }
 
     Component.onCompleted: resetActivityList()
@@ -51,9 +60,13 @@ WizardStyledWindow {
         spacing: Style.wizardSectionSpacing
 
         WindowAccountHeader {
+            id: accountHeader
+
             Layout.fillWidth: true
             title: root.headline
             user: root.account
+            accountMenuEnabled: true
+            onAccountMenuRequested: applicationMenu.toggleUnder(accountHeader)
         }
 
         Rectangle {

--- a/src/gui/activity/qml/ActivitiesWindowMenu.qml
+++ b/src/gui/activity/qml/ActivitiesWindowMenu.qml
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Controls.Basic as BasicControls
+
+import Style
+import com.nextcloud.desktopclient
+import "qrc:/qml/src/gui/wizard/qml"
+
+WizardMenu {
+    id: root
+
+    readonly property bool showAccounts: UserModel.count > 1
+
+    // Emitted when this window is replaced by another one, for example after switching account.
+    signal closeWindowRequested()
+
+    function switchToAccount(userIndex) {
+        if (userIndex === UserModel.currentUserId) {
+            return
+        }
+
+        UserModel.currentUserId = userIndex
+        Systray.showActivitiesWindow(userIndex)
+        root.closeWindowRequested()
+    }
+
+    function toggleUnder(item) {
+        if (opened) {
+            close()
+            return
+        }
+
+        // Keep the menu inside the window by aligning it with the edge the
+        // account area sits at instead of dropping it below its left side.
+        const menuX = item.LayoutMirroring.enabled ? 0 : item.width - width
+        popup(item, menuX, item.height + Style.smallSpacing)
+    }
+
+    objectName: "activitiesApplicationMenu"
+    width: Style.activitiesWindowMenuWidth
+
+    Instantiator {
+        model: root.showAccounts ? UserModel : null
+
+        delegate: WizardMenuItem {
+            objectName: "activitiesAccountMenuItem"
+            // UserModel does not report IsCurrentUserRole changes to its views,
+            // so the current account is derived from currentUserId instead.
+            text: (model.index === UserModel.currentUserId ? "✓ " : "")
+                + "%1 (%2)".arg(model.name).arg(model.server)
+            onTriggered: root.switchToAccount(model.index)
+        }
+
+        onObjectAdded: (index, object) => root.insertItem(index, object)
+        onObjectRemoved: (index, object) => root.removeItem(object)
+    }
+
+    BasicControls.MenuSeparator {
+        objectName: "activitiesAccountsSeparator"
+        height: visible ? implicitHeight : 0
+        visible: root.showAccounts
+    }
+
+    WizardMenuItem {
+        objectName: "activitiesAddAccountMenuItem"
+        height: visible ? implicitHeight : 0
+        visible: Systray.enableAddAccount
+        text: qsTr("Add account")
+        onTriggered: UserModel.addAccount()
+    }
+
+    WizardMenuItem {
+        objectName: "activitiesPauseSyncMenuItem"
+        height: visible ? implicitHeight : 0
+        visible: Systray.canPauseSync
+        text: qsTr("Pause sync for all")
+        onTriggered: Systray.setSyncIsPaused(true)
+    }
+
+    WizardMenuItem {
+        objectName: "activitiesResumeSyncMenuItem"
+        height: visible ? implicitHeight : 0
+        visible: Systray.canResumeSync
+        text: qsTr("Resume sync for all")
+        onTriggered: Systray.setSyncIsPaused(false)
+    }
+
+    WizardMenuItem {
+        objectName: "activitiesSettingsMenuItem"
+        text: qsTr("Settings")
+        onTriggered: Systray.openSettings()
+    }
+
+    WizardMenuItem {
+        objectName: "activitiesQuitMenuItem"
+        text: qsTr("Quit")
+        onTriggered: Systray.shutdown()
+    }
+}

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -1025,12 +1025,14 @@ void Systray::slotUpdateSyncPausedState()
         if (!folder->syncPaused()) {
             _syncIsPaused = false;
             Q_EMIT syncIsPausedChanged();
+            Q_EMIT syncControlStateChanged();
             return;
         }
     }
 
     _syncIsPaused = true;
     Q_EMIT syncIsPausedChanged();
+    Q_EMIT syncControlStateChanged();
 }
 
 void Systray::slotUnpauseAllFolders()
@@ -1048,6 +1050,7 @@ void Systray::slotSyncFoldersChanged(const OCC::Folder::Map &folderMap)
     if (const auto currentAnySyncFolders = !folderMap.isEmpty(); currentAnySyncFolders != _anySyncFolders) {
         _anySyncFolders = currentAnySyncFolders;
         Q_EMIT anySyncFoldersChanged();
+        Q_EMIT syncControlStateChanged();
     }
 }
 
@@ -1213,6 +1216,18 @@ Systray::SyncControlState Systray::syncControlState() const
         return SyncControlState::PauseAndResume;
     }
     return anyPaused ? SyncControlState::Resume : SyncControlState::Pause;
+}
+
+bool Systray::canPauseSync() const
+{
+    const auto state = syncControlState();
+    return state == SyncControlState::Pause || state == SyncControlState::PauseAndResume;
+}
+
+bool Systray::canResumeSync() const
+{
+    const auto state = syncControlState();
+    return state == SyncControlState::Resume || state == SyncControlState::PauseAndResume;
 }
 
 /********************************************************************************************/

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -67,6 +67,8 @@ class Systray : public QSystemTrayIcon
     Q_PROPERTY(bool useNormalWindow READ useNormalWindow CONSTANT)
     Q_PROPERTY(bool syncIsPaused READ syncIsPaused WRITE setSyncIsPaused NOTIFY syncIsPausedChanged)
     Q_PROPERTY(bool anySyncFolders READ anySyncFolders NOTIFY anySyncFoldersChanged)
+    Q_PROPERTY(bool canPauseSync READ canPauseSync NOTIFY syncControlStateChanged)
+    Q_PROPERTY(bool canResumeSync READ canResumeSync NOTIFY syncControlStateChanged)
     Q_PROPERTY(bool isOpen READ isOpen WRITE setIsOpen NOTIFY isOpenChanged)
     Q_PROPERTY(bool enableAddAccount READ enableAddAccount CONSTANT)
 
@@ -102,6 +104,10 @@ public:
     [[nodiscard]] bool anySyncFolders() const;
     /** @brief Returns the actions that the global tray synchronization control should offer. */
     [[nodiscard]] SyncControlState syncControlState() const;
+    /** @brief Returns whether the global synchronization control offers pausing all folders. */
+    [[nodiscard]] bool canPauseSync() const;
+    /** @brief Returns whether the global synchronization control offers resuming all folders. */
+    [[nodiscard]] bool canResumeSync() const;
     [[nodiscard]] bool isOpen() const;
     [[nodiscard]] bool isActivitySurfaceVisible() const;
     void setTrayContextMenuVisible(const bool visible);
@@ -127,6 +133,7 @@ Q_SIGNALS:
 
     void syncIsPausedChanged();
     void anySyncFoldersChanged();
+    void syncControlStateChanged();
     void isOpenChanged();
 
     void hideSettingsDialog();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ nextcloud_add_test(SetUserStatusDialog)
 nextcloud_add_test(TrayAccountMenuPolicy)
 nextcloud_add_test(TrayActivationPolicy)
 nextcloud_add_test(TrayAccountPopupPresentation)
+nextcloud_add_test(SystraySyncControl)
 if(NOT APPLE)
     nextcloud_add_test(SystraySyncControlQt)
 endif()
@@ -135,6 +136,20 @@ add_test(NAME SearchQmlTest
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 set_tests_properties(SearchQmlTest PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+add_executable(ActivitiesMenuQmlTest qml/activitiesmenu/activitiesmenuqmltestrunner.cpp)
+target_link_libraries(ActivitiesMenuQmlTest PRIVATE nextcloudCore Qt::QuickTest)
+target_compile_definitions(ActivitiesMenuQmlTest PRIVATE
+    ACTIVITIES_MENU_QML_TEST_IMPORT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/qml/activitiesmenu/imports"
+)
+set_target_properties(ActivitiesMenuQmlTest PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIRECTORY}
+    FOLDER Tests
+)
+add_test(NAME ActivitiesMenuQmlTest
+    COMMAND ActivitiesMenuQmlTest -input "${CMAKE_CURRENT_SOURCE_DIR}/qml/activitiesmenu/testactivitiesmenu.qml"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+set_tests_properties(ActivitiesMenuQmlTest PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 nextcloud_add_test(TalkReply)
 nextcloud_add_test(LockFile)
 nextcloud_add_test(ShareModel)

--- a/test/qml/activitiesmenu/activitiesmenuqmltestrunner.cpp
+++ b/test/qml/activitiesmenu/activitiesmenuqmltestrunner.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <QQmlEngine>
+#include <QtQuickTest/quicktest.h>
+
+class ActivitiesMenuQmlTestSetup : public QObject
+{
+    Q_OBJECT
+
+public:
+    ActivitiesMenuQmlTestSetup()
+    {
+        Q_INIT_RESOURCE(resources);
+        Q_INIT_RESOURCE(theme);
+    }
+
+public slots:
+    void qmlEngineAvailable(QQmlEngine *engine)
+    {
+        // The Systray and UserModel singletons are provided as QML mocks so that the
+        // menu can be exercised without a running application.
+        engine->addImportPath(QStringLiteral(ACTIVITIES_MENU_QML_TEST_IMPORT_PATH));
+        engine->addImportPath(QStringLiteral("qrc:/qml/theme"));
+    }
+};
+
+QUICK_TEST_MAIN_WITH_SETUP(activitiesmenu, ActivitiesMenuQmlTestSetup)
+
+#include "activitiesmenuqmltestrunner.moc"

--- a/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/Systray.qml
+++ b/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/Systray.qml
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma Singleton
+
+import QtQuick
+
+QtObject {
+    id: root
+
+    property bool enableAddAccount: true
+    property bool canPauseSync: false
+    property bool canResumeSync: false
+
+    property int activitiesWindowUserIndex: -1
+    property int setSyncIsPausedCallCount: 0
+    property bool syncIsPaused: false
+
+    signal openSettings()
+    signal shutdown()
+
+    function setSyncIsPaused(paused) {
+        root.syncIsPaused = paused
+        root.setSyncIsPausedCallCount += 1
+    }
+
+    function showActivitiesWindow(userIndex) {
+        root.activitiesWindowUserIndex = userIndex
+    }
+
+    function reset() {
+        root.enableAddAccount = true
+        root.canPauseSync = false
+        root.canResumeSync = false
+        root.activitiesWindowUserIndex = -1
+        root.setSyncIsPausedCallCount = 0
+        root.syncIsPaused = false
+    }
+}

--- a/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/UserModel.qml
+++ b/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/UserModel.qml
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+pragma Singleton
+
+import QtQuick
+
+ListModel {
+    id: root
+
+    property int currentUserId: 0
+
+    signal addAccount()
+
+    function reset(userCount) {
+        root.clear()
+        for (let index = 0; index < userCount; ++index) {
+            root.append({
+                name: "user" + index,
+                server: "https://cloud" + index + ".example.com",
+                isCurrentUser: index === 0
+            })
+        }
+        root.currentUserId = 0
+    }
+}

--- a/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/qmldir
+++ b/test/qml/activitiesmenu/imports/com/nextcloud/desktopclient/qmldir
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+module com.nextcloud.desktopclient
+singleton Systray 1.0 Systray.qml
+singleton UserModel 1.0 UserModel.qml

--- a/test/qml/activitiesmenu/testactivitiesmenu.qml
+++ b/test/qml/activitiesmenu/testactivitiesmenu.qml
@@ -278,6 +278,21 @@ Item {
             verify(findChild(header, "windowAccountHeaderCaret").visible)
         }
 
+        function test_shortAccountTextIsNotElided()
+        {
+            const header = createTemporaryObject(accountHeaderComponent, testRoot)
+            verify(header)
+
+            const accountRow = findChild(header, "windowAccountHeaderAccountRow")
+            verify(accountRow.width < header.width * 0.55)
+
+            // A name and server that comfortably fit must not be truncated.
+            const server = findChild(header, "windowAccountHeaderServerLabel")
+            const name = findChild(header, "windowAccountHeaderNameLabel")
+            verify(!name.truncated)
+            verify(!server.truncated)
+        }
+
         function test_accountAreaIsInertWhenTheMenuIsDisabled()
         {
             const header = createTemporaryObject(inertAccountHeaderComponent, testRoot)

--- a/test/qml/activitiesmenu/testactivitiesmenu.qml
+++ b/test/qml/activitiesmenu/testactivitiesmenu.qml
@@ -1,0 +1,290 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import QtQuick
+import QtTest
+
+import com.nextcloud.desktopclient
+import "qrc:/qml/src/gui"
+import "qrc:/qml/src/gui/activity/qml"
+
+Item {
+    id: testRoot
+
+    width: 400
+    height: 300
+
+    Component {
+        id: menuComponent
+
+        ActivitiesWindowMenu {
+            anchorItem: testRoot
+        }
+    }
+
+    Component {
+        id: accountHeaderComponent
+
+        WindowAccountHeader {
+            width: testRoot.width
+            title: "Activities"
+            user: ({ name: "alice", server: "localhost:8080", avatar: "" })
+            accountMenuEnabled: true
+        }
+    }
+
+    Component {
+        id: inertAccountHeaderComponent
+
+        WindowAccountHeader {
+            width: testRoot.width
+            title: "Activities"
+            user: ({ name: "alice", server: "localhost:8080", avatar: "" })
+            accountMenuEnabled: false
+        }
+    }
+
+    Component {
+        id: longNameHeaderComponent
+
+        WindowAccountHeader {
+            width: testRoot.width
+            title: "Activities"
+            accountMenuEnabled: true
+            user: ({
+                name: "a-very-long-account-display-name-that-should-be-elided",
+                server: "an-equally-long-server-host-name.example.com",
+                avatar: ""
+            })
+        }
+    }
+
+    TestCase {
+        id: testCase
+
+        name: "ActivitiesWindowMenu"
+        when: windowShown
+
+        property ActivitiesWindowMenu menu
+
+        SignalSpy {
+            id: closeWindowRequestedSpy
+            signalName: "closeWindowRequested"
+        }
+
+        SignalSpy {
+            id: accountMenuRequestedSpy
+            signalName: "accountMenuRequested"
+        }
+
+        SignalSpy {
+            id: openSettingsSpy
+            target: Systray
+            signalName: "openSettings"
+        }
+
+        SignalSpy {
+            id: shutdownSpy
+            target: Systray
+            signalName: "shutdown"
+        }
+
+        SignalSpy {
+            id: addAccountSpy
+            target: UserModel
+            signalName: "addAccount"
+        }
+
+        function accountItems()
+        {
+            const items = []
+            for (let index = 0; index < menu.count; ++index) {
+                const item = menu.itemAt(index)
+                if (item && item.objectName === "activitiesAccountMenuItem") {
+                    items.push(item)
+                }
+            }
+            return items
+        }
+
+        function menuItem(objectName)
+        {
+            for (let index = 0; index < menu.count; ++index) {
+                const item = menu.itemAt(index)
+                if (item && item.objectName === objectName) {
+                    return item
+                }
+            }
+            return null
+        }
+
+        function init()
+        {
+            Systray.reset()
+            UserModel.reset(2)
+
+            menu = createTemporaryObject(menuComponent, testRoot)
+            verify(menu)
+
+            // Menu entries only report their effective visibility while the menu is shown.
+            menu.open()
+            tryCompare(menu, "opened", true)
+
+            closeWindowRequestedSpy.target = menu
+            closeWindowRequestedSpy.clear()
+            openSettingsSpy.clear()
+            shutdownSpy.clear()
+            addAccountSpy.clear()
+            accountMenuRequestedSpy.clear()
+        }
+
+        function test_accountsAreListedWithSeveralAccounts()
+        {
+            compare(accountItems().length, 2)
+        }
+
+        function test_checkmarkFollowsTheCurrentAccount()
+        {
+            const items = accountItems()
+            compare(items.length, 2)
+
+            verify(items[0].text.startsWith("✓ "))
+            verify(!items[1].text.startsWith("✓ "))
+
+            // UserModel does not notify views when the current user changes, so the
+            // mark has to follow currentUserId rather than the isCurrentUser role.
+            UserModel.currentUserId = 1
+
+            verify(!items[0].text.startsWith("✓ "))
+            verify(items[1].text.startsWith("✓ "))
+        }
+
+        function test_singleAccountHidesAccountEntries()
+        {
+            UserModel.reset(1)
+            compare(accountItems().length, 0)
+        }
+
+        function test_selectingAnotherAccountOpensItsActivitiesWindow()
+        {
+            const items = accountItems()
+            compare(items.length, 2)
+
+            items[1].triggered()
+
+            compare(UserModel.currentUserId, 1)
+            compare(Systray.activitiesWindowUserIndex, 1)
+            compare(closeWindowRequestedSpy.count, 1)
+        }
+
+        function test_selectingTheCurrentAccountKeepsTheWindow()
+        {
+            const items = accountItems()
+            items[0].triggered()
+
+            compare(Systray.activitiesWindowUserIndex, -1)
+            compare(closeWindowRequestedSpy.count, 0)
+        }
+
+        function test_settingsAndQuitUseTheApplicationPaths()
+        {
+            menuItem("activitiesSettingsMenuItem").triggered()
+            compare(openSettingsSpy.count, 1)
+
+            menuItem("activitiesQuitMenuItem").triggered()
+            compare(shutdownSpy.count, 1)
+        }
+
+        function test_addAccountFollowsSystray()
+        {
+            const addAccountItem = menuItem("activitiesAddAccountMenuItem")
+            verify(addAccountItem.visible)
+
+            Systray.enableAddAccount = false
+            verify(!addAccountItem.visible)
+
+            Systray.enableAddAccount = true
+            verify(addAccountItem.visible)
+
+            addAccountItem.triggered()
+            compare(addAccountSpy.count, 1)
+        }
+
+        function test_syncControlItemsFollowSyncControlState()
+        {
+            const pauseItem = menuItem("activitiesPauseSyncMenuItem")
+            const resumeItem = menuItem("activitiesResumeSyncMenuItem")
+
+            // Unavailable: no classic sync folders are configured.
+            verify(!pauseItem.visible)
+            verify(!resumeItem.visible)
+
+            // Pause: all folders are running.
+            Systray.canPauseSync = true
+            verify(pauseItem.visible)
+            verify(!resumeItem.visible)
+
+            // Resume: all folders are paused.
+            Systray.canPauseSync = false
+            Systray.canResumeSync = true
+            verify(!pauseItem.visible)
+            verify(resumeItem.visible)
+
+            // PauseAndResume: some folders are paused and others are running.
+            Systray.canPauseSync = true
+            verify(pauseItem.visible)
+            verify(resumeItem.visible)
+        }
+
+        function test_syncControlItemsPauseAndResumeAllFolders()
+        {
+            Systray.canPauseSync = true
+            menuItem("activitiesPauseSyncMenuItem").triggered()
+            compare(Systray.setSyncIsPausedCallCount, 1)
+            compare(Systray.syncIsPaused, true)
+
+            Systray.canResumeSync = true
+            menuItem("activitiesResumeSyncMenuItem").triggered()
+            compare(Systray.setSyncIsPausedCallCount, 2)
+            compare(Systray.syncIsPaused, false)
+        }
+
+        function test_accountAreaRequestsTheMenu()
+        {
+            const header = createTemporaryObject(accountHeaderComponent, testRoot)
+            verify(header)
+            accountMenuRequestedSpy.target = header
+
+            const caret = findChild(header, "windowAccountHeaderCaret")
+            const headerButton = findChild(header, "windowAccountHeaderMenuButton")
+            verify(caret.visible)
+            verify(headerButton.enabled)
+
+            headerButton.clicked()
+            compare(accountMenuRequestedSpy.count, 1)
+        }
+
+        function test_longAccountNamesStayWithinTheHeader()
+        {
+            const header = createTemporaryObject(longNameHeaderComponent, testRoot)
+            verify(header)
+
+            // The account block, including the caret, keeps to its share of the header
+            // so that a long name cannot push it over the title.
+            const accountRow = findChild(header, "windowAccountHeaderAccountRow")
+            verify(accountRow.width <= Math.round(header.width * 0.55) + 1)
+            verify(findChild(header, "windowAccountHeaderCaret").visible)
+        }
+
+        function test_accountAreaIsInertWhenTheMenuIsDisabled()
+        {
+            const header = createTemporaryObject(inertAccountHeaderComponent, testRoot)
+            verify(header)
+
+            verify(!findChild(header, "windowAccountHeaderCaret").visible)
+            verify(!findChild(header, "windowAccountHeaderMenuButton").enabled)
+        }
+    }
+}

--- a/test/testsystraysynccontrol.cpp
+++ b/test/testsystraysynccontrol.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * This software is in the public domain, furnished "as is", without technical
+ * support, and with no warranty, express or implied, as to its usefulness for
+ * any purpose.
+ */
+
+#include <QtTest>
+
+#include "systray.h"
+
+#include "systraysynccontroltesthelper.h"
+
+using namespace OCC;
+
+class TestSystraySyncControl : public QObject
+{
+    Q_OBJECT
+
+    SystraySyncControlTestHelper _helper;
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        QVERIFY(_helper.initialize());
+    }
+
+    void cleanupTestCase()
+    {
+        _helper.cleanup();
+    }
+
+    /** @brief The QML application menu binds its sync entries to these properties. */
+    void syncControlPropertiesFollowTheSyncControlState()
+    {
+        const auto systray = Systray::instance();
+        auto syncControlStateSpy = QSignalSpy{systray, &Systray::syncControlStateChanged};
+
+        // An account without classic folders is also the state used by a File Provider-only client.
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Unavailable);
+        QVERIFY(!systray->canPauseSync());
+        QVERIFY(!systray->canResumeSync());
+
+        QVERIFY(_helper.addClassicFolders());
+        QVERIFY(!syncControlStateSpy.isEmpty());
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
+        QVERIFY(systray->canPauseSync());
+        QVERIFY(!systray->canResumeSync());
+
+        syncControlStateSpy.clear();
+        systray->setSyncIsPaused(true);
+        QVERIFY(!syncControlStateSpy.isEmpty());
+        QVERIFY(_helper.firstFolder()->syncPaused());
+        QVERIFY(_helper.secondFolder()->syncPaused());
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Resume);
+        QVERIFY(!systray->canPauseSync());
+        QVERIFY(systray->canResumeSync());
+
+        syncControlStateSpy.clear();
+        _helper.firstFolder()->setSyncPaused(false);
+        QVERIFY(!syncControlStateSpy.isEmpty());
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::PauseAndResume);
+        QVERIFY(systray->canPauseSync());
+        QVERIFY(systray->canResumeSync());
+
+        systray->setSyncIsPaused(false);
+        QVERIFY(!_helper.firstFolder()->syncPaused());
+        QVERIFY(!_helper.secondFolder()->syncPaused());
+        QVERIFY(systray->syncControlState() == Systray::SyncControlState::Pause);
+        QVERIFY(systray->canPauseSync());
+        QVERIFY(!systray->canResumeSync());
+    }
+};
+
+QTEST_MAIN(TestSystraySyncControl)
+#include "testsystraysynccontrol.moc"

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -152,6 +152,7 @@ QtObject {
     readonly property int accountWizardSyncOptionsHeight: 520
     readonly property int activitiesWindowWidth: 680
     readonly property int activitiesWindowHeight: 700
+    readonly property int activitiesWindowMenuWidth: 320
     readonly property int assistantWindowWidth: 640
     readonly property int assistantWindowHeight: 620
     readonly property int searchWindowWidth: 640


### PR DESCRIPTION
## Resolves
Fixes #10609
Fixes #10551

## Summary

On native Wayland clicking the systray does not open a popup menu but instead falls back to opening the Activities window, and since the 34.x redesign that window has no way to reach Settings or switch accounts. In Sway for example the tray icon itself works fine, so this is not a missing-tray case.
The same menu is exported over DBusMenu and hosts such as waybar or Plasma show it on right click, but swaybar renders no DBusMenu: it calls the item's ContextMenu method instead, which a Wayland client cannot honour because it can only anchor popups to its own surface. On Sway neither middle nor right clicking the icon produces a menu. The account area in the window header also looks like the old account switcher but has never been interactive, on any platform (#10551).

Clicking the account area now opens an application menu with:
- Account switching
- Add account
- Pause/Resume sync for all
- Settings
- Quit

This reuses the existing Systray and UserModel paths, and restores the behaviour the pre-34 client had when clicking the username/icon area. Tray popup behaviour is unchanged, and the header stays inert in the Search and Assistant windows, which opt out.

Also fixed a pre-existing rounding bug in the same header which I found while working on this: the account column is sized from the labels' fractional implicit width, so text that fits could still be elided by a fraction of a pixel. That is the difference visible in the server line of the screenshots below.

### Before: the account area is not interactive
<img width="818" height="842" alt="10609-before" src="https://github.com/user-attachments/assets/45899864-c9c9-429a-8590-c287315d7a78" />



### After: clicking the account area opens the application menu
<img width="818" height="842" alt="10609-after-menu" src="https://github.com/user-attachments/assets/6ff8d876-14fd-432d-b86b-af579da33e06" />



### Testing

Tested on Arch Linux and Sway on native Wayland with no XWayland installed, against a throwaway server with two accounts: the menu opens under the account area and dismisses correctly and all the actions work.

New tests: `ActivitiesMenuQmlTest` (menu contents, account switching, the current-account mark, that the account area is inert unless a window opts in, and that long or tight-fitting account text is not clipped) and `SystraySyncControlTest`.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.