### PR TITLE
refactor(tray): remove legacy tray backend

### DIFF
--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -197,7 +197,6 @@ ownCloudGui::ownCloudGui(Application *parent)
     qRegisterMetaType<OCC::ActivityList>("ActivityList");
 
     qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "UserModel", UserModel::instance());
-    qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "UserAppsModel", UserAppsModel::instance());
     qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "TrayAccountAppsModel", TrayAccountAppsModel::instance());
     qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "Theme", Theme::instance());
     qmlRegisterSingletonInstance("com.nextcloud.desktopclient", 1, 0, "Systray", Systray::instance());

--- a/src/gui/systray.cpp
+++ b/src/gui/systray.cpp
@@ -29,14 +29,12 @@
 #include <QCursor>
 #include <QEvent>
 #include <QGuiApplication>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QQmlApplicationEngine>
-#include <QQmlContext>
 #include <QQuickWindow>
-#include <QVariantMap>
 #include <QScreen>
-#include <QGuiApplication>
-#include <QMenu>
+#include <QVariantMap>
 
 #ifdef USE_FDO_NOTIFICATIONS
 #include <QDBusConnection>
@@ -155,8 +153,6 @@ Systray::Systray()
     setupContextMenu();
 #endif
 
-    connect(UserModel::instance(), &UserModel::currentUserChanged,
-        this, &Systray::slotCurrentUserChanged);
     connect(UserModel::instance(), &UserModel::addAccount,
             this, &Systray::openAccountWizard);
 
@@ -172,33 +168,12 @@ Systray::Systray()
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, [this]{ showTrayPopup(WindowPosition::Center); });
 #endif
-
-    if (FolderMan::instance()) {
-        connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &Systray::slotSyncFoldersChanged);
-        slotSyncFoldersChanged(FolderMan::instance()->map());
-    }
 }
 
 void Systray::create()
 {
-    if (_trayEngine) {
-        if (!AccountManager::instance()->accounts().isEmpty()) {
-            _trayEngine->rootContext()->setContextProperty("activityModel", UserModel::instance()->currentActivityModel());
-        } else {
-            _trayEngine->rootContext()->setContextProperty("activityModel", &_fakeActivityModel);
-        }
-    }
     hideWindow();
     Q_EMIT activated(QSystemTrayIcon::ActivationReason::Unknown);
-    slotUpdateSyncPausedState();
-    connect(FolderMan::instance(), &FolderMan::folderListChanged, this, &Systray::slotUpdateSyncPausedState);
-}
-
-void Systray::showWindow(WindowPosition position)
-{
-    Q_UNUSED(position)
-
-    showActivitiesWindow();
 }
 
 void Systray::showTrayPopup(WindowPosition position)
@@ -236,11 +211,6 @@ void Systray::hideWindow()
     hideQtTrayPopup();
 #endif
     setIsOpen(false);
-}
-
-void Systray::showQMLWindow()
-{
-    showActivitiesWindow();
 }
 
 void Systray::showActivitiesWindow(int userIndex)
@@ -989,33 +959,6 @@ void Systray::presentFileActionsViewInSystray(const QString &localPath)
     createFileActionsDialog(localPath);
 }
 
