### PR TITLE
fix: Include error message in update download error notification

### DIFF
--- a/src/gui/updater/sparkleupdater_mac.mm
+++ b/src/gui/updater/sparkleupdater_mac.mm
@@ -188,7 +188,7 @@ userDidMakeChoice:(SPUUserUpdateChoice)choice
 
     const auto versionQstring = QString::fromNSString(item.displayVersionString);
     const auto errorQstring = QString::fromNSString(error.localizedDescription);
-    const auto message = QObject::tr("Error downloading version %1 update: %2", "%1 is version number, %2 is error message").arg(versionQstring);
+    const auto message = QObject::tr("Error downloading version %1 update: %2", "%1 is version number, %2 is error message").arg(versionQstring, errorQstring);
 
     [self notifyStateChange:OCC::SparkleUpdater::State::Idle
               displayStatus:message];


### PR DESCRIPTION
Current nextcloud log:
```
"Update version 34.0.3 will be installed."
"Downloading version 34.0.3 update."
"Error downloading version 34.0.3 update: %2"

```

%2 should display the sparkle error