### PR TITLE
build(icons): Speed up batch SVG to PNG generation at configure time

### DIFF
--- a/cmake/modules/GenerateIconsUtils.cmake
+++ b/cmake/modules/GenerateIconsUtils.cmake
@@ -14,7 +14,12 @@ if (NOT SVG_CONVERTER)
   message(FATAL_ERROR "Could not find a suitable svg converter. Set SVG_CONVERTER_DIR to the path of either the inkscape or rsvg-convert executable.")
 endif()
 
-function(generate_sized_png_from_svg icon_path size)
+# Separator used to pack a queued conversion job into a single list element.
+set(GENERATE_ICONS_JOB_SEPARATOR "@@@")
+
+# Queue a single SVG -> PNG conversion. Nothing is generated until
+# run_generate_queued_pngs_from_svg() is called to run the queued jobs.
+function(queue_generate_sized_png_from_svg icon_path size)
   set(options)
   set(oneValueArgs OUTPUT_ICON_NAME OUTPUT_ICON_FULL_NAME_WLE OUTPUT_ICON_PATH)
   set(multiValueArgs)
@@ -38,23 +43,142 @@ function(generate_sized_png_from_svg icon_path size)
     set(output_icon_full_name_wle ${ARG_OUTPUT_ICON_FULL_NAME_WLE})
   endif ()
 
-  if (EXISTS "${icon_name_dir}/${output_icon_full_name_wle}.png")
+  set(icon_output_path "${icon_name_dir}/${output_icon_full_name_wle}.png")
+
+  if (EXISTS "${icon_output_path}")
     return()
   endif()
 