-void Systray::slotCurrentUserChanged()
-{
-    if (_trayEngine) {
-        // Change ActivityModel
-        _trayEngine->rootContext()->setContextProperty("activityModel", UserModel::instance()->currentActivityModel());
-    }
-
-    // Rebuild App list
-    UserAppsModel::instance()->buildAppList();
-}
-
-void Systray::slotUpdateSyncPausedState()
-{
-    const auto folderMap = FolderMan::instance()->map();
-    for (const auto folder : folderMap) {
-        connect(folder, &Folder::syncPausedChanged, this, &Systray::slotUpdateSyncPausedState, Qt::UniqueConnection);
-        if (!folder->syncPaused()) {
-            _syncIsPaused = false;
-            Q_EMIT syncIsPausedChanged();
-            return;
-        }
-    }
-
-    _syncIsPaused = true;
-    Q_EMIT syncIsPausedChanged();
-}
-
 void Systray::slotUnpauseAllFolders()
 {
     setPauseOnAllFoldersHelper(false);
@@ -1024,14 +967,6 @@ void Systray::slotUnpauseAllFolders()
 void Systray::slotPauseAllFolders()
 {
     setPauseOnAllFoldersHelper(true);
-}
-
-void Systray::slotSyncFoldersChanged(const OCC::Folder::Map &folderMap)
-{
-    if (const auto currentAnySyncFolders = !folderMap.isEmpty(); currentAnySyncFolders != _anySyncFolders) {
-        _anySyncFolders = currentAnySyncFolders;
-        Q_EMIT anySyncFoldersChanged();
-    }
 }
 
 void Systray::setPauseOnAllFoldersHelper(bool pause)
@@ -1158,25 +1093,13 @@ void Systray::showTalkMessage(const QString &title, const QString &message, cons
 #endif
 }
 
-bool Systray::syncIsPaused() const
-{
-    return _syncIsPaused;
-}
-
 void Systray::setSyncIsPaused(const bool syncIsPaused)
 {
-    _syncIsPaused = syncIsPaused;
-    if (_syncIsPaused) {
+    if (syncIsPaused) {
         slotPauseAllFolders();
     } else {
         slotUnpauseAllFolders();
     }
-    Q_EMIT syncIsPausedChanged();
-}
-
-bool Systray::anySyncFolders() const
-{
-    return _anySyncFolders;
 }
 
 Systray::SyncControlState Systray::syncControlState() const
@@ -1201,23 +1124,6 @@ Systray::SyncControlState Systray::syncControlState() const
 /********************************************************************************************/
 /* Helper functions for cross-platform tray icon position and taskbar orientation detection */
 /********************************************************************************************/
-
-void Systray::positionWindowAtTray(QQuickWindow *window) const
-{
-    if (useNormalWindow()) {
-        return;
-    }
-
-    // need to store the current window size before moving the window to another screen,
-    // otherwise it is being incorrectly resized by the OS or Qt when switching to a screen
-    // with a different DPI setting
-    const auto initialSize = window->size();
-    window->setScreen(currentScreen());
-    window->resize(initialSize);
-
-    const auto position = computeWindowPosition(initialSize.width(), initialSize.height());
-    window->setPosition(position);
-}
 
 void Systray::positionWindowAtScreenCenter(QQuickWindow *window) const
 {
@@ -1347,42 +1253,6 @@ QRect Systray::currentAvailableScreenRect() const
     return screen->availableGeometry();
 }
 
-QPoint Systray::computeWindowReferencePoint() const
-{
-    constexpr auto spacing = 4;
-    const auto trayIconCenter = calcTrayIconCenter();
-    const auto taskbarScreenEdge = taskbarOrientation();
-    const auto screenRect = currentAvailableScreenRect();
-
-    qCDebug(lcSystray) << "screenRect:" << screenRect;
-    qCDebug(lcSystray) << "taskbarScreenEdge:" << taskbarScreenEdge;
-    qCDebug(lcSystray) << "trayIconCenter:" << trayIconCenter;
-
-    switch(taskbarScreenEdge) {
-    case TaskBarPosition::Bottom:
-        return {
-            trayIconCenter.x(),
-            screenRect.bottom() - spacing
-        };
-    case TaskBarPosition::Left:
-        return {
-            screenRect.left() + spacing,
-            trayIconCenter.y()
-        };
-    case TaskBarPosition::Top:
-        return {
-            trayIconCenter.x(),
-            screenRect.top() + spacing
-        };
-    case TaskBarPosition::Right:
-        return {
-            screenRect.right() - spacing,
-            trayIconCenter.y()
-        };
-    }
-    Q_UNREACHABLE();
-}
-
 QPoint Systray::computeNotificationReferencePoint(int spacing, NotificationPosition position) const
 {
     auto trayIconCenter = calcTrayIconCenter();
@@ -1451,38 +1321,6 @@ QRect Systray::computeWindowRect(int spacing, const QPoint &topLeft, const QPoin
     }
 
     return rect.translated(offset);
-}
-
-QPoint Systray::computeWindowPosition(int width, int height) const
-{
-    constexpr auto spacing = 4;
-    const auto referencePoint = computeWindowReferencePoint();
-
-    const auto taskbarScreenEdge = taskbarOrientation();
-    const auto screenRect = currentScreenRect();
-
-    const auto topLeft = [=]() {
-        switch(taskbarScreenEdge) {
-        case TaskBarPosition::Bottom:
-            return referencePoint - QPoint(width / 2, height);
-        case TaskBarPosition::Left:
-            return referencePoint;
-        case TaskBarPosition::Top:
-            return referencePoint - QPoint(width / 2, 0);
-        case TaskBarPosition::Right:
-            return referencePoint - QPoint(width, 0);
-        }
-        Q_UNREACHABLE();
-    }();
-    const auto bottomRight = topLeft + QPoint(width, height);
-    const auto windowRect = computeWindowRect(spacing, topLeft, bottomRight);
-
-    qCDebug(lcSystray) << "taskbarScreenEdge:" << taskbarScreenEdge;
-    qCDebug(lcSystray) << "screenRect:" << screenRect;
-    qCDebug(lcSystray) << "windowRect (reference)" << QRect(topLeft, bottomRight);
-    qCDebug(lcSystray) << "windowRect (adjusted)" << windowRect;
-
-    return windowRect.topLeft();
 }
 
 QPoint Systray::computeNotificationPosition(int width, int height, int spacing, NotificationPosition position) const

--- a/src/gui/systray.h
+++ b/src/gui/systray.h
@@ -10,10 +10,9 @@
 #include "accountmanager.h"
 #include "tray/usermodel.h"
 
-#include <QSystemTrayIcon>
-#include <QQmlNetworkAccessManagerFactory>
 #include <QHash>
-#include <QStringListModel>
+#include <QQmlNetworkAccessManagerFactory>
+#include <QSystemTrayIcon>
 
 class QScreen;
 class QMenu;
@@ -52,7 +51,6 @@ void setTrayWindowLevelAndVisibleOnAllSpaces(QWindow *window);
 double menuBarThickness();
 bool showMacOSTrayPopup(const QRect &iconRect);
 void hideMacOSTrayPopup();
-void showMacOSQMLWindow();
 #endif
 
 /**
@@ -65,8 +63,6 @@ class Systray : public QSystemTrayIcon
 
     Q_PROPERTY(QString windowTitle READ windowTitle CONSTANT)
     Q_PROPERTY(bool useNormalWindow READ useNormalWindow CONSTANT)
-    Q_PROPERTY(bool syncIsPaused READ syncIsPaused WRITE setSyncIsPaused NOTIFY syncIsPausedChanged)
-    Q_PROPERTY(bool anySyncFolders READ anySyncFolders NOTIFY anySyncFoldersChanged)
     Q_PROPERTY(bool isOpen READ isOpen WRITE setIsOpen NOTIFY isOpenChanged)
     Q_PROPERTY(bool enableAddAccount READ enableAddAccount CONSTANT)
 
@@ -98,8 +94,6 @@ public:
     [[nodiscard]] QString windowTitle() const;
     [[nodiscard]] bool useNormalWindow() const;
 
-    [[nodiscard]] bool syncIsPaused() const;
-    [[nodiscard]] bool anySyncFolders() const;
     /** @brief Returns the actions that the global tray synchronization control should offer. */
     [[nodiscard]] SyncControlState syncControlState() const;
     [[nodiscard]] bool isOpen() const;
@@ -113,7 +107,6 @@ public:
     [[nodiscard]] QQmlApplicationEngine* trayEngine() const;
 
 Q_SIGNALS:
-    void currentUserChanged();
     void openAccountWizard();
     void openSettings();
     void openSettingsForSandboxReapproval();
@@ -121,12 +114,9 @@ Q_SIGNALS:
     void shutdown();
 
     void showFileDetailsPage(const QString &fileLocalPath, const OCC::Systray::FileDetailsPage page);
-    void showFileDetails(OCC::AccountState *accountState, const QString &localPath, const OCC::Systray::FileDetailsPage fileDetailsPage);
     void sendChatMessage(const QString &token, const QString &message, const QString &replyTo);
     void showErrorMessageDialog(const QString &error);
 
-    void syncIsPausedChanged();
-    void anySyncFoldersChanged();
     void isOpenChanged();
 
     void hideSettingsDialog();
@@ -149,10 +139,7 @@ public Q_SLOTS:
     void createEncryptionTokenDiscoveryDialog();
     void destroyEncryptionTokenDiscoveryDialog();
 
-    void slotCurrentUserChanged();
-
     void forceWindowInit(QQuickWindow *window) const;
-    void positionWindowAtTray(QQuickWindow *window) const;
     void positionWindowAtScreenCenter(QQuickWindow *window) const;
     void positionNotificationWindow(QQuickWindow *window) const;
 
@@ -160,10 +147,8 @@ public Q_SLOTS:
     // only for those managed by the C++ engine
     void destroyDialog(QQuickWindow *window) const;
 
-    void showWindow(OCC::Systray::WindowPosition position = OCC::Systray::WindowPosition::Default);
     void showTrayPopup(OCC::Systray::WindowPosition position = OCC::Systray::WindowPosition::Default);
     void hideWindow();
-    void showQMLWindow();
     void showActivitiesWindow(int userIndex = -1);
     void showAssistantWindow(int userIndex = -1);
     void showSearchWindow(int userIndex = -1);
@@ -186,10 +171,8 @@ public Q_SLOTS:
     void presentFileActionsViewInSystray(const QString &localPath);
 
 private Q_SLOTS:
-    void slotUpdateSyncPausedState();
     void slotUnpauseAllFolders();
     void slotPauseAllFolders();
-    void slotSyncFoldersChanged(const OCC::Folder::Map &foldeMap);
 
 private:
     // Argument allows user to specify a specific dialog to be raised
@@ -218,19 +201,14 @@ private:
     [[nodiscard]] QScreen *currentScreen() const;
     [[nodiscard]] QRect currentScreenRect() const;
     [[nodiscard]] QRect currentAvailableScreenRect() const;
-    [[nodiscard]] QPoint computeWindowReferencePoint() const;
     [[nodiscard]] QPoint computeNotificationReferencePoint(int spacing = 20, NotificationPosition position = NotificationPosition::Default) const;
     [[nodiscard]] QPoint calcTrayIconCenter() const;
     [[nodiscard]] TaskBarPosition taskbarOrientation() const;
     [[nodiscard]] QRect computeWindowRect(int spacing, const QPoint &topLeft, const QPoint &bottomRight) const;
-    [[nodiscard]] QPoint computeWindowPosition(int width, int height) const;
     [[nodiscard]] QPoint computeNotificationPosition(int width, int height, int spacing = 20, NotificationPosition position = NotificationPosition::Default) const;
 
     bool _isOpen = false;
     bool _isTrayContextMenuVisible = false;
-    bool _syncIsPaused = true;
-    bool _anySyncFolders = false;
-
     std::unique_ptr<QQmlApplicationEngine> _trayEngine;
     QPointer<QMenu> _contextMenu;
     QHash<QString, QPointer<QQuickWindow>> _activitiesWindows;
@@ -243,9 +221,7 @@ private:
     QSet<qint64> _callsAlreadyNotified;
     QPointer<QObject> _editFileLocallyLoadingDialog;
     QPointer<QObject> _encryptionTokenDiscoveryDialog;
-    QVector<QQuickWindow*> _fileDetailDialogs;
-
-    QStringListModel _fakeActivityModel;
+    QVector<QQuickWindow *> _fileDetailDialogs;
 };
 
 #ifndef Q_OS_MACOS

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -175,25 +175,6 @@ SyncStatusInfo syncStatusForAccount(const OCC::AccountStatePtr &accountState)
 
     return {OCC::Theme::instance()->ok(), true};
 }
