### PR TITLE
fix(e2ee): wrap mnemonic text in dialog

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -83,6 +83,7 @@ constexpr auto e2EeUiActionSetupEncryptionId = "setup_encryption";
 constexpr auto e2EeUiActionForgetEncryptionId = "forget_encryption";
 constexpr auto e2EeUiActionDisplayMnemonicId = "display_mnemonic";
 constexpr auto e2EeUiActionMigrateCertificateId = "migrate_certificate";
+constexpr auto mnemonicVisibleLineCount = 2;
 }
 
 namespace OCC {
@@ -1260,20 +1261,24 @@ void AccountSettings::displayMnemonic(const QString &mnemonic)
            "You will need it to set-up the synchronization of encrypted folders on your other devices."));
     QFont monoFont(QStringLiteral("Monospace"));
     monoFont.setStyleHint(QFont::TypeWriter);
-    ui.lineEdit->setFont(monoFont);
-    ui.lineEdit->setText(mnemonic);
-    ui.lineEdit->setReadOnly(true);
 
-    ui.lineEdit->setStyleSheet(QStringLiteral("QLineEdit{ color: black; background: lightgrey; border-style: inset;}"));
+    ui.mnemonicTextEdit->setFont(monoFont);
+    ui.mnemonicTextEdit->setPlainText(mnemonic);
+    ui.mnemonicTextEdit->setStyleSheet(QStringLiteral("QTextEdit{ color: black; background: lightgrey; border-style: inset;}"));
 
-    ui.lineEdit->focusWidget();
-    ui.lineEdit->selectAll();
-    ui.lineEdit->setAlignment(Qt::AlignCenter);
+    const auto textHeight = mnemonicVisibleLineCount * ui.mnemonicTextEdit->fontMetrics().lineSpacing();
+    const auto documentMargins = 2.0 * ui.mnemonicTextEdit->document()->documentMargin();
+    const auto frameMargins = 2 * ui.mnemonicTextEdit->frameWidth();
 
-    const QFont font(QStringLiteral(""), 0);
-    QFontMetrics fm(font);
-    ui.lineEdit->setFixedWidth(fm.horizontalAdvance(mnemonic));
-    widget.resize(widget.sizeHint());
+    const auto mnemonicTextEditHeight = static_cast<int>(std::ceil(textHeight + documentMargins + frameMargins));
+
+    ui.mnemonicTextEdit->setFixedHeight(mnemonicTextEditHeight);
+
+    ui.mnemonicTextEdit->setFocus();
+    ui.mnemonicTextEdit->selectAll();
+    ui.mnemonicTextEdit->setAlignment(Qt::AlignCenter);
+
+    widget.resize(widget.sizeHint().expandedTo(widget.size()));
     widget.exec();
 }
 

--- a/src/gui/mnemonicdialog.ui
+++ b/src/gui/mnemonicdialog.ui
@@ -82,7 +82,20 @@
       </spacer>
      </item>
      <item>
-      <widget class="QLineEdit" name="lineEdit"/>
+      <widget class="QTextEdit" name="mnemonicTextEdit">
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QTextEdit::LineWrapMode::WidgetWidth</enum>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+       <property name="acceptRichText">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">

--- a/test/testaccountsettings.cpp
+++ b/test/testaccountsettings.cpp
@@ -7,12 +7,18 @@
  * any purpose.
  */
 
+#include <QApplication>
+#include <QDialog>
+#include <QTextBlock>
+#include <QTextDocument>
+#include <QTextEdit>
+#include <QTextLayout>
 #include <QtTest>
 
 #include "account.h"
-#include "testhelper.h"
 #include "foldermantestutils.h"
 #include "logger.h"
+#include "testhelper.h"
 
 #include "accountsettings.h"
 
@@ -52,6 +58,84 @@ private Q_SLOTS:
         auto accountState = new FakeAccountState(account);
         QCOMPARE_EQ(accountState->state(), OCC::AccountState::Connected);
         AccountSettings a(accountState);
