### PR TITLE
File Provider Synchronization Blocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,14 @@ These instructions are restricted to `./shell_integration/MacOSX/NextcloudIntegr
 - Relevant run time values to log must be provided through the `arguments` argument.
 - Inclusion of `.debug`-level messages is controlled at runtime by the `debugLoggingEnabled` boolean key under the `com.nextcloud.desktopclient.FileProviderExt` domain in `UserDefaults.standard`. When unset, DEBUG builds include debug messages and release builds do not. Administrators can flip the value with `defaults write` for troubleshooting; changes propagate live via KVO. The gate applies to both Apple unified logging and the JSONL file output. See `Logging.md`.
 
+#### Blocking synchronization
+
+- Synchronization is blocked at runtime by the `blockSync` boolean key under the `com.nextcloud.desktopclient.FileProviderExt` domain in `UserDefaults.standard`, the counterpart on the file provider path to "pause synchronisation" for classic sync folders. When unset, synchronization is not blocked, in every build configuration.
+- Flip it with `defaults write com.nextcloud.desktopclient.FileProviderExt blockSync -bool true` and clear it with `defaults delete com.nextcloud.desktopclient.FileProviderExt blockSync`. It takes effect immediately, without restarting the extension.
+- While blocked, the extension performs no network input or output with the server. Every request from the system which would need it is refused with `NSFileProviderErrorServerUnreachable`, which is what the situation genuinely is as far as the file provider framework is concerned.
+- Both directions are covered by refusing requests in the extension alone. Remote changes are discovered by the main app, but the signal it sends carries no data and reaches the extension as a request for an enumerator, so declining that declines the push and the polling path alike.
+- See `BlockSync.md` for the semantics, including what blocking deliberately does not do.
+
 ### Tests
 
 #### GUI changes

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/BlockSync.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/BlockSync.md
@@ -1,0 +1,91 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: LGPL-3.0-or-later
+-->
+
+# Blocking synchronization
+
+How to stop the extension talking to the server, and what that does and does not cover.
+
+## Overview
+
+Classic sync folders can be paused. The file provider path had no equivalent, and this is it: a
+process-global `blockSync` boolean in `UserDefaults.standard`, which under the extension resolves to
+the `com.nextcloud.desktopclient.FileProviderExt` domain.
+
+```
+defaults write com.nextcloud.desktopclient.FileProviderExt blockSync -bool true
+defaults delete com.nextcloud.desktopclient.FileProviderExt blockSync
+```
+
+It takes effect immediately, without restarting the extension. When the key is absent — or holds
+anything which is not a boolean — synchronization is not blocked. That holds in every build
+configuration: a debug build must not synchronize differently from a release build, and a value
+which cannot be read is not a reason to stop synchronizing.
+
+## What blocking does
+
+**The extension performs no network input or output with the server.** Every request from the system
+which would need it is refused with `NSFileProviderErrorServerUnreachable`. That is not a fiction:
+as far as the file provider framework is concerned the server genuinely is unreachable, and the
+framework already knows how to behave — it presents the situation to the user, throttles the items
+it could not sync, and retries once the extension says the trouble has passed.
+
+Five requests are refused:
+
+| Request | Direction |
+| --- | --- |
+| ``FileProviderExtension/enumerator(for:request:)`` | remote changes arriving |
+| ``FileProviderExtension/fetchContents(for:version:request:completionHandler:)`` | downloads |
+| ``FileProviderExtension/createItem(basedOn:fields:contents:options:request:completionHandler:)`` | uploads |
+| ``FileProviderExtension/modifyItem(_:baseVersion:changedFields:contents:options:request:completionHandler:)`` | uploads |
+| ``FileProviderExtension/deleteItem(identifier:baseVersion:options:request:completionHandler:)`` | uploads |
+
+Refusing to provide an enumerator is what stops remote changes arriving, and it is worth
+understanding why one gate covers both the push and the polling path. Change discovery happens in
+the main app — the websocket for push notifications, the root ETag poll otherwise — but what the app
+sends the extension carries no data. It signals the working set, the framework invalidates it, and
+the framework then asks the extension for an enumerator. Declining that request declines everything
+which was discovered, whichever way it was discovered, and the app needs to know nothing about it.
+
+Looking an item up is deliberately **not** refused. It is answered from the local database, so the
+Finder keeps showing the name and size of everything already known. Classic sync does not hide what
+it has while it is paused, and neither should this.
+
+## What blocking does not do
+
+**Work already under way is not cancelled.** Blocking refuses new requests; it does not reach into
+accepted ones. An upload which began a second before the key was set finishes uploading. Code which
+needs the extension to be quiet rather than merely uncooperative should set the key and then wait
+for the reported sync state to settle.
+
+**Content already on disk stays readable.** For a replicated extension the system serves materialized
+files from its own copy without involving the extension at all, so reading what has already been
+downloaded keeps working. Only a file which still has to be fetched fails.
+
+**A folder never visited before cannot be browsed.** Its contents have to be enumerated to be shown,
+and enumeration is refused. Already-enumerated folders are unaffected.
+
+**Thumbnails still reach the server.** Thumbnail requests take their own path and are not gated. This
+is a known gap rather than a decision.
+
+## Unblocking
+
+Removing the key is enough. The extension notices through a key-value observation, releases the items
+the framework throttled by calling `signalErrorResolved(_:completionHandler:)`, and signals the
+working set so that whatever changed on the server in the meantime is enumerated.
+
+The refusals themselves do not depend on that observation — they read the value directly, each time.
+If the notification is ever missed the only consequence is that recovery waits for whatever the
+system would have done next. Blocking can be left on by accident; it cannot be left on by failure.
+
+## A note on the errors
+
+`NSFileProviderErrorServerUnreachable` is documented as a back-off error for enumeration, fetching
+and deletion: the system reports it, stops asking, and waits to be signalled. For creation and
+modification Apple's documentation lists a different set, so there the error is treated as transient
+and the request is retried instead of throttled. Retries are cheap, because the refusal happens
+before any network call is made, but it does mean a long block costs some repeated work. The
+alternatives are worse and were rejected deliberately: `NSFileProviderErrorCannotSynchronize` is not
+retried until the item is touched again, which would leave changes stranded after unblocking, and
+`NSFileProviderErrorExcludedFromSync` makes the system delete the item.

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Documentation.docc/Documentation.md
@@ -49,6 +49,7 @@ It is designed specifically for the implementation of this file provider extensi
 
 ### Design notes
 
+- <doc:BlockSync>
 - <doc:ChangeEnumeration>
 - <doc:ExcludedFromSyncDeletion>
 - <doc:ChunkedUploads>

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+BlockSync.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension+BlockSync.swift
@@ -1,0 +1,41 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import FileProvider
+import Foundation
+
+public extension FileProviderExtension {
+    ///
+    /// Whether synchronization with the server is currently blocked.
+    ///
+    /// A key which is absent, or set to something which is not a boolean, means synchronization is not blocked. A malformed value must never be a reason to stop synchronizing.
+    ///
+    var blockSync: Bool {
+        config.blockSync ?? false
+    }
+
+    ///
+    /// Watch for synchronization being unblocked, and let the system retry what it held back.
+    ///
+    /// The gates deliberately do not depend on this observation. It exists so that recovery is prompt rather than waiting for whatever the system would have done next: items the framework throttled because of the errors returned while blocked are released with `signalErrorResolved(_:completionHandler:)`, so that the work refused while blocked is asked for again. Should the notification ever be missed, the only consequence is that recovery waits for the next natural signal, and the client can never be left blocked.
+    ///
+    /// The working set is deliberately **not** signalled here. Doing so enumerates the server before the released uploads are retried, and an item which changed on both sides then has its base version refreshed by that enumeration — so the upload which follows no longer looks like a conflict and quietly overwrites the newer version on the server. Remote changes are found soon enough anyway, because the app is still polling or listening and signals the working set itself. Releasing the throttle is this observation's whole job.
+    ///
+    internal func observeBlockSync() {
+        blockSyncObservation = UserDefaults.standard.observe(\.blockSync, options: [.new]) { [weak self] _, _ in
+            guard let self, blockSync == false else {
+                return
+            }
+
+            logger.info("Synchronization is no longer blocked, releasing throttled items.")
+
+            manager?.signalErrorResolved(NSFileProviderError(.serverUnreachable)) { [weak self] error in
+                guard let error else {
+                    return
+                }
+
+                self?.logger.error("Could not report that synchronization is no longer blocked.", [.error: error])
+            }
+        }
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Extension/FileProviderExtension.swift
@@ -27,6 +27,13 @@ import OSLog
     ///
     let manager: NSFileProviderManager?
 
+    ///
+    /// Observation of the process-global `blockSync` user default, used only to notice when synchronization is unblocked.
+    ///
+    /// See ``observeBlockSync()`` for why the gates do not depend on this.
+    ///
+    var blockSyncObservation: NSKeyValueObservation?
+
     // MARK: XPC
 
     ///
@@ -107,10 +114,13 @@ import OSLog
         logger.info("NextcloudKit logging configured.", [.url: NKLogFileManager.shared.currentLogFileURL()])
         keychain = Keychain(log: log)
         super.init()
+        observeBlockSync()
     }
 
     public func invalidate() {
         logger.debug("File provider extension process is being invalidated.")
+        blockSyncObservation?.invalidate()
+        blockSyncObservation = nil
     }
 
     func insertSyncAction(_ actionId: UUID) {
@@ -183,6 +193,13 @@ import OSLog
     }
 
     public func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request _: NSFileProviderRequest, completionHandler: @Sendable @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        guard !blockSync else {
+            logger.info("Not fetching contents of item because synchronization is blocked.", [.item: itemIdentifier])
+            completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
+
+            return Progress()
+        }
+
         let actionId = UUID()
         insertSyncAction(actionId)
         logger.debug("Received request to fetch contents of item.", [.item: itemIdentifier])
@@ -248,6 +265,13 @@ import OSLog
             NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?
         ) -> Void
     ) -> Progress {
+        guard !blockSync else {
+            logger.info("Not creating item because synchronization is blocked.", [.item: itemTemplate.itemIdentifier, .name: itemTemplate.filename])
+            completionHandler(itemTemplate, [], false, NSFileProviderError(.serverUnreachable))
+
+            return Progress()
+        }
+
         let actionId = UUID()
         insertSyncAction(actionId)
         logger.debug("Received request to create item.", [.item: itemTemplate.itemIdentifier, .name: itemTemplate.filename])
@@ -324,6 +348,13 @@ import OSLog
     ) -> Progress {
         // An item was modified on disk, process the item's modification
         // TODO: Handle finder things like tags, other possible item changed fields
+        guard !blockSync else {
+            logger.info("Not modifying item because synchronization is blocked.", [.item: item.itemIdentifier])
+            completionHandler(item, [], false, NSFileProviderError(.serverUnreachable))
+
+            return Progress()
+        }
+
         let actionId = UUID()
         insertSyncAction(actionId)
 
@@ -409,6 +440,13 @@ import OSLog
         request _: NSFileProviderRequest,
         completionHandler: @Sendable @escaping (Error?) -> Void
     ) -> Progress {
+        guard !blockSync else {
+            logger.info("Not deleting item because synchronization is blocked.", [.item: identifier])
+            completionHandler(NSFileProviderError(.serverUnreachable))
+
+            return Progress()
+        }
+
         let actionId = UUID()
         insertSyncAction(actionId)
 
@@ -469,6 +507,14 @@ import OSLog
 
     public func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request _: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
         logger.debug("System requested enumerator.", [.item: containerItemIdentifier])
+
+        // Refusing here is what stops remote changes arriving: the app discovers them and signals the working set, but the signal carries no data and reaches this extension as a request for an enumerator, so declining it declines both the push and the polling path.
+        //
+        // It has to be an error rather than an enumerator which reports nothing. An empty but successful enumeration tells the framework that the container is empty, which for a replicated extension is an instruction to delete every child of it from disk. Failing loses nothing; succeeding emptily loses the user's files.
+        guard !blockSync else {
+            logger.info("Not providing enumerator for item because synchronization is blocked.", [.item: containerItemIdentifier])
+            throw NSFileProviderError(.serverUnreachable)
+        }
 
         guard let ncAccount else {
             logger.debug("Not providing enumerator for item because account is not set up yet.", [.item: containerItemIdentifier])

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/FileProviderDomainDefaults.swift
@@ -22,6 +22,7 @@ public struct FileProviderDomainDefaults {
         case serverUrl
         case lastSeenExtensionVersion
         case debugLoggingEnabled
+        case blockSync
     }
 
     ///
@@ -213,6 +214,43 @@ public struct FileProviderDomainDefaults {
                 logger.debug("Removing key \"debugLoggingEnabled\" (process-global) because the new value is nil.")
                 UserDefaults.standard.removeObject(forKey: key)
             }
+        }
+    }
+
+    ///
+    /// Controls whether synchronization with the server is blocked.
+    ///
+    /// Like ``debugLoggingEnabled`` and unlike the other properties on this type, this value is **process-global and shared across all file provider domains**. It is stored at the top level of `UserDefaults.standard`, bypassing the per-domain `internalConfig` dictionary, so that it can be flipped with a single `defaults write` command per extension bundle.
+    ///
+    /// While this is `true` the extension performs no network input or output with the server: every request from the system which would require it fails with `NSFileProviderErrorServerUnreachable`, which is what the situation genuinely is from the perspective of the file provider framework. Work already in progress when the value is set runs to completion, because blocking refuses new requests rather than cancelling accepted ones.
+    ///
+    /// When unset, synchronization is not blocked. This holds in every build configuration: a debug build must not synchronize differently from a release build, and a value which cannot be read as a boolean is treated as unset rather than as a reason to stop synchronizing.
+    ///
+    public var blockSync: Bool? {
+        get {
+            let key = ConfigKey.blockSync.rawValue
+
+            guard let value = UserDefaults.standard.object(forKey: key) as? Bool else {
+                logger.debug("No existing value for \"blockSync\" (process-global) found.")
+                return nil
+            }
+
+            logger.debug(value ? "Synchronization is blocked (process-global)." : "Synchronization is not blocked (process-global).")
+
+            return value
+        }
+
+        set {
+            let key = ConfigKey.blockSync.rawValue
+
+            guard let newValue else {
+                logger.debug("Removing key \"blockSync\" (process-global) because the new value is nil.")
+                UserDefaults.standard.removeObject(forKey: key)
+
+                return
+            }
+
+            UserDefaults.standard.set(newValue, forKey: key)
         }
     }
 }

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/UserDefaults+BlockSync.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/UserDefaults+BlockSync.swift
@@ -1,0 +1,17 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+extension UserDefaults {
+    ///
+    /// KVO-observable accessor for the process-global `blockSync` user default.
+    ///
+    /// The `@objc dynamic` attribute is required so `FileProviderExtension` can observe the key via `\.blockSync` and notice the moment synchronization is unblocked by `defaults write` without restarting the extension.
+    /// The gates which refuse work read the value directly instead of observing it, so this exists only to catch the edge on which throttled items have to be released.
+    /// `NSNumber?` is used instead of `Bool` so observers can distinguish a reset (key absent) from an explicit `false`.
+    ///
+    @objc dynamic var blockSync: NSNumber? {
+        object(forKey: "blockSync") as? NSNumber
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/BlockSyncTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/BlockSyncTests.swift
@@ -1,0 +1,239 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import FileProvider
+import Foundation
+@testable import NextcloudFileProviderKit
+import NextcloudFileProviderKitMocks
+import Testing
+import UniformTypeIdentifiers
+
+///
+/// Coverage for the process-global `blockSync` user default, which stops the extension from talking to the server.
+///
+/// The gates run before the account is looked at, which is what makes these tests possible without one: an extension with no account still reaches the gate, so the two cases are told apart by which error comes back. That ordering is deliberate and is asserted here, because moving a gate below the account guard would silently turn a blocked request into an authentication failure.
+///
+/// The suite is serialized and clears the key after every test because the gates read the user defaults of whichever process they run in, which under test is this one. Tests running in parallel would otherwise block each other's extensions.
+///
+@Suite("Blocking synchronization", .serialized)
+struct BlockSyncTests {
+    ///
+    /// The key as it is written by an administrator and read by the extension.
+    ///
+    static let key = "blockSync"
+
+    init() {
+        UserDefaults.standard.removeObject(forKey: Self.key)
+    }
+
+    ///
+    /// An extension for a domain which exists only for the duration of one test.
+    ///
+    /// - Returns: The extension.
+    ///
+    private func makeExtension() -> FileProviderExtension {
+        let domain = NSFileProviderDomain(identifier: NSFileProviderDomainIdentifier(UUID().uuidString), displayName: "Test")
+
+        return FileProviderExtension(domain: domain)
+    }
+
+    ///
+    /// The least an item can be and still be handed to the framework methods under test.
+    ///
+    /// These requests are refused before anything reads more than the identifier and the name, so nothing more has to be true of it.
+    ///
+    private final class StubItem: NSObject, NSFileProviderItem {
+        var itemIdentifier: NSFileProviderItemIdentifier {
+            .rootContainer
+        }
+
+        var parentItemIdentifier: NSFileProviderItemIdentifier {
+            .rootContainer
+        }
+
+        var filename: String {
+            "stub.txt"
+        }
+
+        var contentType: UTType {
+            .plainText
+        }
+    }
+
+    @Test("An absent key does not block synchronization.")
+    func absentKeyDoesNotBlock() {
+        #expect(makeExtension().blockSync == false)
+    }
+
+    @Test("The key blocks synchronization when it is set.")
+    func setKeyBlocks() {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        #expect(makeExtension().blockSync)
+    }
+
+    @Test("An explicit negative reads the same as an absent key.")
+    func explicitFalseDoesNotBlock() {
+        UserDefaults.standard.set(false, forKey: Self.key)
+
+        #expect(makeExtension().blockSync == false)
+    }
+
+    ///
+    /// A value which cannot be read as a boolean must never be a reason to stop synchronizing.
+    ///
+    @Test("A value which is not a boolean does not block synchronization.")
+    func malformedValueDoesNotBlock() {
+        UserDefaults.standard.set("yes please", forKey: Self.key)
+
+        #expect(makeExtension().blockSync == false)
+    }
+
+    ///
+    /// This pins the ordering of the gate against the account guard. Without the key set, the same call must fall through to the account check and fail differently.
+    ///
+    @Test("Fetching contents is refused as unreachable rather than unauthenticated.")
+    func fetchContentsIsRefused() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().fetchContents(for: .rootContainer, version: nil, request: NSFileProviderRequest()) { _, _, error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code == .serverUnreachable)
+    }
+
+    @Test("Fetching contents without the key set reaches the account guard.")
+    func fetchContentsWithoutBlockingReachesAccountGuard() async {
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().fetchContents(for: .rootContainer, version: nil, request: NSFileProviderRequest()) { _, _, error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code == .notAuthenticated)
+    }
+
+    @Test("Deleting an item is refused as unreachable.")
+    func deleteItemIsRefused() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().deleteItem(identifier: .rootContainer, baseVersion: NSFileProviderItemVersion(), request: NSFileProviderRequest()) { error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code == .serverUnreachable)
+    }
+
+    ///
+    /// Refusing here is what stops remote changes arriving, because the signal the app sends reaches the extension as a request for an enumerator.
+    ///
+    @Test("Providing an enumerator is refused as unreachable.")
+    func enumeratorIsRefused() {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        #expect(throws: NSFileProviderError(.serverUnreachable)) {
+            _ = try makeExtension().enumerator(for: .workingSet, request: NSFileProviderRequest())
+        }
+    }
+
+    @Test("Providing an enumerator without the key set reaches the account guard.")
+    func enumeratorWithoutBlockingReachesAccountGuard() {
+        #expect(throws: NSFileProviderError(.notAuthenticated)) {
+            _ = try makeExtension().enumerator(for: .workingSet, request: NSFileProviderRequest())
+        }
+    }
+
+    ///
+    /// A refused request is not a synchronization action, so nothing about it may reach the app. Were the gates placed after the bookkeeping instead of before it, a blocked client would report a stream of failures rather than staying quiet.
+    ///
+    @Test("A refused request is not reported to the app as synchronization activity.")
+    func refusedRequestIsNotReported() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let fileProviderExtension = makeExtension()
+        let proxy = SyncStatusCapturingAppProxy()
+        fileProviderExtension.app = proxy
+
+        _ = await withCheckedContinuation { continuation in
+            _ = fileProviderExtension.deleteItem(identifier: .rootContainer, baseVersion: NSFileProviderItemVersion(), request: NSFileProviderRequest()) { error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect(fileProviderExtension.syncActions.isEmpty)
+        #expect(fileProviderExtension.errorActions.isEmpty)
+        #expect(proxy.reportedSyncStatuses.isEmpty)
+    }
+
+    ///
+    /// Looking up an item is answered from the database, so blocking must not stop the Finder showing the name and size of something already known. Classic synchronization does not hide what it has while it is paused either.
+    ///
+    @Test("Looking up an item is not refused.")
+    func itemLookupIsNotRefused() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().item(for: .rootContainer, request: NSFileProviderRequest()) { _, error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code != .serverUnreachable)
+    }
+
+    ///
+    /// The value belongs to the process rather than to a domain, so two domains must see the same thing and neither may carry it in its own dictionary.
+    ///
+    @Test("The value is shared by every domain rather than stored per domain.")
+    func valueIsProcessGlobal() {
+        var defaults = FileProviderDomainDefaults(identifier: NSFileProviderDomainIdentifier("one"), log: FileProviderLogMock())
+        defaults.blockSync = true
+
+        let other = FileProviderDomainDefaults(identifier: NSFileProviderDomainIdentifier("two"), log: FileProviderLogMock())
+        #expect(other.blockSync == true)
+
+        #expect(UserDefaults.standard.dictionary(forKey: "one")?[Self.key] == nil)
+        #expect(UserDefaults.standard.dictionary(forKey: "two")?[Self.key] == nil)
+    }
+
+    @Test("Creating an item is refused as unreachable.")
+    func createItemIsRefused() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().createItem(basedOn: StubItem(), fields: [], contents: nil, request: NSFileProviderRequest()) { _, _, _, error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code == .serverUnreachable)
+    }
+
+    @Test("Modifying an item is refused as unreachable.")
+    func modifyItemIsRefused() async {
+        UserDefaults.standard.set(true, forKey: Self.key)
+
+        let error = await withCheckedContinuation { continuation in
+            _ = makeExtension().modifyItem(StubItem(), baseVersion: NSFileProviderItemVersion(), changedFields: [], contents: nil, request: NSFileProviderRequest()) { _, _, _, error in
+                continuation.resume(returning: error)
+            }
+        }
+
+        #expect((error as? NSFileProviderError)?.code == .serverUnreachable)
+    }
+
+    @Test("Removing the value returns the extension to synchronizing.")
+    func removingTheValueUnblocks() {
+        var defaults = FileProviderDomainDefaults(identifier: NSFileProviderDomainIdentifier("one"), log: FileProviderLogMock())
+        defaults.blockSync = true
+        defaults.blockSync = nil
+
+        #expect(defaults.blockSync == nil)
+        #expect(makeExtension().blockSync == false)
+    }
+}

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ReportCurrentSyncStateTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ReportCurrentSyncStateTests.swift
@@ -6,30 +6,6 @@ import FileProvider
 import NextcloudFileProviderXPC
 import XCTest
 
-/// Captures `reportSyncStatus(_:forDomainIdentifier:)` so the unconditional connect-time report can
-/// be exercised without a real XPC connection.
-private final class SyncStatusCapturingAppProxy: NSObject, AppProtocol {
-    var reportedSyncStatuses: [String] = []
-
-    func reportSyncStatus(_ status: String, forDomainIdentifier _: String) {
-        reportedSyncStatuses.append(status)
-    }
-
-    // The following are unused by these tests but required for protocol conformance.
-    func presentFileActions(_: String, path _: String, remoteItemPath _: String, withDomainIdentifier _: String) {}
-    func openItemInBrowser(_: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
-    func copyInternalLink(forItem _: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
-    func reportItemExcluded(fromSync _: String, fileName _: String, reason _: String, forDomainIdentifier _: String) {}
-    func reportInsufficientQuota(
-        forItem _: String,
-        fileName _: String,
-        fileBytes _: NSNumber?,
-        availableBytes _: NSNumber?,
-        forDomainIdentifier _: String
-    ) {}
-    func reportInsufficientQuotaSummary(forDomainIdentifier _: String) {}
-}
-
 /// Regression coverage for https://github.com/nextcloud/desktop/issues/10053.
 ///
 /// When the main app connects on launch, the extension must report its *current* state — even when

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/SyncStatusCapturingAppProxy.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/SyncStatusCapturingAppProxy.swift
@@ -1,0 +1,35 @@
+//  SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+//  SPDX-License-Identifier: LGPL-3.0-or-later
+
+import Foundation
+import NextcloudFileProviderXPC
+
+///
+/// Captures `reportSyncStatus(_:forDomainIdentifier:)` so that what the extension tells the app can be asserted without a real XPC connection.
+///
+/// Shared between the suites which care about synchronization status reporting, both those asserting what is reported and those asserting that nothing is.
+///
+final class SyncStatusCapturingAppProxy: NSObject, AppProtocol {
+    ///
+    /// Every status reported so far, in the order it was reported.
+    ///
+    var reportedSyncStatuses: [String] = []
+
+    func reportSyncStatus(_ status: String, forDomainIdentifier _: String) {
+        reportedSyncStatuses.append(status)
+    }
+
+    // The following are unused by the tests using this proxy but required for protocol conformance.
+    func presentFileActions(_: String, path _: String, remoteItemPath _: String, withDomainIdentifier _: String) {}
+    func openItemInBrowser(_: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
+    func copyInternalLink(forItem _: String, remoteItemPath _: String, forDomainIdentifier _: String) {}
+    func reportItemExcluded(fromSync _: String, fileName _: String, reason _: String, forDomainIdentifier _: String) {}
+    func reportInsufficientQuota(
+        forItem _: String,
+        fileName _: String,
+        fileBytes _: NSNumber?,
+        availableBytes _: NSNumber?,
+        forDomainIdentifier _: String
+    ) {}
+    func reportInsufficientQuotaSummary(forDomainIdentifier _: String) {}
+}


### PR DESCRIPTION
This is a required feature addition for end-to-end tests and their enablement to set the stage for conflict resolution. This can be reused for a (questionable) "Pause Sync" feature which covers the file provider.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [x] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