-  
-bool isSyncStatusError(const OCC::SyncResult::Status status)
-{
-    switch (status) {
-    case OCC::SyncResult::Error:
-    case OCC::SyncResult::SetupError:
-    case OCC::SyncResult::Problem:
-    case OCC::SyncResult::Undefined:
-        return true;
-    case OCC::SyncResult::Success:
-    case OCC::SyncResult::SyncPrepare:
-    case OCC::SyncResult::SyncRunning:
-    case OCC::SyncResult::NotYetStarted:
-    case OCC::SyncResult::Paused:
-    case OCC::SyncResult::SyncAbortRequested:
-        return false;
-    }
-    return false;
-}
 
 SyncIssueKind syncIssueKindForSyncResult(const OCC::SyncResult::Status status)
 {
@@ -296,33 +277,6 @@ SyncIssueKind syncIssueKindForActivities(const OCC::ActivityListModel *activityM
         }
     }
     return result;
-}
-
-bool accountHasSyncErrors(const OCC::AccountStatePtr &accountState)
-{
-    if (!accountState || !accountState->isConnected()) {
-        return false;
-    }
-
-    const auto &allFolders = OCC::FolderMan::instance()->map().values();
-    for (const auto folder : allFolders) {
-        if (folder->accountState() != accountState.data()) {
-            continue;
-        }
-        const auto status = determineSyncStatus(folder->syncResult());
-        if (isSyncStatusError(status)) {
-            return true;
-        }
-    }
-
-#ifdef BUILD_FILE_PROVIDER_MODULE
-    const auto fileProviderStatus = OCC::Mac::FileProvider::instance()->service()->latestReceivedSyncStatusForAccount(accountState->account());
-    if (fileProviderStatus != OCC::SyncResult::Undefined && isSyncStatusError(fileProviderStatus)) {
-        return true;
-    }
-#endif
-
-    return false;
 }
 
 SyncIssueKind syncIssueKindForAccount(const OCC::AccountStatePtr &accountState)