+    }
+
+    void test_mnemonicDialog_wrapsLongMnemonic()
+    {
+        auto account = Account::create();
+        auto accountState = new FakeAccountState(account);
+        accountState->setStateForTesting(AccountState::SignedOut);
+        AccountSettings accountSettings(accountState);
+
+        const auto mnemonic = QStringLiteral(
+            "squirrel purchase favorite document remember solution "
+            "language discover umbrella tomorrow exercise mountain");
+
+        auto dialogFound = false;
+        auto textEditFound = false;
+        auto readOnly = false;
+        auto displayedMnemonic = QString{};
+        auto lineWrapMode = QTextEdit::NoWrap;
+        auto horizontalScrollBarPolicy = Qt::ScrollBarAsNeeded;
+        auto initialDialogWidth = 0;
+        auto resizedDialogWidth = 0;
+        auto initialTextEditWidth = 0;
+        auto resizedTextEditWidth = 0;
+        auto visualLineCount = 0;
+
+        QMetaObject::invokeMethod(this, [&] {
+            const auto dialog = qobject_cast<QDialog *>(QApplication::activeModalWidget());
+
+            if (!dialog) {
+                QApplication::closeAllWindows();
+                return;
+            }
+
+            dialogFound = true;
+            initialDialogWidth = dialog->width();
+
+            const auto mnemonicTextEdit = dialog->findChild<QTextEdit *>(QStringLiteral("mnemonicTextEdit"));
+
+            if (mnemonicTextEdit) {
+                textEditFound = true;
+                initialTextEditWidth = mnemonicTextEdit->width();
+            }
+
+            dialog->resize(initialDialogWidth / 2, dialog->height());
+
+            QMetaObject::invokeMethod(dialog, [&, dialog, mnemonicTextEdit] {
+                resizedDialogWidth = dialog->width();
+
+                if (mnemonicTextEdit) {
+                    resizedTextEditWidth = mnemonicTextEdit->width();
+                    readOnly = mnemonicTextEdit->isReadOnly();
+                    displayedMnemonic = mnemonicTextEdit->toPlainText();
+                    lineWrapMode = mnemonicTextEdit->lineWrapMode();
+                    horizontalScrollBarPolicy = mnemonicTextEdit->horizontalScrollBarPolicy();
+
+                    const auto textLayout = mnemonicTextEdit->document()->firstBlock().layout();
+
+                    if (textLayout) {
+                        visualLineCount = textLayout->lineCount();
+                    }
+                }
+
+                dialog->accept();
+            }, Qt::QueuedConnection);
+        }, Qt::QueuedConnection);
+
+        const auto invoked = QMetaObject::invokeMethod(&accountSettings, "displayMnemonic", Qt::DirectConnection, Q_ARG(QString, mnemonic));
+
+        QVERIFY(invoked);
+        QVERIFY(dialogFound);
+        QVERIFY(textEditFound);
+        QVERIFY(readOnly);
+        QCOMPARE(displayedMnemonic, mnemonic);
+        QCOMPARE(lineWrapMode, QTextEdit::WidgetWidth);
+        QCOMPARE(horizontalScrollBarPolicy, Qt::ScrollBarAlwaysOff);
+        QVERIFY(resizedDialogWidth < initialDialogWidth);
+        QVERIFY(resizedTextEditWidth < initialTextEditWidth);
+        QVERIFY(visualLineCount > 1);
     }
 };
 


### PR DESCRIPTION
## Resolves
Partially addresses #7701 (mnemonic dialog wrapping only).

## Summary
Updated the "Display Mnemonic" dialog. The dialog now uses a read-only QTextEdit, allowing the generated 12-word mnemonic to wrap instead of being clipped. The text also reflows when the dialog is resized. The line wrapping is visual only. When copied, the mnemonic remains a single line with the original word order and spacing.

Added a regression test that narrows the dialog and verifies that the mnemonic is displayed using multiple visual lines.

Successfully built the desktop client and ran AccountSettingsTest with all five tests passing. Manually verified the mnemonic dialog during E2EE setup and through the "Display Mnemonic" button.

Formatted the modified C++ files with clang-format and ran clang-tidy-21 on the modified C++ files.

### Mnemonic dialog Before

<img width="580" height="189" alt="wrong_button_size" src="https://github.com/user-attachments/assets/c4ad27a1-8a13-4800-ab76-6a178505ec1d" />

### Mnemonic dialog Before

<img width="595" height="244" alt="fix_defaultsize_mnemonic" src="https://github.com/user-attachments/assets/7fd14bd7-3485-4e14-847d-c7d5811378fb" />

<img width="363" height="244" alt="fix_resize_mnemonic" src="https://github.com/user-attachments/assets/19d38b8b-9765-474c-9420-086128101194" />


## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [x] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