-  set(icon_output_name "${output_icon_full_name_wle}.png")
-  message(STATUS "Generate ${icon_output_name}")
-  execute_process(COMMAND
-    "${SVG_CONVERTER}" -w ${size} -h ${size} "${icon_path}" -o "${icon_output_name}"
-    WORKING_DIRECTORY "${icon_name_dir}"
-    RESULT_VARIABLE
-    SVG_CONVERTER_SIDEBAR_ERROR
+  # Pack size, source and destination into one element so the flat CMake list
+  # keeps one entry per job. run_generate_queued_pngs_from_svg() unpacks it again.
+  set(job "${size}${GENERATE_ICONS_JOB_SEPARATOR}${icon_path}${GENERATE_ICONS_JOB_SEPARATOR}${icon_output_path}")
+  set_property(GLOBAL APPEND PROPERTY GENERATE_ICONS_PENDING_JOBS "${job}")
+endfunction()
+
+# Run every conversion queued by queue_generate_sized_png_from_svg() so far.
+#
+# Two strategies are used depending on the converter:
+#  * rsvg-convert (and any other converter) is launched as independent processes
+#    in batches of at most one process per logical core. Within a batch every
+#    converter runs concurrently, because execute_process() starts all of its
+#    COMMAND entries at once.
+#  * Inkscape must not be run as many concurrent instances: separate instances
+#    race during GTK/fontconfig start-up and abort. It is instead driven through
+#    its single-process "--shell" batch mode, which does every conversion in one
+#    process and thereby avoids paying the expensive Inkscape start-up cost once
+#    per icon.
+
+function(run_generate_queued_pngs_from_svg)
+  get_property(pending_jobs GLOBAL PROPERTY GENERATE_ICONS_PENDING_JOBS)
+
+  if (NOT pending_jobs)
+    return()
+  endif()
+
+  # Clear the queue up front so a later call does not reprocess these jobs.
+  set_property(GLOBAL PROPERTY GENERATE_ICONS_PENDING_JOBS "")
+
+  list(LENGTH pending_jobs job_count)
+
+  get_filename_component(converter_name "${SVG_CONVERTER}" NAME_WE)
+  string(TOLOWER "${converter_name}" converter_name)
+
+  if (converter_name MATCHES "inkscape")
+    message(STATUS "Generating ${job_count} icon(s) from SVG in one Inkscape batch")
+    _run_inkscape_shell_jobs("${pending_jobs}")
+    return()
+  endif()
+
+  cmake_host_system_information(RESULT batch_size QUERY NUMBER_OF_LOGICAL_CORES)
+  if (NOT batch_size OR batch_size LESS 1)
+    set(batch_size 4)
+  endif()
+
+  message(STATUS "Generating ${job_count} icon(s) from SVG, up to ${batch_size} in parallel")
+
+  set(batch_index 0)
+  set(process_args "")
+
+  foreach(job IN LISTS pending_jobs)
+    string(REPLACE "${GENERATE_ICONS_JOB_SEPARATOR}" ";" job_parts "${job}")
+    list(GET job_parts 0 job_size)
+    list(GET job_parts 1 job_input)
+    list(GET job_parts 2 job_output)
+
+    list(APPEND process_args
+      COMMAND "${SVG_CONVERTER}" -w ${job_size} -h ${job_size} "${job_input}" -o "${job_output}")
+
+    math(EXPR batch_index "${batch_index} + 1")
+
+    if (batch_index GREATER_EQUAL batch_size)
+      _run_png_conversion_batch("${process_args}")
+      set(batch_index 0)
+      set(process_args "")
+    endif()
+  endforeach()
+
+  if (process_args)
+    _run_png_conversion_batch("${process_args}")
+  endif()
+endfunction()
+
+# Execute one batch of converter invocations concurrently and fail hard if any
+# of them reports an error. Not intended to be called directly.
+function(_run_png_conversion_batch process_args)
+  execute_process(${process_args}
+    RESULTS_VARIABLE batch_results
     OUTPUT_QUIET
     ERROR_QUIET)
 
-  if (SVG_CONVERTER_SIDEBAR_ERROR)
-    message(FATAL_ERROR
-      "${SVG_CONVERTER} could not generate icon: ${SVG_CONVERTER_SIDEBAR_ERROR}")
+  foreach(result IN LISTS batch_results)
+    if (result)
+      message(FATAL_ERROR
+        "${SVG_CONVERTER} could not generate icon: ${result}")
+    endif()
+  endforeach()
+endfunction()
+
+# Convert every queued job in a single Inkscape process using its shell mode.
+# Not intended to be called directly.
+function(_run_inkscape_shell_jobs jobs)
+  set(shell_script "")
+  set(expected_outputs "")
+
+  foreach(job IN LISTS jobs)
+    string(REPLACE "${GENERATE_ICONS_JOB_SEPARATOR}" ";" job_parts "${job}")
+    list(GET job_parts 0 job_size)
+    list(GET job_parts 1 job_input)
+    list(GET job_parts 2 job_output)
+
+    string(APPEND shell_script
+      "file-open:${job_input}; export-width:${job_size}; export-height:${job_size}; export-filename:${job_output}; export-do; file-close\n")
+    list(APPEND expected_outputs "${job_output}")
+  endforeach()
+
+  string(APPEND shell_script "quit\n")
+
+  if (DEFINED CMAKE_CURRENT_BINARY_DIR AND CMAKE_CURRENT_BINARY_DIR)
+    set(shell_script_dir "${CMAKE_CURRENT_BINARY_DIR}")
   else()
+    set(shell_script_dir "${CMAKE_BINARY_DIR}")
   endif()
+  set(shell_script_file "${shell_script_dir}/inkscape-icon-batch.txt")
+  file(WRITE "${shell_script_file}" "${shell_script}")
+
+  execute_process(COMMAND "${SVG_CONVERTER}" --shell
+    INPUT_FILE "${shell_script_file}"
+    RESULT_VARIABLE inkscape_result
+    OUTPUT_QUIET
+    ERROR_QUIET)
+
+  file(REMOVE "${shell_script_file}")
+
+  # Inkscape's shell mode may keep a zero exit code even when an individual
+  # export fails, so verify every expected file was actually produced.
+  foreach(expected_output IN LISTS expected_outputs)
+    if (NOT EXISTS "${expected_output}")
+      message(FATAL_ERROR
+        "${SVG_CONVERTER} could not generate icon: ${expected_output}")
+    endif()
+  endforeach()
 endfunction()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -485,10 +485,12 @@ foreach(state_icons_color ${STATE_ICONS_COLORS})
     foreach(state_icon_svg ${STATE_ICONS_SVG})
         get_filename_component(status_icon_name_wle ${state_icon_svg} NAME_WLE)
         foreach(size IN ITEMS 16;32;64;128;256)
-            generate_sized_png_from_svg(${state_icon_svg} ${size} OUTPUT_ICON_FULL_NAME_WLE "${status_icon_name_wle}-${size}")
+            queue_generate_sized_png_from_svg(${state_icon_svg} ${size} OUTPUT_ICON_FULL_NAME_WLE "${status_icon_name_wle}-${size}")
         endforeach()
     endforeach()
 endforeach()
+
+run_generate_queued_pngs_from_svg()
 
 if ((APPLICATION_ICON_SET MATCHES "PNG")
     AND
@@ -500,8 +502,9 @@ endif()
 
 if(WIN32)
   set(STARTMENU_ICON_SVG "${theme_dir}/colored/${APPLICATION_ICON_NAME}-w10startmenu.svg")
-  generate_sized_png_from_svg(${STARTMENU_ICON_SVG} 70)
-  generate_sized_png_from_svg(${STARTMENU_ICON_SVG} 150)
+  queue_generate_sized_png_from_svg(${STARTMENU_ICON_SVG} 70)
+  queue_generate_sized_png_from_svg(${STARTMENU_ICON_SVG} 150)
+  run_generate_queued_pngs_from_svg()
 endif()
 
 set(APP_ICON_SVG "${theme_dir}/colored/${APPLICATION_ICON_NAME}-icon.svg")
@@ -513,13 +516,15 @@ set(APP_ICON_WIN_FOLDER_SVG "${APP_SECONDARY_ICONS}/${APPLICATION_ICON_NAME}-ico
 # generate primary icon from SVG (due to Win .ico vs .rc dependency issues, primary icon must always be generated last)--------------------------------------
 if(WIN32)
     foreach(size IN ITEMS 16;20;24;32;40;48;64;128;256;512;1024)
-        generate_sized_png_from_svg(${APP_ICON_SVG} ${size})
+        queue_generate_sized_png_from_svg(${APP_ICON_SVG} ${size})
     endforeach()
 else()
     foreach(size IN ITEMS 16;24;32;48;64;128;256;512;1024)
-        generate_sized_png_from_svg(${APP_ICON_SVG} ${size})
+        queue_generate_sized_png_from_svg(${APP_ICON_SVG} ${size})
     endforeach()
 endif()
+
+run_generate_queued_pngs_from_svg()
 
 file(GLOB OWNCLOUD_ICONS "${theme_dir}/colored/*-${APPLICATION_ICON_NAME}-icon*")
 
@@ -537,13 +542,15 @@ if(WIN32 AND EXISTS ${APP_ICON_WIN_FOLDER_SVG})
     get_filename_component(output_icon_name_win ${APP_ICON_WIN_FOLDER_SVG} NAME_WLE)
     # Product icon (for smallest size)
     foreach(size IN ITEMS 16;20)
-        generate_sized_png_from_svg(${APP_ICON_SVG} ${size} OUTPUT_ICON_NAME ${output_icon_name_win} OUTPUT_ICON_PATH "${APP_SECONDARY_ICONS}/")
+        queue_generate_sized_png_from_svg(${APP_ICON_SVG} ${size} OUTPUT_ICON_NAME ${output_icon_name_win} OUTPUT_ICON_PATH "${APP_SECONDARY_ICONS}/")
     endforeach()
 
     # Product icon with Windows folder (for sizes larger than 20)
     foreach(size IN ITEMS 24;32;40;48;64;128;256;512;1024)
-        generate_sized_png_from_svg(${APP_ICON_WIN_FOLDER_SVG} ${size} OUTPUT_ICON_NAME ${output_icon_name_win} OUTPUT_ICON_PATH "${APP_SECONDARY_ICONS}/")
+        queue_generate_sized_png_from_svg(${APP_ICON_WIN_FOLDER_SVG} ${size} OUTPUT_ICON_NAME ${output_icon_name_win} OUTPUT_ICON_PATH "${APP_SECONDARY_ICONS}/")
     endforeach()
+
+    run_generate_queued_pngs_from_svg()
 
     file(GLOB OWNCLOUD_ICONS_WIN_FOLDER "${APP_SECONDARY_ICONS}/*-${APPLICATION_ICON_NAME}-icon*")
     set(APP_ICON_WIN_FOLDER_ICO_NAME "${APPLICATION_ICON_NAME}-win-folder")

--- a/src/libsync/vfs/cfapi/shellext/CMakeLists.txt
+++ b/src/libsync/vfs/cfapi/shellext/CMakeLists.txt
@@ -12,13 +12,15 @@ set(CUSTOM_STATE_ICON_SHARED_PATH "${custom_state_icons_path}/1-shared.svg")
 
 foreach(size IN ITEMS 24;32;40;48;64;128;256;512;1024)
   get_filename_component(output_icon_name_custom_state_locked ${CUSTOM_STATE_ICON_LOCKED_PATH} NAME_WLE)
-  generate_sized_png_from_svg(${CUSTOM_STATE_ICON_LOCKED_PATH} ${size} OUTPUT_ICON_NAME ${output_icon_name_custom_state_locked} OUTPUT_ICON_PATH "${custom_state_icons_path}/")
+  queue_generate_sized_png_from_svg(${CUSTOM_STATE_ICON_LOCKED_PATH} ${size} OUTPUT_ICON_NAME ${output_icon_name_custom_state_locked} OUTPUT_ICON_PATH "${custom_state_icons_path}/")
 endforeach()
 
 foreach(size IN ITEMS 24;32;40;48;64;128;256;512;1024)
   get_filename_component(output_icon_name_custom_state_shared ${CUSTOM_STATE_ICON_SHARED_PATH} NAME_WLE)
-  generate_sized_png_from_svg(${CUSTOM_STATE_ICON_SHARED_PATH} ${size} OUTPUT_ICON_NAME ${output_icon_name_custom_state_shared} OUTPUT_ICON_PATH "${custom_state_icons_path}/")
+  queue_generate_sized_png_from_svg(${CUSTOM_STATE_ICON_SHARED_PATH} ${size} OUTPUT_ICON_NAME ${output_icon_name_custom_state_shared} OUTPUT_ICON_PATH "${custom_state_icons_path}/")
 endforeach()
+
+run_generate_queued_pngs_from_svg()
 
 # offset is used for referencing icon within the binary's resources (indexing start with 0, while IDI_ICON{i} 'i' starts with 1)
 if(NOT DEFINED CUSTOM_STATE_ICON_INDEX_OFFSET)


### PR DESCRIPTION
Problem: During Configure time, each PNG icon is generated in its own converter process, serially. With Inkscape (the default), every launch pays the full GTK startup cost, so generating 100+ icons dominated configure time. I noticed that while building the nextcloud desktop client on my Gentoo machine.

With the help of an LLM, I've made the following changes:

rsvg-convert: independent processes run concurrently, batched per logical core.
Inkscape: driven through single-process --shell batch mode — Inkscape crashes when many instances run at once, and batching also pays the startup cost only once.

queue_generate_sized_png_from_svg() enqueues; run_generate_queued_pngs_from_svg() runs the queue. Callers flush before consuming the PNGs, preserving order. "Skip if already generated" is unchanged.

Here is a benchmark (real theme SVGs, 21 SVGs --> 109 PNGs, Inkscape, warm cache, 3 runs each):

| Variant | PNGs | Runs (seconds) |
|---|---|---|
| Before (serial) | 109 | 48.9, 56.4, 43.7 |
| After (`--shell` batch) | 109 | 1.7, 1.9, 3.3 |

Identical output, ~20–30x faster.

The whole configure now takes ~10 seconds on my system.

Verified identical/correctly-sized PNGs and idempotent re-runs on Linux (Inkscape 1.4, rsvg-convert).

**_AI assistance: CMake changes and benchmark produced with GitHub Copilot (Claude Opus 4.8)._**

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). 
This allows us to coordinate the fix and release without potentially exposing all Nextcloud client users in the meantime.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin
-->

## Resolves
#<!-- related github issue -->

## Summary

### TODO
- [ ] ...

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [ ] The commit messages are following [The Conventional Commits specification](https://www.conventionalcommits.org).
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] Test(s) added to branch, with before/after results included in PR description, for performance improvements where applicable.
- [x] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI
  - [x] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [x] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