@@ -454,8 +408,6 @@ User::User(AccountStatePtr &account, const bool &isCurrent, QObject *parent)
             this, [=, this]() { if (isConnected()) {slotRefreshImmediately();} });
     connect(_account.data(), &AccountState::stateChanged, this, &User::accountStateChanged);
     connect(_account.data(), &AccountState::stateChanged, this, &User::refreshAccountAlert);
-    connect(_account.data(), &AccountState::hasFetchedNavigationApps,
-        this, &User::slotRebuildNavigationAppList);
     connect(_account->account().data(), &Account::accountChangedDisplayName, this, &User::nameChanged);
     connect(_account->account().data(), &Account::rootFolderQuotaChanged, this, &User::slotQuotaChanged);
 
@@ -1130,13 +1082,6 @@ void User::slotRefreshNotifications()
     } else {
         qCWarning(lcActivity) << "Notification request counter not zero.";
     }
-}
-
-void User::slotRebuildNavigationAppList()
-{
-    Q_EMIT featuredAppChanged();
-    // Rebuild App list
-    UserAppsModel::instance()->buildAppList();
 }
 
 void User::slotNotificationRequestFinished(int statusCode)
@@ -1839,31 +1784,6 @@ bool User::hasFileProvider() const
 }
 #endif
 
-bool User::serverHasTalk() const
-{
-    return talkApp() != nullptr;
-}
-
-bool User::isFeaturedAppEnabled() const
-{
-    return isNcAssistantEnabled();
-}
-
-QString User::featuredAppIcon() const
-{
-    return "image://svgimage-custom-color/nc-assistant-app.svg";
-}
-
-QString User::featuredAppAccessibleName() const
-{
-    return tr("Open %1 Assistant", "The placeholder will be the application name. Please keep it").arg(APPLICATION_NAME);
-}
-
-AccountApp *User::talkApp() const
-{
-    return _account->findApp(QStringLiteral("spreed"));
-}
-
 bool User::hasActivities() const
 {
     return _account->account()->capabilities().hasActivities();
@@ -1887,11 +1807,6 @@ QColor User::headerTextColor() const
 QColor User::accentColor() const
 {
     return _account->account()->accentColor();
-}
-
-AccountAppList User::appList() const
-{
-    return _account->appList();
 }
 
 bool User::isCurrentUser() const
@@ -2105,13 +2020,6 @@ UserModel::UserModel(QObject *parent)
         setInitialUser();
     }
 
