### PR TITLE
fix(i18n): add document translation placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Quit all existing client instances before starting this command, and reproduce t
 Use these defaults unless the existing code clearly calls for an exception:
 
 - No magic numbers. Use `Style.qml`, shared metrics or named constants for layout, timing and protocol values.
+- Every new translated string containing replacement placeholders (for example, `%1`, `%2` or `%n`) must have an immediately preceding `//:` translator comment that explains what each placeholder contains and, where useful, gives representative examples. This applies to both C++ `tr()` and QML `qsTr()` strings.
 - Break non-trivial QML delegates, dialogs, popups and reusable components into their own files. Keep a small, single-use visual fragment inline only when it has no meaningful state or behavior of its own.
 - Before writing a new job, connector, model, URL helper, mock or QML registration, use `rg`—or the next available recursive text-search tool, such as `grep`, if `rg` is not installed—to find code that already performs the same task. Reuse or extend that code when it exists. If a new implementation is necessary, state why the existing code cannot be used.
 - Follow ownership contracts exactly. Check whether a job self-deletes and who owns every object before adding cleanup, copies or wrappers.

--- a/src/common/checksums.cpp
+++ b/src/common/checksums.cpp
@@ -297,6 +297,7 @@ void ValidateChecksumHeader::slotChecksumCalculated(const QByteArray &checksumTy
         return;
     }
     if (checksum != _expectedChecksum) {
+        //: %1 is the checksum expected from the server. %2 is the checksum calculated from the downloaded file.
         Q_EMIT validationFailed(tr(R"(The downloaded file does not match the checksum, it will be resumed. "%1" != "%2")").arg(QString::fromUtf8(_expectedChecksum), QString::fromUtf8(checksum)),
             _calculatedChecksumType, _calculatedChecksum, ChecksumMismatch);
         return;

--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -1453,6 +1453,7 @@ void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
     if (total > 0) {
         const auto usedStr = Utility::octetsToString(used);
         const auto totalStr = Utility::octetsToString(total);
+        //: %1 is the used storage size. %2 is the total storage size.
         _spaceUsageText = tr("%1 of %2 in use").arg(usedStr, totalStr);
     } else {
         /* -1 means not computed; -2 means unknown; -3 means unlimited  (#owncloud/client/issues/3940)*/
@@ -1460,6 +1461,7 @@ void AccountSettings::slotUpdateQuota(qint64 total, qint64 used)
             _spaceUsageText.clear();
         } else {
             const auto usedStr = Utility::octetsToString(used);
+            //: %1 is the used storage size.
             _spaceUsageText = tr("%1 in use").arg(usedStr);
         }
     }
@@ -1489,6 +1491,7 @@ void AccountSettings::slotAccountStateChanged()
             if (user.isEmpty()) {
                 user = cred->user();
             }
+            //: %1 is a link to the server. %2 is the user display name or username.
             serverWithUser = tr("%1 as %2").arg(server, Utility::escape(user));
         }
 
@@ -1500,6 +1503,7 @@ void AccountSettings::slotAccountStateChanged()
             }
             auto statusMessage = tr("Connected to %1.").arg(serverWithUser);
             if (!_spaceUsageText.isEmpty()) {
+                //: %1 is the server and user description. %2 is the storage usage description.
                 statusMessage = tr("Connected to %1 (%2).").arg(serverWithUser, _spaceUsageText);
             }
             showConnectionLabel(statusMessage, errors);

