### PR TITLE
fix(lock): file provider handling 412 for UNLOCK requests

### DIFF
--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Sources/NextcloudFileProviderKit/Item/Item+LockFile.swift
@@ -299,10 +299,24 @@ extension Item {
             } else {
                 logger.info("Unlocked file but did not receive lock information.", [.name: originalFileName])
             }
+        } catch let error as NKError where error.isPreconditionFailedError {
+            // files_lock returns 412 when UNLOCK finds no server-side lock. The requested state is
+            // therefore already reached, so finish the local cleanup instead of reporting a sync error.
+            logger.info("Server reported that the file is already unlocked.", [.name: originalFileName])
+        } catch {
+            logger.error("Could not unlock item.", [.name: filename, .error: error])
 
-            logger.info("Removing lock from locally stored target item.", [.name: originalFileName])
+            if let error = error as? NKError {
+                return error.fileProviderError(handlingNoSuchItemErrorUsingItemIdentifier: itemIdentifier)
+            }
 
-            if let targetMetadata = dbManager.itemMetadatas.where({ $0.fileName.equals(originalFileName) }).where({ $0.serverUrl.equals(metadata.serverUrl) }).first {
+            return nil
+        }
+
+        logger.info("Removing lock from locally stored target item.", [.name: originalFileName])
+
+        if let targetMetadata = dbManager.itemMetadatas.where({ $0.fileName.equals(originalFileName) }).where({ $0.serverUrl.equals(metadata.serverUrl) }).first {
+            do {
                 try dbManager.ncDatabase().write {
                     targetMetadata.lock = false
                     targetMetadata.lockOwner = nil
@@ -313,15 +327,11 @@ extension Item {
                     targetMetadata.lockTimeOut = nil
                     targetMetadata.lockToken = nil
                 }
-            } else {
-                logger.error("Failed to find target item for released lock.", [.lock: lock])
+            } catch {
+                logger.error("Could not remove lock from locally stored target item.", [.name: originalFileName, .error: error])
             }
-        } catch {
-            logger.error("Could not unlock item.", [.name: filename, .error: error])
-
-            if let error = error as? NKError {
-                return error.fileProviderError(handlingNoSuchItemErrorUsingItemIdentifier: itemIdentifier)
-            }
+        } else {
+            logger.error("Failed to find target item for released lock.", [.name: originalFileName])
         }
 
         return nil

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/Interface/MockRemoteInterface.swift
@@ -617,6 +617,9 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     /// Lock information returned by lock and unlock requests.
     public var lockUnlockResult: NKLock?
 
+    /// When set, every lock or unlock call throws this error without changing the mock item.
+    public var lockUnlockError: NKError?
+
     /// Handler to track enumerate calls
     public var enumerateCallHandler: ((String, EnumerateDepth, Bool, [String], Data?, Account, NKRequestOptions, @escaping (URLSessionTask) -> Void) -> Void)?
 
@@ -1304,6 +1307,10 @@ public class MockRemoteInterface: RemoteInterface, @unchecked Sendable {
     public func lockUnlockFile(serverUrlFileName: String, type _: NKLockType?, shouldLock: Bool, account: Account, options _: NKRequestOptions, taskHandler _: @escaping (URLSessionTask) -> Void) async throws -> NKLock? {
         guard let item = item(remotePath: serverUrlFileName, account: account.ncKitAccount) else {
             throw NKError.urlError
+        }
+
+        if let lockUnlockError {
+            throw lockUnlockError
         }
 
         item.locked = shouldLock

--- a/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
+++ b/shell_integration/MacOSX/NextcloudFileProviderKit/Tests/NextcloudFileProviderKitTests/ItemDeleteTests.swift
@@ -28,6 +28,86 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
         rootTrashItem.children = []
     }
 
+    private func makeLockFileDeletionScenario(
+        targetFileName: String,
+        remoteInterface: MockRemoteInterface
+    ) -> (
+        lockItem: Item,
+        targetRemote: MockRemoteItem,
+        targetMetadata: SendableItemMetadata,
+        lockFileMetadata: SendableItemMetadata
+    ) {
+        let folderName = "folder-\(targetFileName)"
+        let folderRemote = MockRemoteItem(
+            identifier: "\(folderName)-id",
+            versionIdentifier: "1",
+            name: folderName,
+            remotePath: Self.account.davFilesUrl + "/" + folderName,
+            directory: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+        let targetRemote = MockRemoteItem(
+            identifier: "\(folderName)/\(targetFileName)",
+            versionIdentifier: "1",
+            name: targetFileName,
+            remotePath: folderRemote.remotePath + "/" + targetFileName,
+            data: Data("test data".utf8),
+            locked: true,
+            account: Self.account.ncKitAccount,
+            username: Self.account.username,
+            userId: Self.account.id,
+            serverUrl: Self.account.serverUrl
+        )
+
+        folderRemote.children = [targetRemote]
+        folderRemote.parent = rootItem
+        rootItem.children = [folderRemote]
+
+        var folderMetadata = SendableItemMetadata(
+            ocId: folderRemote.identifier,
+            fileName: folderName,
+            account: Self.account
+        )
+        folderMetadata.directory = true
+        Self.dbManager.addItemMetadata(folderMetadata)
+
+        var targetMetadata = SendableItemMetadata(
+            ocId: targetRemote.identifier,
+            fileName: targetFileName,
+            account: Self.account
+        )
+        targetMetadata.serverUrl = folderRemote.remotePath
+        targetMetadata.lock = true
+        targetMetadata.lockOwner = Self.account.id
+        targetMetadata.lockOwnerDisplayName = "Test User"
+        targetMetadata.lockOwnerEditor = "desktop"
+        targetMetadata.lockOwnerType = NKLockType.token.rawValue
+        targetMetadata.lockTime = Date(timeIntervalSince1970: 1)
+        targetMetadata.lockTimeOut = Date(timeIntervalSince1970: 2)
+        targetMetadata.lockToken = "opaquelocktoken:test-token"
+        Self.dbManager.addItemMetadata(targetMetadata)
+
+        var lockFileMetadata = SendableItemMetadata(
+            ocId: "\(folderName)-lock-id",
+            fileName: ".~lock.\(targetFileName)#",
+            account: Self.account
+        )
+        lockFileMetadata.serverUrl = folderRemote.remotePath
+        Self.dbManager.addItemMetadata(lockFileMetadata)
+
+        let lockItem = Item(
+            metadata: lockFileMetadata,
+            parentItemIdentifier: .init(folderMetadata.ocId),
+            account: Self.account,
+            remoteInterface: remoteInterface,
+            dbManager: Self.dbManager
+        )
+        return (lockItem, targetRemote, targetMetadata, lockFileMetadata)
+    }
+
     func testDeleteFile() async {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem, rootTrashItem: rootTrashItem)
         let itemIdentifier = "file"
@@ -494,78 +574,75 @@ final class ItemDeleteTests: NextcloudFileProviderKitTestCase {
 
     func testDeleteLockFileUnlocksTargetFile() async {
         let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
-
-        // Setup remote folder and file
-        let folderRemote = MockRemoteItem(
-            identifier: "folder-id",
-            versionIdentifier: "1",
-            name: "folder",
-            remotePath: Self.account.davFilesUrl + "/folder",
-            directory: true,
-            account: Self.account.ncKitAccount,
-            username: Self.account.username,
-            userId: Self.account.id,
-            serverUrl: Self.account.serverUrl
+        let scenario = makeLockFileDeletionScenario(
+            targetFileName: "MyDoc.odt",
+            remoteInterface: remoteInterface
         )
 
-        let targetFileName = "MyDoc.odt"
-        let targetRemote = MockRemoteItem(
-            identifier: "folder/\(targetFileName)",
-            versionIdentifier: "1",
-            name: targetFileName,
-            remotePath: folderRemote.remotePath + "/" + targetFileName,
-            data: Data("test data".utf8),
-            locked: true,
-            account: Self.account.ncKitAccount,
-            username: Self.account.username,
-            userId: Self.account.id,
-            serverUrl: Self.account.serverUrl
+        let error = await scenario.lockItem.delete(dbManager: Self.dbManager)
+
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: scenario.lockFileMetadata.ocId)?.deleted,
+            true
         )
-
-        folderRemote.children = [targetRemote]
-        folderRemote.parent = rootItem
-        rootItem.children = [folderRemote]
-
-        // Insert folder and target file into DB
-        var folderMetadata = SendableItemMetadata(
-            ocId: folderRemote.identifier, fileName: "folder", account: Self.account
-        )
-        folderMetadata.directory = true
-        Self.dbManager.addItemMetadata(folderMetadata)
-
-        var targetMetadata = SendableItemMetadata(
-            ocId: targetRemote.identifier, fileName: targetFileName, account: Self.account
-        )
-        targetMetadata.serverUrl += "/folder"
-        Self.dbManager.addItemMetadata(targetMetadata)
-
-        // Construct the lock file metadata (used in deletion)
-        let lockFileName = ".~lock.\(targetFileName)#"
-        var lockFileMetadata = SendableItemMetadata(
-            ocId: "lock-id", fileName: lockFileName, account: Self.account
-        )
-        lockFileMetadata.serverUrl += "/folder"
-        Self.dbManager.addItemMetadata(lockFileMetadata)
-
-        let lockItem = Item(
-            metadata: lockFileMetadata,
-            parentItemIdentifier: .init(folderMetadata.ocId),
-            account: Self.account,
-            remoteInterface: remoteInterface,
-            dbManager: Self.dbManager
-        )
-
-        // Delete the lock file
-        let error = await lockItem.delete(dbManager: Self.dbManager)
-        XCTAssertEqual(Self.dbManager.itemMetadata(ocId: lockFileMetadata.ocId)?.deleted, true)
-
-        // Assert: no error returned
         XCTAssertNil(error)
-
-        // Assert: remote file is now unlocked
         XCTAssertFalse(
-            targetRemote.locked, "Expected the target file to be unlocked after lock file deletion"
+            scenario.targetRemote.locked,
+            "Expected the target file to be unlocked after lock file deletion"
         )
+    }
+
+    func testDeleteLockFileTreatsPreconditionFailureAsAlreadyUnlocked() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.lockUnlockError = NKError(
+            errorCode: 412,
+            errorDescription: "Precondition Failed"
+        )
+        let scenario = makeLockFileDeletionScenario(
+            targetFileName: "AlreadyUnlocked.odt",
+            remoteInterface: remoteInterface
+        )
+
+        let error = await scenario.lockItem.delete(dbManager: Self.dbManager)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: scenario.lockFileMetadata.ocId)?.deleted,
+            true
+        )
+        let targetMetadata = try XCTUnwrap(
+            Self.dbManager.itemMetadata(ocId: scenario.targetMetadata.ocId)
+        )
+        XCTAssertFalse(targetMetadata.lock)
+        XCTAssertNil(targetMetadata.lockOwner)
+        XCTAssertNil(targetMetadata.lockOwnerDisplayName)
+        XCTAssertNil(targetMetadata.lockOwnerEditor)
+        XCTAssertNil(targetMetadata.lockOwnerType)
+        XCTAssertNil(targetMetadata.lockTime)
+        XCTAssertNil(targetMetadata.lockTimeOut)
+        XCTAssertNil(targetMetadata.lockToken)
+    }
+
+    func testDeleteLockFileDoesNotIgnoreLockedResponse() async throws {
+        let remoteInterface = MockRemoteInterface(account: Self.account, rootItem: rootItem)
+        remoteInterface.lockUnlockError = NKError(errorCode: 423, errorDescription: "Locked")
+        let scenario = makeLockFileDeletionScenario(
+            targetFileName: "LockedBySomeoneElse.odt",
+            remoteInterface: remoteInterface
+        )
+
+        let error = await scenario.lockItem.delete(dbManager: Self.dbManager)
+
+        XCTAssertNotNil(error)
+        XCTAssertEqual(
+            Self.dbManager.itemMetadata(ocId: scenario.lockFileMetadata.ocId)?.deleted,
+            true
+        )
+        let targetMetadata = try XCTUnwrap(
+            Self.dbManager.itemMetadata(ocId: scenario.targetMetadata.ocId)
+        )
+        XCTAssertTrue(targetMetadata.lock)
+        XCTAssertEqual(targetMetadata.lockToken, "opaquelocktoken:test-token")
     }
 
     func testDeleteLockFileWithoutCapabilitiesRemovesLocalMetadataButKeepsServerLock() async {


### PR DESCRIPTION
The macOS File Provider creates server-side locks while local application lock files exist. When deleting such a lock file, it sends an X-User-Lock UNLOCK request. If the server has already removed the lock, it returns HTTP 412.

For this specific endpoint, 412 is not an ambiguous precondition failure: the server returns it when LockNotFoundException is raised. An unauthorized unlock instead returns 423. This behavior is documented in the [files_lock WebDAV API](https://github.com/nextcloud/files_lock/blob/8536a5a40409c0ef05ce910ae173a50cfb6519fe/README.md#L190-L225) and implemented in [LockPlugin::httpUnlock](https://github.com/nextcloud/files_lock/blob/8536a5a40409c0ef05ce910ae173a50cfb6519fe/lib/DAV/LockPlugin.php#L227-L258).

The PR therefore treats a 412 from this UNLOCK operation as an idempotent success and completes the normal local cleanup. It clears the document’s cached lock status, owner information, timeout, and lock token instead of returning .cannotSynchronize. This handling is scoped to lock-file deletion; other operations returning 412 are unaffected.

Assisted-by: Codex:GPT-5