-    const auto folderMan = FolderMan::instance();
-    connect(folderMan, &FolderMan::folderListChanged, this, &UserModel::updateSyncErrorUsers);
-    connect(folderMan, &FolderMan::folderSyncStateChange, this, &UserModel::updateSyncErrorUsers);
-#ifdef BUILD_FILE_PROVIDER_MODULE
-    connect(Mac::FileProvider::instance()->service(), &Mac::FileProviderService::syncStateChanged, this, &UserModel::updateSyncErrorUsers);
-#endif
-
     connect(AccountManager::instance(), &AccountManager::accountAdded,
         this, &UserModel::addAccsToUserList);
     connect(AccountManager::instance(), &AccountManager::accountListInitialized,
@@ -2161,11 +2069,6 @@ void UserModel::setInitialUser()
     _init = false;
 }
 
-int UserModel::numUsers()
-{
-    return _users.size();
-}
-
 int UserModel::count() const
 {
     return rowCount();
@@ -2183,31 +2086,6 @@ bool UserModel::isUserConnected(const int id)
     }
 
     return _users[id]->isConnected();
-}
-
-bool UserModel::hasSyncErrors() const
-{
-    return !_syncErrorUserIds.isEmpty();
-}
-
-int UserModel::syncErrorUserCount() const
-{
-    return _syncErrorUserIds.size();
-}
-
-int UserModel::firstSyncErrorUserId() const
-{
-    return _syncErrorUserIds.isEmpty() ? -1 : _syncErrorUserIds.first();
-}
-
-User *UserModel::firstSyncErrorUser() const
-{
-    const auto index = firstSyncErrorUserId();
-    if (index < 0 || index >= _users.size()) {
-        return nullptr;
-    }
-
-    return _users.at(index);
 }
 
 QImage UserModel::avatarById(const int id) const
@@ -2241,15 +2119,6 @@ QImage UserModel::syncStatusIconForRow(const int row) const
     return QIcon(resourcePath).pixmap(18, 18).toImage();
 }
 
-QString UserModel::currentUserServer()
-{
-    if (_currentUserId < 0 || _currentUserId >= _users.size()) {
-        return {};
-    }
-
-    return _users[_currentUserId]->server();
-}
-
 void UserModel::addUser(AccountStatePtr &user, const bool &isCurrent)
 {
     bool containsUser = false;
@@ -2281,12 +2150,10 @@ void UserModel::addUser(AccountStatePtr &user, const bool &isCurrent)
         connect(u, &User::desktopNotificationsAllowedChanged, this, [this, row] {
             Q_EMIT dataChanged(index(row, 0), index(row, 0), { UserModel::DesktopNotificationsAllowedRole });
         });
-        
+
         connect(u, &User::accountStateChanged, this, [this, row] {
             Q_EMIT dataChanged(index(row, 0), index(row, 0), { UserModel::IsConnectedRole });
         });
-        connect(u, &User::accountStateChanged, this, &UserModel::updateSyncErrorUsers);
-
         connect(u, &User::serverHasUserStatusChanged, this, [this, row] {
             Q_EMIT dataChanged(index(row, 0), index(row, 0), { UserModel::ServerHasUserStatusRole });
         });
@@ -2326,13 +2193,6 @@ void UserModel::addUser(AccountStatePtr &user, const bool &isCurrent)
         ConfigFile cfg;
         u->setNotificationRefreshInterval(cfg.notificationRefreshInterval());
     }
-
-    updateSyncErrorUsers();
-}
-
-int UserModel::currentUserIndex()
-{
-    return _currentUserId;
 }
 
 void UserModel::openCurrentAccountLocalFolder()
@@ -2370,27 +2230,6 @@ void UserModel::openCurrentAccountFolderFromTrayInfo(const QString &fullRemotePa
     }
 
     _users[_currentUserId]->openFolderLocallyOrInBrowser(fullRemotePath);
-}
-
-void UserModel::openCurrentAccountFeaturedApp()
-{
-    if (!currentUser()) {
-        return;
-    }
-
-    if (!currentUser()->isFeaturedAppEnabled()) {
-        qCWarning(lcActivity) << "There is no feature app enabled on" << currentUser()->server();
-        return;
-    }
-
-    if (const auto talkApp = currentUser()->talkApp()) {
-        Utility::openBrowser(talkApp->url());
-    }
-}
-
-void UserModel::refreshSyncErrorUsers()
-{
-    updateSyncErrorUsers();
 }
 
 void UserModel::setCurrentUserId(const int id)
@@ -2592,15 +2431,6 @@ QHash<int, QByteArray> UserModel::roleNames() const
     return roles;
 }
 
-ActivityListModel *UserModel::currentActivityModel()
-{
-    if (currentUserIndex() < 0 || currentUserIndex() >= _users.size()) {
-        return nullptr;
-    }
-
-    return _users[currentUserIndex()]->getActivityModel();
-}
-
 void UserModel::fetchCurrentActivityModel()
 {
     if (currentUserId() < 0 || currentUserId() >= _users.size()) {
@@ -2635,15 +2465,6 @@ void UserModel::triggerNotificationAction(const int id, const int activityIndex,
     }
 
     _users[id]->getActivityModel()->slotTriggerAction(activityIndex, actionIndex);
-}
-
-AccountAppList UserModel::appList() const
-{
-    if (_currentUserId < 0 || _currentUserId >= _users.size()) {
-        return {};
-    }
-
-    return _users[_currentUserId]->appList();
 }
 
 User *UserModel::currentUser() const
@@ -2693,32 +2514,6 @@ int UserModel::findUserIdForAccount(AccountState *account) const
     return id;
 }
 