--- a/src/gui/activity/syncstatussummary.cpp
+++ b/src/gui/activity/syncstatussummary.cpp
@@ -365,10 +365,12 @@ void SyncStatusSummary::onFolderProgressInfo(const ProgressInfo &progress)
 
         if (progress.trustEta()) {
             setSyncStatusDetailString(
+                //: %1 is the completed data size. %2 is the total data size. %3 is the remaining duration.
                 tr("%1 of %2 · %3 left")
                     .arg(completedSizeString, totalSizeString)
                     .arg(Utility::durationToDescriptiveString1(progress.totalProgress().estimatedEta)));
         } else {
+            //: %1 is the completed data size. %2 is the total data size.
             setSyncStatusDetailString(tr("%1 of %2").arg(completedSizeString, totalSizeString));
         }
     }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -194,18 +194,18 @@ bool Application::configVersionMigration()
     // We want to message the user either for destructive changes,
     // or if we're ignoring something and the client version changed.
     if (configFile.showConfigBackupWarning() && backupFilesList.count() > 0) {
-        QMessageBox box(
-            QMessageBox::Warning,
-            APPLICATION_SHORTNAME,
-            tr("Some settings were configured in %1 versions of this client and "
-               "use features that are not available in this version.<br>"
-               "<br>"
-               "Continuing will mean <b>%2 these settings</b>.<br>"
-               "<br>"
-               "The current configuration file was already backed up to <i>%3</i>.")
-                .arg((configFile.isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
-                     deleteKeys.isEmpty()? tr("ignoring") : tr("deleting"),
-                     backupFilesList.join("<br>")));
+        QMessageBox box(QMessageBox::Warning,
+                        APPLICATION_SHORTNAME,
+                        //: %1 is either "newer" or "older". %2 is either "ignoring" or "deleting". %3 is a list of configuration backup file paths.
+                        tr("Some settings were configured in %1 versions of this client and "
+                           "use features that are not available in this version.<br>"
+                           "<br>"
+                           "Continuing will mean <b>%2 these settings</b>.<br>"
+                           "<br>"
+                           "The current configuration file was already backed up to <i>%3</i>.")
+                            .arg((configFile.isDowngrade() ? tr("newer", "newer software version") : tr("older", "older software version")),
+                                 deleteKeys.isEmpty() ? tr("ignoring") : tr("deleting"),
+                                 backupFilesList.join("<br>")));
         box.addButton(tr("Quit"), QMessageBox::AcceptRole);
         auto continueBtn = box.addButton(tr("Continue"), QMessageBox::DestructiveRole);
 

--- a/src/gui/assistant/assistantcontroller.cpp
+++ b/src/gui/assistant/assistantcontroller.cpp
@@ -836,6 +836,7 @@ void AssistantController::requestFailed(const QString &context, int statusCode)
 {
     beginRequest();
     setRequestInProgress(false);
+    //: %1 is the HTTP status code returned by the server.
     _error = tr("Assistant request failed (%1).").arg(statusCode);
     Q_EMIT errorChanged();
     qCWarning(lcAssistantController) << "Assistant request error:" << context << statusCode;

--- a/src/gui/assistant/qml/AssistantTaskDelegate.qml
+++ b/src/gui/assistant/qml/AssistantTaskDelegate.qml
@@ -22,6 +22,7 @@ Rectangle {
     required property string statusText
     required property string dateText
 
+    //: %1 is the assistant task status and %2 is the task's date and time in the locale's short format.
     readonly property string statusSummary: root.dateText.length > 0
         ? qsTr("%1 · %2").arg(root.statusText, root.dateText)
         : root.statusText

--- a/src/gui/assistant/qml/AssistantTaskTypeDelegate.qml
+++ b/src/gui/assistant/qml/AssistantTaskTypeDelegate.qml
@@ -97,6 +97,7 @@ Button {
         }
     }
 
+    //: %1 is the name of an assistant task type, for example "Chat".
     Accessible.name: qsTr("Select assistant task type %1").arg(root.name)
     onClicked: root.assistantController.selectTaskType(root.typeId)
 }

--- a/src/gui/cloudproviders/cloudproviderwrapper.cpp
+++ b/src/gui/cloudproviders/cloudproviderwrapper.cpp
@@ -109,6 +109,7 @@ void CloudProviderWrapper::slotUpdateProgress(const QString &folder, const Progr
         QString timeStr = QTime::currentTime().toString("hh:mm");
         QString fileName = progress._lastCompletedItem._file;
         QString elidedFileName = fm.elidedText(fileName, Qt::ElideRight, preferredTextWidth);
+        //: %1 is the elided file name. %2 is the sync result. %3 is the current time.
         QString actionText = tr("%1 (%2, %3)").arg(elidedFileName, elidedKindStr, timeStr);
         if (f) {
             QString fullPath = f->path() + '/' + fileName;

--- a/src/gui/filedetails/FileDetailsWindow.qml
+++ b/src/gui/filedetails/FileDetailsWindow.qml
@@ -25,6 +25,7 @@ ApplicationWindow {
     minimumWidth: 300
     minimumHeight: 300
 
+    //: %1 is the file name. %2 is the application window title, for example "Nextcloud".
     title: qsTr("File details of %1 · %2").arg(fileDetailsPage.fileDetails.name).arg(Systray.windowTitle)
 
     FileDetailsView {

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -1960,6 +1960,7 @@ QString FolderMan::trayTooltipStatusString(SyncResult::Status syncStatus, bool h
     }
     if (paused) {
         // sync is disabled.
+        //: %1 is the current sync status message, for example "Setup error".
         folderMessage = tr("%1 (Sync is paused)").arg(folderMessage);
     }
     return folderMessage;

--- a/src/gui/folderstatusmodel.cpp
+++ b/src/gui/folderstatusmodel.cpp
@@ -163,14 +163,15 @@ QVariant FolderStatusModel::data(const QModelIndex &index, int role) const
 
         switch (role) {
         case Qt::DisplayRole: {
-            //: Example text: "File.txt (23KB)"
             const auto &xParent = static_cast<SubFolderInfo *>(index.internalPointer());
             const auto suffix = (subfolderInfo._isNonDecryptable && subfolderInfo._checked && (!xParent || !xParent->isEncrypted()))
                 ? QStringLiteral(" - ") + tr("Could not decrypt!")
                 : QString{};
+            //: %1 is the file name. %2 is the file size, for example "23 KB".
             return subfolderInfo._size < 0 ? QString(subfolderInfo._name + suffix) : QString(tr("%1 (%2)").arg(subfolderInfo._name, Utility::octetsToString(subfolderInfo._size)) + suffix);
         }
         case Qt::ToolTipRole:
+            //: %1 is the file name. %2 is the file size, for example "23 KB".
             return QString(QLatin1String("<qt>") + Utility::escape(subfolderInfo._size < 0 ? subfolderInfo._name : tr("%1 (%2)").arg(subfolderInfo._name, Utility::octetsToString(subfolderInfo._size))) + QLatin1String("</qt>"));
         case Qt::CheckStateRole:
             if (supportsSelectiveSync) {
@@ -1120,6 +1121,8 @@ void FolderStatusModel::slotSetProgress(const ProgressInfo &progress)
                                         .arg(currentFile)
                                         .arg(totalFileCount);
             } else {
+                //: %1 is the completed data size. %2 is the total data size. %3 is the current file number.
+                //: %4 is the total file count. %5 is the remaining duration.
                 overallSyncString = tr("%5 left, %1 of %2, file %3 of %4")
                                         .arg(completedSizeString, totalSizeString)
                                         .arg(currentFile)

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -422,6 +422,7 @@ void ownCloudGui::slotComputeOverallSyncStatus()
         QStringList messages;
         messages.append(tr("Disconnected from accounts:"));
         for (const auto &accountState : std::as_const(problemAccounts)) {
+            //: %1 is the account display name. %2 is the account connection status.
             QString message = tr("Account %1: %2").arg(accountState->account()->displayName(), accountState->stateString(accountState->state()));
             if (!accountState->connectionErrors().empty()) {
                 message += QLatin1String("\n");
@@ -606,6 +607,7 @@ void ownCloudGui::slotUpdateProgress(const QString &folder, const ProgressInfo &
 
         QString kindStr = Progress::asResultString(progress._lastCompletedItem);
         QString timeStr = QTime::currentTime().toString("hh:mm");
+        //: %1 is the file name. %2 is the sync result. %3 is the current time.
         QString actionText = tr("%1 (%2, %3)").arg(progress._lastCompletedItem._file, kindStr, timeStr);
         auto *action = new QAction(actionText, this);
         Folder *f = FolderMan::instance()->folder(folder);

--- a/src/gui/search/SearchWindow.qml
+++ b/src/gui/search/SearchWindow.qml
@@ -155,6 +155,7 @@ WizardStyledWindow {
                     iconSource: modelData.icon ? "image://tray-image-provider/" + modelData.icon : ""
                     tintIcon: true
                     iconTintColor: Style.wizardPrimaryText
+                    //: %1 is an active search filter label, such as a provider name, date range, or person name.
                     Accessible.name: qsTr("Remove %1 filter").arg(modelData.label)
                     onClicked: root.searchModel.removeFilter(modelData.type, modelData.id)
                 }

--- a/src/gui/search/UnifiedSearchResultDelegate.qml
+++ b/src/gui/search/UnifiedSearchResultDelegate.qml
@@ -80,6 +80,7 @@ Item {
             width: root.width
             height: Style.unifiedSearchProviderHeaderHeight
             flat: true
+            //: %1 is the name of a search provider, for example "Files".
             text: root.hasOverflow ? qsTr("More from %1  →").arg(root.providerName) : root.providerName
             font.bold: false
             font.pixelSize: Style.unifiedSearchResultTitleFontSize

--- a/src/gui/search/UnifiedSearchResultSectionItem.qml
+++ b/src/gui/search/UnifiedSearchResultSectionItem.qml
@@ -22,5 +22,6 @@ EnforcedPlainTextLabel {
     font.pixelSize: Style.unifiedSearchResultTitleFontSize
 
     Accessible.role: Accessible.Separator
+    //: %1 is the search results section heading, for example "Partial matches".
     Accessible.name: qsTr("Search results section %1").arg(section)
 }

--- a/src/gui/search/unifiedsearchresultslistmodel.cpp
+++ b/src/gui/search/unifiedsearchresultslistmodel.cpp
@@ -1246,8 +1246,10 @@ void UnifiedSearchResultsListModel::updateAccessibilityStatus()
     } else if (resultCount == 0) {
         setAccessibilityStatus(tr("No matching results"));
     } else if (_hasPartialFailure) {
+        //: %1 is the number of search results.
         setAccessibilityStatus(tr("%1 results. Some sources are unavailable.").arg(resultCount));
     } else {
+        //: %1 is the number of search results.
         setAccessibilityStatus(tr("%1 results").arg(resultCount));
     }
 }
@@ -1456,6 +1458,7 @@ bool UnifiedSearchResultsListModel::setCustomDateRange(const QString &sinceDate,
     const auto zone = QTimeZone::systemTimeZone();
     _since = QDateTime(first, QTime(0, 0), zone);
     _until = QDateTime(last, QTime(23, 59, 59, 999), zone);
+    //: %1 is the start date and %2 is the end date of a custom search date range. Both use the locale's short date format.
     _dateLabel = tr("%1 – %2").arg(QLocale().toString(first, QLocale::ShortFormat), QLocale().toString(last, QLocale::ShortFormat));
     restartForFilterChange();
     return true;

--- a/src/gui/sslbutton.cpp
+++ b/src/gui/sslbutton.cpp
@@ -128,8 +128,10 @@ QMenu *SslButton::buildCertMenu(QMenu *parent, const QSslCertificate &cert,
         txt += certId;
     } else {
         if (isSelfSigned(cert)) {
+            //: %1 is the certificate identifier, taken from its common name or organizational unit.
             txt += tr("%1 (self-signed)").arg(certId);
         } else {
+            //: %1 is the certificate identifier, taken from its common name or organizational unit.
             txt += tr("%1").arg(certId);
         }
     }

--- a/src/libsync/basepropagateremotedeleteencrypted.cpp
+++ b/src/libsync/basepropagateremotedeleteencrypted.cpp
@@ -82,6 +82,7 @@ void BasePropagateRemoteDeleteEncrypted::slotFolderUnLockFinished(const QByteArr
 {
     if (statusCode != 200) {
         _item->_httpErrorCode = statusCode;
+        //: %1 is the HTTP status code. %2 is the encrypted folder identifier.
         _errorString = tr("\"%1 Failed to unlock encrypted folder %2\".").arg(statusCode).arg(QString::fromUtf8(folderId));
         _item->_errorString = _errorString;
         taskFailed();

--- a/src/libsync/clientsideencryption.cpp
+++ b/src/libsync/clientsideencryption.cpp
@@ -2266,6 +2266,7 @@ void ClientSideEncryption::decryptPrivateKey(const QByteArray &key) {
         return;
     }
 
+    //: %2 is the account username. %3 is the account display name.
     QString msg = tr("Please enter your end-to-end encryption passphrase:<br>"
                      "<br>"
                      "Username: %2<br>"

--- a/src/libsync/theme.cpp
+++ b/src/libsync/theme.cpp
@@ -624,6 +624,8 @@ QString Theme::gitSHA1() const
     const QString githubPrefix(QLatin1String(
         "https://github.com/nextcloud/desktop/commit/"));
     const QString gitSha1(QLatin1String(GIT_SHA1));
+    //: %1 is the full Git commit URL. %2 is the abbreviated Git revision. %3 is the build date.
+    //: %4 is the build time. %5 is the Qt version. %6 is the TLS library version.
     devString = QCoreApplication::translate("nextcloudTheme::aboutInfo()",
         "<p><small>Built from Git revision <a href=\"%1\">%2</a>"
         " on %3, %4 using Qt %5, %6</small></p>")


### PR DESCRIPTION
several translations were added with placeholders that did not have explanations for translators.
The strings are fixed and an instruction was added to the agents.md

Assisted-by: Codex:GPT-5