-bool UserModel::userHasSyncErrors(const User *user) const
-{
-    if (!user) {
-        return false;
-    }
-
-    return accountHasSyncErrors(user->accountState());
-}
-
-void UserModel::updateSyncErrorUsers()
-{
-    QVector<int> newSyncErrorUserIds;
-    newSyncErrorUserIds.reserve(_users.size());
-    for (int i = 0; i < _users.size(); ++i) {
-        if (userHasSyncErrors(_users.at(i))) {
-            newSyncErrorUserIds.push_back(i);
-        }
-    }
-
-    if (newSyncErrorUserIds == _syncErrorUserIds) {
-        return;
-    }
-
-    _syncErrorUserIds = newSyncErrorUserIds;
-    Q_EMIT syncErrorUsersChanged();
-}
 /*-------------------------------------------------------------------------------------*/
 
 class ImageResponse : public QQuickImageResponse
@@ -2797,76 +2592,5 @@ QQuickImageResponse *ImageProvider::requestImageResponse(const QString &id, cons
 {
     const auto response = new class ImageResponse(id, requestedSize, &_pool);
     return response;
-}
-
-/*-------------------------------------------------------------------------------------*/
-
-UserAppsModel *UserAppsModel::_instance = nullptr;
-
-UserAppsModel *UserAppsModel::instance()
-{
-    if (!_instance) {
-        _instance = new UserAppsModel();
-    }
-    return _instance;
-}
-
-UserAppsModel::UserAppsModel(QObject *parent)
-    : QAbstractListModel(parent)
-{
-}
-
-void UserAppsModel::buildAppList()
-{
-    if (rowCount() > 0) {
-        beginRemoveRows(QModelIndex(), 0, rowCount() - 1);
-        _apps.clear();
-        endRemoveRows();
-    }
-
-    if (UserModel::instance()->appList().count() > 0) {
-        const auto &allApps = UserModel::instance()->appList();
-        for (const auto &app : allApps) {
-            beginInsertRows(QModelIndex(), rowCount(), rowCount());
-            _apps << app;
-            endInsertRows();
-        }
-    }
-}
-
-void UserAppsModel::openAppUrl(const QUrl &url)
-{
-    Utility::openBrowser(url);
-}
-
-int UserAppsModel::rowCount(const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    return _apps.count();
-}
-
-QVariant UserAppsModel::data(const QModelIndex &index, int role) const
-{
-    if (index.row() < 0 || index.row() >= _apps.count()) {
-        return QVariant();
-    }
-
-    if (role == NameRole) {
-        return _apps[index.row()]->name();
-    } else if (role == UrlRole) {
-        return _apps[index.row()]->url();
-    } else if (role == IconUrlRole) {
-        return _apps[index.row()]->iconUrl().toString();
-    }
-    return QVariant();
-}
-
-QHash<int, QByteArray> UserAppsModel::roleNames() const
-{
-    QHash<int, QByteArray> roles;
-    roles[NameRole] = "appName";
-    roles[UrlRole] = "appUrl";
-    roles[IconUrlRole] = "appIconUrl";
-    return roles;
 }
 }

--- a/src/gui/tray/usermodel.cpp
+++ b/src/gui/tray/usermodel.cpp
@@ -2316,8 +2316,6 @@ void UserModel::removeAccount(const int id)
     } else if (currentUserId() == id) {
         setCurrentUserId(id < _users.size() ? id : id - 1);
     }
-
-    updateSyncErrorUsers();
 }
 
 std::shared_ptr<OCC::UserStatusConnector> UserModel::userStatusConnector(int id)

--- a/src/gui/tray/usermodel.h
+++ b/src/gui/tray/usermodel.h
@@ -7,14 +7,13 @@
 #define USERMODEL_H
 
 #include <QAbstractListModel>
-#include <QImage>
 #include <QDateTime>
-#include <QStringList>
-#include <QQuickImageProvider>
 #include <QHash>
+#include <QImage>
 #include <QPointer>
+#include <QQuickImageProvider>
+#include <QStringList>
 #include <QTimer>
-#include <QVector>
 #include <QVariantMap>
 
 #include "accountfwd.h"
@@ -68,9 +67,6 @@ class User : public QObject
 #ifdef BUILD_FILE_PROVIDER_MODULE
     Q_PROPERTY(bool hasFileProvider READ hasFileProvider NOTIFY accountStateChanged)
 #endif
-    Q_PROPERTY(bool isFeaturedAppEnabled READ isFeaturedAppEnabled NOTIFY featuredAppChanged)
-    Q_PROPERTY(QString featuredAppIcon READ featuredAppIcon NOTIFY featuredAppChanged)
-    Q_PROPERTY(QString featuredAppAccessibleName READ featuredAppAccessibleName NOTIFY featuredAppChanged)
     Q_PROPERTY(QString avatar READ avatarUrl NOTIFY avatarChanged)
     Q_PROPERTY(QVariantList recentActivities READ recentActivities NOTIFY recentActivitiesChanged)
     Q_PROPERTY(QVariantList trayNotifications READ trayNotifications NOTIFY trayNotificationsChanged)
@@ -109,20 +105,15 @@ public:
 #ifdef BUILD_FILE_PROVIDER_MODULE
     [[nodiscard]] bool hasFileProvider() const;
 #endif
-    [[nodiscard]] bool isFeaturedAppEnabled() const;
-    [[nodiscard]] QString featuredAppIcon() const;
-    [[nodiscard]] QString featuredAppAccessibleName() const;
     [[nodiscard]] QVariantList recentActivities() const;
     [[nodiscard]] QVariantList trayNotifications() const;
     [[nodiscard]] QVariantMap accountAlert() const;
     [[nodiscard]] bool serverHasUserStatus() const;
-    [[nodiscard]] AccountApp *talkApp() const;
     [[nodiscard]] bool hasActivities() const;
     [[nodiscard]] bool isNcAssistantEnabled() const;
     [[nodiscard]] QColor accentColor() const;
     [[nodiscard]] QColor headerColor() const;
     [[nodiscard]] QColor headerTextColor() const;
-    [[nodiscard]] AccountAppList appList() const;
     [[nodiscard]] QImage avatar() const;
     /** @brief Signs in a signed-out account or retries another disconnected state. */
     void login() const;
@@ -144,7 +135,6 @@ public:
 Q_SIGNALS:
     void nameChanged();
     void hasLocalFolderChanged();
-    void featuredAppChanged();
     void avatarChanged();
     void recentActivitiesChanged();
     void trayNotificationsChanged();
@@ -182,7 +172,6 @@ public Q_SLOTS:
     void slotRefreshUserStatus();
     void slotRefreshImmediately();
     void setNotificationRefreshInterval(std::chrono::milliseconds interval);
-    void slotRebuildNavigationAppList();
     void forceSyncNow() const;
     void openServer() const;
     void slotAccountCapabilitiesChangedRefreshGroupFolders();
@@ -242,8 +231,6 @@ private:
     bool notificationAlreadyShown(const qint64 notificationId);
     bool canShowNotification(const qint64 notificationId);
 
-    [[nodiscard]] bool serverHasTalk() const;
-
     AccountStatePtr _account;
     bool _isCurrentUser;
     ActivityListModel *_activityModel;
@@ -300,18 +287,12 @@ class UserModel : public QAbstractListModel
     Q_PROPERTY(User* currentUser READ currentUser NOTIFY currentUserChanged)
     Q_PROPERTY(int currentUserId READ currentUserId WRITE setCurrentUserId NOTIFY currentUserChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
-    Q_PROPERTY(bool hasSyncErrors READ hasSyncErrors NOTIFY syncErrorUsersChanged)
-    Q_PROPERTY(int syncErrorUserCount READ syncErrorUserCount NOTIFY syncErrorUsersChanged)
-    Q_PROPERTY(int firstSyncErrorUserId READ firstSyncErrorUserId NOTIFY syncErrorUsersChanged)
-    Q_PROPERTY(User* firstSyncErrorUser READ firstSyncErrorUser NOTIFY syncErrorUsersChanged)
 public:
 
     static UserModel *instance();
     ~UserModel() override = default;
 
     void addUser(AccountStatePtr &user, const bool &isCurrent = false);
-    int currentUserIndex();
-
     [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
@@ -324,20 +305,12 @@ public:
     [[nodiscard]] User *findUserForAccount(AccountState *account) const;
     [[nodiscard]] int findUserIdForAccount(AccountState *account) const;
 
-    Q_INVOKABLE int numUsers();
     [[nodiscard]] int count() const;
-    Q_INVOKABLE QString currentUserServer();
     [[nodiscard]] int currentUserId() const;
 
     Q_INVOKABLE bool isUserConnected(const int id);
-    [[nodiscard]] bool hasSyncErrors() const;
-    [[nodiscard]] int syncErrorUserCount() const;
-    [[nodiscard]] int firstSyncErrorUserId() const;
-    [[nodiscard]] User *firstSyncErrorUser() const;
 
     Q_INVOKABLE std::shared_ptr<OCC::UserStatusConnector> userStatusConnector(int id);
-
-    ActivityListModel *currentActivityModel();
 
     enum UserRoles {
         NameRole = Qt::UserRole + 1,
@@ -362,13 +335,10 @@ public:
         AccountAlertRole,
     };
 
-    [[nodiscard]] AccountAppList appList() const;
-
 Q_SIGNALS:
     void addAccount();
     void currentUserChanged();
     void countChanged();
-    void syncErrorUsersChanged();
 
 public Q_SLOTS:
     void fetchCurrentActivityModel();
@@ -381,8 +351,6 @@ public Q_SLOTS:
 #endif
     void openCurrentAccountServer();
     void openCurrentAccountFolderFromTrayInfo(const QString &fullRemotePath);
-    void openCurrentAccountFeaturedApp();
-    Q_INVOKABLE void refreshSyncErrorUsers();
     void setCurrentUserId(const int id);
     void login(const int id);
     void logout(const int id);
@@ -397,11 +365,6 @@ private:
     QList<User*> _users;
     int _currentUserId = -1;
     bool _init = true;
-    QVector<int> _syncErrorUserIds;
-
-    void updateSyncErrorUsers();
-    [[nodiscard]] bool userHasSyncErrors(const User *user) const;
-
     void buildUserList();
     void addAccsToUserList();
     void setInitialUser();
@@ -417,38 +380,6 @@ public:
 
 private:
     QThreadPool _pool;
-};
-
-class UserAppsModel : public QAbstractListModel
-{
-    Q_OBJECT
-public:
-    static UserAppsModel *instance();
-    ~UserAppsModel() override = default;
-
-    [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-
-    [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-
-    enum UserAppsRoles {
-        NameRole = Qt::UserRole + 1,
-        UrlRole,
-        IconUrlRole
-    };
-
-    void buildAppList();
-
-public Q_SLOTS:
-    void openAppUrl(const QUrl &url);
-
-protected:
-    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
-
-private:
-    static UserAppsModel *_instance;
-    UserAppsModel(QObject *parent = nullptr);
-
-    AccountAppList _apps;
 };
 }
 #endif // USERMODEL_H

--- a/theme/Style/Style.qml
+++ b/theme/Style/Style.qml
@@ -71,7 +71,6 @@ QtObject {
 
     // Dimensions and sizes
     property int trayWindowWidth: variableSize(400)
-    property int trayWindowHeight: variableSize(510)
     // text input and main windows radius
     property int trayWindowRadius: 10
     // dropdown menus radius
@@ -107,7 +106,6 @@ QtObject {
     property int filesActionsWidth: 380
     property int filesActionsHeight: 350
     property int trayListItemIconSize: accountAvatarSize
-    property int trayDrawerMargin: trayWindowHeaderHeight
     property real thumbnailImageSizeReduction: 0.2  // We reserve some space within the thumbnail "item", here about 20%.
                                                     // This is because we need to also add the added/modified icon and we
                                                     // want them to fit within the general icon size. We also need to know
@@ -181,9 +179,7 @@ QtObject {
 
     property int minimumScrollBarWidth: 12
     property real minimumScrollBarThumbSize: 0
-    property int currentAccountButtonWidth: 220
     property int currentAccountButtonRadius: 2
-    property int currentAccountLabelWidth: 128
 
     property int normalBorderWidth: 1
     property int thickBorderWidth: 2
@@ -200,22 +196,12 @@ QtObject {
     property int folderStateIndicatorSize: 16
     property int accountLabelWidth: 128
 
-    property int accountDropDownCaretSize: 10
-    property int accountDropDownCaretMargin: 8
-
     property int trayFoldersMenuButtonStateIndicatorBottomOffset: 5
-    property double trayFoldersMenuButtonDropDownCaretIconSizeFraction: 0.3
-    property double trayFoldersMenuButtonMainIconSizeFraction: 1.0 - trayFoldersMenuButtonDropDownCaretIconSizeFraction
 
     property int activityListButtonWidth: 42
     property int activityListButtonHeight: 32
     property int activityListButtonIconSize: 18
-    property int headerButtonIconSize: 48
     property int minimumActivityItemHeight: 24
-
-    property int accountIconsMenuMargin: 7
-
-    property int activityLabelBaseWidth: 240
 
     property int talkReplyTextFieldPreferredHeight: 34
     property int talkReplyTextFieldPreferredWidth: 250
@@ -230,18 +216,13 @@ QtObject {
     property int roundedButtonBackgroundVerticalMargins: 5
 
     property int userStatusEmojiSize: 8
-    property int userStatusSpacing: trayHorizontalMargin
     property int userStatusAnchorsMargin: 2
-    property int userLineSpacing: smallSpacing
     property int accountServerAnchorsMargin: 10
     property int accountLabelsSpacing: 4
     property int accountsServerMargin: 6
     property int accountLabelsAnchorsMargin: 5
     property int accountLabelsLayoutMargin: 12
     property int accountLabelsLayoutTopMargin: 10
-
-    // Visual behaviour
-    property bool hoverEffectsEnabled: true
 
     // unified search constants
     readonly property int unifiedSearchDetailHeaderHeight: standardPrimaryButtonHeight
@@ -294,19 +275,8 @@ QtObject {
     readonly property int defaultWidthGovernanceLabelsDialog: 400
     readonly property int defaultHeightGovernanceLabelsDialog: 300
 
-    readonly property double smallIconScaleFactor: 0.6
-
     readonly property double trayFolderListButtonWidthScaleFactor: 1.75
-    readonly property int trayFolderStatusIndicatorSizeOffset: 2
-    readonly property double trayFolderStatusIndicatorRadiusFactor: 0.5
     readonly property double trayFolderStatusIndicatorMouseHoverOpacityFactor: 0.2
-
-    readonly property double trayWindowMenuWidthFactor: 0.35
-
-    readonly property int trayWindowMenuOffsetX: -2
-    readonly property int trayWindowMenuOffsetY: 2
-
-    readonly property int trayWindowMenuEntriesMargin: 6
 
     // animation durations
     readonly property int shortAnimationDuration: 200


### PR DESCRIPTION
Remove backend models, properties, and positioning helpers that only served the deleted tray QML. Drop the style constants left unused by those components.

Assisted-by: Codex:GPT-5
